### PR TITLE
Add platform requirements to composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,6 +16,8 @@
 
     "require": {
         "php": ">=5.4.0",
+        "ext-json": "*",
+        "ext-mbstring": "*",
         "phpunit/phpunit": "~4.0",
         "facebook/webdriver": "~0.4",
         "guzzlehttp/guzzle": "4.*",


### PR DESCRIPTION
I tried to run Codeception on a machine without `mbstring` extension and got a fatal error, so I added the respective platform deps to `composer.json`:
- json
- mbstring

There might be other required php extensions, but those are the ones I could spot quickly.

Cheers!
