### PR TITLE
Fix Yii1 Module parsing query parameters

### DIFF
--- a/src/Codeception/Util/Connector/Yii1.php
+++ b/src/Codeception/Util/Connector/Yii1.php
@@ -56,11 +56,11 @@ class Yii1 extends \Symfony\Component\BrowserKit\Client
 		else
 			$_POST = $request->getParameters();
 
-		$queryString = parse_url($uri,PHP_URL_QUERY);
-		parse_str($queryString,$params);
-
 		$uri = str_replace('http://localhost','',$request->getUri());
 		$scriptName =  str_replace('http://localhost','',$this->url);
+
+		$queryString = parse_url($uri,PHP_URL_QUERY);
+		parse_str($queryString,$params);
 
 		if (strpos($uri,$scriptName) === false)
 			$uri = $scriptName.$queryString;


### PR DESCRIPTION
The original code attempted to parse parse_url() and parse_str based off $uri before it was initialized. I've simply reordered it.
