### PR TITLE
fix REST.php - correct the debug logging for non-GET methods

### DIFF
--- a/src/Codeception/Module/REST.php
+++ b/src/Codeception/Module/REST.php
@@ -339,7 +339,11 @@ class REST extends \Codeception\Module
             if (!empty($parameters) && $method == 'GET') {
                 $url .= '?' . http_build_query($parameters);
             }
-            $this->debugSection("Request", "$method $url");
+            if($method == 'GET') {
+                $this->debugSection("Request", "$method $url");
+            } else {
+                $this->debugSection("Request", "$method $url ".json_encode($parameters));
+            }
             $this->client->request($method, $url, $parameters, $files);
 
         } else {


### PR DESCRIPTION
After my last commit non-GET requests miss the parameters in the debug section logging.

This fixes the issue.

As far as I understood - this is BC fix: refs #659
