### PR TITLE
Always output CodeCoverage if requested to (1.7)

### DIFF
--- a/src/Codeception/Subscriber/CodeCoverage.php
+++ b/src/Codeception/Subscriber/CodeCoverage.php
@@ -135,11 +135,18 @@ class CodeCoverage implements EventSubscriberInterface
 
     public function printResult(\Codeception\Event\PrintResult $e)
     {
-        if ($this->options['steps']) return;
-        $this->printText($e->getPrinter());
         $this->printPHP();
-        if ($this->options['html']) $this->printHtml();
-        if ($this->options['xml']) $this->printXml();
+        
+        if ($this->options['html']) {
+            $this->printHtml();
+        }
+        if ($this->options['xml']) {
+            $this->printXml();
+        }
+        
+        if (!$this->options['steps']) {
+            $this->printText($e->getPrinter());
+        }
     }
 
     protected function printText(\PHPUnit_Util_Printer $printer)


### PR DESCRIPTION
Backported from master
