### PR TITLE
PSR-4 Autoloader

### DIFF
--- a/docs/08-Customization.md
+++ b/docs/08-Customization.md
@@ -54,7 +54,7 @@ If your applications uses same helpers, follow the next section of this chapter.
 
 ## Autoload Helper classes
 
-There is global `_bootstrap.php` file. This file is included at the very beginning of execution. We recommend to use it to initialize autoloaders and constants. It is especially useful if you want to include Modules or Helper classes that are not stored in `tests/_helpers` directory.
+There is global `_bootstrap.php` file. This file is included at the very beginning of execution. We recommend to use it to initialize autoloaders and constants. It is especially useful if you want to include `Module` or `Helper` classes that are not stored in `tests/_helpers` directory, or those which are organized in namespaces.
 
 ```php
 <?php
@@ -62,34 +62,33 @@ require_once __DIR__.'/../lib/tests/helpers/MyHelper.php';
 ?>
 ```
 
-Alternatively you can use Composer's autoloader. Codeception has its autoloader too.
-It's not PSR-0 compatible (yet), but it is still very useful when you need to declare alternative path for Helper classes:
+Alternatively you can use Composer's autoloader. Codeception has its autoloader too, and it's [PSR-4](https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-4-autoloader.md) compatible:
 
 ```php
 <?php
-Codeception\Util\Autoload::registerSuffix('Helper', __DIR__.'/../lib/tests/helpers');
+Codeception\Util\Autoload::addNamespace('', __DIR__.'/../lib/tests/helpers');
 ?>
 ```
 
-Now all classes with suffix `Helper` will be additionally searched in `__DIR__.'/../lib/tests/helpers'. You can declare to load helpers of specific namespace. 
+Now all classes in global namespace will be additionally searched in `__DIR__.'/../lib/tests/helpers'`. You can declare to load helpers from namespaces with specified prefixes too:
 
 ```php
 <?php
-Codeception\Util\Autoload::register('MyApp\\Test', 'Helper', __DIR__.'/../lib/tests/helpers');
+Codeception\Util\Autoload::addNamespace('MyApp\\Test', __DIR__.'/../lib/tests/helpers');
 ?>
 ```
 
-That will point autoloader to look for classes like `MyApp\Test\MyHelper` in path `__DIR__.'/../lib/tests/helpers'`.
+That will point autoloader to load class named `MyApp\Test\MyHelper` from `__DIR__.'/../lib/tests/helpers/MyHelper.php'`, and `MyApp\Test\User\MyHelper` will be loaded from `__DIR__.'/../lib/tests/helpers/User/MyHelper.php'`.
 
-Alternatively you can use autoloader to specify path for **PageObject and Controller** classes, if they have appropriate suffixes in their names.
+Autoloader can also be used to specify base directories for your `PageObject` and `Controller` classes.
 
 Example of `tests/_bootstrap.php` file:
 
 ``` php
 <?php
-Codeception\Util\Autoload::register('MyApp\\Test', 'Helper', __DIR__.'/../lib/tests/helpers');
-Codeception\Util\Autoload::register('MyApp\\Test', 'Page', __DIR__.'/pageobjects');
-Codeception\Util\Autoload::register('MyApp\\Test', 'Controller', __DIR__.'/controller');
+Codeception\Util\Autoload::addNamespace('MyApp\\Test', __DIR__.'/../lib/tests/helpers');
+Codeception\Util\Autoload::addNamespace('MyApp\\Test', __DIR__.'/pageobjects');
+Codeception\Util\Autoload::addNamespace('MyApp\\Test', __DIR__.'/controller');
 ?>
 ```
 
@@ -264,4 +263,4 @@ Now Admin group class will listen to all events of tests that belong to the `adm
 
 ## Conclusion
 
-Each feature mentioned above may dramatically help when using Codeception to automate testing of large projects, although some features may require advanced knowledge of PHP. There is no "best practice" or "use cases" when we talk about groups, extensions, or other powerful features of Codeception. If you see you have a problem that can be solved using these extensions, then give them a try. 
+Each feature mentioned above may dramatically help when using Codeception to automate testing of large projects, although some features may require advanced knowledge of PHP. There is no "best practice" or "use cases" when we talk about groups, extensions, or other powerful features of Codeception. If you see you have a problem that can be solved using these extensions, then give them a try.

