### PR TITLE
Laravel4: Updated projectDir to work on Workbench tests

### DIFF
--- a/src/Codeception/Module/Laravel4.php
+++ b/src/Codeception/Module/Laravel4.php
@@ -68,7 +68,7 @@ class Laravel4 extends Framework implements ActiveRecord
 
     public function _initialize()
     {
-        $projectDir = \Codeception\Configuration::projectDir();
+        $projectDir = explode('workbench', \Codeception\Configuration::projectDir())[0];
         require $projectDir .  'vendor' . DIRECTORY_SEPARATOR . 'autoload.php';
 
         \Illuminate\Support\ClassLoader::register();


### PR DESCRIPTION
Fix for https://github.com/Codeception/Codeception/issues/1208

Fixed up $projectDir to always use base laravel codeception.yml even when testing a workbench package.
