### PR TITLE
Typo

### DIFF
--- a/src/Codeception/Util/WebInterface.php
+++ b/src/Codeception/Util/WebInterface.php
@@ -363,7 +363,7 @@ interface WebInterface
      *
      * ``` php
      * <?php
-     * // file is stored in 'tests/data/tests.xls'
+     * // file is stored in 'tests/_data/tests.xls'
      * $I->attachFile('prices.xls');
      * ?>
      * ```


### PR DESCRIPTION
Fixed 'tests/data/tests.xls' typo to 'tests/_data/tests.xls', reflecting the directories created by Codeception.
