### PR TITLE
Fix-for-after/failed-events-in-Cest-classes

### DIFF
--- a/src/Codeception/TestCase/Cest.php
+++ b/src/Codeception/TestCase/Cest.php
@@ -59,7 +59,7 @@ class Cest extends \Codeception\TestCase\Cept
             $this->dispatcher->dispatch('test.after', new \Codeception\Event\Test($this));
             throw $e;
         }
-        $this->dispatcher->dispatch('test.before', new \Codeception\Event\Test($this));
+        $this->dispatcher->dispatch('test.after', new \Codeception\Event\Test($this));
     }
 
     protected function executeTestMethod($I)


### PR DESCRIPTION
Events fixed, so in Cest-classes after called always even if test failed, and if test failed `_after` is called after `_failed`.
