### PR TITLE
Improve generated <title> for documentation

### DIFF
--- a/src/Codeception/Module/REST.php
+++ b/src/Codeception/Module/REST.php
@@ -134,12 +134,12 @@ class REST extends \Codeception\Module
     {
         if ($value) {
             \PHPUnit_Framework_Assert::assertEquals(
-                $this->client->getResponse()->getHeader($name),
+                $this->client->getInternalResponse()->getHeader($name),
                 $value
             );
         }
         else {
-            \PHPUnit_Framework_Assert::assertNotNull($this->client->getResponse()->getHeader($name));
+            \PHPUnit_Framework_Assert::assertNotNull($this->client->getInternalResponse()->getHeader($name));
         }
     }
 
@@ -153,12 +153,12 @@ class REST extends \Codeception\Module
     public function dontSeeHttpHeader($name, $value = null) {
         if ($value) {
             \PHPUnit_Framework_Assert::assertNotEquals(
-                $this->client->getResponse()->getHeader($name),
+                $this->client->getInternalResponse()->getHeader($name),
                 $value
             );
         }
         else {
-            \PHPUnit_Framework_Assert::assertNull($this->client->getResponse()->getHeader($name));
+            \PHPUnit_Framework_Assert::assertNull($this->client->getInternalResponse()->getHeader($name));
         }
     }
 
@@ -172,7 +172,7 @@ class REST extends \Codeception\Module
      * @return string|array The first header value if $first is true, an array of values otherwise
      */
     public function grabHttpHeader($name, $first = true) {
-        return $this->client->getResponse()->getHeader($name, $first);
+        return $this->client->getInternalResponse()->getHeader($name, $first);
     }
 
     /**
@@ -346,14 +346,14 @@ class REST extends \Codeception\Module
             $this->debugSection("Request", "$method $url " . $parameters);
             $this->client->request($method, $url, array(), $files, array(), $parameters);
         }
-        $this->response = $this->client->getResponse()->getContent();
+        $this->response = $this->client->getInternalResponse()->getContent();
         $this->debugSection("Response", $this->response);
 
         if (count($this->client->getRequest()->getCookies())) {
             $this->debugSection('Cookies', json_encode($this->client->getRequest()->getCookies()));
         }
-        $this->debugSection("Headers", json_encode($this->client->getResponse()->getHeaders()));
-        $this->debugSection("Status", json_encode($this->client->getResponse()->getStatus()));
+        $this->debugSection("Headers", json_encode($this->client->getInternalResponse()->getHeaders()));
+        $this->debugSection("Status", json_encode($this->client->getInternalResponse()->getStatus()));
     }
 
     protected function encodeApplicationJson($method, $parameters)
@@ -603,7 +603,7 @@ class REST extends \Codeception\Module
      */
     public function seeResponseCodeIs($code)
     {
-        $this->assertEquals($code, $this->client->getResponse()->getStatus());
+        $this->assertEquals($code, $this->client->getInternalResponse()->getStatus());
     }
 
     /**
@@ -613,6 +613,6 @@ class REST extends \Codeception\Module
      */
     public function dontSeeResponseCodeIs($code)
     {
-        $this->assertNotEquals($code, $this->client->getResponse()->getStatus());
+        $this->assertNotEquals($code, $this->client->getInternalResponse()->getStatus());
     }
 }

