### PR TITLE
Fixes #582, suites running twice

### DIFF
--- a/src/Codeception/Configuration.php
+++ b/src/Codeception/Configuration.php
@@ -115,7 +115,7 @@ class Configuration
         self::$suites = array();
         foreach ($suites as $suite) {
             preg_match('~(.*?)(\.suite|\.suite\.dist)\.yml~', $suite->getFilename(), $matches);
-            self::$suites[] = $matches[1];
+            self::$suites[$matches[1]] = $matches[1];
         }
     }
 


### PR DESCRIPTION
If a .suite.dist.yml and a .dist.yml file exist, the according tests would run twice.
