### PR TITLE
Adding support for subfolders

### DIFF
--- a/src/Codeception/Command/GenerateCept.php
+++ b/src/Codeception/Command/GenerateCept.php
@@ -42,10 +42,10 @@ class GenerateCept extends Base
 
         $res = $this->save($suiteconf['path'].DIRECTORY_SEPARATOR . $filename, $file);
         if (!$res) {
-            $output->writeln("<error>Test $filename already exists</error>");
+            $output->writeln("<error>Test $suite/$filename already exists</error>");
             exit;
         }
-        $output->writeln("<info>Test was generated in $filename</info>");
+        $output->writeln("<info>Test was generated in $suite/$filename</info>");
     }
 
 

--- a/src/Codeception/Command/GenerateCest.php
+++ b/src/Codeception/Command/GenerateCest.php
@@ -67,7 +67,7 @@ EOF;
         $filename = $path.DIRECTORY_SEPARATOR.$filename;
 
         if (file_exists($filename)) {
-            $output->writeln("<error>Test $filename already exists</error>");
+            $output->writeln("<error>Test $suite/$filename already exists</error>");
             exit;
         }
 
@@ -77,7 +77,7 @@ EOF;
 
         file_put_contents($filename, sprintf($this->template, $ns, 'class', $classname, $tests));
 
-        $output->writeln("<info>Cest was created in $filename</info>");
+        $output->writeln("<info>Cest was created in $suite/$filename</info>");
 
     }
 }

--- a/src/Codeception/Command/GeneratePhpUnit.php
+++ b/src/Codeception/Command/GeneratePhpUnit.php
@@ -65,11 +65,11 @@ EOF;
 
         $res = $this->save($filename, sprintf($this->template, $ns, 'class', $classname));
         if (!$res) {
-            $output->writeln("<error>Test $filename already exists</error>");
+            $output->writeln("<error>Test $suite/$filename already exists</error>");
             exit;
         }
 
-        $output->writeln("<info>Test for $class was created in $filename</info>");
+        $output->writeln("<info>Test for $class was created in $suite/$filename</info>");
     }
 
 }

--- a/src/Codeception/Command/GenerateSuite.php
+++ b/src/Codeception/Command/GenerateSuite.php
@@ -30,14 +30,26 @@ class GenerateSuite extends Base
     public function execute(InputInterface $input, OutputInterface $output)
     {
         $suite = $input->getArgument('suite');
+
         $guy = $input->getArgument('guy');
 
         $config = \Codeception\Configuration::config($input->getOption('config'));
 
-        $dir = \Codeception\Configuration::projectDir().$config['paths']['tests'].DIRECTORY_SEPARATOR;
-        if (file_exists($dir.DIRECTORY_SEPARATOR.$suite)) throw new \Exception("Directory $suite already exists.");
-        if (file_exists($dir.$suite.'.suite.yml')) throw new \Exception("Suite configuration file '$suite.suite.yml' already exists.");
+        $dir = \Codeception\Configuration::projectDir().$config['paths']['tests'];
 
+        $suitePath = $dir . DIRECTORY_SEPARATOR . $suite;
+        $paths = explode(DIRECTORY_SEPARATOR, $suitePath);
+        $prevPath = '';
+
+        foreach ($paths as $path) {
+            $prevPath = $prevPath . $path . DIRECTORY_SEPARATOR;
+
+            if(!is_dir($prevPath)) {
+                mkdir($prevPath);
+            }
+        }
+
+        if (file_exists($dir.$suite.'.suite.yml')) throw new \Exception("Suite configuration file '$suite.suite.yml' already exists.");
         @mkdir($dir.DIRECTORY_SEPARATOR.$suite);
 
         // generate bootstrap
@@ -55,7 +67,7 @@ class GenerateSuite extends Base
             'modules' => array('enabled' => array($guyname.'Helper')),
         );
 
-        file_put_contents($dir.$suite.'.suite.yml', Yaml::dump($conf, 2));
+        file_put_contents($dir.DIRECTORY_SEPARATOR.$suite.'.suite.yml', Yaml::dump($conf, 2));
 
         $output->writeln("<info>Suite $suite generated</info>");
     }

--- a/src/Codeception/Command/GenerateTest.php
+++ b/src/Codeception/Command/GenerateTest.php
@@ -72,12 +72,12 @@ EOF;
         $filename = $path.$filename;
 
         if (file_exists($filename)) {
-            $output->writeln("<error>Test $filename already exists</error>");
+            $output->writeln("<error>Test $suite/$filename already exists</error>");
             exit;
         }
         file_put_contents($filename, sprintf($this->template, $ns, 'class', $classname, $guy, lcfirst($guy), lcfirst($guy), $guy));
 
-        $output->writeln("<info>Test for $class was created in $filename</info>");
+        $output->writeln("<info>Test for $class was created in $suite/$filename</info>");
 
     }
 }

--- a/src/Codeception/Configuration.php
+++ b/src/Codeception/Configuration.php
@@ -45,11 +45,15 @@ class Configuration
         }
 
         if (!isset($config['suites'])) {
-            $suites = Finder::create()->files()->name('*.suite.yml')->in($dir . DIRECTORY_SEPARATOR . $config['paths']['tests'])->depth('< 1');
+            $suites = Finder::create()->files()->name('*.suite.yml')->in($dir . DIRECTORY_SEPARATOR . $config['paths']['tests'])->depth('< 5');
             $config['suites'] = array();
             foreach ($suites as $suite) {
                 preg_match('~(.*?)(\.suite|\.suite\.dist)\.yml~', $suite->getFilename(), $matches);
-                $config['suites'][] = $matches[1];
+                if(!$suite->getRelativePath()) {
+                    $config['suites'][] = $matches[1];
+                } else {
+                    $config['suites'][] = $suite->getRelativePath() . DIRECTORY_SEPARATOR . $matches[1];
+                }
             }
         }
 


### PR DESCRIPTION
So we just starting using Codeception for testing our application but we had troubles to get the structure we wanting for our large-scale application. So this pull-requests fixes this and enables you to store your suites and tests in subfolders.

The logs are stored in the same structure that you have your suite and tests in.
