### PR TITLE
Platform-independent test signatures

### DIFF
--- a/src/Codeception/TestLoader.php
+++ b/src/Codeception/TestLoader.php
@@ -57,7 +57,7 @@ class TestLoader {
 
     protected function relativeName($file)
     {
-        return $name = str_replace($this->path, '', $file);
+        return $name = str_replace([$this->path, '\\'], ['', '/'], $file);
     }
 
     public function loadTest($path)


### PR DESCRIPTION
I ran `TestLoaderTest` on Windows and it failed because it could not verify loading of `order/AnotherCept` by its signature, which actually was `order\AnotherCept`.
