### PR TITLE
[Bug Fix] Ability to check for records in sqlite DB using NULL

### DIFF
--- a/src/Codeception/Lib/Driver/Db.php
+++ b/src/Codeception/Lib/Driver/Db.php
@@ -131,9 +131,14 @@ class Db
         $query = "select %s from `%s` $where";
         $params = array();
         foreach ($criteria as $k => $v) {
-            $params[] = "$k = ? ";
+            $k = $this->getQuotedName($k);
+            if ($v === null) {
+                $params[] = "$k IS ?";
+            } else {
+                $params[] = "$k = ?";
+            }
         }
-        $params = implode('AND ', $params);
+        $params = implode(' AND ', $params);
 
         return sprintf($query, $column, $table, $params);
     }


### PR DESCRIPTION
Currently seeInDatabase() fails with "null" values in SQLite. It has already been fixed for other drivers.

This is a copy of the fix applied to the MySQL driver, but needs to be applied here to allow it to fix sqlite.

Fix applied to mySQL: https://github.com/Codeception/Codeception/commit/9467f61c97bc23c2a5b35ff4f89deb26f10ab1fc