--- a/src/Codeception/Module/SOAP.php
+++ b/src/Codeception/Module/SOAP.php
@@ -336,7 +336,7 @@ class SOAP extends \Codeception\Module
      * @param $code
      */
     public function seeResponseCodeIs($code) {
-        \PHPUnit_Framework_Assert::assertEquals($code, $this->client->getResponse()->getStatus(), "soap response code matches expected");
+        \PHPUnit_Framework_Assert::assertEquals($code, $this->client->getInternalResponse()->getStatus(), "soap response code matches expected");
     }
 
     /**
@@ -466,7 +466,7 @@ class SOAP extends \Codeception\Module
     protected function processExternalRequest($action, $body)
     {
         $this->processRequest($action, $body);
-        return $this->client->getResponse()->getContent();
+        return $this->client->getInternalResponse()->getContent();
     }
 
 }

--- a/src/Codeception/Module/Symfony2.php
+++ b/src/Codeception/Module/Symfony2.php
@@ -147,7 +147,7 @@ class Symfony2 extends \Codeception\Util\Framework
     {
         if (!$this->kernel->getContainer()->has('profiler')) return null;
         $profiler = $this->kernel->getContainer()->get('profiler');
-        return $profiler->loadProfileFromResponse($this->client->getResponse());
+        return $profiler->loadProfileFromResponse($this->client->getInternalResponse());
     }
 
     protected function debugResponse()

--- a/src/Codeception/Module/XMLRPC.php
+++ b/src/Codeception/Module/XMLRPC.php
@@ -105,7 +105,7 @@ class XMLRPC extends \Codeception\Module
      * @param $num
      */
     public function seeResponseCodeIs($num) {
-        \PHPUnit_Framework_Assert::assertEquals($num, $this->client->getResponse()->getStatus());
+        \PHPUnit_Framework_Assert::assertEquals($num, $this->client->getInternalResponse()->getStatus());
     }
 
     /**
@@ -144,7 +144,7 @@ class XMLRPC extends \Codeception\Module
         $this->debugSection('Request', $url . PHP_EOL . $requestBody);
         $this->client->request('POST', $url, array(), array(), array(), $requestBody);
 
-        $this->response = $this->client->getResponse()->getContent();
+        $this->response = $this->client->getInternalResponse()->getContent();
         $this->debugSection('Response', $this->response);
 
     }

--- a/src/Codeception/Util/Framework.php
+++ b/src/Codeception/Util/Framework.php
@@ -32,8 +32,8 @@ abstract class Framework extends \Codeception\Module implements FrameworkInterfa
 
     public function _failed(\Codeception\TestCase $test, $fail)
     {
-        if (!$this->client || !$this->client->getResponse()) return;
-        file_put_contents(\Codeception\Configuration::logDir() . basename($test->getFileName()) . '.page.debug.html', $this->client->getResponse()->getContent());
+        if (!$this->client || !$this->client->getInternalResponse()) return;
+        file_put_contents(\Codeception\Configuration::logDir() . basename($test->getFileName()) . '.page.debug.html', $this->client->getInternalResponse()->getContent());
     }
 
     public function _after(\Codeception\TestCase $test)
@@ -126,7 +126,7 @@ abstract class Framework extends \Codeception\Module implements FrameworkInterfa
 
     public function dontSee($text, $selector = null)
     {
-        if (!$selector) return $this->assertPageNotContains($text, $this->client->getResponse()->getContent());
+        if (!$selector) return $this->assertPageNotContains($text, $this->client->getInternalResponse()->getContent());
         $nodes = $this->match($selector);
         $this->assertDomNotContains($nodes, $selector, $text);
     }
@@ -387,7 +387,7 @@ abstract class Framework extends \Codeception\Module implements FrameworkInterfa
     protected function getResponseStatusCode()
     {
         // depending on Symfony version
-        $response = $this->client->getResponse();
+        $response = $this->client->getInternalResponse();
         if (method_exists($response, 'getStatus')) return $response->getStatus();
         if (method_exists($response, 'getStatusCode')) return $response->getStatusCode();
         return "N/A";
@@ -415,7 +415,7 @@ abstract class Framework extends \Codeception\Module implements FrameworkInterfa
         if ($nodes) {
             return $nodes->first()->text();
         }
-        if (@preg_match($cssOrXPathOrRegex, $this->client->getResponse()->getContent(), $matches)) {
+        if (@preg_match($cssOrXPathOrRegex, $this->client->getInternalResponse()->getContent(), $matches)) {
             return $matches[1];
         }
         throw new ElementNotFound($cssOrXPathOrRegex, 'Element that matches CSS or XPath or Regex');
@@ -521,13 +521,13 @@ abstract class Framework extends \Codeception\Module implements FrameworkInterfa
     protected function assertPageContains($needle, $message = '')
     {
         $constraint = new \Codeception\PHPUnit\Constraint\Page($needle, $this->_getCurrentUri());
-        $this->assertThat($this->client->getResponse()->getContent(), $constraint,$message);
+        $this->assertThat($this->client->getInternalResponse()->getContent(), $constraint,$message);
     }
 
     protected function assertPageNotContains($needle, $message = '')
     {
         $constraint = new \Codeception\PHPUnit\Constraint\Page($needle, $this->_getCurrentUri());
-        $this->assertThatItsNot($this->client->getResponse()->getContent(), $constraint,$message);
+        $this->assertThatItsNot($this->client->getInternalResponse()->getContent(), $constraint,$message);
     }
 
 


### PR DESCRIPTION
All the pages of the project documentation are named "Codeception - documentation", which is less than ideal, if only for finding the right tab/window when browsing the documentation.

This patch re-uses the main h1 title defined in the markdown page to set the <title> of the generated page.
