### PR TITLE
Duplicate class names in one namespace fix

### DIFF
--- a/src/Codeception/TestCase/Cept.php
+++ b/src/Codeception/TestCase/Cept.php
@@ -2,7 +2,7 @@
 namespace Codeception\TestCase;
 
 use Codeception\Event\Fail;
-use Codeception\Event\Test;
+use Codeception\Event\Test as TestEvent;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 use Codeception\Step;
 
@@ -57,14 +57,14 @@ class Cept extends \Codeception\TestCase
         if (file_exists($this->bootstrap)) require $this->bootstrap;
         require $this->testfile;
 
-        $this->fire('test.parsed', new Test($this));
+        $this->fire('test.parsed', new TestEvent($this));
     }
 
     public function testCodecept()
     {
         $scenario = $this->scenario;
 
-        $this->fire('test.before', new Test($this));
+        $this->fire('test.before', new TestEvent($this));
         $scenario->run();
         if (file_exists($this->bootstrap)) require $this->bootstrap;
 
@@ -74,7 +74,7 @@ class Cept extends \Codeception\TestCase
             // fails and errors are now handled by Codeception\PHPUnit\Listener
             throw $e;
         }
-        $this->fire('test.after', new Test($this));
+        $this->fire('test.after', new TestEvent($this));
     }
 
 }

--- a/src/Codeception/TestCase/Cest.php
+++ b/src/Codeception/TestCase/Cest.php
@@ -1,7 +1,7 @@
 <?php
 namespace Codeception\TestCase;
 
-use Codeception\Event\Test;
+use Codeception\Event\Test as TestEvent;
 
 class Cest extends Cept
 {
@@ -21,7 +21,7 @@ class Cest extends Cept
         if (file_exists($this->bootstrap)) require $this->bootstrap;
         $I = $this->makeIObject();
         $this->executeTestMethod($I);
-        $this->fire('test.parsed', new Test($this));
+        $this->fire('test.parsed', new TestEvent($this));
     }
 
     public function testCodecept() {
@@ -29,7 +29,7 @@ class Cest extends Cept
 
         $this->scenario->run();
         $I = $this->makeIObject();
-        $this->fire('test.before', new Test($this));
+        $this->fire('test.before', new TestEvent($this));
 
         try {
             $this->executeTestMethod($I);
@@ -37,7 +37,7 @@ class Cest extends Cept
             // fails and errors are now handled by Codeception\PHPUnit\Listener
             throw $e;
         }
-        $this->fire('test.after', new Test($this));
+        $this->fire('test.after', new TestEvent($this));
     }
 
     protected function makeIObject()


### PR DESCRIPTION
@davertMik I've made small fix for imported class name, because you already have class with such name in current namespace. You have class with name Test in Codeception\TestCase and you trying to import  Codeception\Event\Test. It's cause an error
"Fatal error: Cannot use Codeception\Event\Test as Test because the name is already in use..."
