### PR TITLE
Add module IM, testing messaging services (hipchat included)

### DIFF
--- a/src/Codeception/Lib/Driver/HipChat.php
+++ b/src/Codeception/Lib/Driver/HipChat.php
@@ -1,0 +1,140 @@
+<?php
+namespace Codeception\Lib\Driver;
+
+use Codeception\Lib\Interfaces\IM;
+
+class HipChat implements IM
+{
+
+    protected $client;
+    protected $roomID;
+
+    /**
+     * @var array Default Supported Colors
+     */
+    protected $colors = array(
+        'yellow' => \GorkaLaucirica\HipchatAPIv2Client\Model\Message::COLOR_YELLOW,
+        'red'    => \GorkaLaucirica\HipchatAPIv2Client\Model\Message::COLOR_RED,
+        'gray'   => \GorkaLaucirica\HipchatAPIv2Client\Model\Message::COLOR_GRAY,
+        'green'  => \GorkaLaucirica\HipchatAPIv2Client\Model\Message::COLOR_GREEN,
+        'purple' => \GorkaLaucirica\HipchatAPIv2Client\Model\Message::COLOR_PURPLE,
+        'random' => \GorkaLaucirica\HipchatAPIv2Client\Model\Message::COLOR_RANDOM
+    );
+
+    /**
+     * Connect to the IM service.
+     *
+     * @param array $config
+     */
+    public function setup($config)
+    {
+        $auth = new \GorkaLaucirica\HipchatAPIv2Client\Auth\OAuth2($config['token']);
+        $this->client = new \GorkaLaucirica\HipchatAPIv2Client\Client($auth);
+
+        $this->roomID = $config['room'];
+    }
+
+    /**
+     * Send message to IM service.
+     *
+     * @param $message
+     * @param array $options
+     *
+     * @return mixed
+     */
+    public function sendMessage($message, array $options = array())
+    {
+        try {
+            $envelope = new \GorkaLaucirica\HipchatAPIv2Client\Model\Message();
+            $envelope->setMessage($message);
+            $envelope->setNotify(isset($options['notify']) && $options['notify']);
+            $envelope->setColor((isset($options['color']) && isset($this->colors[$options['color']])) ? $this->colors[$options['color']] : $this->colors['yellow']);
+
+            $roomAPI = new \GorkaLaucirica\HipchatAPIv2Client\API\RoomAPI($this->client);
+            $roomAPI->sendRoomNotification($this->roomID, $envelope);
+        } catch (\Exception $ex) {
+            \PHPUnit_Framework_Assert::fail('connection failed or timed-out, please check your connection and ensure your api token has sufficient permissions.');
+        }
+    }
+
+    /**
+     * Grab the last message on the service.
+     *
+     * @return mixed
+     */
+    public function grabLastMessage()
+    {
+        try {
+            $roomAPI = new \GorkaLaucirica\HipchatAPIv2Client\API\RoomAPI($this->client);
+            $messages = $roomAPI->getRecentHistory($this->roomID, array('max-results' => 1));
+
+            if (count($messages) <= 0) {
+                \PHPUnit_Framework_Assert::fail('the selected room/channel has no messages.');
+            }
+            return $messages[0]->toJson();
+
+        } catch (\Exception $ex) {
+            \PHPUnit_Framework_Assert::fail('connection failed or timed-out, please check your connection and ensure your api token has sufficient permissions.');
+        }
+    }
+
+    /**
+     * Grab the from field for the last message.
+     *
+     * @return string
+     */
+    public function grabLastMessageFrom()
+    {
+        return $this->grabLastMessage()['from'];
+    }
+
+    /**
+     * Grab the message field for the last message.
+     *
+     * @return mixed
+     */
+    public function grabLastMessageContent()
+    {
+        return $this->grabLastMessage()['message'];
+    }
+
+    /**
+     * Grab the color field for the last message.
+     *
+     * @return mixed
+     */
+    public function grabLastMessageColor()
+    {
+        return $this->grabLastMessage()['color'];
+    }
+
+    /**
+     * Grab the date field for the last message.
+     *
+     * @return mixed
+     */
+    public function grabLastMessageDate()
+    {
+        return $this->grabLastMessage()['date'];
+    }
+
+    /**
+     * Configuration options
+     *
+     * @return array
+     */
+    public function getRequiredConfig()
+    {
+        return ['token', 'room'];
+    }
+
+    /**
+     * Default configuration options
+     *
+     * @return array
+     */
+    public function getDefaultConfig()
+    {
+        return [];
+    }
+}

