### PR TITLE
Fixing issue #997

### DIFF
--- a/src/Codeception/Module/ZF2.php
+++ b/src/Codeception/Module/ZF2.php
@@ -73,6 +73,7 @@ class ZF2 extends \Codeception\Lib\Framework
         $events->detach($this->application->getServiceManager()->get('SendResponseListener'));
 
         $this->client->setApplication($this->application);
+        $_SERVER['REQUEST_URI'] = '';
     }
 
     public function _after(\Codeception\TestCase $test) {


### PR DESCRIPTION
...by setting REQUEST_URI to a blank value, so that exception is not thrown here: https://github.com/zendframework/zf2/blob/master/library/Zend/View/Helper/ServerUrl.php#L59
