### PR TITLE
Don't remove .gitignore when Codeception clean logs

### DIFF
--- a/src/Codeception/Util/FileSystem.php
+++ b/src/Codeception/Util/FileSystem.php
@@ -22,7 +22,8 @@ class FileSystem
                 }
                 rmdir($dir);
             } else {
-                if( basename( (string) $path ) === '.gitignore' ){
+                $file = (string)$path;
+                if (basename($file) === '.gitignore') {
                     continue;
                 }
                 unlink($path->__toString());


### PR DESCRIPTION
Sorry for my poor English, so the problem is:
When I have Codeception tests in my own project, I add `.gitignore` file in my `tests/_log`, to track it and to ignore all logs. Because if folder is not exists, Codeception can't create it and throws an error.
But when I do `php codecept.phar clean` it remove all logs and `.gitignore` also from `tests/_log` dir. I think it's problem, because first I need to create `.gitignore` again and if I forget to add it, all logs can be pushed in repository.
