### PR TITLE
I haven't tested this in enough varying circumstances, but this fixed a number of failure-to-execute problems for me...

### DIFF
--- a/autoload.php
+++ b/autoload.php
@@ -11,6 +11,17 @@ $loader->registerNamespaces(array(
 
 $loader->register();
 
-@include_once 'PHPUnit/Autoload.php';
-@include_once 'mink/autoload.php';
-@include_once 'vendor/.composer/autoload.php';
+if (stream_resolve_include_path('PHPUnit/Autoload.php') 
+		|| file_exists('PHPUnit/Autoload.php')) {
+    include_once 'PHPUnit/Autoload.php';
+}
+if (stream_resolve_include_path('mink/autoload.php') 
+		|| file_exists('mink/autoload.php')) {
+    include_once 'mink/autoload.php';
+}
+
+if ((stream_resolve_include_path('vendor/.composer/autoload.php')
+		|| file_exists('vendor/.composer/autoload.php'))
+		&& !class_exists('Composer\Autoload\ClassLoader')) {
+	include_once 'vendor/.composer/autoload.php';
+}


### PR DESCRIPTION
This now checks for the existence of the autoload files either in the current
path or the include_path before loading.

In addition, mink/autoload.php loads 'vendor/.composer/autoload.php'
and if mink exists then composer/autoload.php tries to redeclare the class. This catches that.

Not tested beyond 'Works for me!'
