### PR TITLE
fix adding parameters to url to non-GET HTTP methods

### DIFF
--- a/src/Codeception/Module/REST.php
+++ b/src/Codeception/Module/REST.php
@@ -336,7 +336,7 @@ class REST extends \Codeception\Module
         $parameters = $this->encodeApplicationJson($method, $parameters);
         
         if (is_array($parameters) || $method == 'GET') {
-            if (!empty($parameters)) {
+            if (!empty($parameters) && $method == 'GET') {
                 $url .= '?' . http_build_query($parameters);
             }
             $this->debugSection("Request", "$method $url");


### PR DESCRIPTION
trying $I->sendPOST with non-empty parameters found that the requested url includes the parameters as if it were GET request.
