### PR TITLE
Bug when creating tests with phpunit using namespaces

### DIFF
--- a/src/Codeception/Command/Base.php
+++ b/src/Codeception/Command/Base.php
@@ -50,6 +50,7 @@ class Base extends \Symfony\Component\Console\Command\Command
 
     protected function breakParts($class)
     {
+        $class = str_replace('/', '\\', $class);
         $namespaces = explode('\\', $class);
         if (count($namespaces)) $namespaces[0] = ltrim($namespaces[0],'\\');
         if (!$namespaces[0]) array_shift($namespaces); // remove empty namespace caused of \\
@@ -61,6 +62,9 @@ class Base extends \Symfony\Component\Console\Command\Command
         if (strpos(strrev($filename), strrev($suffix)) === 0) $filename .= '.php';
         if (strpos(strrev($filename), strrev($suffix.'.php')) !== 0) $filename .= $suffix.'.php';
         if (strpos(strrev($filename), strrev('.php')) !== 0) $filename .= '.php';
+
+        $filename = pathinfo($filename, PATHINFO_BASENAME);
+
         return $filename;
     }
 

--- a/src/Codeception/Command/GeneratePhpUnit.php
+++ b/src/Codeception/Command/GeneratePhpUnit.php
@@ -60,7 +60,7 @@ EOF;
         $ns = $this->getNamespaceString($suiteconf['namespace'].'\\'.$class);
 
         $filename = $this->completeSuffix($classname, 'Test');
-        $filename = $path.DIRECTORY_SEPARATOR.$filename;
+        $filename = trim($path, DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR . $filename;
 
         $classname = $this->removeSuffix($classname, 'Test');
 

--- a/tests/cli/GeneratePhpUnitWithHierarchyPathsCept.php
+++ b/tests/cli/GeneratePhpUnitWithHierarchyPathsCept.php
@@ -1,0 +1,9 @@
+<?php
+$I = new CliGuy($scenario);
+$I->wantTo('generate sample Test in hierarchy path');
+$I->amInPath('tests/data/sandbox');
+$I->executeCommand('generate:phpunit dummy Dummy/Foo/Bar');
+$I->seeFileFound('Dummy/Foo/BarTest.php');
+$I->seeInThisFile('namespace Dummy/Foo;');
+$I->seeInThisFile('class Bar extends \PHPUnit_Framework_TestCase');
+$I->seeInThisFile('function setUp()');


### PR DESCRIPTION
Test tests/cli/GeneratePhpUnitWithHierarchyPathsCept show the problem.
When I create a test 'codecept generate:phpunit unit SiteTest/Model/Service/Extra, it fails:

PHP Warning:  file_put_contents(/path/tests/SiteTest/Model/Service//SiteTest/Model/Service/ExtraTest.php): failed to open stream: No such file or directory in /path/vendor/codeception/codeception/src/Codeception/Command/Base.php on line 70
