### PR TITLE
unable to send more than 1 parameters using SOAP.sendSoapRequest

### DIFF
--- a/src/Codeception/Module/SOAP.php
+++ b/src/Codeception/Module/SOAP.php
@@ -134,8 +134,12 @@ class SOAP extends \Codeception\Module
         $call = $xml->createElement('ns:' . $action);
         if ($body) {
             $bodyXml = SoapUtils::toXml($body);
-            $bodyNode = $xml->importNode($bodyXml->documentElement, true);
-            $call->appendChild($bodyNode);
+            if ($bodyXml->hasChildNodes()) {
+                foreach ($bodyXml->childNodes as $bodyChildNode) {
+                    $bodyNode = $xml->importNode($bodyChildNode, true);
+                    $call->appendChild($bodyNode);
+                }
+            }
         }
 
         $xmlBody = $xml->getElementsByTagNameNS($soap_schema_url, 'Body')->item(0);


### PR DESCRIPTION
method sendSoapRequest is appending to call only one top level node:

$I->sendSoapRequest('signIn', Soap::request()
        ->login->val('username')->parent()
        ->password->val('password')
);

is generating request containing only login parameter.
