### PR TITLE
Generate coverage output when 'steps' is true

### DIFF
--- a/src/Codeception/Subscriber/CodeCoverage.php
+++ b/src/Codeception/Subscriber/CodeCoverage.php
@@ -152,17 +152,17 @@ class CodeCoverage implements EventSubscriberInterface
 
     public function printResult(PrintResultEvent $e)
     {
-        if ($this->options['steps']) {
-            return;
-        }
-        $this->printText($e->getPrinter());
-        $this->printPHP();
         if ($this->options['html']) {
             $this->printHtml();
         }
         if ($this->options['xml']) {
             $this->printXml();
         }
+        if ($this->options['steps']) {
+            return;
+        }
+        $this->printText($e->getPrinter());
+        $this->printPHP();
     }
 
     protected function printText(\PHPUnit_Util_Printer $printer)


### PR DESCRIPTION
- Fixes coverage not being outputted to file if "steps" is true

This did not make sense to me, although I can sort of understand not outputting to command line? Even this is slightly strange to me. I assume it breaks something that parses the console perhaps?
