### PR TITLE
Fixes #582, suites running twice

### DIFF
--- a/src/Codeception/Configuration.php
+++ b/src/Codeception/Configuration.php
@@ -115,7 +115,7 @@ class Configuration
         self::$suites = array();
         foreach ($suites as $suite) {
             preg_match('~(.*?)(\.suite|\.suite\.dist)\.yml~', $suite->getFilename(), $matches);
-            self::$suites[] = $matches[1];
+            self::$suites[$matches[1]] = $matches[1];
         }
     }
 
@@ -124,7 +124,7 @@ class Configuration
         // cut namespace name from suite name
         if ($suite != $config['namespace'] && substr($suite, 0, strlen($config['namespace'])) == $config['namespace']) {
             $suite = substr($suite, strlen($config['namespace']));
-        }         
+        }
 
         if (!in_array($suite, self::$suites)) throw new \Exception("Suite $suite was not loaded");
 


### PR DESCRIPTION
added changes to 1.8 (see #799)

if a .suite.yml and a .suite.dist.yml file exist, the according suite would run twice.

this occures only if "codeception run" is called. (if no suite is defined)
