### PR TITLE
Fix where an uninitialized client would throw error on failure.

### DIFF
--- a/src/Codeception/Util/Framework.php
+++ b/src/Codeception/Util/Framework.php
@@ -27,7 +27,7 @@ abstract class Framework extends \Codeception\Module implements FrameworkInterfa
 
     public function _failed(\Codeception\TestCase $test, $fail)
     {
-        if (!$this->client->getResponse()) return;
+        if (!$this->client || !$this->client->getResponse()) return;
         file_put_contents(\Codeception\Configuration::logDir() . basename($test->getFileName()) . '.page.debug.html', $this->client->getResponse()->getContent());
     }
 


### PR DESCRIPTION
Might be silly but sometimes on failure, the client might have somehow missed to be initialized or out right was set to null, as it is in the _after method. The _after will be called before _failed and therefore throw an exception where getResponse() is called on a non object. This resolves the issue.
