### PR TITLE
Keep method signatures the same 

### DIFF
--- a/src/Codeception/Util/Driver/PostgreSql.php
+++ b/src/Codeception/Util/Driver/PostgreSql.php
@@ -47,7 +47,7 @@ class PostgreSql extends Db
         }
     }
 
-    public function select($column, $table, array &$criteria) {
+    public function select($column, $table, array $criteria) {
         $where = $criteria ? "where %s" : '';
         $query = 'select %s from "%s" '.$where;
         $params = array();


### PR DESCRIPTION
Apologies, you merged this in earlier, but my last PR reintroduced this bug. Could you please merge this in again ?
This removes STRICT warnings. 

Thanks!
