### PR TITLE
Improving suite settings

### DIFF
--- a/src/Codeception/Configuration.php
+++ b/src/Codeception/Configuration.php
@@ -116,7 +116,7 @@ class Configuration
     public static function suiteSettings($suite, $config)
     {
         // cut namespace name from suite name
-        if (substr($suite, 0, strlen($config['namespace'])) == $config['namespace']) {
+        if ($suite != $config['namespace'] && substr($suite, 0, strlen($config['namespace'])) == $config['namespace']) {
             $suite = substr($suite, strlen($config['namespace']));
         }         
 


### PR DESCRIPTION
I was trying to generate my custom `api` suite for testing my project API part (using your [manual](http://codeception.com/docs/10-WebServices)).
My project structure is described [here](https://github.com/Borales/yiitinializr-codeception) and my codeception-config for testing API is located [here](https://github.com/Borales/yiitinializr-codeception/blob/master/api/codeception.yml). As you can see, I have a separated sub-app `api`, so I've added `api` namespace to my config file.

I've tried to build my suites with `./codecept build --config=api/` and I got an exception `Suite  was not loaded`. 
Turns out that Codeception library cuts off a namespace part from the suite name.
Since Codeception allows to create suite with the name equals to a namespace - I've added a small improvement for such case, when a namespace and a suite name are equals.
