### PR TITLE
Updated to be able to use 'seeOptionIsSelected' and 'dontSeeOptionIsSelected' by label

### DIFF
--- a/src/Codeception/Util/Framework.php
+++ b/src/Codeception/Util/Framework.php
@@ -476,8 +476,7 @@ abstract class Framework extends \Codeception\Module implements FrameworkInterfa
 
     protected function matchSelectedOption($select)
     {
-        $nodes = $this->match($select);
-        $this->assertDomContains($nodes, "select '$select'");
+        $nodes = $this->getFieldByLabelOrCss($select);
         return $nodes->first()->filter('option[selected]');
     }
 

--- a/tests/unit/Codeception/Module/FrameworksTest.php
+++ b/tests/unit/Codeception/Module/FrameworksTest.php
@@ -428,6 +428,42 @@ class FrameworksTest extends \PHPUnit_Framework_TestCase
         $this->module->dontSeeInTitle('TestEd Beta 2.0');
     }
 
+    public function testSeeOptionIsSelectedByCss()
+    {
+        $this->module->amOnPage('/form/select');
+        $this->module->seeOptionIsSelected('form select[name=age]', '60-100');
+    }
+
+    public function testSeeOptionIsSelectedByXPath()
+    {
+        $this->module->amOnPage('/form/select');
+        $this->module->seeOptionIsSelected("descendant-or-self::form/descendant::select[@name='age']", '60-100');
+    }
+
+    public function testSeeOptionIsSelectedByLabel()
+    {
+        $this->module->amOnPage('/form/select');
+        $this->module->seeOptionIsSelected('Select your age', '60-100');
+    }
+
+    public function testDontSeeOptionIsSelectedByCss()
+    {
+        $this->module->amOnPage('/form/select');
+        $this->module->seeOptionIsSelected('form select[name=age]', '60-100');
+    }
+
+    public function testDontSeeOptionIsSelectedByXPath()
+    {
+        $this->module->amOnPage('/form/select');
+        $this->module->seeOptionIsSelected("descendant-or-self::form/descendant::select[@name='age']", '60-100');
+    }
+
+    public function testDontSeeOptionIsSelectedByLabel()
+    {
+        $this->module->amOnPage('/form/select');
+        $this->module->seeOptionIsSelected('Select your age', '60-100');
+    }
+
     // fails
 
     public function testSeeFails()


### PR DESCRIPTION
Hi, 

I want to use `seeOptionIsSelected` by label...

Test:

```
$I->fillField('Name', 'Mike');             // by label -> OK
$I->fillField('Address', 'Tokyo');         // by label -> OK
$I->selectOption('Age', '60-100');         // by label -> OK
$I->seeOptionIsSelected('Age', '60-100');  // by label -> ERROR 
```

Error Detail:

```
Sorry, I couldn't see option is selected "Age","60-100":
Element located either by name, CSS or XPath 'select 'Age'' was not found on page.
```
