### PR TITLE
Fix Documentation mentioning faulty Namespace for SOAP Webservices

### DIFF
--- a/docs/10-WebServices.md
+++ b/docs/10-WebServices.md
@@ -139,7 +139,7 @@ In the next example we will use `XmlBuilder` (created from SoapUtils factory) in
 
 ```php
 <?php
-use \Codeception\Utils\Soap;
+use \Codeception\Util\Soap;
 
 $I = new ApiTester($scenario);
 $I->wantTo('create user');


### PR DESCRIPTION
This PR is for branch `2.0` @DavertMik see codeception/codeception#1241

It looks like i misunderstood «Bugfixes should be sent to to current stable branch, which is the same as major version number.» in [readme.md](/Codeception/Codeception/blob/2.0/readme.md) as beeing asked to commit to `1.8` which is marked as **stable**.
