### PR TITLE
Fix PG DbTest::testHaveAndSeeInDatabase

### DIFF
--- a/src/Codeception/Module/Db.php
+++ b/src/Codeception/Module/Db.php
@@ -123,7 +123,7 @@ class Db extends \Codeception\Module implements \Codeception\Util\DbInterface
         } catch (\PDOException $e) {
             throw new ModuleException(__CLASS__, $e->getMessage() . ' while creating PDO connection');
         }
-        
+
         $this->dbh = $this->driver->getDbh();
 
         // starting with loading dump
@@ -226,7 +226,7 @@ class Db extends \Codeception\Module implements \Codeception\Util\DbInterface
         $res = $sth->execute();
         if (!$res) $this->fail(sprintf("Record with %s couldn't be inserted into %s", json_encode($data), $table));
 
-        $lastInsertId = (int) $this->driver->getDbh()->lastInsertId();
+        $lastInsertId = (int) $this->driver->lastInsertId($table);
 
         $this->insertedIds[] = array('table' => $table, 'id' => $lastInsertId);
 

--- a/src/Codeception/Util/Driver/Db.php
+++ b/src/Codeception/Util/Driver/Db.php
@@ -127,6 +127,10 @@ class Db
         $this->sqlQuery($query);
     }
 
+    public function lastInsertId($table) {
+      return $this->getDbh()->lastInsertId();
+    }
+
     protected function sqlLine($sql)
     {
         if (trim($sql) == "") return true;

--- a/src/Codeception/Util/Driver/PostgreSql.php
+++ b/src/Codeception/Util/Driver/PostgreSql.php
@@ -62,4 +62,10 @@ class PostgreSql extends Db
 
         return sprintf($query, $column, $table, $params);
     }
+
+    public function lastInsertId($table) {
+      /*We make an assumption that the sequence name for this table is based on how postgres names sequences for SERIAL columns */
+      $sequenceName = $table.'_id_seq';
+      return $this->getDbh()->lastInsertId($sequenceName);
+    }
 }


### PR DESCRIPTION
- The test was failing because the value for lastInsertId when
  using PG was always 0.
- As per http://www.php.net/manual/en/pdo.lastinsertid.php,
  PDO::lastInsertId for PG requires the sequence name. This fix
  guesses the sequence name based on the table. The test now passes.