--- a/src/Codeception/Command/Bootstrap.php
+++ b/src/Codeception/Command/Bootstrap.php
@@ -79,7 +79,7 @@ class Bootstrap extends Command
         $output->writeln(
             "<fg=white;bg=magenta>Initializing Codeception in " . $realpath . "</fg=white;bg=magenta>\n"
         );
-        
+
         if ($input->getOption('compat')) {
             $this->compatibilitySetup($output);
         } elseif ($input->getOption('customize')) {
@@ -129,7 +129,7 @@ class Bootstrap extends Command
 
         $str = Yaml::dump($basicConfig, 4);
         if ($this->namespace) {
-            $str = "namespace: {$this->namespace} \n" . $str;
+            $str = "namespace: {$this->namespace}\n" . $str;
         }
         file_put_contents('codeception.yml', $str);
     }
@@ -182,7 +182,7 @@ class Bootstrap extends Command
         $str = "# Codeception Test Suite Configuration\n\n";
         $str .= "# suite for unit (internal) tests.\n";
         $str .= Yaml::dump($suiteConfig, 2);
-        
+
         $this->createSuite('unit', $actor, $str);
     }
 
@@ -268,7 +268,7 @@ class Bootstrap extends Command
         $this->actorSuffix = $dialog->ask($output,
             "<question> Enter default actor name </question> Proposed: <info>Tester</info>; Formerly: Guy\n",
             'Tester'
-        );              
+        );
 
         $output->writeln("Basic Actor is set to: <info>{$this->actorSuffix}</info>");
 

--- a/src/Codeception/Command/GenerateGroup.php
+++ b/src/Codeception/Command/GenerateGroup.php
@@ -36,7 +36,7 @@ class GenerateGroup extends Command
         $filename = $this->completeSuffix($class, 'Group');
         $filename = $path.$filename;
 
-        $this->introduceAutoloader($config['paths']['tests'].DIRECTORY_SEPARATOR.$config['settings']['bootstrap'],'Group','_groups');
+        $this->introduceAutoloader($config['paths']['tests'].DIRECTORY_SEPARATOR.$config['settings']['bootstrap'], $config['namespace'], '_groups');
 
         $gen = new GroupGenerator($config, $group);
         $res = $this->save($filename, $gen->produce());
@@ -45,7 +45,7 @@ class GenerateGroup extends Command
             $output->writeln("<error>Group $filename already exists</error>");
             return;
         }
-        
+
         $output->writeln("<info>Group extension was created in $filename</info>");
         $output->writeln('To use this group extension, include it to "extensions" option of global Codeception config.');
     }

--- a/src/Codeception/Command/GeneratePageObject.php
+++ b/src/Codeception/Command/GeneratePageObject.php
@@ -71,7 +71,7 @@ class GeneratePageObject extends Command
     {
         $path = $this->buildPath(Configuration::projectDir().$config['paths']['tests'].'/_pages/', $class);
         $filename = $this->completeSuffix($class, 'Page');
-        $this->introduceAutoloader(Configuration::projectDir().$config['paths']['tests'].DIRECTORY_SEPARATOR.$config['settings']['bootstrap'],'Page','_pages');
+        $this->introduceAutoloader(Configuration::projectDir().$config['paths']['tests'].DIRECTORY_SEPARATOR.$config['settings']['bootstrap'], $config['namespace'], '_pages');
         return  $path.$filename;
     }
 
@@ -79,7 +79,7 @@ class GeneratePageObject extends Command
     {
         $path = $this->buildPath($config['path'].'/_pages/', $class);
         $filename = $this->completeSuffix($class, 'Page');
-        $this->introduceAutoloader($config['path'].DIRECTORY_SEPARATOR.$config['bootstrap'],'Page','_pages');
+        $this->introduceAutoloader($config['path'].DIRECTORY_SEPARATOR.$config['bootstrap'], $config['namespace'], '_pages');
         return  $path.$filename;
     }
 

