### PR TITLE
Update Db.php

### DIFF
--- a/src/Codeception/Util/Driver/Db.php
+++ b/src/Codeception/Util/Driver/Db.php
@@ -93,7 +93,7 @@ class Db
                 continue;
             }
 
-            $query .= rtrim($sqlLine) . "\n";
+            $query .= "\n" . rtrim($sqlLine);
 
             if (substr($query, - 1 * $delimiterLength, $delimiterLength) == $delimiter) {
                 $this->sqlToRun = substr($query, 0, - 1 * $delimiterLength);


### PR DESCRIPTION
Fixing query building when origin multiline query has few lines which starts from beginning of a lines. Example: 
`CREATE  FUNCTION``functionName``(id INT) RETURNS varchar(100) CHARSET utf8
BEGIN`
converted to 
`CREATE  FUNCTION``functionName``(id INT) RETURNS varchar(100) CHARSET utf8BEGIN`
