### PR TITLE
Fix rest module to reset request variables in the before hook

### DIFF
--- a/src/Codeception/Module/REST.php
+++ b/src/Codeception/Module/REST.php
@@ -68,12 +68,9 @@ class REST extends \Codeception\Module
 
     public function _before(\Codeception\TestCase $test)
     {
-        $this->headers = array();
-        $this->params = array();
-        $this->response = "";
-
         $this->prepareConnection();
         $this->client = &$this->connectionModule->client;
+        $this->resetVariables();
 
         if ($this->config['xdebug_remote']
             && function_exists('xdebug_is_enabled')
@@ -82,6 +79,16 @@ class REST extends \Codeception\Module
         ) {
             $cookie = new Cookie('XDEBUG_SESSION', $this->config['xdebug_remote'], null, '/');
             $this->client->getCookieJar()->set($cookie);
+        }
+    }
+
+    protected function resetVariables()
+    {
+        $this->headers = array();
+        $this->params = array();
+        $this->response = "";
+        if ($this->client) {
+            $this->client->setServerParameters(array());
         }
     }
 

--- a/tests/unit/Codeception/Module/RestTest.php
+++ b/tests/unit/Codeception/Module/RestTest.php
@@ -9,12 +9,18 @@ class RestTest extends \PHPUnit_Framework_TestCase
      */
     protected $module;
 
-    public function setUp() {
+    public function setUp()
+    {
 
         $connector = new \Codeception\Lib\Connector\Universal();
         $connector->setIndex(\Codeception\Configuration::dataDir().'/rest/index.php');
 
-        $this->module = Stub::make('\Codeception\Module\REST', ['getModules' => [new \Codeception\Module\PhpBrowser()]]);
+        $this->module = Stub::make(
+            '\Codeception\Module\REST',
+            [
+                'getModules' => [new \Codeception\Module\PhpBrowser()]
+            ]
+        );
         $this->module->_initialize();
         $this->module->_before(Stub::makeEmpty('\Codeception\TestCase\Cest'));
         $this->module->client = $connector;
@@ -26,7 +32,21 @@ class RestTest extends \PHPUnit_Framework_TestCase
         ));
     }
 
-    public function testGet() {
+    public function testBeforeHookResetsVariables()
+    {
+        $this->module->haveHttpHeader('Origin','http://www.example.com');
+        $this->module->sendGET('/rest/user/');
+        $this->assertEquals(
+            'http://www.example.com',
+            $this->module->client->getServerParameter('HTTP_ORIGIN')
+        );
+
+        $this->module->_before(Stub::makeEmpty('\Codeception\TestCase\Cest'));
+        $this->assertNull($this->module->client->getServerParameter('HTTP_ORIGIN', null));
+    }
+
+    public function testGet()
+    {
         $this->module->sendGET('/rest/user/');
         $this->module->seeResponseIsJson();
         $this->module->seeResponseContains('davert');
@@ -35,20 +55,23 @@ class RestTest extends \PHPUnit_Framework_TestCase
         $this->module->dontSeeResponseCodeIs(404);
     }
 
-    public function testPost() {
+    public function testPost()
+    {
         $this->module->sendPOST('/rest/user/', array('name' => 'john'));
         $this->module->seeResponseContains('john');
         $this->module->seeResponseContainsJson(array('name' => 'john'));
     }
 
-    public function testPut() {
+    public function testPut()
+    {
         $this->module->sendPUT('/rest/user/', array('name' => 'laura'));
         $this->module->seeResponseContains('davert@mail.ua');
         $this->module->seeResponseContainsJson(array('name' => 'laura'));
         $this->module->dontSeeResponseContainsJson(array('name' => 'john'));
     }
 
-    public function testGrabDataFromJsonResponse() {
+    public function testGrabDataFromJsonResponse()
+    {
         $this->module->sendGET('/rest/user/');
         // simple assoc array
         $this->assertEquals('davert@mail.ua', $this->module->grabDataFromJsonResponse('email'));
@@ -178,7 +201,7 @@ class RestTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(array('no-cache', 'no-store'), $this->module->grabHttpHeader('Cache-Control', false));
 
     }
-    
+
     public function testSeeHeadersOnce()
     {
         $this->shouldFail();


### PR DESCRIPTION
The rest module is not resetting the headers on each test, thus carrying the same headers all over the test suite. This PR fixes that, resetting the server parameters of the client on each test.
