### PR TITLE
Fixed compatibility with PHP 5.5

### DIFF
--- a/src/Codeception/SuiteManager.php
+++ b/src/Codeception/SuiteManager.php
@@ -249,7 +249,7 @@ class SuiteManager
 
             if ($tokens[$i][0] === T_CLASS) {
                 for ($j = $i + 1; $j < count($tokens); $j++) {
-                    if ($tokens[$j] === '{') {
+                    if ($tokens[$j] === '{' && isset($tokens[$i + 2][1])) {
                         $classes[] = $namespace . $tokens[$i + 2][1];
                         break;
                     }


### PR DESCRIPTION
Hi, I found a bug in Codeception 2.0-alpha1 (I didn't test older versions). When I put `Mockery::mock(\DateTime::class);` into my test I get this error:

```
Notice: Uninitialized string offset: 1 in ... \vendor\codeception\codeception\src\Codeception\SuiteManager.php on line 253
```

Note that the new PHP 5.5 `::class` feature is used. This commit is a quick workaround I came up with but it may not be the best fix. Feel free to fix it in different way.
