### PR TITLE
Fixes `Getting unknown property` in Yii2 module

### DIFF
--- a/src/Codeception/Module/Yii2.php
+++ b/src/Codeception/Module/Yii2.php
@@ -105,7 +105,7 @@ class Yii2 extends Framework implements ActiveRecord
             $this->fail("Record $model was not saved");
         }
 
-        return $record->id;
+        return $record->primaryKey;
     }
 
     /**


### PR DESCRIPTION
If record primary key is not `id`, then error is thrown when using `haveRecord()` method.

```
yii\base\UnknownPropertyException: Getting unknown property: app\models\ModelName::id
```
