### PR TITLE
Close any open ZF2 sessions

### DIFF
--- a/src/Codeception/Module/ZF2.php
+++ b/src/Codeception/Module/ZF2.php
@@ -89,7 +89,10 @@ class ZF2 extends \Codeception\Lib\Framework
         if (Version::compareVersion('2.2.0') >= 0) {
             Placeholder\Registry::unsetRegistry();
         }
-
+        //Close the session, if any are open
+        if (session_status() == PHP_SESSION_ACTIVE) {
+            session_write_close();
+        }
         $this->queries = 0;
         $this->time = 0;
     }


### PR DESCRIPTION
Since the ZF2 re-instantiates the application for each test, each module is also re-instantiated. 

If the session config is being changed in the modules bootstrap file, then php will try to do it again. If a session is open for a retry, then an Error will be thrown `[PHPUnit_Framework_ExceptionWrapper] Invalid save handler specified: ini_set(): A session is active. You cannot change the session module's ini settings at this time`

Therefore we close any open sessions. Since we are already clearing the Sessions data above, this should not impact any uses cases. 
