### PR TITLE
Missing backslash

### DIFF
--- a/docs/07-AdvancedUsage.md
+++ b/docs/07-AdvancedUsage.md
@@ -431,10 +431,10 @@ class MemberSteps extends \WebGuy
     function login($name, $password)
     {
         $I = $this;
-        $I->amOnPage(LoginPage::$URL);
-        $I->fillField(LoginPage::$usernameField, $name);
-        $I->fillField(LoginPage::$passwordField, $password);
-        $I->click(LoginPage::$loginButton);
+        $I->amOnPage(\LoginPage::$URL);
+        $I->fillField(\LoginPage::$usernameField, $name);
+        $I->fillField(\LoginPage::$passwordField, $password);
+        $I->click(\LoginPage::$loginButton);
     }
 }
 ?>


### PR DESCRIPTION
In the StepObject, the LoginPage object is not in the same namespace as the MemberSteps StepObject. So you should precede it with a '\'.
