### PR TITLE
fix Doctrine2 error "Invalid parameter format" in seeInRepository method...

### DIFF
--- a/src/Codeception/Module/Doctrine2.php
+++ b/src/Codeception/Module/Doctrine2.php
@@ -301,8 +301,9 @@ class Doctrine2 extends \Codeception\Module
             if ($val === null) {
                 $qb->andWhere("s.$key IS NULL");
             } else {
-                $qb->andWhere("s.$key = :$key");
-                $qb->setParameter($key, $val);
+                $paramname = "s__$key";
+                $qb->andWhere("s.$key = :$paramname");
+                $qb->setParameter($paramname, $val);
             }
 
         }


### PR DESCRIPTION
seeInRepository assertion is failed incorrectly, 
when second argument has a column name starting with '_'.

For example:

```
        $I->seeInRepository(
            "Entity\User",
            array(                                      
                '_id' => 1
            )
        );
```

Output error after functional test is below:

```
Sorry, I couldn't see in repository "Entity\User",{"_id":1}:
Doctrine\ORM\Query\QueryException: Invalid parameter format, : given, but :<name> or ?<num> expected.
```

I fixed it.
