### PR TITLE
Missing .php extension in 02-GettingStarted.md

### DIFF
--- a/docs/02-GettingStarted.md
+++ b/docs/02-GettingStarted.md
@@ -159,7 +159,7 @@ $ php codecept.phar run tests/acceptance/SigninCept.php
 You can execute one test from a test class (for Cest or Test formats)
 
 ```bash
-$ php codecept.phar run tests/acceptance/SignInCest:anonymousLogin
+$ php codecept.phar run tests/acceptance/SignInCest.php:anonymousLogin
 ```
 
 You can provide a directory path as well:


### PR DESCRIPTION
Added ".php" after the filename, otherwise codeception will not find the correct test file.
