### PR TITLE
Make WebDriver config docs match actual config values

### DIFF
--- a/src/Codeception/Module/WebDriver.php
+++ b/src/Codeception/Module/WebDriver.php
@@ -39,12 +39,12 @@ use Codeception\PHPUnit\Constraint\Page as PageConstraint;
  *
  * * url *required* - start url for your app
  * * browser *required* - browser that would be launched
- * * host  - Selenium server host (localhost by default)
+ * * host  - Selenium server host (127.0.0.1 by default)
  * * port - Selenium server port (4444 by default)
- * * restart - set to false to share browser sesssion between tests, or set to true (by default) to create a session per test
+ * * restart - set to false (default) to share browser sesssion between tests, or set to true to create a session per test
  * * window_size - initial window size. Values `maximize` or dimensions in format `640x480` are accepted.
- * * clear_cookies - set to false to keep cookies (not default), or set to true to delete all cookies between cases.
- * * wait - set the implicit wait (5 secs) by default.
+ * * clear_cookies - set to false to keep cookies, or set to true (default) to delete all cookies between cases.
+ * * wait - set the implicit wait (0 secs) by default.
  * * capabilities - sets Selenium2 [desired capabilities](http://code.google.com/p/selenium/wiki/DesiredCapabilities). Should be a key-value array.
  *
  * ### Example (`acceptance.suite.yml`)


### PR DESCRIPTION
There seems to be a bit of variation (across versions/branches) between what the doc says regarding defaults and what is set as defaults - but one thing is consistent - that the doc doesn't match the config being utilized.
