### PR TITLE
generate better <title> in documentation

### DIFF
--- a/bin/build_site.php
+++ b/bin/build_site.php
@@ -34,7 +34,13 @@ foreach ($docs as $doc) {
     $contents = preg_replace('~```\s?php(.*?)```~ms',"{% highlight php %}\n$1\n{% endhighlight %}", $contents);
     $contents = preg_replace('~```\s?html(.*?)```~ms',"{% highlight html %}\n$1\n{% endhighlight %}", $contents);
     $contents = preg_replace('~```(.*?)```~ms',"{% highlight yaml %}\n$1\n{% endhighlight %}", $contents);
-    $contents = "---\nlayout: doc\ntitle: Codeception - Documentation\n---\n\n".$contents;
+    $matches = array();
+    $title = "";
+    // Extracting page h1 to re-use in <title>
+    if (preg_match('/^# (.*)$/m', $contents, $matches)) {
+      $title = $matches[1];
+    }
+    $contents = "---\nlayout: doc\ntitle: ".($title!="" ? $title." - " : "")."Codeception - Documentation\n---\n\n".$contents;
 
     file_put_contents($newfile, $contents);
 }


### PR DESCRIPTION
All the pages of the project documentation are named "Codeception - documentation", which is less than ideal, if  only for finding the right tab/window when browsing the documentation.

This patch re-uses the main h1 title defined in the markdown page to set the of the generated page. 
