### PR TITLE
[composer] Allow Guzzle 5 (it looks compatible with 4.*)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "ext-mbstring": "*",
         "phpunit/phpunit": "~4.0",
         "facebook/webdriver": "~0.4",
-        "guzzlehttp/guzzle": ">=4.0",
+        "guzzlehttp/guzzle": "~4.0|~5.0",
         "symfony/finder": "~2.4",
         "symfony/console": "~2.4",
         "symfony/event-dispatcher": "~2.4",


### PR DESCRIPTION
Adding `"guzzlehttp/guzzle": "5.*"` to composer.json downgrades Codeception to 1.\* version.
Guzzle 5 is compatible with Guzzle 4 so let's allow it in composer.json
