### PR TITLE
Adding javascript files to phar archive

### DIFF
--- a/bin/build_phar.php
+++ b/bin/build_phar.php
@@ -29,6 +29,7 @@ $p->startBuffering();
 $p->buildFromDirectory(__DIR__.'/../package/phar/vendor','~\.html.dist$~');
 $p->buildFromDirectory(__DIR__.'/../package/phar/vendor','~\.tpl.dist$~');
 $p->buildFromDirectory(__DIR__.'/../package/phar/vendor','~\.php$~');
+$p->buildFromDirectory(__DIR__.'/../package/phar/vendor','~\.js$~');
 $p->addFile(__DIR__.'/../package/bin','codecept');
 $p->setStub(file_get_contents(__DIR__.'/../package/stub.php'));
 $p->stopBuffering();


### PR DESCRIPTION
Mink selenium(2) driver have a javascript files (syn.js) for simulate user actions (typing, clicking, dragging)
