### PR TITLE
Use getInternalRequest to return Symfony\Component\BrowserKit\Request

### DIFF
--- a/src/Codeception/Module/REST.php
+++ b/src/Codeception/Module/REST.php
@@ -393,8 +393,8 @@ class REST extends \Codeception\Module
         $this->response = $this->client->getInternalResponse()->getContent();
         $this->debugSection("Response", $this->response);
 
-        if (count($this->client->getRequest()->getCookies())) {
-            $this->debugSection('Cookies', json_encode($this->client->getRequest()->getCookies()));
+        if (count($this->client->getInternalRequest()->getCookies())) {
+            $this->debugSection('Cookies', json_encode($this->client->getInternalRequest()->getCookies()));
         }
         $this->debugSection("Headers", json_encode($this->client->getInternalResponse()->getHeaders()));
         $this->debugSection("Status", json_encode($this->client->getInternalResponse()->getStatus()));


### PR DESCRIPTION
Attempting to use the REST module with a Symfony 2.3 client results in the following error:

> Error: Call to undefined method Symfony\Component\HttpFoundation\Request::getCookies() in codeception/codeception/src/Codeception/Module/REST.php line 352

As in #621,  Symfony 2.3 `Symfony\Component\BrowserKit\Client::getRequest()` returns `Symfony\Component\HttpFoundation\Request`, which does not have a `getCookies` method. Use `getInternalRequest` to return `Symfony\Component\BrowserKit\Request`, which does.
