### PR TITLE
Oracle Connect through OCI added

### DIFF
--- a/src/Codeception/Util/Driver/Db.php
+++ b/src/Codeception/Util/Driver/Db.php
@@ -38,6 +38,8 @@ class Db
                 return new MsSql($dsn, $user, $password);
             case 'oracle':
                 return new Oracle($dsn, $user, $password);
+            case 'oci':
+                return new Oci($dsn, $user, $password);
             default:
                 return new Db($dsn, $user, $password);
         }

--- a/src/Codeception/Util/Driver/Oci.php
+++ b/src/Codeception/Util/Driver/Oci.php
@@ -1,0 +1,17 @@
+<?php
+namespace Codeception\Util\Driver;
+
+class Oci extends Oracle
+{
+    public function select($column, $table, array &$criteria) {
+        $where = $criteria ? "where %s" : '';
+        $query = "select %s from %s $where";
+        $params = array();
+        foreach ($criteria as $k => $v) {
+            $params[] = "$k = ? ";
+        }
+        $params = implode('AND ', $params);
+
+        return sprintf($query, $column, $table, $params);
+    }
+}


### PR DESCRIPTION
While using an Oracle DB the `Codeception\Util\Driver\DB` class generate a wrong SQL query which causes this error message:

```
PDOException: SQLSTATE[HY000]: General error: 911 OCIStmtExecute: ORA-00911: invalid character
 (/opt/php-5.4.28/ext/pdo_oci/oci_statement.c:148)
```

The invalid character is in the `select` method which wraps the table name like ``TBL_TABLE_NAME`` which is not supported in Oracle DBs.
