### PR TITLE
Laravel 4 Module Extra Forward Slash and Dir Separator

### DIFF
--- a/src/Codeception/Module/Laravel4.php
+++ b/src/Codeception/Module/Laravel4.php
@@ -52,13 +52,13 @@ class Laravel4 extends \Codeception\Util\Framework implements \Codeception\Util\
 
     protected $config = array(
         'cleanup' => true,
-        'start' => 'bootstrap/start.php'
+        'start' => 'bootstrap'  . DIRECTORY_SEPARATOR .  'start.php'
     );
 
     public function _initialize()
     {
         $projectDir = \Codeception\Configuration::projectDir();
-        require $projectDir . '/vendor/autoload.php';
+        require $projectDir .  'vendor' . DIRECTORY_SEPARATOR . 'autoload.php';
 
         \Illuminate\Support\ClassLoader::register();
 


### PR DESCRIPTION
Currently, this module makes an assumption about the directory separator. I've fixed that in this pull request. The current state is essentially breaking all my tests on a Windows machine.  
