### PR TITLE
Fixes undefined method setAuth on REST module

### DIFF
--- a/src/Codeception/Lib/Connector/Guzzle.php
+++ b/src/Codeception/Lib/Connector/Guzzle.php
@@ -37,6 +37,11 @@ class Guzzle extends Client
         $this->requestOptions['headers'][$header] = $value;
     }
 
+    public function setAuth($username, $password)
+    {
+        $this->requestOptions['auth'] = [$username, $password];
+    }
+
     /**
      * Taken from Mink\BrowserKitDriver
      *


### PR DESCRIPTION
After the replace of Goutte to Guzzle, I'm getting the `Fatal error: 
Call to undefined method Codeception\Lib\Connector\Guzzle::setAuth() in /vendor/codeception/codeception/src/Codeception/Module/REST.php on line 198`