--- a/src/Codeception/Command/GenerateStepObject.php
+++ b/src/Codeception/Command/GenerateStepObject.php
@@ -38,18 +38,18 @@ class GenerateStepObject extends Command
     {
         $suite = $input->getArgument('suite');
         $step = $input->getArgument('step');
-        $conf = $this->getSuiteConfig($suite, $input->getOption('config'));
+        $config = $this->getSuiteConfig($suite, $input->getOption('config'));
 
         $class = $this->getClassName($step);
         $class = $this->removeSuffix($class, 'Steps');
 
-        $path = $this->buildPath($conf['path'].'/_steps/', $class);
+        $path = $this->buildPath($config['path'].'/_steps/', $class);
         $filename = $this->completeSuffix($class, 'Steps');
         $filename = $path.$filename;
 
         $dialog = $this->getHelperSet()->get('dialog');
 
-        $gen = new StepObjectGenerator($conf, $class);
+        $gen = new StepObjectGenerator($config, $class);
 
         if (!$input->getOption('silent')) {
             do {
@@ -61,8 +61,8 @@ class GenerateStepObject extends Command
         }
 
         $res = $this->save($filename, $gen->produce());
-        
-        $this->introduceAutoloader($conf['path'].'/'.$conf['bootstrap'], 'Steps', '_steps');
+
+        $this->introduceAutoloader($config['path'].'/'.$config['bootstrap'], trim($config['namespace'].'\\'.$config['class_name'], '\\'), '_steps');
 
         if (!$res) {
             $output->writeln("<error>StepObject $filename already exists</error>");

--- a/src/Codeception/Command/Shared/FileSystem.php
+++ b/src/Codeception/Command/Shared/FileSystem.php
@@ -67,20 +67,20 @@ trait FileSystem
         return true;
     }
 
-    protected function introduceAutoloader($file, $suffix, $relativePath)
+    protected function introduceAutoloader($file, $prefix, $baseDir)
     {
         $line = sprintf(
-            '\Codeception\Util\Autoload::registerSuffix(\'%s\', __DIR__.DIRECTORY_SEPARATOR.\'%s\');',
-            $suffix,
-            $relativePath
+            '\Codeception\Util\Autoload::addNamespace(\'%s\', __DIR__.DIRECTORY_SEPARATOR.\'%s\');',
+            $prefix,
+            $baseDir
         );
 
         if (!file_exists($file)) {
-            return $this->save($file, "<?php \n" . $line);
+            return $this->save($file, "<?php\n" . $line);
         }
 
         $contents = file_get_contents($file);
-        if (preg_match('~Autoload::registerSuffix\([\'"]' . $suffix . '[\'"]~', $contents)) {
+        if (strpos($contents, $line) !== false) {
             return false;
         }
         $contents .= "\n" . $line;
@@ -89,4 +89,4 @@ trait FileSystem
     }
 
 
-} 
+}

--- a/src/Codeception/Configuration.php
+++ b/src/Codeception/Configuration.php
@@ -18,7 +18,7 @@ class Configuration
 
     /**
      * @var string Directory containing main configuration file.
-     * @see self::projectDir() 
+     * @see self::projectDir()
      */
     protected static $dir = null;
 
@@ -178,7 +178,9 @@ class Configuration
 
     protected static function autoloadHelpers()
     {
-        Autoload::registerSuffix('Helper', self::helpersDir());
+        $namespace = self::$config['namespace'];
+        Autoload::addNamespace($namespace, self::helpersDir());
+        Autoload::addNamespace($namespace.'\Codeception\Module', self::helpersDir());
     }
 
     protected static function loadSuites()
@@ -266,7 +268,7 @@ class Configuration
     /**
      * Return instances of enabled modules according suite config.
      * Requires Guy class if it exists.
-     * 
+     *
      * @param array $settings suite settings
      * @return array|\Codeception\Module[]
      */

--- a/src/Codeception/Util/Autoload.php
+++ b/src/Codeception/Util/Autoload.php
@@ -3,98 +3,149 @@
 namespace Codeception\Util;
 
 /**
- * Custom autoloader to load classes by suffixes: `Helper`, `Page`, `Step`, etc.
- *
+ * Autoloader, which is fully compatible with PSR-4, and can be used to autoload your `Helper`, `Page`, and `Step` classes.
  */
 class Autoload
 {
     protected static $registered = false;
-    protected static $map = array();
+    /**
+     * An associative array where the key is a namespace prefix and the value is an array of base directories for classes in that namespace.
+     * @var array
+     */
+    protected static $map = [];
+
+    private function __construct() {}
 
     /**
-     * A very basic yet useful autoloader, not compatible with PSR-0.
-     * It is used to autoload classes by namespaces with suffixes.
+     * Adds a base directory for a namespace prefix.
      *
      * Example:
      *
-     * ``` php
+     * ```php
      * <?php
-     * // loads UserHelper in 'helpers/UserHelper.php'
-     * Autoload::register('app\Codeception\Helper', 'Helper', __DIR__.'/helpers/');
-     * // loads LoginPage in 'pageobjects/LoginPage.php'
-     * Autoload::register('app\tests', 'Page', __DIR__.'/pageobjects/');
-     * Autoload::register('app\tests', 'Controller', __DIR__.'/controllers/');
+     * // app\Codeception\UserHelper will be loaded from '/path/to/helpers/UserHelper.php'
+     * Autoload::addNamespace('app\Codeception', '/path/to/helpers');
+     *
+     * // LoginPage will be loaded from '/path/to/pageobjects/LoginPage.php'
+     * Autoload::addNamespace('', '/path/to/pageobjects');
+     *
+     * Autoload::addNamespace('app\Codeception', '/path/to/controllers');
      * ?>
      * ```
      *
-     * @param $namespace
-     * @param $suffix
-     * @param $path
+     * @param string $prefix The namespace prefix.
+     * @param string $base_dir A base directory for class files in the namespace.
+     * @param bool $prepend If true, prepend the base directory to the stack instead of appending it; this causes it to be searched first rather than last.
+     * @return void
      */
-    public static function register($namespace, $suffix, $path)
+    public static function addNamespace($prefix, $base_dir, $prepend = false)
     {
-        self::$map[] = array(self::regex($namespace, $suffix), $path);
         if (!self::$registered) {
             spl_autoload_register(array(__CLASS__, 'load'));
             self::$registered = true;
         }
+
+        // normalize namespace prefix
+        $prefix = trim($prefix, '\\').'\\';
+
+        // normalize the base directory with a trailing separator
+        $base_dir = rtrim($base_dir, '/').DIRECTORY_SEPARATOR;
+        $base_dir = rtrim($base_dir, DIRECTORY_SEPARATOR).'/';
+
+        // initialize the namespace prefix array
+        if (isset(self::$map[$prefix]) === false) {
+            self::$map[$prefix] = [];
+        }
+
+        // retain the base directory for the namespace prefix
+        if ($prepend) {
+            array_unshift(self::$map[$prefix], $base_dir);
+        } else {
+            array_push(self::$map[$prefix], $base_dir);
+        }
     }
 
     /**
-     * Shortcut for {@link self::register} for classes with empty namespaces.
-     *
-     * @param $suffix
-     * @param $path
+     * @deprecated Use self::addNamespace() instead.
+     */
+    public static function register($namespace, $suffix, $path)
+    {
+        self::addNamespace($namespace, $path);
+    }
+
+    /**
+     * @deprecated Use self::addNamespace() instead.
      */
     public static function registerSuffix($suffix, $path)
     {
-        self::register('', $suffix, $path);
+        self::addNamespace('', $path);
     }
 
-    /**
-     * @param $class
-     * @return bool
-     */
     public static function load($class)
     {
-        $map = array_reverse(self::$map);
-        foreach ($map as $record) {
-            list($regex, $path) = $record;
-            if (!preg_match($regex, $class)) {
-                continue;
+        // the current namespace prefix
+        $prefix = $class;
+
+        // work backwards through the namespace names of the fully-qualified class name to find a mapped file name
+        while (false !== ($pos = strrpos($prefix, '\\'))) {
+
+            // retain the trailing namespace separator in the prefix
+            $prefix = substr($class, 0, $pos + 1);
+
+            // the rest is the relative class name
+            $relative_class = substr($class, $pos + 1);
+
+            // try to load a mapped file for the prefix and relative class
+            $mapped_file = self::loadMappedFile($prefix, $relative_class);
+            if ($mapped_file) {
+                return $mapped_file;
             }
-            $className = str_replace('\\', '', substr($class, (int)strrpos($class, '\\')));
-            $file      = $path . DIRECTORY_SEPARATOR . $className . '.php';
-            if (!file_exists($file)) {
-                continue;
-            }
-            include_once $file;
-            return true;
+
+            // remove the trailing namespace separator for the next iteration of strrpos()
+            $prefix = rtrim($prefix, '\\');
+        }
+
+        // fix for empty prefix
+        if (isset(self::$map['\\']) && ($class[0] != '\\')) {
+            return self::load('\\'.$class);
         }
 
         return false;
     }
 
     /**
-     * *is public for testing purposes*
+     * Load the mapped file for a namespace prefix and relative class.
      *
-     * @param $class
-     * @param $namespace
-     * @param $suffix
-     * @return bool
+     * @param string $prefix The namespace prefix.
+     * @param string $relative_class The relative class name.
+     * @return mixed Boolean false if no mapped file can be loaded, or the name of the mapped file that was loaded.
      */
-    public static function matches($class, $namespace, $suffix)
+    protected static function loadMappedFile($prefix, $relative_class)
     {
-        return (bool)preg_match(self::regex($namespace, $suffix), $class);
+        if (!isset(self::$map[$prefix])) {
+            return false;
+        }
+
+        foreach (self::$map[$prefix] as $base_dir) {
+            $file = $base_dir
+                .str_replace('\\', '/', $relative_class)
+                .'.php';
+
+            // 'static' is for testing purposes
+            if (static::requireFile($file)) {
+                return $file;
+            }
+        }
+
+        return false;
     }
 
-    protected static function regex($namespace, $suffix)
+    protected static function requireFile($file)
     {
-        $namespace = str_replace("\\", '\\\\', $namespace);
-        if ($namespace) {
-            return sprintf('~\\\\?%s\\\\\w*?%s$~', $namespace, $suffix);
-        } else {
-            return sprintf('~\w*?%s$~', $suffix);
+        if (file_exists($file)) {
+            require $file;
+            return true;
         }
+        return false;
     }
 }

--- a/src/Codeception/Util/Autoload.php
+++ b/src/Codeception/Util/Autoload.php
@@ -110,6 +110,16 @@ class Autoload
             return self::load('\\'.$class);
         }
 
+        // backwards compatibility with old autoloader
+        // :TODO: it should be removed
+        if (strpos($class, '\\') !== false) {
+            $relative_class = substr(strrchr($class, '\\'), 1); // Foo\Bar\ClassName -> ClassName
+            $mapped_file = self::loadMappedFile('\\', $relative_class);
+            if ($mapped_file) {
+                return $mapped_file;
+            }
+        }
+
         return false;
     }
 

--- a/tests/cli/GenerateGroupCept.php
+++ b/tests/cli/GenerateGroupCept.php
@@ -7,4 +7,4 @@ $I->seeFileWithGeneratedClass('CoreGroup','tests/_groups');
 $I->seeInThisFile("static \$group = 'core'");
 $I->dontSeeInThisFile('public function _before(\Codeception\Event\Test \$e)');
 $I->seeFileFound('tests/_bootstrap.php');
-$I->seeInThisFile("\\Codeception\\Util\\Autoload::registerSuffix('Group', __DIR__.DIRECTORY_SEPARATOR.'_groups'");
+$I->seeInThisFile("\\Codeception\\Util\\Autoload::addNamespace('', __DIR__.DIRECTORY_SEPARATOR.'_groups'");

--- a/tests/cli/GeneratePageObjectCest.php
+++ b/tests/cli/GeneratePageObjectCest.php
@@ -12,7 +12,7 @@ class GeneratePageObjectCest
         $I->seeInThisFile('static $URL = ');
         $I->dontSeeInThisFile('public static function of(DummyGuy $I)');
         $I->seeFileFound('tests/_bootstrap.php');
-        $I->seeInThisFile("\\Codeception\\Util\\Autoload::registerSuffix('Page', __DIR__.DIRECTORY_SEPARATOR.'_pages'");
+        $I->seeInThisFile("\\Codeception\\Util\\Autoload::addNamespace('', __DIR__.DIRECTORY_SEPARATOR.'_pages'");
     }
 
     public function generateSuitePageObject(CliGuy\GeneratorSteps $I) {
@@ -23,7 +23,7 @@ class GeneratePageObjectCest
         $I->seeInThisFile('protected $dumbGuy;');
         $I->seeInThisFile('public static function of(DumbGuy $I)');
         $I->seeInThisFile('@return LoginPage');
-        $I->seeAutoloaderWasAdded('Page', 'tests/dummy');
+        $I->seeAutoloaderWasAdded('', 'tests/dummy');
 
     }
 
@@ -35,7 +35,7 @@ class GeneratePageObjectCest
         $I->seeInThisFile('static $URL = ');
         $I->dontSeeInThisFile('public static function of(DummyGuy $I)');
         $I->seeFileFound('tests/_bootstrap.php');
-        $I->seeInThisFile("\\Codeception\\Util\\Autoload::registerSuffix('Page', __DIR__.DIRECTORY_SEPARATOR.'_pages'");
+        $I->seeInThisFile("\\Codeception\\Util\\Autoload::addNamespace('', __DIR__.DIRECTORY_SEPARATOR.'_pages'");
 
     }
 

