### PR TITLE
Fixed broken mongo tests

### DIFF
--- a/tests/unit/Codeception/Module/MongoDbTest.php
+++ b/tests/unit/Codeception/Module/MongoDbTest.php
@@ -1,12 +1,20 @@
 <?php
+use Codeception\Module\MongoDb;
+use PHPUnit_Framework_TestCase;
 
-use Codeception\Util\Stub;
-
-class MongoDbTest extends \PHPUnit_Framework_TestCase
+class MongoDbTest extends PHPUnit_Framework_TestCase
 {
-
     /**
-     * @var \Codeception\Module\MongoDb
+     * @var type 
+     */
+    private $mongoConfig = array(
+        'dsn' => 'mongodb://localhost:27017/test',
+        'user' => '',
+        'password' => ''
+    );
+    
+    /**
+     * @var MongoDb
      */
     protected $module;
 
@@ -14,29 +22,34 @@ class MongoDbTest extends \PHPUnit_Framework_TestCase
      * @var \MongoDb
      */
     protected $db;
+    
+    /**
+     * @var \MongoCollection
+     */
+    private $userCollection;
 
     protected function setUp()
     {
-        if (!class_exists('\Mongo')) $this->markTestSkipped('Mongo is not installed');
+        if (!class_exists('\Mongo')) {
+            $this->markTestSkipped('Mongo is not installed');
+        }
 
         $mongo = new \Mongo();
-
-        $this->module = new \Codeception\Module\MongoDb();
-        $this->module->_setConfig(array(
-                'dsn' => 'mongodb://localhost:27017/test',
-                'user' => '',
-                'password' => ''
-        ));
+        
+        $this->module = new MongoDb();
+        $this->module->_setConfig($this->mongoConfig);
         $this->module->_initialize();
 
         $this->db = $mongo->selectDB('test');
-        $userCol = $this->db->createCollection('users');
-        $userCol->insert(array('id' => 1, 'email' => 'miles@davis.com'));
+        $this->userCollection = $this->db->createCollection('users');
+        $this->userCollection->insert(array('id' => 1, 'email' => 'miles@davis.com'));
     }
 
     protected function tearDown()
     {
-        $this->db->dropCollection('users');
+        if (!is_null($this->userCollection)) {
+            $this->userCollection->drop();
+        }
     }
 
     public function testSeeInCollection()


### PR DESCRIPTION
- Proper codeformatting
- Using collection::drop() instead of deprecated Mongo::dropCollection()
- checking collection status before droping to fix test
