### PR TITLE
Fix for InnerBrowser::submitForm with document-relative paths

### DIFF
--- a/src/Codeception/Lib/InnerBrowser.php
+++ b/src/Codeception/Lib/InnerBrowser.php
@@ -289,53 +289,14 @@ class InnerBrowser extends Module implements Web
 
     public function submitForm($selector, $params)
     {
-        $form = $this->match($selector)->first();
+        $form = $this->getFormFor($this->match($selector)->first());
+        $form->setValues($params);
+        
+        $this->debugSection('Uri', $form->getUri());
+        $this->debugSection($form->getMethod(), $form->getValues());
 
-        if (!count($form)) {
-            throw new ElementNotFound($selector, 'Form');
-        }
-
-        $url    = '';
-        /** @var  \Symfony\Component\DomCrawler\Crawler|\DOMElement[] $fields */
-        $fields = $form->filter('input');
-        foreach ($fields as $field) {
-            if ($field->getAttribute('type') == 'checkbox') {
-                continue;
-            }
-            if ($field->getAttribute('type') == 'radio') {
-                continue;
-            }
-            $url .= sprintf('%s=%s', $field->getAttribute('name'), $field->getAttribute('value')) . '&';
-        }
-
-        /** @var  \Symfony\Component\DomCrawler\Crawler|\DOMElement[] $fields */
-        $fields = $form->filter('textarea');
-        foreach ($fields as $field) {
-            $url .= sprintf('%s=%s', $field->getAttribute('name'), $field->nodeValue) . '&';
-        }
-        /** @var  \Symfony\Component\DomCrawler\Crawler|\DOMElement[] $fields */
-        $fields = $form->filter('select');
-        foreach ($fields as $field) {
-            /** @var  \DOMElement $option */
-            foreach ($field->childNodes as $option) {
-                if ($option->getAttribute('selected') == 'selected') {
-                    $url .= sprintf('%s=%s', $field->getAttribute('name'), $option->getAttribute('value')) . '&';
-                }
-            }
-        }
-
-        $url .= http_build_query($params);
-        parse_str($url, $params);
-        $method = $form->attr('method') ? $form->attr('method') : 'GET';
-        $query  = '';
-        if (strtoupper($method) == 'GET') {
-            $query = '?' . http_build_query($params);
-        }
-        $this->debugSection('Uri', $this->getFormUrl($form));
-        $this->debugSection('Method', $method);
-        $this->debugSection('Parameters', $params);
-
-        $this->crawler = $this->client->request($method, $this->getFormUrl($form) . $query, $params);
+        $this->crawler = $this->client->request($form->getMethod(), $form->getUri(), $form->getPhpValues(), $form->getPhpFiles());
+        $this->forms = [];
         $this->debugResponse();
     }
 

--- a/tests/data/app/view/form/example12.php
+++ b/tests/data/app/view/form/example12.php
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <title>Test submitting a form with a document-relative path for action</title>
+</head>
+<body>
+    <form method="POST" action="example12">
+        <input type="text" name="test" value="" />
+        <input type="submit" name="submit" value="Submit" />
+    </form>
+</body>
+</html>

--- a/tests/unit/Codeception/Module/TestsForWeb.php
+++ b/tests/unit/Codeception/Module/TestsForWeb.php
@@ -687,6 +687,18 @@ abstract class TestsForWeb extends \PHPUnit_Framework_TestCase
     }
 
     /**
+     * https://github.com/Codeception/Codeception/issues/1274
+     */
+    public function testSubmitFormWithDocRelativePathForAction()
+    {
+        $this->module->amOnPage('/form/example12');
+        $this->module->submitForm('form', array(
+            'test' => 'value'
+        ));
+        $this->module->seeCurrentUrlEquals('/form/example12');
+    }
+
+    /**
      * @issue #1180
      */
     public function testClickLinkWithInnerSpan()


### PR DESCRIPTION
Unit test and fix for forms with document-relative paths for action -
issue #1274

This fix relies on the fix for issue #1381 to pass all tests (that issue
causes another test to fail with a fatal error)
