### PR TITLE
Fixes to WebDriver::submitForm

### DIFF
--- a/src/Codeception/Module/WebDriver.php
+++ b/src/Codeception/Module/WebDriver.php
@@ -817,11 +817,12 @@ class WebDriver extends \Codeception\Module implements WebInterface, RemoteInter
         foreach ($params as $param => $value) {
             $els = $form->findElements(\WebDriverBy::name($param));
             $el = reset($els);
+            if (empty($el)) throw new ElementNotFound($param);
             if ($el->getTagName() == 'textarea') $this->fillField($el, $value);
             if ($el->getTagName() == 'select') $this->selectOption($el, $value);
             if ($el->getTagName() == 'input') {
                 $type = $el->getAttribute('type');
-                if ($type == 'text') $this->fillField($el, $value);
+                if ($type == 'text'  or $type == 'password') $this->fillField($el, $value);
                 if ($type == 'radio' or $type == 'checkbox') {
                     foreach ($els as $radio) {
                         if ($radio->getAttribute('value') == $value) $this->checkOption($radio);


### PR DESCRIPTION
Fixes two issues in the WebDriver::submitForm method:

(1) Inputs with type="password" were not being filled in.
(2) Added check that $el exists before calling getTagName() (without this the test suite would end in a fatal error)
