### PR TITLE
grabTextFrom doesn't work with regex

### DIFF
--- a/src/Codeception/Lib/InnerBrowser.php
+++ b/src/Codeception/Lib/InnerBrowser.php
@@ -676,7 +676,7 @@ class InnerBrowser extends Module implements Web
     public function grabTextFrom($cssOrXPathOrRegex)
     {
         $nodes = $this->match($cssOrXPathOrRegex);
-        if ($nodes) {
+        if ($nodes->count()) {
             return $nodes->first()->text();
         }
         if (@preg_match($cssOrXPathOrRegex, $this->client->getInternalResponse()->getContent(), $matches)) {

--- a/tests/unit/Codeception/Module/TestsForWeb.php
+++ b/tests/unit/Codeception/Module/TestsForWeb.php
@@ -400,6 +400,8 @@ abstract class TestsForWeb extends \PHPUnit_Framework_TestCase
         $this->assertEquals("Welcome to test app!", $result);
         $result = $this->module->grabTextFrom('descendant-or-self::h1');
         $this->assertEquals("Welcome to test app!", $result);
+        $result = $this->module->grabTextFrom('~Welcome to (\w+) app!~');
+        $this->assertEquals('test', $result);
     }
 
     public function testGrabValueFrom() {


### PR DESCRIPTION
A change to the match() function returns an empty crawler rather than
null.  Added a test for regex with grabTextFrom
