### PR TITLE
enabling generation of phpunit file

### DIFF
--- a/package/bin
+++ b/package/bin
@@ -24,6 +24,7 @@ use Symfony\Component\Console\Application,
  $app->add(new Codeception\Command\GenerateCept('generate:cept'));
  $app->add(new Codeception\Command\GenerateCest('generate:cest'));
  $app->add(new Codeception\Command\GenerateTest('generate:test'));
+ $app->add(new Codeception\Command\GeneratePhpUnit('generate:phpunit'));
  $app->add(new Codeception\Command\GenerateSuite('generate:suite'));
  $app->add(new Codeception\Command\GenerateScenarios('generate:scenarios'));
  $app->run();


### PR DESCRIPTION
it is not possible to use generate:phpunit via the phar file (but the documentation says so ;) )
