### PR TITLE
Make the postgresql loader load $$ syntax correctly

### DIFF
--- a/src/Codeception/Lib/Driver/PostgreSql.php
+++ b/src/Codeception/Lib/Driver/PostgreSql.php
@@ -26,7 +26,7 @@ class PostgreSql extends Db
                 continue;
             }
 
-            if (strpos($sqlLine, '$$') !== false) {
+            if (strpos(trim($sqlLine), '$$') === 0) {
                 $dollarsOpen = !$dollarsOpen;
             }
 

--- a/tests/data/dumps/postgres.sql
+++ b/tests/data/dumps/postgres.sql
@@ -280,7 +280,10 @@ ALTER TABLE ONLY permissions
     ADD CONSTRAINT pg1 FOREIGN KEY (group_id) REFERENCES groups(id);
 
 
--- test for triggers with $$ syntax
+--
+-- start test for triggers with $$ syntax
+--
+INSERT INTO users (name, email) VALUES ('This $$ should work', 'user@example.org');
 CREATE OR REPLACE FUNCTION upd_timestamp() RETURNS TRIGGER
 LANGUAGE plpgsql
 AS
@@ -289,7 +292,12 @@ BEGIN
     NEW.created_at = CURRENT_TIMESTAMP;
     RETURN NEW;
 END;
-$$;
+  $$;
+
+INSERT INTO users (name, email) VALUES ('This should work as well', 'user2@example.org');
+--
+-- end test for triggers with $$ syntax
+--
 
 --
 -- PostgreSQL database dump complete

--- a/tests/unit/Codeception/Lib/Driver/PostgresTest.php
+++ b/tests/unit/Codeception/Lib/Driver/PostgresTest.php
@@ -59,6 +59,10 @@ class postgresTest extends \PHPUnit_Framework_TestCase
         $res = $this->postgres->getDbh()->query("select * from groups where name = 'coders'");
         $this->assertNotEquals(false, $res);
         $this->assertGreaterThan(0, $res->rowCount());
+
+        $res = $this->postgres->getDbh()->query("select * from users where email = 'user2@example.org'");
+        $this->assertNotEquals(false, $res);
+        $this->assertGreaterThan(0, $res->rowCount());
     }
 
     public function testSelectWithEmptyCriteria() {


### PR DESCRIPTION
I found it to be impossible to import postgresql triggers made with the $$ syntax, so I fixed it.
To fix it I had to copy paste the entire loader code from the abstract Db driver and added some extra parsing logic. Perhaps there is a better way to fix it, and I'm open for input on that.

This is the SQL code that didn't work:

``` sql
-- test for triggers with $$ syntax
CREATE OR REPLACE FUNCTION upd_timestamp() RETURNS TRIGGER
LANGUAGE plpgsql
AS
$$
BEGIN
    NEW.created_at = CURRENT_TIMESTAMP;
    RETURN NEW;
END;
$$;
```

Without the fix I got this error in the testsuite

```
There was 1 error:

---------
1) postgresTest::testLoadDump
PDOException: SQLSTATE[42601]: Syntax error: 7 ERROR:  unterminated dollar-quoted string at or near "$$
BEGIN
    NEW.created_at = CURRENT_TIMESTAMP"
LINE 5: $$
        ^
```

With the fix the SQL code gets imported without any problems.

Please let me know what you think!
