### PR TITLE
Fix for issue #1004.

### DIFF
--- a/src/Codeception/Module/ZF1.php
+++ b/src/Codeception/Module/ZF1.php
@@ -100,7 +100,11 @@ class ZF1 extends \Codeception\Util\Framework implements \Codeception\Util\Frame
 
     public function _before(\Codeception\TestCase $test) {
         \Zend_Session::$_unitTestEnabled = true;
-        $this->bootstrap = new \Zend_Application($this->config['env'], Configuration::projectDir() . $this->config['config']);
+        try {
+            $this->bootstrap = new \Zend_Application($this->config['env'], Configuration::projectDir() . $this->config['config']);
+        } catch (\Exception $e) {
+            throw new \Codeception\Exception\Module(__CLASS__, $e->getMessage());
+        }
         $this->bootstrap->bootstrap();
         $this->client->setBootstrap($this->bootstrap);
 
@@ -117,9 +121,11 @@ class ZF1 extends \Codeception\Util\Framework implements \Codeception\Util\Frame
         $_GET     = array();
         $_POST    = array();
         $_COOKIE  = array();
-        $fc = $this->bootstrap->getBootstrap()->getResource('frontcontroller');
-        if ($fc) {
-            $fc->resetInstance();
+        if ($this->bootstrap) {
+            $fc = $this->bootstrap->getBootstrap()->getResource('frontcontroller');
+            if ($fc) {
+                $fc->resetInstance();
+            }
         }
         \Zend_Layout::resetMvcInstance();
         \Zend_Controller_Action_HelperBroker::resetHelpers();


### PR DESCRIPTION
Pack any Zend initialization exception into a Codeception module exception and don't let the _after method stumble upon a not initialized bootstrap variable.