--- a/tests/cli/GenerateStepObjectCept.php
+++ b/tests/cli/GenerateStepObjectCept.php
@@ -5,4 +5,4 @@ $I->amInPath('tests/data/sandbox');
 $I->executeCommand('generate:stepobject dummy Login --silent');
 $I->seeFileWithGeneratedClass('LoginSteps','tests/dummy/_steps');
 $I->seeInThisFile('LoginSteps extends \DumbGuy');
-$I->seeAutoloaderWasAdded('Steps','tests/dummy');
+$I->seeAutoloaderWasAdded('DumbGuy', 'tests/dummy');

--- a/tests/cli/_bootstrap.php
+++ b/tests/cli/_bootstrap.php
@@ -1,2 +1,2 @@
-<?php 
-\Codeception\Util\Autoload::registerSuffix('Steps', __DIR__.DIRECTORY_SEPARATOR.'_steps');
+<?php
+\Codeception\Util\Autoload::addNamespace('CliGuy', __DIR__.DIRECTORY_SEPARATOR.'_steps');

--- a/tests/cli/_steps/GeneratorSteps.php
+++ b/tests/cli/_steps/GeneratorSteps.php
@@ -10,11 +10,11 @@ class GeneratorSteps extends \CliGuy
         $I->seeInThisFile('class '.$class);
     }
 
