### PR TITLE
Added basic yii support for codeception

### DIFF
--- a/plugins/frameworks/yii/web/CodeceptionHttpRequest.php
+++ b/plugins/frameworks/yii/web/CodeceptionHttpRequest.php
@@ -1,0 +1,56 @@
+<?php
+
+
+class CodeceptionHttpRequest extends \CHttpRequest
+{
+
+	private $_headers = array();
+
+	protected $_cookies;
+
+	public function setHeader($name,$value)
+	{
+		$this->_headers[$name] = $value;
+	}
+
+	public function getHeader($name,$default=null)
+	{
+		return isset($this->_headers[$name])? $this->_headers[$name] : $default;
+	}
+
+	public function getAllHeaders()
+	{
+		return $this->_headers;
+	}
+
+	public function getCookies()
+	{
+		if($this->_cookies!==null)
+			return $this->_cookies;
+		else
+			return $this->_cookies=new CodeceptionCookieCollection($this);
+	}
+
+	public function redirect($url, $terminate = true, $statusCode = 302)
+	{
+		$this->setHeader('Location', $url);
+		if($terminate)
+			Yii::app()->end(0,false);
+	}
+
+}
+
+class CodeceptionCookieCollection extends CCookieCollection
+{
+
+	protected function addCookie($cookie)
+	{
+		$_COOKIE[$cookie->name] = $cookie->value;
+	}
+
+	protected function removeCookie($cookie)
+	{
+		unset($_COOKIE[$cookie->name]);
+	}
+
+}

--- a/src/Codeception/Util/Connector/Yii1.php
+++ b/src/Codeception/Util/Connector/Yii1.php
@@ -46,8 +46,8 @@ class Yii1 extends \Symfony\Component\BrowserKit\Client
 	public function doRequest($request)
 	{
 		$this->_headers = array();
-		$_COOKIE = $request->getCookies();
-		$_SERVER = $request->getServer();
+		$_COOKIE = array_merge($_COOKIE,$request->getCookies());
+		$_SERVER = array_merge($_SERVER,$request->getServer());
 		$_FILES = $request->getFiles();
 		$_REQUEST = $request->getParameters();
 
@@ -78,7 +78,6 @@ class Yii1 extends \Symfony\Component\BrowserKit\Client
 		$_SERVER['SCRIPT_FILENAME'] = $this->appPath;
 
 		ob_start();
-
 		Yii::setApplication(null);
 		Yii::createApplication($this->appSettings['class'],$this->appSettings['config']);
 		Yii::app()->onEndRequest->add(array($this,'setHeaders'));
@@ -90,11 +89,18 @@ class Yii1 extends \Symfony\Component\BrowserKit\Client
 		return $response;
 	}
 
+	/**
+	 * Set current client headers when terminating yii application (onEndRequest)
+	 */
 	public function setHeaders()
 	{
-		$this->_headers = Yii::app()->request->getHeaders();
+		$this->_headers = Yii::app()->request->getAllHeaders();
 	}
 
+	/**
+	 * Returns current client headers
+	 * @return array headers
+	 */
 	public function getHeaders()
 	{
 		return $this->_headers;


### PR DESCRIPTION
This PR provides basic yii and codeception integration. In Codeception\Module\Yii1 there are docs about how to use it and how to patch CHttpRequest. I did tests on basic yii application that was created by `yiic webapp` and they passed. Scenario that i use is in the Yii1 module docs. So i will later do a gist with those docs and will add link on it in the module description, and i think will provide some debug info for this module like in the codeception docs are written (http://codeception.com/docs/05-FunctionalTests)

> It's preferred that it be able to print additional debug information.

But i think this one can be merged so other developers will already have working integration and they can modify it or add something new. What do u think @DavertMik ?
