### PR TITLE
fix Goutte headers building in case of empty port

### DIFF
--- a/src/Codeception/Util/Connector/Goutte.php
+++ b/src/Codeception/Util/Connector/Goutte.php
@@ -14,7 +14,11 @@ class Goutte extends Client {
     {
         $server = $request->getServer();
         $uri = Url::factory($request->getUri());
-        $server['HTTP_HOST'] = $uri->getHost() . ':' . $uri->getPort();
+        $server['HTTP_HOST'] = $uri->getHost();
+        $port = $uri->getPort();
+        if ($port) {
+            $server['HTTP_HOST'] .= (':' . $port);
+        }
 
         return new Request(
             $request->getUri(),


### PR DESCRIPTION
If port is not specified Host header was "Host: www.example.com:" with excess colon at the end.
