### PR TITLE
Fixes #582, suites running twice

### DIFF
--- a/src/Codeception/Configuration.php
+++ b/src/Codeception/Configuration.php
@@ -115,7 +115,7 @@ class Configuration
         self::$suites = array();
         foreach ($suites as $suite) {
             preg_match('~(.*?)(\.suite|\.suite\.dist)\.yml~', $suite->getFilename(), $matches);
-            self::$suites[] = $matches[1];
+            self::$suites[$matches[1]] = $matches[1];
         }
     }
 


### PR DESCRIPTION
if a .suite.yml and a .suite.dist.yml file exist, the according suite would run twice.

this occures only if "codeception run" is called. (if no suite is defined)
