### PR TITLE
Randomize the order tests run

### DIFF
--- a/src/Codeception/TestLoader.php
+++ b/src/Codeception/TestLoader.php
@@ -51,7 +51,15 @@ class TestLoader {
 
     public function getTests()
     {
-        return $this->tests;
+        $total = array_keys($this->tests);
+        $tests = array();
+        do {
+            $i = array_rand($total, 1);
+            $tests[] = $this->tests[$i];
+            unset($total[$i]);
+        } while(count($tests) < count($this->tests));
+        return $tests;
+
     }
     
 

--- a/src/Codeception/TestLoader.php
+++ b/src/Codeception/TestLoader.php
@@ -51,6 +51,7 @@ class TestLoader {
 
     public function getTests()
     {
+        if(count($this->tests) == 0) return $this->tests;
         $total = array_keys($this->tests);
         $tests = array();
         do {


### PR DESCRIPTION
To ensure that tests don't depend on one another, randomize the order in which they run.