### PR TITLE
Enh improved generate cest command

### DIFF
--- a/src/Codeception/Command/GenerateCest.php
+++ b/src/Codeception/Command/GenerateCest.php
@@ -124,10 +124,10 @@ class {cestName}Cest
         $tests = str_replace('{guyClass}',$guy,$this->methodTemplate);
 
         $cestFileContent = str_replace(
-		array('{namespace}', '{cestName}', '{testMethod}'),
-		array($ns, $classname, $tests),
-		$this->template
-	);
+            array('{namespace}', '{cestName}', '{testMethod}'),
+            array($ns, $classname, $tests),
+            $this->template
+        );
 
         file_put_contents($filename, $cestFileContent);
 


### PR DESCRIPTION
Improved template for cest-classes.
command: 
`php codecept.phar generate:cest acceptance TestOneCest`
in file:

``` php
<?php

/**
 * TestOneCest class file.
 *
 * @author codeception
 * @version $Id$
 */


use Codeception\Util\Stub;

class TestOneCest
{

    /**
     * @param \Codeception\Event\Test $event
     */
    public function _before($event)
    {
    // called before each public method of this class
    }

    /**
     * @param \Codeception\Event\Test $event
     */
    public function _after($event)
    {
    //called after each public method of this class, even if test failed
    }

    /**
     * @param \Codeception\Event\Fail $event
     */
    public function _failed($event)
    {
    //called when test failed
    }

    // tests

    /**
     *
     * @param \WebGuy $I
     * @param \Codeception\Scenario $scenario
     */
    public function tryToTest(\WebGuy $I, $scenario)
    {
        //$scenario->incomplete('not implemented yet'); use this to mark scenario as incomplete
        //$scenario->skip('some important reason');     use this to skip scenario

        $I->wantTo('Test index page of my application');                      //describe your feature
        $I->am('system root user');                                           //describe who you are
        $I->amGoingTo('check that all required elements presented on page');  //describe what you want to do
    }

}
```
