### PR TITLE
Extend selectOption() to select text that partially match

### DIFF
--- a/src/Codeception/Module/WebDriver.php
+++ b/src/Codeception/Module/WebDriver.php
@@ -469,14 +469,24 @@ class WebDriver extends \Codeception\Module implements WebInterface, RemoteInter
             try {
                 $wdSelect->selectByVisibleText($opt);
                 $matched = true;
-            } catch (\NoSuchElementWebDriverError $e) {}
+            } catch (\NoSuchElementException $e) {}
         }
         if ($matched) return;
         foreach ($option as $opt) {
             try {
                 $wdSelect->selectByValue($opt);
                 $matched = true;
-            } catch (\NoSuchElementWebDriverError $e) {}
+            } catch (\NoSuchElementException $e) {}
+        }
+        if ($matched) return;
+                foreach ($option as $opt) {
+            try {
+                $optElement = $el->findElement(\WebDriverBy::xpath('//option [contains (., "'.$opt.'")]'));
+                $matched = true;
+                if (!$optElement->isSelected()) {
+                    $optElement->click();
+                }
+            } catch (\NoSuchElementException $e) {}
         }
         if ($matched) return;
         throw new ElementNotFound(json_encode($option), "Option inside $select matched by name or value");


### PR DESCRIPTION
The WebDriver module is intended to be a replacement of Selenium2
module. In the Selenium2 module selectOption($field, $option) would
select an option where the text of the option contained $option.
php-facebook's WebDriverSelect->selectByVisibleText() only selects
on full match. This patch updates the function to match the behavior
of Selenium2.
