### PR TITLE
Selenium 2 Grid

### DIFF
--- a/src/Codeception/Module/Selenium2.php
+++ b/src/Codeception/Module/Selenium2.php
@@ -54,7 +54,7 @@ class Selenium2 extends \Codeception\Util\MinkJS
         $driver = new \Behat\Mink\Driver\Selenium2Driver(
             $this->config['browser'],
             null,
-            sprintf('http://%s:%d/wd/hub',$this->config['host'],$this->config['port'])
+            sprintf('http://%s:%d/node/hub',$this->config['host'],$this->config['port'])
         );
         $this->session = new \Behat\Mink\Session($driver);
         parent::_initialize();


### PR DESCRIPTION
If I use Selenium 2 Server with grid (-role hub) I have problem with connection to node (-role node).

http://localhost:4444/wd/hub is deprecated in Selenium 2
