### PR TITLE
New mink methods introduced for select elements

### DIFF
--- a/src/Codeception/Util/Mink.php
+++ b/src/Codeception/Util/Mink.php
@@ -358,8 +358,18 @@ abstract class Mink extends \Codeception\Module implements RemoteInterface, WebI
         $field->attachFile($path);
     }
 
+    public function seeOptionIsSelected($select, $option)
+    {
+        $this->see($option, "$select option[selected]");
+    }
+
+    public function dontSeeOptionIsSelected($select, $option)
+    {
+        $this->dontSee($option, "$select option[selected]");
+    }
+
     public function seeCheckboxIsChecked($checkbox) {
-       $node = $this->findField($checkbox);
+        $node = $this->findField($checkbox);
         if (!$node) return \PHPUnit_Framework_Assert::fail(", checkbox not found");
         \PHPUnit_Framework_Assert::assertTrue($node->isChecked());
     }


### PR DESCRIPTION
This one is for this issue https://github.com/Codeception/Codeception/issues/261. This PR add new mink methods for html-select element, according to HTML4 only `selected` is enough for option to be selected, according XHMTL it must be `selected="selected"`, so i've decided that simple `option[selected]` would be enough to check if option is selected and to satisfy both of them. I think that this implementation can be called a "hack", but it is better then implementing for each low-level mink session drivers this methods. Also coudl you please add implementation of this methods to `Framework` so later we can add signature of them to the `WebInterface` and some docs in interface:

`````` php
    /**
     * Assert if the specified option is selected.
     * Use css selector to match.
     *
     * Example:
     *
     * ``` php
     * <?php
     * $I->seeOptionIsSelected('#country','USA');
     * $I->seeOptionIsSelected('#register_form select[name="country"]','USA');
     *
     * ```
     *
     * @param $select
     * @param $option
     */
    public function seeOptionIsSelected($select, $option);

    /**
     * Assert if the specified option is not selected.
     * Use css selector to match.
     *
     * Example:
     *
     * ``` php
     * <?php
     * $I->dontSeeOptionIsSelected('#country','SomeBadCountry');
     * $I->dontSeeOptionIsSelected('#register_form select[name="country"]','SomeBadCountry');
     *
     * ```
     *
     * @param $select
     * @param $option
     */
    public function dontSeeOptionIsSelected($select, $option);
``````
