### PR TITLE
[composer.json] Using behat/mink 1.4.*@stable

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     ],
     "require":{
         "php":">=5.3.3",
-        "behat/mink": "1.4@stable",
+        "behat/mink": "1.4.*@stable",
         "phpunit/phpunit": "3.7.*@stable",
         "fabpot/goutte": "@stable",
         "behat/mink-goutte-driver": "*",


### PR DESCRIPTION
Will give access to behat/mink 1.4.1 and superior, which are compatible with Symfony 2.2
