### PR TITLE
waitForElementChange() callback return value was not being used

### DIFF
--- a/src/Codeception/Module/WebDriver.php
+++ b/src/Codeception/Module/WebDriver.php
@@ -828,7 +828,8 @@ class WebDriver extends \Codeception\Module implements WebInterface, RemoteInter
     }
 
     /**
-     * Waits until element has changed according to callback function or for $time seconds to pass.
+     * Waits for element to change or for $timeout seconds to pass. Element "change" is determined
+     * by a callback function which is called repeatedly until it returns true.
      *
      * ``` php
      * <?php
@@ -849,7 +850,7 @@ class WebDriver extends \Codeception\Module implements WebInterface, RemoteInter
         if (!count($els)) throw new ElementNotFound($element, "CSS or XPath");
         $el = reset($els);
         $checker = function() use ($el, $callback) {
-            $callback($el);
+            return $callback($el);
         };
         $this->webDriver->wait($timeout)->until($checker);
     }


### PR DESCRIPTION
It appears that the waitForElementChange() method is broken and can only ever exit on timeout. This is because the `$checker` function never actually returns the value from the user-provided callback function.
