### PR TITLE
#948 - 2.0 code coverage HTML - uncovered files missing

### DIFF
--- a/src/Codeception/Coverage/Subscriber/Printer.php
+++ b/src/Codeception/Coverage/Subscriber/Printer.php
@@ -5,6 +5,7 @@ use Codeception\Events;
 use Codeception\Configuration;
 use Codeception\Event\PrintResultEvent;
 use Codeception\Subscriber\Shared\StaticEvents;
+use Codeception\Coverage\Filter;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
 class Printer implements EventSubscriberInterface {
@@ -31,6 +32,12 @@ class Printer implements EventSubscriberInterface {
         $this->logDir = Configuration::outputDir();
         $this->settings = array_merge($this->settings, Configuration::config()['coverage']);
         self::$coverage = new \PHP_CodeCoverage();
+
+        // Apply filter
+        $filter = new Filter(self::$coverage);
+        $filter
+            ->whiteList(Configuration::config())
+            ->blackList(Configuration::config());
     }
 
     protected function absolutePath($path)


### PR DESCRIPTION
This commit fixes issue #948. The filter settings are now handled for the \PHP_CodeCoverage instance of the printer subscriber.
