### PR TITLE
Disabled skipped/incomplete tests logging in jUnit logger.

### DIFF
--- a/src/Codeception/PHPUnit/Runner.php
+++ b/src/Codeception/PHPUnit/Runner.php
@@ -127,7 +127,7 @@ class Runner extends \PHPUnit_TextUI_TestRunner
         }
         if ($arguments['xml']) {
             codecept_debug('Printing JUNIT report into '.$arguments['xml']);
-            self::$persistentListeners[] = new JUnit($this->absolutePath($arguments['xml']), true);
+            self::$persistentListeners[] = new JUnit($this->absolutePath($arguments['xml']), false);
         }
         if ($arguments['tap']) {
             codecept_debug('Printing TAP report into '.$arguments['tap']);


### PR DESCRIPTION
If you enable logging skipped/incomplete tests in jUnit logger (second parameter) than PHPUnit writes those tests as errors in report file, which causes Bamboo builds to fail, because it thinks that skipped tests are errors.
