### PR TITLE
PhpBrowser::submitForm method enh.

### DIFF
--- a/src/Codeception/Module/PhpBrowser.php
+++ b/src/Codeception/Module/PhpBrowser.php
@@ -2,6 +2,8 @@
 
 namespace Codeception\Module;
 
+use Codeception\Exception\TestRuntime;
+
 /**
  * Uses [Mink](http://mink.behat.org) with [Goutte](https://github.com/fabpot/Goutte) and [Guzzle](http://guzzlephp.org/) to interact with your application over CURL.
  *
@@ -24,7 +26,7 @@ namespace Codeception\Module;
  *
  * ### Example (`acceptance.suite.yml`)
  *
- *     modules: 
+ *     modules:
  *        enabled: [PhpBrowser]
  *        config:
  *           PhpBrowser:
@@ -47,26 +49,32 @@ class PhpBrowser extends \Codeception\Util\Mink implements \Codeception\Util\Fra
     }
 
     public function submitForm($selector, $params) {
-
         $form = $this->session->getPage()->find('css',$selector);
-	    $fields = $this->session->getPage()->findAll('css', $selector.' input');
-	    $url = '';
-	    foreach ($fields as $field) {
-		    $url .= sprintf('%s=%s',$field->getAttribute('name'), $field->getAttribute('value')).'&';
-	    }
 
-	    $fields = $this->session->getPage()->findAll('css', $selector.' textarea');
-	    foreach ($fields as $field) {
-		    $url .= sprintf('%s=%s',$field->getAttribute('name'), $field->getValue()).'&';
-	    }
+        if ($form === null)
+            throw new TestRuntime("Form with selector: \"$selector\" was not found on given page.");
 
-	    $fields = $this->session->getPage()->findAll('css', $selector.' select');
+        $fields = $this->session->getPage()->findAll('css', $selector.' input');
+        $url = '';
+
         foreach ($fields as $field) {
-   		    $url .= sprintf('%s=%s',$field->getAttribute('name'), $field->getValue()).'&';
-   	    }
+            $url .= sprintf('%s=%s',$field->getAttribute('name'), $field->getAttribute('value')).'&';
+        }
 
-		$url .= '&'.http_build_query($params);
-	    parse_str($url, $params);
+        $fields = $this->session->getPage()->findAll('css', $selector.' textarea');
+
+        foreach ($fields as $field) {
+            $url .= sprintf('%s=%s',$field->getAttribute('name'), $field->getValue()).'&';
+        }
+
+        $fields = $this->session->getPage()->findAll('css', $selector.' select');
+
+        foreach ($fields as $field) {
+            $url .= sprintf('%s=%s',$field->getAttribute('name'), $field->getValue()).'&';
+        }
+
+        $url .= '&'.http_build_query($params);
+        parse_str($url, $params);
         $url = $form->getAttribute('action');
         $method = $form->getAttribute('method');
 


### PR DESCRIPTION
Added exception throw if form not found, and i made some formatting fix (changed tabs to spaces). This is PR for this issue https://github.com/Codeception/Codeception/issues/256.
Sorry for that i did not provide tests, i just got stuck with them, because when i run `php codecept run` then when it is turn of `unit-tests` some of them failing with php-error `can not redeclare class....` i think it is because i already has full phpunit installed and it is in my include_path. But anyway i've tested compiled phar and when form does not exist exception was correctly thrown like this: 

```
1) Couldn't test index page in Codeception\TestCase\Cest::testMySimpleApp
Codeception\Exception\TestRuntime: Form with selector: "#not-existing" was not found on given page.
```

so i think this one can be merged.
