### PR TITLE
Doctrine2 module : made grabFromRepository public

### DIFF
--- a/src/Codeception/Module/Doctrine2.php
+++ b/src/Codeception/Module/Doctrine2.php
@@ -240,7 +240,7 @@ class Doctrine2 extends \Codeception\Module
      * @param array $params
      * @return array
      */
-    protected function grabFromRepository($entity, $field, $params = array())
+    public function grabFromRepository($entity, $field, $params = array())
     {
         // we need to store to database...
         self::$em->flush();


### PR DESCRIPTION
Changed grabFromRepository visibility to public, in order for the example in the method docblock to work
