### PR TITLE
test generation (generate:test) and running fix

### DIFF
--- a/src/Codeception/Command/GenerateTest.php
+++ b/src/Codeception/Command/GenerateTest.php
@@ -29,7 +29,6 @@ use Codeception\Util\Stub;
         if (\$this->bootstrap) require \$this->bootstrap;
         \$this->dispatcher->dispatch('test.before', new \Codeception\Event\Test(\$this));
         \$this->%s = new %s(\$scenario = new \Codeception\Scenario(\$this));
-        \$scenario->run();
 
         // initialization code
     }

--- a/src/Codeception/TestCase/Test.php
+++ b/src/Codeception/TestCase/Test.php
@@ -29,4 +29,8 @@ class Test extends \Codeception\TestCase implements \PHPUnit_Framework_SelfDescr
         return strtolower($text);
     }
 
+    public function getTrace()
+    {
+        return $this->trace;
+    }
 }


### PR DESCRIPTION
Generate test by running:

<pre># codecept generate:test integration My</pre>


and it generates:

<?php

use Codeception\Util\Stub;

class MyTest extends \Codeception\TestCase\Test
{
   /**
    \* @var TestGuy
    */
    protected $testGuy;

```
// keep this setupUp and tearDown to enable proper work of Codeception modules
protected function setUp()    {
    if ($this->bootstrap) require $this->bootstrap;
    $this->dispatcher->dispatch('test.before', new \Codeception\Event\Test($this));
    $this->testGuy = new TestGuy($scenario = new \Codeception\Scenario($this));
    $scenario->run();

    // initialization code
}

protected function tearDown()
{
    $this->dispatcher->dispatch('test.after', new \Codeception\Event\Test($this));
}

// tests
```

}

where

<pre>$scenario->run();</pre>


is probably wrong, because when I add one test method:

<pre>
    public function testSomething()
    {
        $this->testGuy->wantTo('test some code');
        $this->testGuy->execute(function() {
            return 'something';
        });

        $this->testGuy->seeExceptionThrown('MyException');
        $this->testGuy->seeResultEquals('something else');
    }
</pre>


I got exception throw in Codeception/Module/Unit.php at line 424 with message: 

<pre>New steps were added to scenario in realtime. Can't proceed. Remove loops from your unit test to fix it</pre> and code 0.

which also can't be displayed because of "Fatal error: Call to undefined method MyTest::getTrace() in src/Codeception/Subscriber/Console.php on line 141"


The first problem can be fixed by removing "$scenario->run() from setUp() method", second - by copying getTrace method from Codeception\TestCase\Cept class to Codeception\TestCase\Test class.

Anyway - after fixing these problems - I got:
<pre># codecept run integration</pre>

<pre>
Codeception PHP Testing Framework v1.1.1
Powered by PHPUnit 3.6.10 by Sebastian Bergmann.

Suite integration started
Trying to test something (MyTest::testSomething) - Ok


Time: 1 second, Memory: 6.50Mb

OK (1 test, 0 assertions)
</pre>


where we see 0 assertions - should be 2 and both failed:

<pre>
    $this->testGuy->seeExceptionThrown('MyException');
    $this->testGuy->seeResultEquals('something else');
</pre>


what I'm doing wrong? :)
