### PR TITLE
Zend_Controller_Response_HttpTestCase

### DIFF
--- a/src/Codeception/Util/Connector/ZF1.php
+++ b/src/Codeception/Util/Connector/ZF1.php
@@ -50,7 +50,7 @@ class ZF1 extends \Symfony\Component\BrowserKit\Client
         $zendRequest->setHeaders($request->getServer());
         $_FILES = $request->getFiles();
 
-        $zendResponse = new \Zend_Controller_Response_Http;
+        $zendResponse = new \Zend_Controller_Response_HttpTestCase;
         $this->front->setRequest($zendRequest)->setResponse($zendResponse);
 
         ob_start();


### PR DESCRIPTION
Use Zend_Controller_Response_HttpTestCase instead of Zend_Controller_Response_Http that is basically developped for tests.
It's also used in ControllerTestCase that was your reference when you "ported" source code for codeception according to your documentation.
