### PR TITLE
Fixed cest filename

### DIFF
--- a/src/Codeception/TestCase/Cest.php
+++ b/src/Codeception/TestCase/Cest.php
@@ -122,7 +122,7 @@ class Cest extends \Codeception\TestCase\Cept
     }
 
     public function getFileName() {
-        return get_class($this)."::".$this->getTestMethod();
+        return $this->signature;
     }
 
 }


### PR DESCRIPTION
Before this fix, cest-classes filename was wrong, and for example in console output it was like this:

```
Trying to test basic crud operations of system client user (Codeception\TestCase\Cest::test_basic_crud_operations) - Ok
```

with this fix it is correct:

```
Trying to test basic crud operations of system client user (modules\users\CrudCest::test_basic_crud_operations) - Ok
```