-    public function seeAutoloaderWasAdded($suffix, $path)
+    public function seeAutoloaderWasAdded($prefix, $path)
     {
         $I = $this;
-        $I->seeFileFound('_bootstrap.php',$path);
-        $I->seeInThisFile("\\Codeception\\Util\\Autoload::registerSuffix('$suffix', __DIR__.DIRECTORY_SEPARATOR.");
+        $I->seeFileFound('_bootstrap.php', $path);
+        $I->seeInThisFile("\\Codeception\\Util\\Autoload::addNamespace('$prefix', __DIR__.DIRECTORY_SEPARATOR.");
     }
 
 }

--- a/tests/helpers/Shire/Codeception/Module/EmulateModuleHelper.php
+++ b/tests/helpers/Shire/Codeception/Module/EmulateModuleHelper.php
@@ -1,0 +1,23 @@
+<?php
+namespace Shire\Codeception\Module;
+
+// here you can define custom functions for CodeGuy 
+
+class EmulateModuleHelper extends \Codeception\Module
+{
+    public $assertions = 0;
+
+    public function seeEquals($expected, $actual) {
+        \PHPUnit_Framework_Assert::assertEquals($expected, $actual);
+        $this->assertions++;
+    }
+    
+    public function seeFeaturesEquals($expected) {
+        \PHPUnit_Framework_Assert::assertEquals($expected, $this->scenario->getFeature());
+    }
+
+    public function _before(\Codeception\TestCase $test) {
+        $this->scenario = $test->getScenario();
+    }
+
+}

