### PR TITLE
Fix regex for dump parsing

### DIFF
--- a/src/Codeception/Util/Driver/Db.php
+++ b/src/Codeception/Util/Driver/Db.php
@@ -136,7 +136,7 @@ class Db
     {
         if (trim($sql) == "") return true;
         if (trim($sql) == ";") return true;
-        if (preg_match('~^(--.*?)|(#)~s', $sql)) return true;
+        if (preg_match('~^((--.*?)|(#))~s', $sql)) return true;
         return false;
     }
 


### PR DESCRIPTION
Faced with trouble - string in dump contains sharp symbol (#), but not at start of line. That non-fixed regex recognize such string as comment, because sharp was founded in middle of line.
