### PR TITLE
Fixed problem with encoding in $I->wantTo()

### DIFF
--- a/src/Codeception/AbstractGuy.php
+++ b/src/Codeception/AbstractGuy.php
@@ -44,7 +44,7 @@ abstract class AbstractGuy implements \ArrayAccess
             $this->scenario->runStep();
             return $this;
         }
-        $this->scenario->setFeature(mb_strtolower($text));
+        $this->scenario->setFeature(mb_strtolower($text, 'utf-8'));
         return $this;
     }
 


### PR DESCRIPTION
When I put cyrillic string into $I->wantTo() I see only ������������������ in console.

Thanks to Artem (ostapetc) for solution.
