### PR TITLE
Updates to Db module docs

### DIFF
--- a/docs/modules/Db.md
+++ b/docs/modules/Db.md
@@ -46,9 +46,9 @@ Check out drivers if you get problems loading dumps and cleaning databases.
 * dsn *required* - PDO DSN
 * user *required* - user to access database
 * password *required* - password
-* dump - path to database dump.
+* dump - *required* path to database dump.
 * populate: true - should the dump be loaded before test suite is started.
-* cleanup: true - should the dump be reloaded after each test
+* cleanup: true - should the dump be reloaded before each test
 
 ### Example
 


### PR DESCRIPTION
1. Make dump a required config option, as the module does not actually
   have a default dump location and doesn't really do anything if its not
   provided.
2. The documentation states that setting "cleanup" option to true,
   reloads the dump "after" each test. In my mind this would mean after a
   test is run, the database is restored to its original states.
   In actual fact the code actually restores the dump "before" each test.
   This means that after a test is run, the database is in has the test
   changes. This difference is important if one is having more tests
   run (maybe a different suite) after the current suite which might not
   be using the Db module.
