### PR TITLE
[ZF2] Fixed handling of query parameters

### DIFF
--- a/src/Codeception/Util/Connector/ZF2.php
+++ b/src/Codeception/Util/Connector/ZF2.php
@@ -45,14 +45,12 @@ class ZF2 extends \Symfony\Component\BrowserKit\Client
 
         if ($queryString) {
             parse_str($queryString, $query);
+            $zendRequest->setQuery(new Parameters($query));
         }
 
         if ($method == HttpRequest::METHOD_POST) {
             $post = $request->getParameters();
             $zendRequest->setPost(new Parameters($post));
-        } elseif ($method == HttpRequest::METHOD_GET) {
-            $query = $request->getParameters();
-            $zendRequest->setQuery(new Parameters($query));
         } elseif ($method == HttpRequest::METHOD_PUT) {
             $zendRequest->setContent($request->getContent());
         }


### PR DESCRIPTION
I found a bug that ZF2 module faild to pass query parameters to controller.

---

Case 1:    
- test

``` php
$I->amOnPage('/?foo=bar');
```

Case 2:
- html

``` html
<form method="POST" action="/?foo=bar">
    <input type="submit" value="Submit" />
</form>
```
- test

``` php
$I->click('Submit');
```

---

In both cases, I got `Array()` by the following code. (expected `Array([foo] => bar)`)

``` php
class IndexController extends AbstractActionController
{
    public function indexAction()
    {
        print_r($this->params()->fromQuery());exit;
    }
}
```
