### PR TITLE
Update WebDriver.php

### DIFF
--- a/src/Codeception/Module/WebDriver.php
+++ b/src/Codeception/Module/WebDriver.php
@@ -1032,12 +1032,12 @@ class WebDriver extends \Codeception\Module implements WebInterface, RemoteInter
      *
      * If the window has no name, the only way to access it is via the `executeInSelenium()` method like so:
      *
-     * ```
+     * ``` php
      * <?php
      * $I->executeInSelenium(function (\Webdriver $webdriver) {
-     *      $handles=$webDriver->getWindowHandles();
+     *      $handles=$webdriver->getWindowHandles();
      *      $last_window = end($handles);
-     *      $webDriver->switchTo()->window($name);
+     *      $webdriver->switchTo()->window($last_window);
      * });
      * ?>
      * ```


### PR DESCRIPTION
Resolving minor documentation typos in the information about switching windows when unnamed. 

<ul>
<li>$webDriver should have been $webdriver</li>
<li>$name variable should have been $last_window</li>
</ul>
