### PR TITLE
Updated Docs - radio buttons should not use selectOption

### DIFF
--- a/docs/modules/Selenium2.md
+++ b/docs/modules/Selenium2.md
@@ -117,7 +117,7 @@ $I->cancelPopup();
 
 
 Ticks a checkbox.
-For radio buttons use `click`.
+For radio buttons use the `click` method.
 
 Example:
 


### PR DESCRIPTION
Took out the recommendation that for radio buttons we use selectOption because this does not work.

Said that they should use click instead as per recommendation in an issye
