### PR TITLE
Placeholder\Registry::unsetRegistry() should only be used with < 2.2.0

### DIFF
--- a/src/Codeception/Module/ZF2.php
+++ b/src/Codeception/Module/ZF2.php
@@ -6,6 +6,7 @@ use Zend\Console\Console;
 use Zend\EventManager\StaticEventManager;
 use Zend\Mvc\Application;
 use Zend\View\Helper\Placeholder;
+use Zend\Version\Version;
 
 /**
  * This module allows you to run tests inside Zend Framework 2.
@@ -82,7 +83,11 @@ class ZF2 extends \Codeception\Util\Framework implements \Codeception\Util\Frame
 
         // reset singleton
         StaticEventManager::resetInstance();
-        Placeholder\Registry::unsetRegistry();
+        
+        // Reset singleton placeholder if version < 2.2.0, no longer required in 2.2.0+
+        if (Version::compareVersion('2.2.0') >= 0) {
+            Placeholder\Registry::unsetRegistry();
+        }
 
         $this->queries = 0;
         $this->time = 0;


### PR DESCRIPTION
Currently the ZF2 module will trigger errors, causing failures with ZF >= 2.2.0, as the placeholder view helpers no longer use singleton registries.
Added a compareVersion call to check for < 2.2.0 to still conditionally reset the singleton registry for only appropriate versions of ZF2.
