### PR TITLE
Properly initialize Laravel4 module config

### DIFF
--- a/src/Codeception/Module/Laravel4.php
+++ b/src/Codeception/Module/Laravel4.php
@@ -50,10 +50,20 @@ class Laravel4 extends \Codeception\Util\Framework implements \Codeception\Util\
      */
     public $kernel;
 
-    protected $config = array(
-        'cleanup' => true,
-        'start' => 'bootstrap'  . DIRECTORY_SEPARATOR .  'start.php'
-    );
+    protected $config = array();
+
+    public function __construct($config = null)
+    {
+        $this->config = array_merge(
+            array(
+                'cleanup' => true,
+                'start' => 'bootstrap'  . DIRECTORY_SEPARATOR .  'start.php'
+            ),
+            (array) $config
+        );
+
+        parent::__construct();
+    }
 
     public function _initialize()
     {


### PR DESCRIPTION
This PR fixes the error

``` php
Parse error: syntax error, unexpected '.', expecting ')' in /vagrant/vendor/codeception/codeception/src/Codeception/Module/Laravel4.php on line 55
```

by properly initialising the module config.
