### PR TITLE
Client connector trait to convert request params and files into PHP form

### DIFF
--- a/src/Codeception/Lib/Connector/Kohana.php
+++ b/src/Codeception/Lib/Connector/Kohana.php
@@ -7,6 +7,8 @@ use Symfony\Component\BrowserKit\Response;
 
 class Kohana extends \Symfony\Component\BrowserKit\Client
 {
+    use PhpSuperGlobalsConverter;
+
     public function setIndex($index)
     {
         $this->index = $index;
@@ -16,7 +18,7 @@ class Kohana extends \Symfony\Component\BrowserKit\Client
     {
         $_COOKIE = $request->getCookies();
         $_SERVER = $request->getServer();
-        $_FILES  = $request->getFiles();
+        $_FILES  = $this->remapFiles($request->getFiles());
 
         $uri = str_replace('http://localhost', '', $request->getUri());
 
@@ -30,10 +32,10 @@ class Kohana extends \Symfony\Component\BrowserKit\Client
         $kohanaRequest->method($_SERVER['REQUEST_METHOD']);
 
         if (strtoupper($request->getMethod()) == 'GET') {
-            $kohanaRequest->query($request->getParameters());
+            $kohanaRequest->query($this->remapRequestParameters($request->getParameters()));
         }
         if (strtoupper($request->getMethod()) == 'POST') {
-            $kohanaRequest->post($request->getParameters());
+            $kohanaRequest->post($this->remapRequestParameters($request->getParameters()));
         }
 
         $kohanaRequest->cookie($_COOKIE);

--- a/src/Codeception/Lib/Connector/Phalcon1.php
+++ b/src/Codeception/Lib/Connector/Phalcon1.php
@@ -11,6 +11,8 @@ use Symfony\Component\BrowserKit\Request,
 
 class Phalcon1 extends Client
 {
+    use PhpSuperGlobalsConverter;
+
     private $application;
 
     /**
@@ -59,14 +61,14 @@ class Phalcon1 extends Client
         }
 
         $_COOKIE                   = $request->getCookies();
-        $_FILES                    = $request->getFiles();
+        $_FILES                    = $this->remapFiles($request->getFiles());
         $_SERVER['REQUEST_METHOD'] = strtoupper($request->getMethod());
+        $_REQUEST = $this->remapRequestParameters($request->getParameters());
         if (strtoupper($request->getMethod()) == 'GET') {
-            $_GET = $request->getParameters();
+            $_GET = $_REQUEST;
         } else {
-            $_POST = $request->getParameters();
+            $_POST = $_REQUEST;
         }
-        $_REQUEST                = $request->getParameters();
         $uri                     = str_replace('http://localhost', '', $request->getUri());
         $_SERVER['REQUEST_URI']  = $uri;
         $_GET['_url']            = strtok($uri, '?');

--- a/src/Codeception/Lib/Connector/PhpSuperGlobalsConverter.php
+++ b/src/Codeception/Lib/Connector/PhpSuperGlobalsConverter.php
@@ -1,0 +1,116 @@
+<?php
+
+namespace Codeception\Lib\Connector;
+
+/**
+ * Converts BrowserKit\Request's request parameters and files into PHP-compatible structure
+ *
+ * @see https://bugs.php.net/bug.php?id=25589
+ * @see https://bugs.php.net/bug.php?id=25589
+ *
+ * @package Codeception\Lib\Connector
+ */
+trait PhpSuperGlobalsConverter {
+
+    /**
+     * Rearrange files array to be compatible with PHP $_FILES superglobal structure
+     * @see https://bugs.php.net/bug.php?id=25589
+     *
+     * @param array $requestFiles
+     *
+     * @return array
+     */
+    protected function remapFiles(array $requestFiles)
+    {
+        $files = $this->rearrangeFiles($requestFiles);
+
+        return $this->replaceSpaces($files);
+    }
+
+    /**
+     * Escape high-level variable name with dots, underscores and other "special" chars
+     * to be compatible with PHP "bug"
+     * @see https://bugs.php.net/bug.php?id=40000
+     *
+     * @param array $parameters
+     *
+     * @return array
+     */
+    protected function remapRequestParameters(array $parameters)
+    {
+        return $this->replaceSpaces($parameters);
+    }
+
+    private function rearrangeFiles($requestFiles)
+    {
+        $files = [];
+        foreach ($requestFiles as $name => $info) {
+            if (!is_array($info)) {
+                continue;
+            }
+
+            /**
+             * If we have a form with fields like
+             * ```
+             * <input type="file" name="foo" />
+             * <input type="file" name="foo[bar]" />
+             * ```
+             * then only array variable will be used while simple variable will be ignored in php $_FILES
+             * (eg $_FILES = [
+             *                 foo => [
+             *                     tmp_name => [
+             *                         'bar' => 'asdf'
+             *                     ],
+             *                     //...
+             *                ]
+             *              ]
+             * )
+             * (notice there is no entry for file "foo", only for file "foo[bar]"
+             * this will check if current element contains inner arrays within it's keys
+             * so we can ignore element itself and only process inner files
+             */
+            $hasInnerArrays = count(array_filter($info, 'is_array'));
+
+            if ($hasInnerArrays || !isset($info['tmp_name'])) {
+                $inner = mapFiles($info);
+                foreach ($inner as $innerName => $innerInfo) {
+                    /**
+                     * Convert from ['a' => ['tmp_name' => '/tmp/test.txt'] ]
+                     * to ['tmp_name' => ['a' => '/tmp/test.txt'] ]
+                     */
+                    $innerInfo = array_map(function($v) use($innerName) {
+                        return [$innerName => $v];
+                    }, $innerInfo);
+
+                    if (empty($files[$name])) {
+                        $files[$name] = [];
+                    }
+
+                    $files[$name] = array_replace_recursive($files[$name], $innerInfo);
+                }
+            } else {
+                $files[$name] = $info;
+            }
+        }
+
+        return $files;
+    }
+
+    /**
+     * Replace spaces and dots and other chars in high-level query parameters for
+     * compatibility with PHP bug (or not a bug)
+     * @see https://bugs.php.net/bug.php?id=40000
+     *
+     * @param array $parameters Array of request parameters to be converted
+     *
+     * @return array
+     */
+    private function replaceSpaces($parameters)
+    {
+        $qs = http_build_query($parameters, '', '&');
+        parse_str($qs, $output);
+
+        return $output;
+    }
+
+}

--- a/src/Codeception/Lib/Connector/SocialEngine.php
+++ b/src/Codeception/Lib/Connector/SocialEngine.php
@@ -6,6 +6,7 @@ use Symfony\Component\BrowserKit\Response;
 
 class SocialEngine extends \Symfony\Component\BrowserKit\Client
 {
+    use PhpSuperGlobalsConverter;
 
     /**
      * @var \Zend_Controller_Front
@@ -56,16 +57,16 @@ class SocialEngine extends \Symfony\Component\BrowserKit\Client
         $zendRequest->setCookies($request->getCookies());
         //$zendRequest->setParams($request->getParameters());
         if (strtoupper($request->getMethod()) == 'GET') {
-            $_GET = $request->getParameters();
+            $_GET = $this->remapRequestParameters($request->getParameters());
         }
         if (strtoupper($request->getMethod()) == 'POST') {
-            $_POST = $request->getParameters();
+            $_POST = $this->remapRequestParameters($request->getParameters());
         }
 
         $zendRequest->setRequestUri(str_replace('http://localhost', '', $request->getUri()));
         $zendRequest->setHeaders($request->getServer());
 
-        $_FILES = $request->getFiles();
+        $_FILES = $this->remapFiles($request->getFiles());
 
         // это нужно для нормальной работы SE
         $_SERVER['HTTP_HOST'] = str_replace('http://', '', $this->host);

--- a/src/Codeception/Lib/Connector/Universal.php
+++ b/src/Codeception/Lib/Connector/Universal.php
@@ -6,6 +6,8 @@ use Symfony\Component\BrowserKit\Response;
 
 class Universal extends Client
 {
+    use PhpSuperGlobalsConverter;
+
     protected $mockedResponse;
 
     public function setIndex($index)
@@ -28,16 +30,16 @@ class Universal extends Client
 
         $_COOKIE = $request->getCookies();
         $_SERVER = $request->getServer();
-        $_FILES  = $request->getFiles();
+        $_FILES  = $this->remapFiles($request->getFiles());
 
         $uri = str_replace('http://localhost', '', $request->getUri());
 
+        $_REQUEST = $this->remapRequestParameters($request->getParameters());
         if (strtoupper($request->getMethod()) == 'GET') {
-            $_GET = $request->getParameters();
+            $_GET = $_REQUEST;
         } else {
-            $_POST = $request->getParameters();
+            $_POST = $_REQUEST;
         }
-        $_REQUEST = $request->getParameters();
 
         $_SERVER['REQUEST_METHOD'] = strtoupper($request->getMethod());
         $_SERVER['REQUEST_URI']    = $uri;

--- a/src/Codeception/Lib/Connector/Yii1.php
+++ b/src/Codeception/Lib/Connector/Yii1.php
@@ -14,6 +14,7 @@ use Yii;
  */
 class Yii1 extends Client
 {
+    use PhpSuperGlobalsConverter
     /**
      * http://localhost/path/to/your/app/index.php
      * @var string url of the entry Yii script
@@ -49,13 +50,13 @@ class Yii1 extends Client
         $this->_headers = array();
         $_COOKIE        = array_merge($_COOKIE, $request->getCookies());
         $_SERVER        = array_merge($_SERVER, $request->getServer());
-        $_FILES         = $request->getFiles();
-        $_REQUEST       = $request->getParameters();
+        $_FILES         = $this->remapFiles($request->getFiles());
+        $_REQUEST       = $this->remapRequestParameters($request->getParameters());
 
         if (strtoupper($request->getMethod()) == 'GET')
-            $_GET = $request->getParameters();
+            $_GET = $_REQUEST;
         else {
-            $_POST = $request->getParameters();
+            $_POST = $_REQUEST;
         }
 
         // Parse url parts

--- a/src/Codeception/Lib/Connector/Yii2.php
+++ b/src/Codeception/Lib/Connector/Yii2.php
@@ -11,6 +11,8 @@ use Codeception\Util\Debug;
 
 class Yii2 extends Client
 {
+    use PhpSuperGlobalsConverter;
+
     /**
      * @var string application config file
      */
@@ -42,14 +44,14 @@ class Yii2 extends Client
     {
         $_COOKIE  = $request->getCookies();
         $_SERVER  = $request->getServer();
-        $_FILES   = $request->getFiles();
-        $_REQUEST = $request->getParameters();
+        $_FILES   = $this->remapFiles($request->getFiles());
+        $_REQUEST = $this->remapRequestParameters($request->getParameters());
         $_POST    = $_GET = array();
 
         if (strtoupper($request->getMethod()) == 'GET') {
-            $_GET = $request->getParameters();
+            $_GET = $_REQUEST;
         } else {
-            $_POST = $request->getParameters();
+            $_POST = $_REQUEST;
         }
 
         $uri = $request->getUri();

--- a/src/Codeception/Lib/Connector/ZF1.php
+++ b/src/Codeception/Lib/Connector/ZF1.php
@@ -7,6 +7,8 @@ use Symfony\Component\BrowserKit\Response;
 
 class ZF1 extends Client
 {
+    use PhpSuperGlobalsConverter;
+
     /**
      * @var \Zend_Controller_Front
      */
@@ -55,7 +57,7 @@ class ZF1 extends Client
         $zendRequest->setPost($request->getParameters());
         $zendRequest->setRequestUri(str_replace('http://localhost','',$request->getUri()));
         $zendRequest->setHeaders($request->getServer());
-        $_FILES  = $request->getFiles();
+        $_FILES  = $this->remapFiles($request->getFiles());
         $_SERVER = array_merge($_SERVER, $request->getServer());
 
         $zendResponse = new \Zend_Controller_Response_HttpTestCase;


### PR DESCRIPTION
PHP has very strange format for $_FILES superglobal array if form field name contains square brackets. This code convert BrowserKit\Client files format into PHP-compatible one.
PHP request parameters and files high-level names can not contain dots or spaces and PHP converts all of them into underscores. So we have to convert all that as well.

see https://github.com/symfony/symfony/issues/6908 
https://github.com/symfony/symfony/pull/10444 
https://github.com/symfony/symfony/pull/10193 
https://bugs.php.net/bug.php?id=25589 
https://bugs.php.net/bug.php?id=25589
