### PR TITLE
Fixing docblock for wait function in WebDriver

### DIFF
--- a/src/Codeception/Module/WebDriver.php
+++ b/src/Codeception/Module/WebDriver.php
@@ -918,7 +918,8 @@ class WebDriver extends \Codeception\Module implements WebInterface, RemoteInter
     /**
      * Explicit wait.
      *
-     * @param $timeout secs
+     * @param int $timeout secs
+     * @throws \Codeception\Exception\TestRuntime
      */
     public function wait($timeout)
     {


### PR DESCRIPTION
Hope I'm going about this the right way, let me know if I should have done it differently.

PHPStorm is showing a warning when using $I->wait(5); for example.  It's due to the docblock missing details, so I've added them in.
