### PR TITLE
Doctrine2 module to rollback only on active transaction

### DIFF
--- a/src/Codeception/Module/Doctrine2.php
+++ b/src/Codeception/Module/Doctrine2.php
@@ -80,7 +80,7 @@ class Doctrine2 extends \Codeception\Module
             "You can use your bootstrap file to assign the EntityManager:\n\n" .
             '\Codeception\Module\Doctrine2::$em = $em');
 
-        if ($this->config['cleanup']) {
+        if ($this->config['cleanup'] && self::$em->getConnection()->isTransactionActive()) {
             self::$em->getConnection()->rollback();
         }
         $this->clean();


### PR DESCRIPTION
I made a small fix to rollback only on an active transaction. Sometimes, it may be possible that the transaction has been cut off or already rollbacked due to an error and instead of showing that error the Doctrine2 Module will throw the "Invalid transaction" error.
