### PR TITLE
Fixes to the arrayIntersectAssocRecursive() of REST module

### DIFF
--- a/src/Codeception/Module/REST.php
+++ b/src/Codeception/Module/REST.php
@@ -608,7 +608,7 @@ class REST extends \Codeception\Module
         if (empty($commonkeys)) {
             foreach ($arr2 as $arr) {
                 $_return = $this->arrayIntersectAssocRecursive($arr1, $arr);
-                if ($_return) return $_return;
+                if ($_return && $_return == $arr1) return $_return;
             }
         }
 

--- a/tests/unit/Codeception/Module/RestTest.php
+++ b/tests/unit/Codeception/Module/RestTest.php
@@ -105,6 +105,7 @@ class RestTest extends \PHPUnit_Framework_TestCase
         $this->module->response = '[{"user":"Blacknoir","age":27,"tags":["wed-dev","php"]},{"user":"John Doe","age":27,"tags":["web-dev","java"]}]';
         $this->module->seeResponseIsJson();
         $this->module->seeResponseContainsJson(array('tags' => array('web-dev', 'java')));
+        $this->module->seeResponseContainsJson(array('user' => 'John Doe', 'age' => 27));
     }
 
 


### PR DESCRIPTION
Two fixes to the _arrayIntersectAssocRecursive()_ used by _seeResponseContainsJson()_. Bugs appeared when trying recursively match json data inside the collection of similar-looking json items. E.g. assume api responds the below json collection of web-developer info:

``` php
 Array
(
    [0] => Array
        (
            [user] => Blacknoir
            [age] => 27
            [tags] => Array
                (
                    [0] => wed-dev
                    [1] => php
                )

        )

    [1] => Array
        (
            [user] => John Doe
            [age] => 27
            [tags] => Array
                (
                    [0] => web-dev
                    [1] => java
                )

        )

)
```

1) Such $I->seeResponseContainsJson(array('tags' => array('web-dev', 'java'))) test would fail. Fixed at dbb68a1
2) Such $I->seeResponseContainsJson(array('user' => 'John Doe', 'age' => 27)) test would fail. Fixed at 476d3c0
