### PR TITLE
added debug option to speed up Symfony

### DIFF
--- a/src/Codeception/Module/Symfony2.php
+++ b/src/Codeception/Module/Symfony2.php
@@ -31,6 +31,7 @@ use Symfony\Component\HttpFoundation\Response;
  *           Symfony2:
  *              app_path: 'app/front'
  *              environment: 'local_test'
+ *              debug: true
  *
  * ## Public Properties
  *
@@ -52,7 +53,7 @@ class Symfony2 extends \Codeception\Lib\Framework
      */
     public $container;
 
-    public $config = array('app_path' => 'app', 'environment' => 'test');
+    public $config = array('app_path' => 'app', 'environment' => 'test', 'debug' => true);
     
     /**
      * @var
@@ -67,7 +68,7 @@ class Symfony2 extends \Codeception\Lib\Framework
         if (!file_exists($cache)) throw new ModuleRequire(__CLASS__, 'Symfony2 bootstrap file not found in '.$cache);
         require_once $cache;
         $this->kernelClass = $this->getKernelClass();
-        $this->kernel = new $this->kernelClass($this->config['environment'], true);
+        $this->kernel = new $this->kernelClass($this->config['environment'], $this->config['debug']);
     }
     
     public function _before(\Codeception\TestCase $test) {


### PR DESCRIPTION
Symfony Acceptance tests can be painfully slow when using debug. You can speed up by optionally turning off debug.
