### PR TITLE
When calling WebDriver::attachFile(), if the specified file does not

### DIFF
--- a/src/Codeception/Module/WebDriver.php
+++ b/src/Codeception/Module/WebDriver.php
@@ -770,6 +770,9 @@ class WebDriver extends \Codeception\Module implements WebInterface, RemoteInter
         $el = $this->findField($field);
         // in order to be compatible on different OS
         $filePath = realpath(\Codeception\Configuration::dataDir().$filename);
+        if (!is_readable($filePath)) {
+        	throw new \InvalidArgumentException("file not found or not readable: $filePath");
+        }
         // in order for remote upload to be enabled
         $el->setFileDetector(new \LocalFileDetector);
         $el->sendKeys($filePath);


### PR DESCRIPTION
exist, RemoteWebElement::sendKeys() winds up being called anyway and
then WebDriverKeys::encode attempts to do a "foreach" over a null.  

This fails with " [ErrorException] Invalid argument supplied for
foreach()". This errors is confusing to the folks we are trying to train
to do test automation.  

Modfied WebDriver::attachFile() to verify that the file exists and is
readable.  If not, an exception is thrown.
