### PR TITLE
Configurable error_level

### DIFF
--- a/config/codeception.yml
+++ b/config/codeception.yml
@@ -10,3 +10,4 @@ settings:
     silent: false
     memory_limit: 1024M
     silent: false
+    error_level: E_ALL | E_STRICT


### PR DESCRIPTION
Configurable error level for tests, `E_ALL | E_STRICT` by default, can be set to whatever wanted with `settings/error_level` in yml. Affects error_reporting and error-to-exception conversion.

Not sure which of several codeception.yml's is actually a true one for defaults, so i edited only one of them, think you know better where to place it.
