### PR TITLE
handle returning id with getter for haveRecord() from Phalcon1 Module

### DIFF
--- a/src/Codeception/Module/Phalcon1.php
+++ b/src/Codeception/Module/Phalcon1.php
@@ -208,7 +208,15 @@ class Phalcon1 extends Framework implements ActiveRecordInterface
             $this->fail("Record $model was not saved. Messages: ".implode(', ', $record->getMessages()));
         }
         $this->debugSection($model, json_encode($record));
-        return $record->id;
+        
+        $reflectedProperty = new ReflectionProperty($record, 'id');
+        
+        if($reflectedProperty->isProtected() || $reflectedProperty->isPrivate()) {
+        	return $record->getId();
+        }
+        else {
+        	return $record->id;
+        }
     }
 
     /**


### PR DESCRIPTION
I added a case to return id from getter using standard convention "getId()" if id property is protected or private.
