### PR TITLE
Added missing return in toString() method.

### DIFF
--- a/src/Codeception/TestCase.php
+++ b/src/Codeception/TestCase.php
@@ -65,7 +65,7 @@ abstract class TestCase extends \PHPUnit_Framework_TestCase implements \PHPUnit_
 
     public function toString()
     {
-        $this->getFeature();
+        return $this->getFeature();
     }
 
 }


### PR DESCRIPTION
There is return statement missing in toString() method, thus resulting jUnit logs are missing test name in report.xml
