### PR TITLE
fixed location

### DIFF
--- a/src/Codeception/Util/Connector/Yii2.php
+++ b/src/Codeception/Util/Connector/Yii2.php
@@ -69,8 +69,8 @@ class Yii2 extends Client
 		$app->handleRequest($app->getRequest())->send();
 		$content = ob_get_clean();
 
-		# catch "location" header and display it in debug, otherwise it would be handled 
-		# by symfony browser-kit and not displayed.
+		// catch "location" header and display it in debug, otherwise it would be handled 
+		// by symfony browser-kit and not displayed.
 		if (isset($this->headers['location'])) {
 			Debug::debug("[Headers] " . json_encode($this->headers));
 		}


### PR DESCRIPTION
Fixed issue when no headers were displayed if it was redirection. Because of symfony browser-kit internally holds this situation: 
https://github.com/symfony/BrowserKit/blob/master/Client.php#L326
https://github.com/symfony/BrowserKit/blob/master/Client.php#L332

Now user will be able to see all headers before he will be redirected.

Example:

``` yaml
Trying to ensure that login works (LoginCept.php)       
Scenario:
* I am on page "/basic/web/index-test.php?r=site/login"
  [Response] 200
  [Page] http://localhost/basic/web/index-test.php?r=site/login
  [Cookies] []
  [Headers] {"content-type":["text\/html; charset=UTF-8"]}
* I see "Login","h1"
* I am going to try to login with correct credentials
* I submit form "#login-form",{"LoginForm[username]":"admin","LoginForm[password]":"admin"}
  [Uri] /basic/web/index-test.php?r=site/login
  [Method] post
  [Parameters] {"_csrf":"aVBnTzd5a0U4HzYlUCwRfBEWUzh6NwEnGQUGJ0IoOhoLNwAeWiwocQ==","LoginForm":{"username":"admin","password":"admin","rememberMe":"0"}}
  [Headers] {"location":["http:\/\/localhost\/basic\/web\/index-test.php"]}
  [Response] 200
  [Page] http://localhost/basic/web/index-test.php
  [Cookies] {"_csrf":"fe2ccfc38a2c95ff099379b79decd03addd67702bbc004df46131eae7fe3df66s:32:\"QOQjgUz9xF4wMNjbpUahuQQ_bggQmUC4\";"}
  [Headers] {"content-type":["text\/html; charset=UTF-8"]}
* I expect to see user info
* I see "Logout (admin)"
 PASSED 
```
