### PR TITLE
Quote mysql names with respect to dots

### DIFF
--- a/src/Codeception/Util/Driver/MySql.php
+++ b/src/Codeception/Util/Driver/MySql.php
@@ -21,7 +21,8 @@ class MySql extends Db
 
     public function select($column, $table, array &$criteria) {
         $where = $criteria ? "where %s" : '';
-        $query = "select %s from `%s` $where";
+        $table = $this->getQuotedName($table);
+        $query = "select %s from %s $where";
         $params = array();
         foreach ($criteria as $k => $v) {
             $k = $this->getQuotedName($k);


### PR DESCRIPTION
I have two databases in my project.
And I want to insert data with haveInDatabase function to both databases.

For example like that:

```
$I->haveInDatabase('db1.table', $data);
$I->haveInDatabase('db2.other_table', $other_data);
```

This patch fixes wrong quoting in this case.
