### PR TITLE
Generating Cests in subdirectories

### DIFF
--- a/src/Codeception/Command/Base.php
+++ b/src/Codeception/Command/Base.php
@@ -9,13 +9,13 @@ class Base extends \Symfony\Component\Console\Command\Command
     protected function buildPath($basePath, $testName)
     {
         $testName = str_replace('/',DIRECTORY_SEPARATOR, $testName);
-        $dirs = explode(DIRECTORY_SEPARATOR, $testName);
-        array_pop($dirs);
+        $dir = pathinfo($testName, PATHINFO_DIRNAME);
 
-        $path = $basePath;
-        foreach ($dirs as $dir) {
-            $path .= DIRECTORY_SEPARATOR.$dir;
-            @mkdir($path);
+
+        $path = $basePath.$dir;
+        if (!file_exists($path)) {
+            // Second argument should be mode. Well, umask() doesn't seem to return any if not set. Config may fix this.
+            mkdir($path, 0775, true); // Third parameter commands to create directories recursively
         }
         return $path;
     }

--- a/src/Codeception/Command/GenerateCest.php
+++ b/src/Codeception/Command/GenerateCest.php
@@ -14,6 +14,8 @@ class GenerateCest extends Base
     protected $template  = "<?php\n%s %sCest\n{\n    // the class name you want to test\n    public %s = '';\n\n%s\n}\n";
     protected $methodTemplate = "    // sample test\n    public function %s(\\%s %s) {\n    \n    }";
 
+    const SUFFIX = 'Cest';
+
     protected function configure()
     {
         $this->setDefinition(array(
@@ -42,7 +44,13 @@ class GenerateCest extends Base
 
         $path = $this->buildPath($suiteconf['path'], $testName);
 
-        $filename = $this->completeSuffix($testName, 'Cest');
+        $file = pathinfo($testName);
+        $filename = $file['filename'];
+        // filename already ends with Cest
+        if (strpos($filename, $this::SUFFIX, strlen($filename) - strlen($this::SUFFIX)) === false) {
+            $filename .= $this::SUFFIX;
+        }
+        $filename .= '.' . empty($file['extension']) ? '.php' : $file['extension'];
 
         $filename = $path.DIRECTORY_SEPARATOR . $filename;
 


### PR DESCRIPTION
First off, thanks for such a nice tool.

Generating Cest files was a pain. Now it should work fine both with the following:

```
./codecept generate:cest SimpleTest
```

and with:

```
./codecept generate:cest Not/So/Simple/But/Sometimes/Occures
```

Also simplifies the checks when generating

```
./codecept generate:cest OloloCest.php
```

But still provides the ability to set the extension for the test file (some crazy perks might want that =):

```
./codecept generate:cest Trololo.superduperextension
```
