### PR TITLE
[BUG] click causes Selenium 2 Exception if a javascript alert is opened.

### DIFF
--- a/src/Codeception/Module/Selenium2.php
+++ b/src/Codeception/Module/Selenium2.php
@@ -83,6 +83,19 @@ class Selenium2 extends \Codeception\Util\MinkJS
 
     // please, add more custom Selenium functions here
 
+
+    /**
+     * Clicks on either link or button (for PHPBrowser) or on any selector for JS browsers.
+     * Link text or css selector can be passed.
+     *
+     * @param $link
+     */
+    public function click($link) {
+        $url = $this->session->getCurrentUrl();
+        $el = $this->findClickable($link);
+        $el->click();
+    }
+
     /**
      * Accept alert or confirm popup
      *


### PR DESCRIPTION
In Codeception/Util/Mink.php when click() is called, after the click()
is executed, there is a second call to getCurrentUrl() to determine
whether we should add a debug message indicating that the browser has
moved to a new page.

The second call to getCurrentUrl() triggers a selenium exception as at
this point the alert is open and the only valid actions are
acceptPopup(), cancelPopup(), seeInPopup() or dontSeeInPopup().

There is no method in the JsonWireProtocol for testing whether a popup
is present before attempting getCurrentUrl().

So, until a better solution presents itself, I have overridden the
click() method in the Selenium2 module to exclude the second call to
getCurrentUrl().

Documentation of JsonWireProtocol is available here:
http://code.google.com/p/selenium/wiki/JsonWireProtocol#Response_Status_
Codes