--- a/tests/unit/Codeception/Command/GenerateStepObjectTest.php
+++ b/tests/unit/Codeception/Command/GenerateStepObjectTest.php
@@ -23,7 +23,7 @@ class GenerateStepObjectTest extends BaseCommandRunner {
         $this->assertIsValidPhp($generated['content']);
 
         $bootstrap = $this->content;
-        $this->assertContains("\\Codeception\\Util\\Autoload::registerSuffix('Steps', __DIR__.DIRECTORY_SEPARATOR.'_steps');", $bootstrap);
+        $this->assertContains("\\Codeception\\Util\\Autoload::addNamespace('HobbitGuy', __DIR__.DIRECTORY_SEPARATOR.'_steps');", $bootstrap);
         $this->assertIsValidPhp($bootstrap);
 
     }
@@ -37,9 +37,9 @@ class GenerateStepObjectTest extends BaseCommandRunner {
         $this->assertContains('namespace MiddleEarth\HobbitGuy;', $generated['content']);
         $this->assertContains('class LoginSteps extends \MiddleEarth\HobbitGuy', $generated['content']);
         $this->assertIsValidPhp($generated['content']);
-        
+
         $bootstrap = $this->content;
-        $this->assertContains("\\Codeception\\Util\\Autoload::registerSuffix('Steps', __DIR__.DIRECTORY_SEPARATOR.'_steps');", $bootstrap);
+        $this->assertContains("\\Codeception\\Util\\Autoload::addNamespace('MiddleEarth\HobbitGuy', __DIR__.DIRECTORY_SEPARATOR.'_steps');", $bootstrap);
         $this->assertIsValidPhp($bootstrap);
     }
 

