### PR TITLE
Upgraded facebook webdriver to v0.4 [1.8 backport]

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         "php": ">=5.3.19",
         "behat/mink": "1.5.*",
         "phpunit/phpunit": "3.7.*",
-        "facebook/webdriver": "0.3",
+        "facebook/webdriver": "0.4",
         "behat/mink-goutte-driver": "1.0.*",
         "behat/mink-selenium2-driver": "1.1.*",
         "monolog/monolog": "*",

--- a/composer.lock
+++ b/composer.lock
@@ -1,9 +1,10 @@
 {
     "_readme": [
         "This file locks the dependencies of your project to a known state",
-        "Read more about it at http://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file"
+        "Read more about it at http://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
+        "This file is @generated automatically"
     ],
-    "hash": "d055045b7effb84ac68009051c814bd7",
+    "hash": "c4ca24f7c98e50fb00e2a9b322589423",
     "packages": [
         {
             "name": "behat/mink",
@@ -284,20 +285,22 @@
         },
         {
             "name": "facebook/webdriver",
-            "version": "v0.3",
+            "version": "v0.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/facebook/php-webdriver.git",
-                "reference": "1b0facc33133f0ff990df8cebe7f2e19b2603da3"
+                "reference": "342df507312ea5ae5337be47e16e4268d7ed661f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/facebook/php-webdriver/zipball/1b0facc33133f0ff990df8cebe7f2e19b2603da3",
-                "reference": "1b0facc33133f0ff990df8cebe7f2e19b2603da3",
+                "url": "https://api.github.com/repos/facebook/php-webdriver/zipball/342df507312ea5ae5337be47e16e4268d7ed661f",
+                "reference": "342df507312ea5ae5337be47e16e4268d7ed661f",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.19",
+                "php": ">=5.3.19"
+            },
+            "require-dev": {
                 "phpunit/phpunit": "3.7.*"
             },
             "type": "library",
@@ -318,7 +321,7 @@
                 "selenium",
                 "webdriver"
             ],
-            "time": "2013-11-26 23:16:02"
+            "time": "2014-02-21 18:22:11"
         },
         {
             "name": "guzzle/common",


### PR DESCRIPTION
v0.4 was released Feb 21 and solves various issues, including https://github.com/Codeception/Codeception/issues/1063 thanks to https://github.com/facebook/php-webdriver/commit/db04099a69719ad2e21a1a86480e35a0e790dcb3
