### PR TITLE
Fix Yii1 running multiple tests

### DIFF
--- a/src/Codeception/Module/Yii1.php
+++ b/src/Codeception/Module/Yii1.php
@@ -94,18 +94,25 @@ class Yii1 extends \Codeception\Util\Framework implements \Codeception\Util\Fram
 		$_SERVER['SCRIPT_FILENAME'] = $this->config['appPath'];
 
 		Yii::createApplication($this->appSettings['class'],$this->_appConfig);
+	}
 
-		$this->client = new \Codeception\Util\Connector\Yii1();
-		$this->client->appPath = $this->config['appPath'];
-		$this->client->url = $this->config['url'];
-		$this->client->appSettings = array(
-			'class' => $this->appSettings['class'],
-			'config' => $this->_appConfig,
-		);
+	/*
+	 * Create the client connector. Called before each test
+	 */
+	public function createClient()
+	{
+                $this->client = new \Codeception\Util\Connector\Yii1();
+                $this->client->appPath = $this->config['appPath'];
+                $this->client->url = $this->config['url'];
+                $this->client->appSettings = array(
+                        'class' => $this->appSettings['class'],
+                        'config' => $this->_appConfig,
+                );
 	}
 
 	public function _before(\Codeception\TestCase $test)
 	{
+		$this->createClient();
 	}
 
 	public function _after(\Codeception\TestCase $test)


### PR DESCRIPTION
Fixes #165. Allows multiple Yii tests to be run in sequence by recreating the client connector before each test.
