### PR TITLE
headers, cookies monitoring added

### DIFF
--- a/src/Codeception/Util/Framework.php
+++ b/src/Codeception/Util/Framework.php
@@ -395,6 +395,8 @@ abstract class Framework extends \Codeception\Module implements FrameworkInterfa
     {
         $this->debugSection('Response', $this->getResponseStatusCode());
         $this->debugSection('Page', $this->client->getHistory()->current()->getUri());
+        $this->debugSection('Cookies', json_encode($this->client->getRequest()->getCookies()));
+        $this->debugSection('Headers', json_encode($this->client->getResponse()->getHeaders()));
     }
 
     protected function getResponseStatusCode()


### PR DESCRIPTION
Added headers and cookies in debug monitoring, similar to this PR - https://github.com/Codeception/Codeception/pull/776, but it was submited in master long time ago, and `1.8.*` was without this very useful feature.