--- a/src/Codeception/Lib/Interfaces/IM.php
+++ b/src/Codeception/Lib/Interfaces/IM.php
@@ -1,0 +1,74 @@
+<?php
+namespace Codeception\Lib\Interfaces;
+
+interface IM {
+
+    /**
+     * Connect to the IM service.
+     *
+     * @param array $config
+     *
+     * @return
+     */
+    public function setup($config);
+
+    /**
+     * Send message to IM service.
+     *
+     * @param $message
+     * @param array $options
+     *
+     * @return mixed
+     */
+    public function sendMessage($message, array $options = array());
+
+    /**
+     * Grab the last message on the service.
+     *
+     * @return mixed
+     */
+    public function grabLastMessage();
+
+    /**
+     * Grab the from field for the last message.
+     *
+     * @return mixed
+     */
+    public function grabLastMessageFrom();
+
+    /**
+     * Grab the message field for the last message.
+     *
+     * @return mixed
+     */
+    public function grabLastMessageContent();
+
+    /**
+     * Grab the color field for the last message.
+     *
+     * @return mixed
+     */
+    public function grabLastMessageColor();
+
+    /**
+     * Grab the date field for the last message.
+     *
+     * @return mixed
+     */
+    public function grabLastMessageDate();
+
+    /**
+     * Configuration options
+     *
+     * @return array
+     */
+    public function getRequiredConfig();
+
+    /**
+     * Default configuration options
+     *
+     * @return array
+     */
+    public function getDefaultConfig();
+
+}

