### PR TITLE
handle returning id with getter for haveRecord() from Phalcon1 Module

### DIFF
--- a/src/Codeception/Module/Phalcon1.php
+++ b/src/Codeception/Module/Phalcon1.php
@@ -208,14 +208,9 @@ class Phalcon1 extends \Codeception\Util\Framework implements \Codeception\Util\
         }
         $this->debugSection($model, json_encode($record));
         
-        $reflectedProperty =   new \ReflectionProperty($record, 'id');
-        
-        if($reflectedProperty->isProtected() || $reflectedProperty->isPrivate()) {
-            return $record->getId();
-        }
-        else {
-           return $record->id; 
-        }
+        $reflectedProperty =   new \ReflectionProperty(get_class($record), 'id');
+        $reflectedProperty->setAccessible(true);
+        return $reflectedProperty->getValue($record);
     }
 
     /**


### PR DESCRIPTION
I added a case to return id from getter using standard convention "getId()" if id property is protected or private.
