### PR TITLE
Removed buggy exception error handler

### DIFF
--- a/src/Codeception/Subscriber/ErrorHandler.php
+++ b/src/Codeception/Subscriber/ErrorHandler.php
@@ -31,7 +31,6 @@ class ErrorHandler implements EventSubscriberInterface
             $this->errorLevel = eval("return {$settings['error_level']};");
         }
         error_reporting($this->errorLevel);
-        set_exception_handler(array($this, 'errorHandler'));
         set_error_handler(array($this, 'errorHandler'));
         register_shutdown_function(array($this, 'shutdownHandler'));
     }


### PR DESCRIPTION
`set_exception_handler` expects a function that takes exception as a single argument (see http://php.net/manual/en/function.set-exception-handler.php).

Setting `handleError` as exception handler produces the following error:
 `PHP Fatal error:  Uncaught exception 'ErrorException' with message 'Missing argument 2 for Codeception\Subscriber\ErrorHandler::errorHandler()' in /some/path/codeception/codeception/src/Codeception/Subscriber/ErrorHandler.php:31`
