### PR TITLE
dont rollback outside of a transaction

### DIFF
--- a/src/Codeception/Module/Dbh.php
+++ b/src/Codeception/Module/Dbh.php
@@ -66,7 +66,9 @@ class Dbh extends \Codeception\Module implements \Codeception\Util\DbInterface
             "You can use your bootstrap file to assign the dbh:\n\n" .
             '\Codeception\Module\Dbh::$dbh = $dbh');
 
-        self::$dbh->rollback();
+        if(self::$dbh->inTransaction()) {
+          self::$dbh->rollback();
+        }
     }
 
     public function seeInDatabase($table, $criteria = array())

--- a/tests/unit/Codeception/Module/DbhTest.php
+++ b/tests/unit/Codeception/Module/DbhTest.php
@@ -1,0 +1,41 @@
+<?php
+
+use Codeception\Util\Stub;
+use Codeception\Util\Driver\Db as Driver;
+
+class DbhTest extends \PHPUnit_Framework_TestCase
+{
+    protected $config = array(
+        'dsn' => 'sqlite:tests/data/sqlite.db',
+        'user' => 'root',
+        'password' => ''
+    );
+
+    protected $testCase = null;
+
+    /**
+     * @var \Codeception\Module\Dbh
+     */
+    protected $module = null;
+
+    public function setUp() {
+      $this->testCase = Stub::make('\Codeception\TestCase');
+
+      $module = new \Codeception\Module\Dbh();
+
+      try {
+        $driver = Driver::create($this->config['dsn'], $this->config['user'], $this->config['password']);
+        $module::$dbh = $driver->getDbh();
+      } catch (\PDOException $e) {
+          $this->markTestSkipped('Coudn\'t establish connection to database');
+          return;
+      }
+
+      $this->module = $module;
+    }
+
+    public function testDontRollbackOutsideATransaction() {
+      $this->module->_after($this->testCase);
+    }
+
+}


### PR DESCRIPTION
On assertion failures `Codeception/Module/Dbh.php:69` will try to rollback a transaction regardless as to whether one is active (may have been killed by an assertion failure) and then it throws the PDOException... and tests abort.  This can be prevented by checking to see if there is a current transaction before rolling back.
