### PR TITLE
attachFile didn't have a field in the example

### DIFF
--- a/docs/modules/Selenium2.md
+++ b/docs/modules/Selenium2.md
@@ -102,8 +102,8 @@ Example:
 
 ``` php
 <?php
-// file is stored in 'tests/data/tests.xls'
-$I->attachFile('prices.xls');
+// file is stored in 'tests/_data/tests.xls'
+$I->attachFile('input[file=input]', 'prices.xls');
 ?>
 ```
 


### PR DESCRIPTION
Also, the default folder that is created is _data not data, maybe this was syntax from Selenium1
