### PR TITLE
Fix for Codeception #1507 - submitForm default input values

### DIFF
--- a/src/Codeception/Lib/InnerBrowser.php
+++ b/src/Codeception/Lib/InnerBrowser.php
@@ -299,10 +299,7 @@ class InnerBrowser extends Module implements Web
         /** @var  \Symfony\Component\DomCrawler\Crawler|\DOMElement[] $fields */
         $fields = $form->filter('input');
         foreach ($fields as $field) {
-            if ($field->getAttribute('type') == 'checkbox') {
-                continue;
-            }
-            if ($field->getAttribute('type') == 'radio') {
+            if (($field->getAttribute('type') == 'checkbox' || $field->getAttribute('type') == 'radio') && !$field->hasAttribute('checked')) {
                 continue;
             }
             $url .= sprintf('%s=%s', $field->getAttribute('name'), $field->getAttribute('value')) . '&';

--- a/tests/data/app/view/form/example16.php
+++ b/tests/data/app/view/form/example16.php
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <title>Test submitting a form with default radio/checkbox values</title>
+</head>
+<body>
+    <form method="POST" action="/form/example16">
+        <input type="text" name="test" value="" />
+        <input type="checkbox" name="checkbox1" value="testing" checked="checked" />
+        <input type="radio" name="radio1" value="to be sent" checked="checked" />
+        <input type="radio" name="radio1" value="not to be sent" />
+        <input type="submit" name="submit" value="Submit" />
+    </form>
+</body>
+</html>

--- a/tests/unit/Codeception/Module/TestsForWeb.php
+++ b/tests/unit/Codeception/Module/TestsForWeb.php
@@ -771,6 +771,22 @@ abstract class TestsForWeb extends \PHPUnit_Framework_TestCase
         ));
         $this->module->seeCurrentUrlEquals('/form/example11');
     }
+    
+    /*
+     * https://github.com/Codeception/Codeception/issues/1507
+     */
+    public function testSubmitFormWithDefaultRadioAndCheckboxValues()
+    {
+        $this->module->amOnPage('/form/example16');
+        $this->module->submitForm('form', array(
+            'test' => 'value'
+        ));
+        $form = data::get('form');
+        $this->assertTrue(isset($form['checkbox1']), 'Checkbox value not sent');
+        $this->assertTrue(isset($form['radio1']), 'Radio button value not sent');
+        $this->assertEquals($form['checkbox1'], 'testing');
+        $this->assertEquals($form['radio1'], 'to be sent');
+    }
 
     /**
      * https://github.com/Codeception/Codeception/issues/1409


### PR DESCRIPTION
submitForm default input values for radio buttons and checkboxes are not
sent with the submitted form