--- a/tests/unit/Codeception/Util/AutoloadTest.php
+++ b/tests/unit/Codeception/Util/AutoloadTest.php
@@ -1,17 +1,80 @@
 <?php
 
+require_once 'MockAutoload.php';
 
-use Codeception\Util\Autoload;
+use Codeception\Util\MockAutoload as Autoload;
 
 class AutoloadTest extends PHPUnit_Framework_TestCase {
 
-    public function testMatches()
+    protected function setUp()
     {
-        $this->assertTrue(Autoload::matches('api\frontend\UserHelper', 'api\frontend', 'Helper'));
-        $this->assertTrue(Autoload::matches('\api\frontend\ModelHelper', 'api\frontend', 'Helper'));
-        $this->assertTrue(Autoload::matches('\api\Codeception\UserController', 'api\Codeception', 'Controller'));
-        $this->assertTrue(Autoload::matches('\api\Codeception\UserController', 'api\Codeception', 'Controller'));
-        $this->assertTrue(Autoload::matches('\api\Codeception\UserController', '', 'Controller'));
+        Autoload::setFiles([
+            '/vendor/foo.bar/src/ClassName.php',
+            '/vendor/foo.bar/src/DoomClassName.php',
+            '/vendor/foo.bar/tests/ClassNameTest.php',
+            '/vendor/foo.bardoom/src/ClassName.php',
+            '/vendor/foo.bar.baz.dib/src/ClassName.php',
+            '/vendor/foo.bar.baz.dib.zim.gir/src/ClassName.php',
+            '/vendor/src/ClassName.php',
+            '/vendor/src/Foo/Bar/AnotherClassName.php',
+            '/vendor/src/Bar/Baz/ClassName.php',
+        ]);
+
+        Autoload::addNamespace('Foo\Bar', '/vendor/foo.bar/src');
+        Autoload::addNamespace('Foo\Bar', '/vendor/foo.bar/tests');
+        Autoload::addNamespace('Foo\BarDoom', '/vendor/foo.bardoom/src');
+        Autoload::addNamespace('Foo\Bar\Baz\Dib', '/vendor/foo.bar.baz.dib/src');
+        Autoload::addNamespace('Foo\Bar\Baz\Dib\Zim\Gir', '/vendor/foo.bar.baz.dib.zim.gir/src');
+        Autoload::addNamespace('', '/vendor/src');
     }
 
+    public function testExistingFile()
+    {
+        $actual = Autoload::load('Foo\Bar\ClassName');
+        $expect = '/vendor/foo.bar/src/ClassName.php';
+        $this->assertSame($expect, $actual);
+
+        $actual = Autoload::load('Foo\Bar\ClassNameTest');
+        $expect = '/vendor/foo.bar/tests/ClassNameTest.php';
+        $this->assertSame($expect, $actual);
+    }
+
+    public function testMissingFile()
+    {
+        $actual = Autoload::load('No_Vendor\No_Package\NoClass');
+        $this->assertFalse($actual);
+    }
+
+    public function testDeepFile()
+    {
+        $actual = Autoload::load('Foo\Bar\Baz\Dib\Zim\Gir\ClassName');
+        $expect = '/vendor/foo.bar.baz.dib.zim.gir/src/ClassName.php';
+        $this->assertSame($expect, $actual);
+    }
+
+    public function testConfusion()
+    {
+        $actual = Autoload::load('Foo\Bar\DoomClassName');
+        $expect = '/vendor/foo.bar/src/DoomClassName.php';
+        $this->assertSame($expect, $actual);
+
+        $actual = Autoload::load('Foo\BarDoom\ClassName');
+        $expect = '/vendor/foo.bardoom/src/ClassName.php';
+        $this->assertSame($expect, $actual);
+    }
+
+    public function testEmptyPrefix()
+    {
+        $actual = Autoload::load('ClassName');
+        $expect = '/vendor/src/ClassName.php';
+        $this->assertSame($expect, $actual);
+
+        $actual = Autoload::load('Foo\Bar\AnotherClassName');
+        $expect = '/vendor/src/Foo/Bar/AnotherClassName.php';
+        $this->assertSame($expect, $actual);
+
+        $actual = Autoload::load('Bar\Baz\ClassName');
+        $expect = '/vendor/src/Bar/Baz/ClassName.php';
+        $this->assertSame($expect, $actual);
+    }
 }

