### PR TITLE
Reset status code in ZF2 connector

### DIFF
--- a/src/Codeception/Lib/Connector/ZF2.php
+++ b/src/Codeception/Lib/Connector/ZF2.php
@@ -40,6 +40,8 @@ class ZF2 extends Client
         $zendRequest  = $this->application->getRequest();
         $zendResponse = $this->application->getResponse();
 
+        $zendResponse->setStatusCode(200);
+
         $uri         = new HttpUri($request->getUri());
         $queryString = $uri->getQuery();
         $method      = strtoupper($request->getMethod());


### PR DESCRIPTION
If statuscode is not reset, it will get the statuscode of previous request. This will result in redirect loops.
