### PR TITLE
Enable logging in Yii2

### DIFF
--- a/src/Codeception/Lib/Connector/Yii2.php
+++ b/src/Codeception/Lib/Connector/Yii2.php
@@ -70,11 +70,6 @@ class Yii2 extends Client
 
         $app->getResponse()->on(YiiResponse::EVENT_AFTER_PREPARE, array($this, 'processResponse'));
 
-        // disabling logging. Logs are slowing test execution down
-        foreach ($app->log->targets as $target) {
-            $target->enabled = false;
-        }
-
         $this->headers    = array();
         $this->statusCode = null;
 


### PR DESCRIPTION
I have not found any measurable slowdown for 89 tests and 412 assertions even with profile and trace levels.
And It is very important to me to have logs in tests.

Here is my logger config:
```
'log' => [
    'traceLevel' => 3,
    'targets' => [
        [
            'class' => 'yii\log\FileTarget',
            'levels' => ['error', 'warning', 'info', 'profile', 'trace'],
        ],
    ],
],
```