### PR TITLE
Fixes syntax error in Yii1 connector

### DIFF
--- a/src/Codeception/Lib/Connector/Yii1.php
+++ b/src/Codeception/Lib/Connector/Yii1.php
@@ -7,7 +7,8 @@ use Yii;
 
 class Yii1 extends Client
 {
-    use Shared\PhpSuperGlobalsConverter
+    use Shared\PhpSuperGlobalsConverter;
+    
     /**
      * http://localhost/path/to/your/app/index.php
      * @var string url of the entry Yii script


### PR DESCRIPTION
8ffb171800735049b136934d11f15e8e2ff9b513 introduced a syntax error in the Yii1 connector that prevents tests from running. https://github.com/Codeception/Codeception/blob/8ffb171800735049b136934d11f15e8e2ff9b513/src/Codeception/Lib/Connector/Yii1.php#L10

```
$ php -l vendor/codeception/codeception/src/Codeception
/Lib/Connector/Yii1.php
PHP Parse error:  syntax error, unexpected 'public' (T_PUBLIC), expecting ',' or ';' or '{' in vendor/codeception/codeception/src/Codeception/Lib/Connector/Yii1.php on line 15

Parse error: syntax error, unexpected 'public' (T_PUBLIC), expecting ',' or ';' or '{' in vendor/codeception/codeception/src/Codeception/Lib/Connector/Yii1.php on line 15
```

Looks like a missing `;`. Adding the `;` on line 10 fixes the issue.
