### PR TITLE
Skip Cest-tests with private constructor

### DIFF
--- a/src/Codeception/TestLoader.php
+++ b/src/Codeception/TestLoader.php
@@ -135,7 +135,7 @@ class TestLoader {
 
         foreach ($testClasses as $testClass) {
             $reflected = new \ReflectionClass($testClass);
-            if ($reflected->isAbstract()) {
+            if (!$reflected->isInstantiable()) {
                 continue;
             }
 


### PR DESCRIPTION
Just a little fix in order to prevent fatal error.