--- a/tests/unit/Codeception/Util/MockAutoload.php
+++ b/tests/unit/Codeception/Util/MockAutoload.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Codeception\Util;
+
+class MockAutoload extends Autoload
+{
+    protected static $files = [];
+
+    public static function setFiles(array $files)
+    {
+        self::$files = $files;
+    }
+
+    protected static function requireFile($file)
+    {
+        return in_array($file, self::$files);
+    }
+}


### PR DESCRIPTION
Hi!

I've recently found that Codeception doesn't support neither PSR-0 nor PSR-4 autoloading for its Helpers, StepObjects etc. So I took example autoloader with tests from [here](https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-4-autoloader-examples.md).

Then I added support for empty namespace prefix, so one can use `Autoload::addNamespace('', 'path')` to load `Foo\Bar\ClassName` from `path/Foo/Bar/ClassName.php`.

Finally, this autoloader is backward compatible with an old autoloader, so all existing code should work as before.

**Old default autoloading:** all classes with `Helper` suffix from `helpers` dir. Namespace doesn't matter, because Autoloader doesn't look in subdirectories.

**New default autoloading:** according to PSR-4, all Helpers in global namespace and those in `Codeception\Module` will be autoloaded. Basically, it's done in runtime like this:
```php
// paths.helpers from codeception.yml
Autoload::addNamespace('', 'path/to/helpers');
Autoload::addNamespace('Codeception\Module', 'path/to/helpers');

// or if 'namespace' is set to 'frontend', for example:
Autoload::addNamespace('frontend', 'path/to/helpers');
Autoload::addNamespace('frontend\Codeception\Module', 'path/to/helpers');
```

The only issue users might face with strict PSR-4 autoloader is that classes in custom namespaces wouldn't be autoloaded, i.e.:
```php
Autoload::registerSuffix('Helper', 'path'); // in existing code
// is now equal to this
Autoload::addNamespace('', 'path');
// so if Foo\Bar\UserHelper is located in 'path/UserHelper.php',
// it will NOT be autoloadable via PSR-4 rules
$a = new \Foo\Bar\UserHelper; // Autoloader will look for it in 'path/Foo/Bar/UserHelper.php'
```

That's why in case of missing file for `Foo\Bar\UserHelper` using strict rules of PSR-4, this autoloader also tries to load it from `path/UserHelper.php`, just like an old autoloader did. Again, this behavior will not introduce any conflicts in existing code.

p.s. Maybe, this hack can be removed in Codeception :three: