### PR TITLE
Wording change related to _bootstrap.php generation

### DIFF
--- a/src/Codeception/Command/Bootstrap.php
+++ b/src/Codeception/Command/Bootstrap.php
@@ -149,7 +149,7 @@ class Bootstrap extends Command
 
         file_put_contents(
             'tests/functional/_bootstrap.php',
-            "<?php\n// Here you can initialize variables that will for your tests\n"
+            "<?php\n// Here you can initialize variables that will be available to your tests\n"
         );
         file_put_contents(
             'tests/_helpers/TestHelper.php',
@@ -184,7 +184,7 @@ class Bootstrap extends Command
 
         file_put_contents(
             'tests/acceptance/_bootstrap.php',
-            "<?php\n// Here you can initialize variables that will for your tests\n"
+            "<?php\n// Here you can initialize variables that will be available to your tests\n"
         );
         file_put_contents(
             'tests/_helpers/WebHelper.php',
@@ -208,7 +208,7 @@ class Bootstrap extends Command
 
         file_put_contents(
             'tests/unit/_bootstrap.php',
-            "<?php\n// Here you can initialize variables that will be used for your tests\n"
+            "<?php\n// Here you can initialize variables that will be available to your tests\n"
         );
         file_put_contents(
             'tests/_helpers/CodeHelper.php',


### PR DESCRIPTION
Just a suggestion of a change in wording for the default contents of the _bootstrap.php-files.

"...variables that will be available to your tests" feels, at least to me, like a good explanation of what to put in these files.
