### PR TITLE
Bugfix - REST module: reset client server parameters _before each test.

### DIFF
--- a/src/Codeception/Module/REST.php
+++ b/src/Codeception/Module/REST.php
@@ -82,6 +82,9 @@ class REST extends \Codeception\Module
                 $this->client = &$this->getModule('PhpBrowser')->client;
             }
         }
+        if($this->isFunctional) {
+            $this->client->setServerParameters(array());
+        }
 
         $this->headers = array();
         $this->params = array();


### PR DESCRIPTION
When \Codeception\Module\REST::amHttpAuthenticated used in tests with Framework module (Symfony client) - client server parameters will not reset after tests. 
So, after first use of http authentication all next requests uses http authentication headers also.
