### PR TITLE
Autoloader Fix

### DIFF
--- a/src/Codeception/Util/Autoload.php
+++ b/src/Codeception/Util/Autoload.php
@@ -69,6 +69,6 @@ class Autoload {
     protected static function regex($namespace, $suffix)
     {
         $namespace = str_replace("\\",'\\\\', $namespace);
-        return sprintf('~\\\\?%s\\\\\w*?%s$~', $namespace, $suffix);
+        return sprintf('~\\\\?%s\\w*?%s$~', $namespace, $suffix);
     }
 }


### PR DESCRIPTION
Autoload doesn't work properly for \wHelper in helpers folder.
This is definitley the problem. 

Dont have enough time to check if this fix breakes something else. 

Also don't have enough time to dig into autoloader logics. Sorry =)

This might be the reason for https://github.com/Codeception/Codeception/issues/422
