### PR TITLE
Ignore errors from lastInsertId()

### DIFF
--- a/src/Codeception/Module/Db.php
+++ b/src/Codeception/Module/Db.php
@@ -230,8 +230,14 @@ class Db extends \Codeception\Module implements \Codeception\Lib\Interfaces\Db
             $this->fail(sprintf("Record with %s couldn't be inserted into %s", json_encode($data), $table));
         }
 
-        $lastInsertId = (int) $this->driver->lastInsertId($table);
-        $this->insertedIds[] = array('table' => $table, 'id' => $lastInsertId);
+        try {
+            $lastInsertId = (int) $this->driver->lastInsertId($table);
+            $this->insertedIds[] = array('table' => $table, 'id' => $lastInsertId);
+        } catch (\Exception $e) {
+            // ignore errors due to uncommon DB structure,
+            // such as tables without _id_seq in PGSQL
+            $lastInsertId = 0;
+        }
 
         return $lastInsertId;
     }


### PR DESCRIPTION
lastInsertId() fails if the DB structure does not match Db module's assumption, for example, a table without tablename_id_seq sequence in PostgreSQL.

I agree with the opinion in #989, Db module is to be simple.
However, it is better to avoid causing error even if the database structure is unexpected.
So I suggest to ignore the exception for uncommon conditions.

This provides the same behavior as other RDBMS like MySQL for PostgreSQL.
I think this is good meeting ground between simplicity and stability.
