### PR TITLE
Fix namespace of cept

### DIFF
--- a/src/Codeception/Command/GenerateCept.php
+++ b/src/Codeception/Command/GenerateCept.php
@@ -36,7 +36,7 @@ class GenerateCept extends Base
         $suiteconf = $this->getSuiteConfig($suite, $input->getOption('config'));
 
         $guy = $suiteconf['class_name'];
-        $use = $suiteconf['namespace'] ? " use ".$suiteconf['namespace'].'\\Codeception\\'.$guy.";\n" : '';
+        $use = $suiteconf['namespace'] ? " use ".$suiteconf['namespace'].'\\'.$guy.";\n" : '';
 
         $file = sprintf($this->template, $use, $guy);
 

--- a/tests/unit/Codeception/Command/GenerateCeptTest.php
+++ b/tests/unit/Codeception/Command/GenerateCeptTest.php
@@ -46,7 +46,7 @@ class GenerateCeptTest extends BaseCommandRunner {
         $this->config['namespace'] = 'MiddleEarth';
         $this->execute(array('suite' => 'shire', 'test' => 'HomeCanInclude12Dwarfs'));
         $this->assertEquals($this->filename, 'tests/shire/HomeCanInclude12DwarfsCept.php');
-        $this->assertContains('use MiddleEarth\Codeception\HobbitGuy;', $this->content);
+        $this->assertContains('use MiddleEarth\HobbitGuy;', $this->content);
         $this->assertContains('$I = new HobbitGuy($scenario);', $this->content);
         $this->assertIsValidPhp($this->content);
     }


### PR DESCRIPTION
Hi, 

I got following error when running generated cept.

```
PHP Fatal error:  Class 'Foo\Bar\Codeception\TestGuy' not found in /path/to/testCept.php on line 3
```

**Steps to reproduce the error:**
1. <code>php codecept.phar bootstrap --namespace Foo\Bar</code>
2. <code>php codecept.phar generate:cept functional test</code>
3. <code>php codecept.phar run functional</code>

**Similar issue:** https://github.com/Codeception/Codeception/pull/485#issuecomment-22840738

> I found that Codeception\Guy is too long name, thus I removed Codeception namespace from Guy classes.

Regards, thx
