### PR TITLE
Fix PG DbTest::testDontSeeInDatabaseWithEmptyTable

### DIFF
--- a/src/Codeception/Util/Driver/PostgreSql.php
+++ b/src/Codeception/Util/Driver/PostgreSql.php
@@ -47,8 +47,9 @@ class PostgreSql extends Db
         }
     }
 
-    public function select($column, $table, array $criteria) {
-        $query = 'select %s from "%s" where %s';
+    public function select($column, $table, array &$criteria) {
+        $where = $criteria ? "where %s" : '';
+        $query = 'select %s from "%s" '.$where;
         $params = array();
         foreach ($criteria as $k => $v) {
             if($v === NULL) {

--- a/tests/data/dumps/postgres.sql
+++ b/tests/data/dumps/postgres.sql
@@ -18,8 +18,35 @@ SET default_tablespace = '';
 SET default_with_oids = false;
 
 --
--- TOC entry 1498 (class 1259 OID 32786)
--- Dependencies: 1783 3
+-- Name: empty_table; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+--
+
+CREATE TABLE empty_table (
+    id integer NOT NULL,
+    field character varying
+);
+
+
+--
+-- Name: empty_table_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE empty_table_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: empty_table_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE empty_table_id_seq OWNED BY empty_table.id;
+
+
+--
 -- Name: groups; Type: TABLE; Schema: public; Owner: -; Tablespace: 
 --
 
@@ -31,8 +58,6 @@ CREATE TABLE groups (
 
 
 --
--- TOC entry 1502 (class 1259 OID 32822)
--- Dependencies: 3 1498
 -- Name: groups_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
@@ -45,8 +70,6 @@ CREATE SEQUENCE groups_id_seq
 
 
 --
--- TOC entry 1801 (class 0 OID 0)
--- Dependencies: 1502
 -- Name: groups_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
@@ -54,17 +77,6 @@ ALTER SEQUENCE groups_id_seq OWNED BY groups.id;
 
 
 --
--- TOC entry 1802 (class 0 OID 0)
--- Dependencies: 1502
--- Name: groups_id_seq; Type: SEQUENCE SET; Schema: public; Owner: -
---
-
-SELECT pg_catalog.setval('groups_id_seq', 2, true);
-
-
---
--- TOC entry 1499 (class 1259 OID 32791)
--- Dependencies: 3
 -- Name: permissions; Type: TABLE; Schema: public; Owner: -; Tablespace: 
 --
 
@@ -77,8 +89,6 @@ CREATE TABLE permissions (
 
 
 --
--- TOC entry 1501 (class 1259 OID 32812)
--- Dependencies: 1499 3
 -- Name: permissions_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
@@ -91,8 +101,6 @@ CREATE SEQUENCE permissions_id_seq
 
 
 --
--- TOC entry 1803 (class 0 OID 0)
--- Dependencies: 1501
 -- Name: permissions_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
@@ -100,17 +108,6 @@ ALTER SEQUENCE permissions_id_seq OWNED BY permissions.id;
 
 
 --
--- TOC entry 1804 (class 0 OID 0)
--- Dependencies: 1501
--- Name: permissions_id_seq; Type: SEQUENCE SET; Schema: public; Owner: -
---
-
-SELECT pg_catalog.setval('permissions_id_seq', 10, true);
-
-
---
--- TOC entry 1497 (class 1259 OID 32778)
--- Dependencies: 1781 3
 -- Name: users; Type: TABLE; Schema: public; Owner: -; Tablespace: 
 --
 
@@ -123,8 +120,6 @@ CREATE TABLE users (
 
 
 --
--- TOC entry 1500 (class 1259 OID 32806)
--- Dependencies: 1497 3
 -- Name: users_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
@@ -137,8 +132,6 @@ CREATE SEQUENCE users_id_seq
 
 
 --
--- TOC entry 1805 (class 0 OID 0)
--- Dependencies: 1500
 -- Name: users_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
@@ -146,44 +139,49 @@ ALTER SEQUENCE users_id_seq OWNED BY users.id;
 
 
 --
--- TOC entry 1806 (class 0 OID 0)
--- Dependencies: 1500
--- Name: users_id_seq; Type: SEQUENCE SET; Schema: public; Owner: -
---
-
-SELECT pg_catalog.setval('users_id_seq', 4, true);
-
-
---
--- TOC entry 1782 (class 2604 OID 32824)
--- Dependencies: 1502 1498
 -- Name: id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE groups ALTER COLUMN id SET DEFAULT nextval('groups_id_seq'::regclass);
+ALTER TABLE ONLY empty_table ALTER COLUMN id SET DEFAULT nextval('empty_table_id_seq'::regclass);
 
 
 --
--- TOC entry 1784 (class 2604 OID 32814)
--- Dependencies: 1501 1499
 -- Name: id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE permissions ALTER COLUMN id SET DEFAULT nextval('permissions_id_seq'::regclass);
+ALTER TABLE ONLY groups ALTER COLUMN id SET DEFAULT nextval('groups_id_seq'::regclass);
 
 
 --
--- TOC entry 1780 (class 2604 OID 32808)
--- Dependencies: 1500 1497
 -- Name: id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE users ALTER COLUMN id SET DEFAULT nextval('users_id_seq'::regclass);
+ALTER TABLE ONLY permissions ALTER COLUMN id SET DEFAULT nextval('permissions_id_seq'::regclass);
 
 
 --
--- TOC entry 1794 (class 0 OID 32786)
--- Dependencies: 1498
+-- Name: id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY users ALTER COLUMN id SET DEFAULT nextval('users_id_seq'::regclass);
+
+
+--
+-- Data for Name: empty_table; Type: TABLE DATA; Schema: public; Owner: -
+--
+
+COPY empty_table (id, field) FROM stdin;
+\.
+
+
+--
+-- Name: empty_table_id_seq; Type: SEQUENCE SET; Schema: public; Owner: -
+--
+
+SELECT pg_catalog.setval('empty_table_id_seq', 1, false);
+
+
+--
 -- Data for Name: groups; Type: TABLE DATA; Schema: public; Owner: -
 --
 
@@ -194,8 +192,13 @@ jazzman	2012-02-02 22:33:35.271	2
 
 
 --
--- TOC entry 1795 (class 0 OID 32791)
--- Dependencies: 1499
+-- Name: groups_id_seq; Type: SEQUENCE SET; Schema: public; Owner: -
+--
+
+SELECT pg_catalog.setval('groups_id_seq', 2, true);
+
+
+--
 -- Data for Name: permissions; Type: TABLE DATA; Schema: public; Owner: -
 --
 
@@ -208,8 +211,13 @@ COPY permissions (user_id, group_id, role, id) FROM stdin;
 
 
 --
--- TOC entry 1793 (class 0 OID 32778)
--- Dependencies: 1497
+-- Name: permissions_id_seq; Type: SEQUENCE SET; Schema: public; Owner: -
+--
+
+SELECT pg_catalog.setval('permissions_id_seq', 10, true);
+
+
+--
 -- Data for Name: users; Type: TABLE DATA; Schema: public; Owner: -
 --
 
@@ -222,8 +230,13 @@ bird	charlie@parker.com	2012-02-02 22:32:13.107	4
 
 
 --
--- TOC entry 1788 (class 2606 OID 32829)
--- Dependencies: 1498 1498
+-- Name: users_id_seq; Type: SEQUENCE SET; Schema: public; Owner: -
+--
+
+SELECT pg_catalog.setval('users_id_seq', 4, true);
+
+
+--
 -- Name: g1; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
 --
 
@@ -232,8 +245,6 @@ ALTER TABLE ONLY groups
 
 
 --
--- TOC entry 1790 (class 2606 OID 32821)
--- Dependencies: 1499 1499
 -- Name: p1; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
 --
 
@@ -242,8 +253,6 @@ ALTER TABLE ONLY permissions
 
 
 --
--- TOC entry 1786 (class 2606 OID 32819)
--- Dependencies: 1497 1497
 -- Name: u1; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
 --
 
@@ -252,8 +261,6 @@ ALTER TABLE ONLY users
 
 
 --
--- TOC entry 1791 (class 2606 OID 32853)
--- Dependencies: 1497 1785 1499
 -- Name: pf1; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -262,28 +269,12 @@ ALTER TABLE ONLY permissions
 
 
 --
--- TOC entry 1792 (class 2606 OID 32858)
--- Dependencies: 1499 1498 1787
 -- Name: pg1; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY permissions
     ADD CONSTRAINT pg1 FOREIGN KEY (group_id) REFERENCES groups(id);
 
-
---
--- TOC entry 1800 (class 0 OID 0)
--- Dependencies: 3
--- Name: public; Type: ACL; Schema: -; Owner: -
---
-
-REVOKE ALL ON SCHEMA public FROM PUBLIC;
-REVOKE ALL ON SCHEMA public FROM postgres;
-GRANT ALL ON SCHEMA public TO postgres;
-GRANT ALL ON SCHEMA public TO PUBLIC;
-
-
--- Completed on 2012-02-03 00:00:32
 
 --
 -- PostgreSQL database dump complete

--- a/tests/unit/Codeception/Util/Driver/PostgresTest.php
+++ b/tests/unit/Codeception/Util/Driver/PostgresTest.php
@@ -49,7 +49,7 @@ class postgresTest extends \PHPUnit_Framework_TestCase
         $this->postgres->cleanup();
         $this->assertEmpty($this->postgres->getDbh()->query("SELECT * FROM pg_tables where schemaname = 'public'")->fetchAll());
     }
-    
+
     public function testLoadDump() {
         $this->postgres->load($this->sql);
         $res = $this->postgres->getDbh()->query("select * from users where name = 'davert'");
@@ -59,6 +59,14 @@ class postgresTest extends \PHPUnit_Framework_TestCase
         $res = $this->postgres->getDbh()->query("select * from groups where name = 'coders'");
         $this->assertNotEquals(false, $res);
         $this->assertGreaterThan(0, $res->rowCount());
+    }
+
+    public function testSelectWithEmptyCriteria() {
+      $emptyCriteria = array();
+      $generatedSql = $this->postgres->select('test_column', 'test_table', $emptyCriteria);
+
+      $this->assertNotContains('where', $generatedSql);
+
     }
 
 }


### PR DESCRIPTION
- The Postgresql::select command was generating erroneous when the criteria was an empty array
- Updates the postgresql.sql dump to include empty_table
