### PR TITLE
Use stable versions by default.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
             "homepage":"http://codegyre.com"
         }
     ],
-    "minimum-stability": "dev",
+
     "require":{
         "php":">=5.3.3",
         "behat/mink": "1.4@stable",
@@ -27,7 +27,7 @@
         "symfony/console": "*",
         "symfony/event-dispatcher": "*",
         "symfony/yaml": "*",
-        "videlalvaro/php-amqplib": "dev-master"
+        "videlalvaro/php-amqplib": "2.*"
     },
 
     "autoload":{


### PR DESCRIPTION
As Codeception is a library to be used by other projects, it is desirable that stable releases are used as much as possible.

I would really like it if you could release a 1.5.2 release with this patch :smile: 
