### PR TITLE
default to port 80

### DIFF
--- a/src/Codeception/Util/Connector/Goutte.php
+++ b/src/Codeception/Util/Connector/Goutte.php
@@ -13,7 +13,8 @@ class Goutte extends Client {
     {
         $server = $request->getServer();
         $uri = $request->getUri();
-        $server['HTTP_HOST'] = parse_url($uri, PHP_URL_HOST).':'.parse_url($uri, PHP_URL_PORT);
+        $port = parse_url($uri, PHP_URL_PORT) ?: 80;
+        $server['HTTP_HOST'] = parse_url($uri, PHP_URL_HOST).':'.$port;
 
         return new Request(
             $request->getUri(),


### PR DESCRIPTION
In Issue #533, it took me a long time to figure out that the port number must be included in acceptance.suite.yml in order for the codeception to work at all. This pull request just sets the default to port 80 if no port was entered, to save other people the confusion.
