### PR TITLE
Fixed syntax error in Silex module sendAjaxRequest() example

### DIFF
--- a/src/Codeception/Lib/InnerBrowser.php
+++ b/src/Codeception/Lib/InnerBrowser.php
@@ -569,7 +569,7 @@ class InnerBrowser extends Module implements Web
      *
      * ``` php
      * <?php
-     * $I->sendAjaxRequest('PUT', /posts/7', array('title' => 'new title');
+     * $I->sendAjaxRequest('PUT', /posts/7', array('title' => 'new title'));
      *
      * ```
      *


### PR DESCRIPTION
In the source code this time versus the generated Markdown...
