### PR TITLE
Update Db.php

### DIFF
--- a/src/Codeception/Module/Db.php
+++ b/src/Codeception/Module/Db.php
@@ -116,7 +116,9 @@ class Db extends \Codeception\Module implements \Codeception\Lib\Interfaces\Db
             }
             $sql = file_get_contents(Configuration::projectDir() . $this->config['dump']);
             $sql = preg_replace('%/\*(?!!\d+)(?:(?!\*/).)*\*/%s', "", $sql);
-            $this->sql = explode("\n", $sql);
+            if( ! empty($sql)) {
+                $this->sql = explode("\n", $sql);
+            }
         }
 
         try {


### PR DESCRIPTION
`Line 178` will never be executed, because `count($this->sql)` returns not less than one, even if the file dump.sql is empty.

Cause:

``` php
explode("\n", "");
/*
    returns:
    array(1) {
        [0] => string(0) ""
    }
*/
```
