### PR TITLE
Modules fullname feature

### DIFF
--- a/src/Codeception/Configuration.php
+++ b/src/Codeception/Configuration.php
@@ -256,7 +256,7 @@ class Configuration
         foreach ($moduleNames as $moduleName) {
             $moduleConfig = (isset($settings['modules']['config'][$moduleName])) ? $settings['modules']['config'][$moduleName] : array();
             $moduleConfig['class'] = $moduleName;
-            $modules[$moduleName] = static::createModule($moduleConfig);
+            $modules[$moduleName] = static::createModule($moduleConfig, $namespace);
         }
 
         return $modules;


### PR DESCRIPTION
Added ability to specify in suite configs full helpers and modules classes, for example:

``` yaml
class_name: CodeGuy
modules:
    enabled:
      - CodeHelper
      - common\tests\_helpers\FixtureHelper
```

This is very useful when you separate your tests per application tier and dont want to copy-paste helpers and modules. For example we use it in `yii2-advanced` where application is separated on `backend`, `common`, `console`, `frontend`.