--- a/src/Codeception/Module/IM.php
+++ b/src/Codeception/Module/IM.php
@@ -1,0 +1,336 @@
+<?php
+namespace Codeception\Module;
+
+use Codeception\Exception\ModuleConfig;
+use Codeception\Lib\Driver\HipChat;
+
+/**
+ *
+ * Works with IM services.
+ *
+ * Testing with a selection of remote instant messaging services, including HipChat.
+ *
+ * Supported and tested queue types are:
+ *
+ * * [HipChat](http://hipchat.com/)
+ *
+ * The following dependencies are needed for the listed IM services:
+ *
+ * * HipChat: "gorkalaucirica/hipchat-v2-api-client": "~1.0"
+ *
+ * ## Status
+ *
+ * * Maintainer: **nathanmac**
+ * * Stability:
+ *     - HipChat:    **stable**
+ * * Contact: nathan.macnamara@outlook.com
+ *
+ * ## Config
+ *
+ * The configuration settings depending on which queueing service is being used, all the options are listed
+ * here. Refer to the configuration examples below to identify the configuration options required for your chosen
+ * service.
+ *
+ * * service - the messaging service.
+ * * token - API token and/or Access Token.
+ * * room - The room/channel id for the messaging service.
+ *
+ * N.B. The API key for HipChat must be an users API token in order to provide sufficient access the last messages in
+ *      a given room, however if you are just looking to send a messages to the service a room API token will be
+ *      sufficient to send the message. Consult the HipChat API documentation for clarification on this topic.
+ *
+ * ### Example
+ * #### Example (hipchat)
+ *
+ *     modules:
+ *        enabled: [IM]
+ *        config:
+ *           IM:
+ *              service: 'hipchat'
+ *              token: API_TOKEN
+ *              room: ROOM_ID
+ *
+ */
+class IM extends \Codeception\Module
+{
+
+    /**
+     * @var \Codeception\Lib\Interfaces\IM
+     */
+    public $IMDriver;
+
+    /**
+     * Setup connection and open/setup the connection with config settings
+     *
+     * @param \Codeception\TestCase $test
+     */
+    public function _before(\Codeception\TestCase $test)
+    {
+        $this->IMDriver->setup($this->config);
+    }
+
+    /**
+     * Provide and override for the config settings and allow custom settings depending on the service being used.
+     */
+    protected function validateConfig()
+    {
+        $this->IMDriver = $this->createIMDriver();
+        $this->requiredFields = $this->IMDriver->getRequiredConfig();
+        $this->config = array_merge($this->IMDriver->getDefaultConfig(), $this->config);
+        parent::validateConfig();
+    }
+
+    /**
+     * @return \Codeception\Lib\Interfaces\IM
+     * @throws ModuleConfig
+     */
+    protected function createIMDriver()
+    {
+        switch (strtolower($this->config['service'])) {
+            case 'hipchat':
+                return new HipChat();
+            default:
+                throw new ModuleConfig(
+                    __CLASS__, "Unknown IM service {$this->config}; Supported IM services include: HipChat"
+                );
+        }
+    }
+
+    // ----------- METHODS BELOW HERE ------------------------//
+
+    /**
+     * Method for sending a messages to an messaging service.
+     *
+     * ```php
+     * <?php
+     * $I->sendInstantMessage('Testing message to be send to IM service.', array('color' => 'red', 'notify' => true);
+     * ?>
+     * ```
+     *
+     * @param string $message Message to be sent.
+     * @param array $options Depends on service, for HipChat these include the color and the notify option.
+     */
+    public function sendInstantMessage($message, $options = array())
+    {
+        $this->IMDriver->sendMessage($message, $options);
+    }
+
+    /**
+     * Grabber method to return the last messages on the service.
+     *
+     * ```php
+     * <?php
+     * $messages = $I->grabLastInstantMessage();
+     * ?>
+     * ```
+     *
+     * @return array
+     */
+    public function grabLastInstantMessage(){
+        $message = $this->IMDriver->grabLastMessage();
+        $this->debug("Message -->");
+        $this->debug($message);
+        return $message;
+    }
+
+    /**
+     * Grabber method to return the from field of the last message.
+     *
+     * ```php
+     * <?php
+     * $from = $this->grabLastInstantMessageFrom();
+     * ?>
+     * ```
+     *
+     * @return string
+     */
+    public function grabLastInstantMessageFrom()
+    {
+        $from = $this->IMDriver->grabLastMessageFrom();
+        $this->debug('From: [' . $from . ']');
+        return $from;
+    }
+
+    /**
+     * Checks whether the last messages from address matches.
+     *
+     * ```php
+     * <?php
+     * $I->seeInLastInstantMessageFrom('Codeception');
+     * ?>
+     * ```
+     *
+     * @param string $from
+     */
+    public function seeInLastInstantMessageFrom($from)
+    {
+        \PHPUnit_Framework_Assert::assertEquals($from, $this->grabLastInstantMessageFrom());
+    }
+
+    /**
+     * Checks whether the last messages from address does not match.
+     *
+     * ```php
+     * <?php
+     * $I->dontSeeInLastInstantMessageFrom('Codeception');
+     * ?>
+     * ```
+     *
+     * @param string $from
+     */
+    public function dontSeeInLastInstantMessageFrom($from)
+    {
+        \PHPUnit_Framework_Assert::assertNotEmpty($from, $this->grabLastInstantMessageFrom());
+    }
+
+    /**
+     * Grabber method to return the content/text of the last message.
+     *
+     * ```php
+     * <?php
+     * $from = $this->grabLastInstantMessageContent();
+     * ?>
+     * ```
+     *
+     * @return string
+     */
+    public function grabLastInstantMessageContent()
+    {
+        $content = $this->IMDriver->grabLastMessageContent();
+        $this->debug('Content: [' . $content . ']');
+        return $content;
+    }
+
+    /**
+     * Checks whether the last messages content/text matches.
+     *
+     * ```php
+     * <?php
+     * $I->seeInLastInstantMessageContent('Hello this is the messages I am expecting to see.');
+     * ?>
+     * ```
+     *
+     * @param string $content
+     */
+    public function seeInLastInstantMessageContent($content)
+    {
+        \PHPUnit_Framework_Assert::assertEquals($content, $this->grabLastInstantMessageContent());
+    }
+
+    /**
+     * Checks whether the last messages content/text does not match.
+     *
+     * ```php
+     * <?php
+     * $I->dontSeeInLastInstantMessageContent('Hello this is the messages I am not expecting to see.');
+     * ?>
+     * ```
+     *
+     * @param string $content
+     */
+    public function dontSeeInLastInstantMessageContent($content)
+    {
+        \PHPUnit_Framework_Assert::assertNotEmpty($content, $this->grabLastInstantMessageContent());
+    }
+
+    /**
+     * Grabber method to return the color of the last message.
+     *
+     * ```php
+     * <?php
+     * $from = $this->grabLastInstantMessageColor();
+     * ?>
+     * ```
+     *
+     * @return string
+     */
+    public function grabLastInstantMessageColor()
+    {
+        $color = $this->IMDriver->grabLastMessageColor();
+        $this->debug('Color: [' . $color . ']');
+        return $color;
+    }
+
+    /**
+     * Checks whether the last messages color matches.
+     *
+     * ```php
+     * <?php
+     * $I->seeInLastInstantMessageColor('red');
+     * ?>
+     * ```
+     *
+     * @param string $color
+     */
+    public function seeInLastInstantMessageColor($color)
+    {
+        \PHPUnit_Framework_Assert::assertEquals($color, $this->grabLastInstantMessageColor());
+    }
+
+    /**
+     * Checks whether the last messages color does not match.
+     *
+     * ```php
+     * <?php
+     * $I->dontSeeInLastInstantMessageColor('red');
+     * ?>
+     * ```
+     *
+     * @param string $color
+     */
+    public function dontSeeInLastInstantMessageColor($color)
+    {
+        \PHPUnit_Framework_Assert::assertNotEmpty($color, $this->grabLastInstantMessageColor());
+    }
+
+    /**
+     * Grabber method to return the date/time of the last message.
+     *
+     * ```php
+     * <?php
+     * $from = $this->grabLastInstantMessageDate();
+     * ?>
+     * ```
+     *
+     * @return string
+     */
+    public function grabLastInstantMessageDate()
+    {
+        $date = $this->IMDriver->grabLastMessageDate();
+        $this->debug('Date/Time: [' . $date . ']');
+        return $date;
+    }
+
+    /**
+     * Checks whether the last messages date matches.
+     *
+     * ```php
+     * <?php
+     * $I->seeInLastInstantMessageDate('2014-10-13T16:30:48.657455+00:00');
+     * ?>
+     * ```
+     *
+     * @param string $date
+     */
+    public function seeInLastInstantMessageDate($date)
+    {
+        \PHPUnit_Framework_Assert::assertEquals($date, $this->grabLastInstantMessageDate());
+    }
+
+    /**
+     * Checks whether the last messages date does not match.
+     *
+     * ```php
+     * <?php
+     * $I->dontSeeInLastInstantMessageDate('2015-11-13T16:30:48.657455+00:00');
+     * ?>
+     * ```
+     *
+     * @param string $date
+     */
+    public function dontSeeInLastInstantMessageDate($date)
+    {
+        \PHPUnit_Framework_Assert::assertNotEmpty($date, $this->grabLastInstantMessageDate());
+    }
+
+}


### PR DESCRIPTION
Adding a IM module, to support testing with instant messaging services. Currently supporting HipChat testing.
### Supported Functions
- Send Message
- Test against last message.
### Example (IMCept.php)

``` php
<?php
$I = new IMGuy($scenario);
$I->wantTo('grab the recent messages on the IM server and run some tests');

$message = $I->grabLastInstantMessage();
$I->seeInLastInstantMessageFrom('Tester');
$I->dontSeeInLastInstantMessageFrom('Codeception');
$I->seeInLastInstantMessageContent('Testing has been completed with no issues.');
$I->dontSeeInLastInstantMessageContent('Random Message not there');
$I->seeInLastInstantMessageColor('yello');
$I->dontSeeInLastInstantMessageColor('red');
$date = $I->grabLastInstantMessageDate();
$I->seeInLastInstantMessageDate('2014-10-21T16:41:48.657455+00:00');
$I->dontSeeInLastInstantMessageDate('2015-10-21T16:41:48.657455+00:00');

$I->sendInstantMessage("Testing has been completed with no issues.", array('color' => 'yellow', 'notify' => true));

```
