### PR TITLE
Update to better handle non-standard path layouts in ZF1 module

### DIFF
--- a/src/Codeception/Module/ZF1.php
+++ b/src/Codeception/Module/ZF1.php
@@ -7,12 +7,14 @@ namespace Codeception\Module;
  * Currently this module is a bit *alpha* as I have a little bit experience with ZF. Thus, contributions are welcome.
  *
  * It assumes, you have standard structure with __APPLICATION_PATH__ set to './application'
- * and LIBRARY_PATH set to './library'. If it's not redefine this constants in bootstrap file of your suite.
+ * and LIBRARY_PATH set to './library'. If it's not then set the appropriate path in the Config.
  *
  * ## Config
  *
  * * env  - environment used for testing ('testing' by default).
  * * config - relative path to your application config ('application/configs/application.ini' by default).
+ * * app_path - relative path to your application folder ('applicaiton' by default).
+ * * lib_path - relative path to your library folder ('library' by default).
  *
  * ## API
  *
@@ -51,8 +53,8 @@ namespace Codeception\Module;
 
 class ZF1 extends \Codeception\Util\Framework implements \Codeception\Util\FrameworkInterface
 {
-    protected $config = array('env' => 'testing', 'config' => 'application/configs/application.ini');
-    // 'app_path' => 'application', 'lib_path' => 'library',
+    protected $config = array('env' => 'testing', 'config' => 'application/configs/application.ini',
+        'app_path' => 'application', 'lib_path' => 'library');
 
     /**
      * @var \Zend_Application
@@ -74,8 +76,8 @@ class ZF1 extends \Codeception\Util\Framework implements \Codeception\Util\Frame
 
     public function _initialize() {
         defined('APPLICATION_ENV') || define('APPLICATION_ENV', $this->config['env']);
-        defined('APPLICATION_PATH') || define('APPLICATION_PATH', getcwd().DIRECTORY_SEPARATOR.'application');
-        defined('LIBRARY_PATH') || define('LIBRARY_PATH', getcwd().DIRECTORY_SEPARATOR.'library');
+        defined('APPLICATION_PATH') || define('APPLICATION_PATH', getcwd().DIRECTORY_SEPARATOR.$this->config['app_path']);
+        defined('LIBRARY_PATH') || define('LIBRARY_PATH', getcwd().DIRECTORY_SEPARATOR.$this->config['lib_path']);
 
         // Ensure library/ is on include_path
         set_include_path(implode(PATH_SEPARATOR, array(


### PR DESCRIPTION
Instruction to set APPLICATION_PATH or LIBRARY_PATH in _bootstrap.php file is eroneous - this file is loaded after the _initialize method has already been run.

Altered to utilise yaml config to allow override of paths earlier in the bootstrap process.
