### PR TITLE
Keep method signature the same to remove STRICT warnings

### DIFF
--- a/src/Codeception/Util/Driver/PostgreSql.php
+++ b/src/Codeception/Util/Driver/PostgreSql.php
@@ -47,7 +47,7 @@ class PostgreSql extends Db
         }
     }
 
-    public function select($column, $table, array &$criteria) {
+    public function select($column, $table, array $criteria) {
         $query = 'select %s from "%s" where %s';
         $params = array();
         foreach ($criteria as $k => $v) {


### PR DESCRIPTION
Due to the difference in the method signature, when running with E_STRICT, we get the following error:

Declaration of Codeception\Util\Driver\PostgreSql::select() should be compatible with Codeception\Util\Driver\Db::select($column, $table, array $criteria)

This fixes that error. I have run all the tests (upon applying https://github.com/Codeception/Codeception/pull/499, https://github.com/Codeception/Codeception/pull/498 ) and they are passing with this change.
