### PR TITLE
Add header helpers

### DIFF
--- a/src/Codeception/Module/REST.php
+++ b/src/Codeception/Module/REST.php
@@ -28,11 +28,11 @@ use Codeception\Exception\ModuleConfig as ModuleConfigException;
  *
  * ### Example
  *
- *     modules: 
+ *     modules:
  *        enabled: [REST]
  *        config:
  *           REST:
- *              url: 'http://serviceapp/api/v1/' 
+ *              url: 'http://serviceapp/api/v1/'
  *              timeout: 90
  *
  * ## Public Properties
@@ -123,6 +123,57 @@ class REST extends \Codeception\Module
         $this->headers[$name] = $value;
     }
 
+    /**
+     * Checks over the given HTTP header and (optionally)
+     * its value, asserting that are there
+     *
+     * @param $name
+     * @param $value
+     */
+    public function seeHttpHeader($name, $value = null)
+    {
+        if ($value) {
+            \PHPUnit_Framework_Assert::assertEquals(
+                $this->client->getResponse()->getHeader($name),
+                $value
+            );
+        }
+        else {
+            \PHPUnit_Framework_Assert::assertNotNull($this->client->getResponse()->getHeader($name));
+        }
+    }
+
+    /**
+     * Checks over the given HTTP header and (optionally)
+     * its value, asserting that are not there
+     *
+     * @param $name
+     * @param $value
+     */
+    public function dontSeeHttpHeader($name, $value = null) {
+        if ($value) {
+            \PHPUnit_Framework_Assert::assertNotEquals(
+                $this->client->getResponse()->getHeader($name),
+                $value
+            );
+        }
+        else {
+            \PHPUnit_Framework_Assert::assertNull($this->client->getResponse()->getHeader($name));
+        }
+    }
+
+
+    /**
+     * Returns the value of the specified header name
+     *
+     * @param $name
+     * @param Boolean $first  Whether to return the first value or all header values
+     *
+     * @return string|array The first header value if $first is true, an array of values otherwise
+     */
+    public function grabHttpHeader($name, $first = true) {
+        return $this->client->getResponse()->getHeader($name, $first);
+    }
 
     /**
      * Adds HTTP authentication via username/password.
@@ -142,7 +193,7 @@ class REST extends \Codeception\Module
 
 	/**
 	 * Adds Digest authentication via username/password.
-	 * 
+	 *
 	 * @param $username
 	 * @param $password
 	 */
@@ -311,7 +362,7 @@ class REST extends \Codeception\Module
     }
 
     /**
-     * Checks weather last response was valid JSON.
+     * Checks whether last response was valid JSON.
      * This is done with json_last_error function.
      *
      */
@@ -326,7 +377,7 @@ class REST extends \Codeception\Module
     }
 
     /**
-     * Checks weather the last response contains text.
+     * Checks whether the last response contains text.
      *
      * @param $text
      */
@@ -336,7 +387,7 @@ class REST extends \Codeception\Module
     }
 
     /**
-     * Checks weather last response do not contain text.
+     * Checks whether last response do not contain text.
      *
      * @param $text
      */
@@ -346,7 +397,7 @@ class REST extends \Codeception\Module
     }
 
     /**
-     * Checks weather the last JSON response contains provided array.
+     * Checks whether the last JSON response contains provided array.
      * The response is converted to array with json_decode($response, true)
      * Thus, JSON is represented by associative array.
      * This method matches that response array contains provided array.
@@ -425,7 +476,7 @@ class REST extends \Codeception\Module
             $this->fail('Response is not of JSON format or is malformed');
             $this->debugSection('Response', $this->response);
         }
-        
+
         if ($path === '') {
             return $data;
         }

--- a/src/Codeception/Util/Connector/Universal.php
+++ b/src/Codeception/Util/Connector/Universal.php
@@ -34,11 +34,20 @@ class Universal extends Client
         $content = ob_get_contents();
         ob_end_clean();
 
-        $headers = headers_list();
-        $headers['Content-type'] = "text/html; charset=UTF-8";
-        // header_remove();
+        $headers = array();
+        $php_headers = headers_list();
+        foreach ($php_headers as $value) {
+            // Get the header name
+            $parts = explode(':', $value);
+            if (count($parts) > 1) {
+                $name = trim(array_shift($parts));
+                // Build the header hash map
+                $headers[$name] = trim(implode(':', $parts));
+            }
+        }
+        $headers['Content-type'] = isset($headers['Content-type']) ? $headers['Content-type']: "text/html; charset=UTF-8";
 
-        $response = new Response($content,200,$headers);
+        $response = new Response($content, 200, $headers);
         return $response;
     }
 }


### PR DESCRIPTION
I wasn't able to write test since I couldn't fix the [Output](https://github.com/Codeception/Codeception/blob/master/src/Codeception/Output.php#L26) file to delay the print so the php headers are in the test script...

Test are fairly easy, I just need to add some headers in the [index.php](https://github.com/Codeception/Codeception/blob/master/tests/data/rest/index.php)

Also I fixed a bad header-merge logic in the Universal Connector.
