### PR TITLE
Update Db.php

### DIFF
--- a/src/Codeception/Module/Db.php
+++ b/src/Codeception/Module/Db.php
@@ -153,14 +153,14 @@ class Db extends \Codeception\Module implements \Codeception\Lib\Interfaces\Db
 
     protected function removeInserted()
     {
-        foreach ($this->insertedIds as $insertedIndex => $insertId) {
+        foreach ($this->insertedIds as $insertId) {
             try {
             $this->driver->deleteQuery($insertId['table'], $insertId['id']);
             } catch (\Exception $e) {
                 $this->debug("coudn\'t delete record {$insertId['id']} from {$insertId['table']}");
-                unset($this->insertedIds[$insertedIndex]);
             }
         }
+        $this->insertedIds = array();
     }
 
     protected function cleanup()


### PR DESCRIPTION
This array grows if the inserted id can't be removed by this function resulting in an ever growing list of "could\'t delete record $X from $tablename" throughout a test run. The full list is output at the end of each test within a single run. An alternative would be to clean up this array between test runs elsewhere or setting `$this->insertedIds = array();` at the end of this function.
