### PR TITLE
Update to make use of pecl_http 2.x.x series code

### DIFF
--- a/src/Codeception/Module/ZombieJS.php
+++ b/src/Codeception/Module/ZombieJS.php
@@ -113,7 +113,7 @@ JS
             ,addslashes($url))
         );
 
-        if (method_exists('http\Header', 'parse')) {
+        if (method_exists('\http\Header', 'parse')) {
             return \http\Header::parse(str_replace("\n","\r\n",$headers));
         } else {
             return http_parse_headers(str_replace("\n","\r\n",$headers));


### PR DESCRIPTION
Check for \http\Heaader namespace version of code, implies newer 2.x.x series of code
