### PR TITLE
ignore http port when possible

### DIFF
--- a/src/Codeception/Util/Connector/Goutte.php
+++ b/src/Codeception/Util/Connector/Goutte.php
@@ -14,7 +14,11 @@ class Goutte extends Client {
     {
         $server = $request->getServer();
         $uri = Url::factory($request->getUri());
-        $server['HTTP_HOST'] = $uri->getHost() . ':' . $uri->getPort();
+        $server['HTTP_HOST'] = $uri->getHost();
+        $port = $uri->getPort();
+        if ($port !== null && $port !== 443 && $port != 80) {
+            $server['HTTP_HOST'] .= ':' . $port;
+        }
 
         return new Request(
             $request->getUri(),


### PR DESCRIPTION
Fix the problem when the method `getPort()` return `443` `80` or `null`.
