### PR TITLE
In Selenium2 docs, fixed link to php-webdriver

### DIFF
--- a/docs/modules/Selenium2.md
+++ b/docs/modules/Selenium2.md
@@ -45,7 +45,7 @@ Don't forget to turn on Db repopulation if you are using database.
 ## Public Properties
 
 * session - contains Mink Session
-* webDriverSession - contains webDriverSession object, i.e. $session from [php-webdriver](https://github.com/facebook/php-webdriver)
+* webDriverSession - contains \WebDriver\Session object from [php-webdriver](https://github.com/instaclick/php-webdriver)
 
 ## Actions
 


### PR DESCRIPTION
The docs for Selenium2 linked to Facebook's php-webdriver, but we're actually using instaclick's fork which behaves differently.
