### PR TITLE
Reverted changes since php-code-coverage shows decoupling the Result Printer was reverted.

### DIFF
--- a/src/Codeception/Subscriber/CodeCoverage.php
+++ b/src/Codeception/Subscriber/CodeCoverage.php
@@ -119,9 +119,9 @@ class CodeCoverage implements EventSubscriberInterface
     protected function printText(\PHPUnit_Util_Printer $printer)
     {
         $writer = new \PHP_CodeCoverage_Report_Text(
-            $this->settings['low_limit'], $this->settings['high_limit'], $this->settings['show_uncovered']
+            $printer, $this->settings['low_limit'], $this->settings['high_limit'], $this->settings['show_uncovered']
         );
-        $printer->write($writer->process($this->coverage, $this->options['colors']));
+        $writer->process($this->coverage, $this->options['colors']);
     }
 
     protected function printHtml()


### PR DESCRIPTION
So sorry about that...
