### PR TITLE
Correctly return to main page when switchToIFrame() is called

### DIFF
--- a/src/Codeception/Module/WebDriver.php
+++ b/src/Codeception/Module/WebDriver.php
@@ -1070,7 +1070,11 @@ class WebDriver extends \Codeception\Module implements WebInterface, RemoteInter
      * @param string|null $name
      */
     public function switchToIFrame($name = null) {
-        $this->webDriver->switchTo()->frame($name);
+    	if (is_null($name)) {
+    		$this->webDriver->switchTo()->defaultContent();
+    	} else {
+        	$this->webDriver->switchTo()->frame($name);	
+    	}
     }
 
     /**


### PR DESCRIPTION
In facebooks new php-webdriver module, when you want to switch to the
main window instead of an iframe, there is a new function defaultContent().
This update modifies the WebDriver module to match the behavior of the existing
Selenium2 module and the provided documentation. This could alternatively be
accomplished by changing the default $name = array(), as that is what
defaultContent() passes, but using their methods struck me as a better choice.
