### PR TITLE
Db::seeInDatabase can work with NULL values

### DIFF
--- a/src/Codeception/Util/Driver/PostgreSql.php
+++ b/src/Codeception/Util/Driver/PostgreSql.php
@@ -50,11 +50,16 @@ class PostgreSql extends Db
         }
     }
 
-    public function select($column, $table, array $criteria) {
+    public function select($column, $table, array &$criteria) {
         $query = 'select %s from "%s" where %s';
         $params = array();
         foreach ($criteria as $k => $v) {
-            $params[] = "$k = ? ";
+            if($v === NULL) {
+                $params[] = "$k IS NULL ";
+                unset($criteria[$k]);
+            } else {
+                $params[] = "$k = ? ";
+            }
         }
         $params = implode('AND ', $params);
 


### PR DESCRIPTION
I managed to fix the problem described in issue 337. I made fix only to PostgreSQL driver, because I have no other DB to check. 

This fix makes such assertions work:
$I->seeInDatabase('table', array('fieldName' => NULL)); 
