### PR TITLE
HaveInDatabase will now return the primary id of the inserted row

### DIFF
--- a/src/Codeception/Module/Db.php
+++ b/src/Codeception/Module/Db.php
@@ -214,7 +214,7 @@ class Db extends \Codeception\Module implements \Codeception\Util\DbInterface
 
         $sth = $this->driver->getDbh()->prepare($query);
         if (!$sth) \PHPUnit_Framework_Assert::fail("Query '$query' can't be executed.");
-	
+
 	    $i = 1;
         foreach ($data as $val) {
             $sth->bindValue($i, $val);
@@ -222,7 +222,12 @@ class Db extends \Codeception\Module implements \Codeception\Util\DbInterface
         }
         $res = $sth->execute();
         if (!$res) $this->fail(sprintf("Record with %s couldn't be inserted into %s", json_encode($data), $table));
-        $this->insertedIds[] = array('table' => $table, 'id' => $this->driver->getDbh()->lastInsertId());
+
+        $lastInsertId = $this->driver->getDbh()->lastInsertId();
+
+        $this->insertedIds[] = array('table' => $table, 'id' => $lastInsertId);
+
+        return $lastInsertId;
     }
 
     public function seeInDatabase($table, $criteria = array())


### PR DESCRIPTION
Easy change but its very useful.

The DB Module already used `LastInsertId` to remove the entry after the test.
But i would like to use it in my test, so I return the `LastInsterId`.

Simple example:

``` php
$personId = $I->haveInDatabase('person', array(
    'username' => 'Mitchel'
));

$I->sendPOST('/index', array(
    'function' => 'REMOVE-PERSON',
    'personid' => $personId
));
```

Maybe I should add a example in the documentation. First waiting for the feedback.
