### PR TITLE
fixed #1283

### DIFF
--- a/src/Codeception/Lib/Connector/ZF2.php
+++ b/src/Codeception/Lib/Connector/ZF2.php
@@ -44,6 +44,8 @@ class ZF2 extends Client
         $queryString = $uri->getQuery();
         $method      = strtoupper($request->getMethod());
 
+        $zendRequest->setCookies(new Parameters($request->getCookies()));
+
         if ($queryString) {
             parse_str($queryString, $query);
             $zendRequest->setQuery(new Parameters($query));


### PR DESCRIPTION
Problem: ZF2 application doesn't get cookies from Codeception request.
Solution: set Codeception cookies to Zend Request object
