### PR TITLE
IS NULL criteria added to the `select` method in OCI connect

### DIFF
--- a/src/Codeception/Util/Driver/Oci.php
+++ b/src/Codeception/Util/Driver/Oci.php
@@ -9,7 +9,8 @@ class Oci extends Oracle
         $params = array();
         foreach ($criteria as $k => $v) {
             if ($v === null) {
-                $params[] = "$k IS ? ";
+                $params[] = "$k IS NULL ";
+                unset($criteria[$k]);
             } else {
                 $params[] = "$k = ? ";
             }


### PR DESCRIPTION
## find records with IS NULL criteria

Now you can use the `$I->seeInDatabase` method - and other methods with db usage - with `null` criterias
## load dump files with triggers

SQL commands should ends with `//` in the dump file
IF you want to load triggers too.
IF you do not want to load triggers you can use the `;` character
but in this case you need to change the $delimiter from `//` to `;`

in Oracle DBs for autoincrementing the ID value you need to use a trigger. So in the most of the cases triggers are exists. Thats why I set the default delimiter to `//` instead of `;`.
