### PR TITLE
Generates the right method name for actor classes.

### DIFF
--- a/src/Codeception/Lib/Generator/Actor.php
+++ b/src/Codeception/Lib/Generator/Actor.php
@@ -69,7 +69,8 @@ EOF;
             if (in_array($action, $methods)) {
                 continue;
             }
-            $method = new \ReflectionMethod($this->modules[$moduleName], $action);
+            $class = new \ReflectionClass($this->modules[$moduleName]);
+            $method = $class->getMethod($action);
             $code[] = $this->addMethod($method);
             $methods[] = $action;
             $this->numMethods++;


### PR DESCRIPTION
It seems there is a unexpected behavior in the `\ReflectionMethod` contructor when used with classes with an aliased method.  E.g. the Asserts module use a trait and aliases the assertion methods, when we use:

``` php
$method = new \ReflectionMethod('\Codeception\Module\Asserts', 'seeTrue');
echo $method->name;
```

it shows `assertTrue`, the method name in the trait, but when we use:

``` php
$class = new \ReflectionClass('\Codeception\Module\Asserts');
$method = $class->getMethod('seeTrue');
echo $method->name;
```

it shows `seeTrue`, the aliased name in the class, which seems like the desirable behavior.
