### PR TITLE
Fix for windows for cest-classes

### DIFF
--- a/src/Codeception/Module/PhpBrowser.php
+++ b/src/Codeception/Module/PhpBrowser.php
@@ -94,7 +94,7 @@ class PhpBrowser extends \Codeception\Util\Mink implements \Codeception\Util\Fra
         $fields = $this->session->getPage()->findAll('css', $selector.' select');
         foreach ($fields as $field) {
    		    $url .= sprintf('%s=%s',$field->getAttribute('name'), $field->getValue()).'&';
-   	    }
+   	 }
 
         $url .= '&'.http_build_query($params);
         parse_str($url, $params);
@@ -166,18 +166,16 @@ class PhpBrowser extends \Codeception\Util\Mink implements \Codeception\Util\Fra
 
 	protected function call($uri, $method = 'get', $params = array())
 	{
-        if (strpos($uri,'#')) $uri = substr($uri,0,strpos($uri,'#'));
-        $browser = $this->session->getDriver()->getClient();
+		if (strpos($uri,'#')) $uri = substr($uri,0,strpos($uri,'#'));
+			$browser = $this->session->getDriver()->getClient();
 
-    	$this->debug('Request ('.$method.'): '.$uri.' '. json_encode($params));
+		$this->debug('Request ('.$method.'): '.$uri.' '. json_encode($params));
 		$browser->request($method, $uri, $params);
-
-
 		$this->debug('Response code: '.$this->session->getStatusCode());
 	}
 
 	public function _failed(\Codeception\TestCase $test, $fail) {
-                $fileName = str_replace('::','-',$test->getFileName());
+		$fileName = str_replace('::','-',$test->getFileName());
 		file_put_contents(\Codeception\Configuration::logDir().basename($fileName).'.page.fail.html', $this->session->getPage()->getContent());
 	}
 


### PR DESCRIPTION
this fix is for this issue https://github.com/Codeception/Codeception/issues/254 . I've decided to not modify cest-class name by itself (https://github.com/Codeception/Codeception/blob/master/src/Codeception/TestCase/Cest.php#L124) because in console output it also used and there `::` makes sense and easy to read, so i made replacement only in `PhpBrowser` when it saves snapshot.
P.S. i will also provide some formatting fix for this file later.
