### PR TITLE
fix for users of Symfony 3 dir strcture without breaking backward compat...

### DIFF
--- a/src/Codeception/Module/Symfony2.php
+++ b/src/Codeception/Module/Symfony2.php
@@ -20,10 +20,11 @@ use Symfony\Component\HttpFoundation\Response;
  *
  * ## Config
  *
+ * ### Symfony 2.x
  * * app_path: 'app' - specify custom path to your app dir, where bootstrap cache and kernel interface is located.
  * * environment: 'local' - environment used for load kernel
-* 
- * ### Example (`functional.suite.yml`)
+ *
+ * ### Example (`functional.suite.yml`) - Symfony 2.x Directory Structure
  *
  *     modules: 
  *        enabled: [Symfony2]
@@ -31,6 +32,22 @@ use Symfony\Component\HttpFoundation\Response;
  *           Symfony2:
  *              app_path: 'app/front'
  *              environment: 'local_test'
+ *
+ * ### Symfony 3.x Directory Structure
+ * * app_path: 'app' - specify custom path to your app dir, where the kernel interface is located.
+ * * var_path: 'var' - specify custom path to your var dir, where bootstrap cache is located.
+ * * environment: 'local' - environment used for load kernel
+ *
+ * ### Example (`functional.suite.yml`) - Symfony 3 Directory Structure
+ *
+ *     modules:
+ *        enabled: [Symfony2]
+ *        config:
+ *           Symfony2:
+ *              app_path: 'app/front'
+ *              var_path: 'var'
+ *              environment: 'local_test'
+ *
  *
  * ## Public Properties
  *
@@ -51,7 +68,7 @@ class Symfony2 extends \Codeception\Util\Framework
      */
     public $container;
 
-    public $config = array('app_path' => 'app', 'environment' => 'test');
+    public $config = array('app_path' => 'app', 'var_path' => 'app', 'environment' => 'test');
     
     /**
      * @var
@@ -62,7 +79,7 @@ class Symfony2 extends \Codeception\Util\Framework
 
 
     public function _initialize() {
-        $cache = \Codeception\Configuration::projectDir() . $this->config['app_path'] . DIRECTORY_SEPARATOR . 'bootstrap.php.cache';
+        $cache = \Codeception\Configuration::projectDir() . $this->config['var_path'] . DIRECTORY_SEPARATOR . 'bootstrap.php.cache';
         if (!file_exists($cache)) throw new ModuleRequire(__CLASS__, 'Symfony2 bootstrap file not found in '.$cache);
         require_once $cache;
         $this->kernelClass = $this->getKernelClass();
@@ -98,7 +115,7 @@ class Symfony2 extends \Codeception\Util\Framework
         $finder->name('*Kernel.php')->depth('0')->in(\Codeception\Configuration::projectDir() . $this->config['app_path']);
         $results = iterator_to_array($finder);
         if (!count($results)) {
-            throw new ModuleRequire(__CLASS__, 'AppKernel was not found. Specify directory where Kernel class for your application is located in "app_dir" parameter.');
+            throw new ModuleRequire(__CLASS__, 'AppKernel was not found. Specify directory where Kernel class for your application is located in "app_path" parameter.');
         }
 
         $file = current($results);


### PR DESCRIPTION
Symfony 2.5 allows the use of the new Symfony 3 dir structure. 

In this new structure, amongst other things, the bootstrap.cache.php file has been moved to the /var directory, with the AppKernel.php remaining in the /app dir. 

The Symfony2 module currently doesn't cater for having these two files in different dirs. 

However, there is a confusing error message in Codeception\Module\Symfony2::getKernelClass which hints at two different config params:

app_path

and

app_dir

Adding in both params to the *.suite.yml file resolves this (app_path: var, app_dir: app) but breaks backwards compatibility by requiring the new param.

This commit should enable users of the new dir structure to use an additional param to specify the location of the var dir, whilst not breaking anything for existing 2.x users.  
