### PR TITLE
generate:cest _before() and _after() made public

### DIFF
--- a/src/Codeception/Command/GenerateCest.php
+++ b/src/Codeception/Command/GenerateCest.php
@@ -19,11 +19,11 @@ class GenerateCest extends Base
 {
     protected $%s = '%s';
 
-    protected function _before()
+    public function _before()
     {
     }
 
-    protected function _after()
+    public function _after()
     {
     }
 


### PR DESCRIPTION
File generated by `generate:cest` was not working, saying that subj methods should be public.
