### PR TITLE
Updates for WebDriver documentation

### DIFF
--- a/src/Codeception/Lib/Interfaces/Remote.php
+++ b/src/Codeception/Lib/Interfaces/Remote.php
@@ -5,8 +5,8 @@ namespace Codeception\Lib\Interfaces;
 interface Remote
 {
     /**
-     * Sets 'url' configuration parameter to hosts subdomain.
-     * It does not open a page on subdomain. Use `amOnPage` for that
+     * Changes the subdomain for the 'url' configuration parameter.
+     * Does not open a page; use `amOnPage` for that.
      *
      * ``` php
      * <?php
@@ -27,8 +27,7 @@ interface Remote
     public function amOnSubdomain($subdomain);
 
     /**
-     * Open web page at absolute URL.
-     * Base url will be reconfigured to use the host of provided Url.
+     * Open web page at the given absolute URL and sets its hostname as the base host.
      *
      * ``` php
      * <?php

--- a/src/Codeception/Lib/Interfaces/Web.php
+++ b/src/Codeception/Lib/Interfaces/Web.php
@@ -5,10 +5,7 @@ namespace Codeception\Lib\Interfaces;
 interface Web
 {
     /**
-     * Opens the page.
-     * Requires relative uri as parameter
-     *
-     * Example:
+     * Opens the page for the given relative URI.
      *
      * ``` php
      * <?php
@@ -24,10 +21,8 @@ interface Web
     public function amOnPage($page);
 
     /**
-     * Check if current page contains the text specified.
-     * Specify the css selector to match only specific region.
-     *
-     * Examples:
+     * Checks that the current page contains the given string.
+     * Specify a locator as the second parameter to match a specific region.
      *
      * ``` php
      * <?php
@@ -43,10 +38,8 @@ interface Web
     public function see($text, $selector = null);
 
     /**
-     * Check if current page doesn't contain the text specified.
-     * Specify the css selector to match only specific region.
-     *
-     * Examples:
+     * Checks that the current page doesn't contain the text specified.
+     * Give a locator as the second parameter to match a specific region.
      *
      * ```php
      * <?php
@@ -62,11 +55,10 @@ interface Web
     public function dontSee($text, $selector = null);
 
     /**
-     * Submits a form located on page.
-     * Specify the form by it's css or xpath selector.
-     * Fill the form fields values as array.
+     * Submits the given form on the page, optionally with the given form values.
+     * Give the form fields values as an array.
      *
-     * Skipped fields will be filled by their values from page.
+     * Skipped fields will be filled by their values from the page.
      * You don't need to click the 'Submit' button afterwards.
      * This command itself triggers the request to form's action.
      *
@@ -85,7 +77,7 @@ interface Web
      *
      * ```
      *
-     * For a sample Sign Up form:
+     * For example, given this sample "Sign Up" form:
      *
      * ``` html
      * <form action="/sign_up">
@@ -96,6 +88,7 @@ interface Web
      *     <input type="submit" name="submitButton" value="Submit" />
      * </form>
      * ```
+     *
      * You could write the following to submit it:
      *
      * ``` php
@@ -120,17 +113,15 @@ interface Web
     public function submitForm($selector, $params, $button = null);
 
     /**
-     * Perform a click on link or button.
-     * Link or button are found by their names or CSS selector.
-     * Submits a form if button is a submit type.
+     * Perform a click on a link or a button, given by a locator.
+     * If a fuzzy locator is given, the page will be searched for a button, link, or image matching the locator string.
+     * For buttons, the "value" attribute, "name" attribute, and inner text are searched.
+     * For links, the link text is searched.
+     * For images, the "alt" attribute and inner text of any parent links are searched.
      *
-     * If link is an image it's found by alt attribute value of image.
-     * If button is image button is found by it's value
-     * If link or button can't be found by name they are searched by CSS selector.
+     * The second parameter is a context (CSS or XPath locator) to narrow the search.
      *
-     * The second parameter is a context: CSS or XPath locator to narrow the search.
-     *
-     * Examples:
+     * Note that if the locator matches a button of type `submit`, the form will be submitted.
      *
      * ``` php
      * <?php
@@ -155,10 +146,8 @@ interface Web
     public function click($link, $context = null);
 
     /**
-     * Checks if there is a link with text specified.
-     * Specify url to match link with exact this url.
-     *
-     * Examples:
+     * Checks that there's a link with the specified text.
+     * Give a full URL as the second parameter to match links with that exact URL.
      *
      * ``` php
      * <?php
@@ -173,24 +162,23 @@ interface Web
     public function seeLink($text, $url = null);
 
     /**
-     * Checks if page doesn't contain the link with text specified.
-     * Specify url to narrow the results.
-     *
-     * Examples:
+     * Checks that the page doesn't contain a link with the given string.
+     * If the second parameter is given, only links with a matching "href" attribute will be checked.
      *
      * ``` php
      * <?php
      * $I->dontSeeLink('Logout'); // I suppose user is not logged in
+     * $I->dontSeeLink('Checkout now', '/store/cart.php');
      * ?>
      * ```
      *
-     * @param      $text
+     * @param $text
      * @param null $url
      */
     public function dontSeeLink($text, $url = null);
 
     /**
-     * Checks that current uri contains a value
+     * Checks that current URI contains the given string.
      *
      * ``` php
      * <?php
@@ -206,8 +194,8 @@ interface Web
     public function seeInCurrentUrl($uri);
 
     /**
-     * Checks that current url is equal to value.
-     * Unlike `seeInCurrentUrl` performs a strict check.
+     * Checks that the current URL is equal to the given string.
+     * Unlike `seeInCurrentUrl`, this only matches the full URL.
      *
      * ``` php
      * <?php
@@ -221,7 +209,7 @@ interface Web
     public function seeCurrentUrlEquals($uri);
 
     /**
-     * Checks that current url is matches a RegEx value
+     * Checks that the current URL matches the given regular expression.
      *
      * ``` php
      * <?php
@@ -235,7 +223,7 @@ interface Web
     public function seeCurrentUrlMatches($uri);
 
     /**
-     * Checks that current uri does not contain a value
+     * Checks that the current URI doesn't contain the given string.
      *
      * ``` php
      * <?php
@@ -248,8 +236,8 @@ interface Web
     public function dontSeeInCurrentUrl($uri);
 
     /**
-     * Checks that current url is not equal to value.
-     * Unlike `dontSeeInCurrentUrl` performs a strict check.
+     * Checks that the current URL doesn't equal the given string.
+     * Unlike `dontSeeInCurrentUrl`, this only matches the full URL.
      *
      * ``` php
      * <?php
@@ -263,7 +251,7 @@ interface Web
     public function dontSeeCurrentUrlEquals($uri);
 
     /**
-     * Checks that current url does not match a RegEx value
+     * Checks that current url doesn't match the given regular expression.
      *
      * ``` php
      * <?php
@@ -277,8 +265,8 @@ interface Web
     public function dontSeeCurrentUrlMatches($uri);
 
     /**
-     * Takes a parameters from current URI by RegEx.
-     * If no url provided returns full URI.
+     * Executes the given regular expression against the current URI and returns the first match.
+     * If no parameters are provided, the full URI is returned.
      *
      * ``` php
      * <?php
@@ -295,10 +283,7 @@ interface Web
     public function grabFromCurrentUrl($uri = null);
 
     /**
-     * Assert if the specified checkbox is checked.
-     * Use css selector or xpath to match.
-     *
-     * Example:
+     * Checks that the specified checkbox is checked.
      *
      * ``` php
      * <?php
@@ -313,10 +298,7 @@ interface Web
     public function seeCheckboxIsChecked($checkbox);
 
     /**
-     * Assert if the specified checkbox is unchecked.
-     * Use css selector or xpath to match.
-     *
-     * Example:
+     * Check that the specified checkbox is unchecked.
      *
      * ``` php
      * <?php
@@ -330,10 +312,8 @@ interface Web
     public function dontSeeCheckboxIsChecked($checkbox);
 
     /**
-     * Checks that an input field or textarea contains value.
-     * Field is matched either by label or CSS or Xpath
-     *
-     * Example:
+     * Checks that the given input field or textarea contains the given value. 
+     * For fuzzy locators, fields are matched by label text, the "name" attribute, CSS, and XPath.
      *
      * ``` php
      * <?php
@@ -352,9 +332,8 @@ interface Web
     public function seeInField($field, $value);
 
     /**
-     * Checks that an input field or textarea doesn't contain value.
-     * Field is matched either by label or CSS or Xpath
-     * Example:
+     * Checks that an input field or textarea doesn't contain the given value.
+     * For fuzzy locators, the field is matched by label text, CSS and XPath.
      *
      * ``` php
      * <?php
@@ -363,7 +342,7 @@ interface Web
      * $I->dontSeeInField('form input[type=hidden]','hidden_value');
      * $I->dontSeeInField('#searchform input','Search');
      * $I->dontSeeInField('//form/*[@name=search]','Search');
-     * $I->seeInField(['name' => 'search'], 'Search');
+     * $I->dontSeeInField(['name' => 'search'], 'Search');
      * ?>
      * ```
      *
@@ -373,9 +352,7 @@ interface Web
     public function dontSeeInField($field, $value);
 
     /**
-     * Selects an option in select tag or in radio button group.
-     *
-     * Example:
+     * Selects an option in a select tag or in radio button group.
      *
      * ``` php
      * <?php
@@ -385,7 +362,7 @@ interface Web
      * ?>
      * ```
      *
-     * Can select multiple options if second argument is array:
+     * Provide an array for the second argument to select multiple options:
      *
      * ``` php
      * <?php
@@ -399,10 +376,7 @@ interface Web
     public function selectOption($select, $option);
 
     /**
-     * Ticks a checkbox.
-     * For radio buttons use `selectOption` method.
-     *
-     * Example:
+     * Ticks a checkbox. For radio buttons, use the `selectOption` method instead.
      *
      * ``` php
      * <?php
@@ -417,8 +391,6 @@ interface Web
     /**
      * Unticks a checkbox.
      *
-     * Example:
-     *
      * ``` php
      * <?php
      * $I->uncheckOption('#notify');
@@ -430,9 +402,7 @@ interface Web
     public function uncheckOption($option);
 
     /**
-     * Fills a text field or textarea with value.
-     *
-     * Example:
+     * Fills a text field or textarea with the given string.
      *
      * ``` php
      * <?php
@@ -447,9 +417,7 @@ interface Web
     public function fillField($field, $value);
 
     /**
-     * Attaches file from Codeception data directory to upload field.
-     *
-     * Example:
+     * Attaches a file relative to the Codeception data directory to the given file upload field.
      *
      * ``` php
      * <?php
@@ -464,16 +432,14 @@ interface Web
     public function attachFile($field, $filename);
 
     /**
-     * Finds and returns text contents of element.
-     * Element is searched by CSS selector, XPath or matcher by regex.
-     *
-     * Example:
+     * Finds and returns the text contents of the given element.
+     * If a fuzzy locator is used, the element is found using CSS, XPath, and by matching the full page source by regular expression.
      *
      * ``` php
      * <?php
      * $heading = $I->grabTextFrom('h1');
      * $heading = $I->grabTextFrom('descendant-or-self::h1');
-     * $value = $I->grabTextFrom('~<input value=(.*?)]~sgi');
+     * $value = $I->grabTextFrom('~<input value=(.*?)]~sgi'); // match with a regex
      * ?>
      * ```
      *
@@ -484,10 +450,8 @@ interface Web
     public function grabTextFrom($cssOrXPathOrRegex);
 
     /**
-     * Finds and returns field and returns it's value.
-     * Searches by field name, then by CSS, then by XPath
-     *
-     * Example:
+     * Finds the value for the given form field.
+     * If a fuzzy locator is used, the field is found by field name, CSS, and XPath.
      *
      * ``` php
      * <?php
@@ -506,7 +470,7 @@ interface Web
 
 
     /**
-     * Grabs attribute value from an element.
+     * Grabs the value of the given attribute value from the given element.
      * Fails if element is not found.
      *
      * ``` php
@@ -524,7 +488,7 @@ interface Web
     public function grabAttributeFrom($cssOrXpath, $attribute);
 
     /**
-     * Checks if element exists on a page, matching it by CSS or XPath.
+     * Checks that the given element exists on the page and is visible.
      * You can also specify expected attributes of this element.
      *
      * ``` php
@@ -546,10 +510,8 @@ interface Web
     public function seeElement($selector, $attributes = array());
 
     /**
-     * Checks if element does not exist (or is visible) on a page, matching it by CSS or XPath
+     * Checks that the given element is invisible or not present on the page.
      * You can also specify expected attributes of this element.
-     *
-     * Example:
      *
      * ``` php
      * <?php
@@ -561,11 +523,12 @@ interface Web
      * ```
      *
      * @param $selector
+     * @param array $attributes
      */
-    public function dontSeeElement($selector);
+    public function dontSeeElement($selector, $attributes = array());
 
    /**
-     * Tests number of $elements on page
+     * Checks that there are a certain number of elements matched by the given locator on the page.
      * 
      * ``` php
      * <?php
@@ -581,7 +544,7 @@ interface Web
     public function seeNumberOfElements($selector, $expected);    
     
     /**
-     * Checks if option is selected in select field.
+     * Checks that the given option is selected.
      *
      * ``` php
      * <?php
@@ -597,7 +560,7 @@ interface Web
     public function seeOptionIsSelected($selector, $optionText);
 
     /**
-     * Checks if option is not selected in select field.
+     * Checks that the given option is not selected.
      *
      * ``` php
      * <?php
@@ -613,7 +576,7 @@ interface Web
     public function dontSeeOptionIsSelected($selector, $optionText);
 
     /**
-     * Checks that page title contains text.
+     * Checks that the page title contains the given string.
      *
      * ``` php
      * <?php
@@ -628,7 +591,7 @@ interface Web
     public function seeInTitle($title);
 
     /**
-     * Checks that page title does not contain text.
+     * Checks that the page title does not contain the given string.
      *
      * @param $title
      *
@@ -637,7 +600,13 @@ interface Web
     public function dontSeeInTitle($title);
 
     /**
-     * Checks that cookie is set.
+     * Checks that a cookie with the given name is set.
+     *
+     * ``` php
+     * <?php
+     * $I->seeCookie('PHPSESSID');
+     * ?>
+     * ```
      *
      * @param $cookie
      *
@@ -646,7 +615,7 @@ interface Web
     public function seeCookie($cookie);
 
     /**
-     * Checks that cookie doesn't exist
+     * Checks that there isn't a cookie with the given name.
      *
      * @param $cookie
      *
@@ -655,7 +624,13 @@ interface Web
     public function dontSeeCookie($cookie);
 
     /**
-     * Sets a cookie.
+     * Sets a cookie with the given name and value.
+     *
+     * ``` php
+     * <?php
+     * $I->setCookie('PHPSESSID', 'el4ukv0kqbvoirg7nkp4dncpk3');
+     * ?>
+     * ```
      *
      * @param $cookie
      * @param $value
@@ -665,7 +640,7 @@ interface Web
     public function setCookie($cookie, $value);
 
     /**
-     * Unsets cookie
+     * Unsets cookie with the given name.
      *
      * @param $cookie
      *

--- a/src/Codeception/Module/WebDriver.php
+++ b/src/Codeception/Module/WebDriver.php
@@ -19,15 +19,17 @@ use Codeception\PHPUnit\Constraint\Page as PageConstraint;
  *
  * ## Selenium Installation
  *
- * Download [Selenium Server](http://docs.seleniumhq.org/download/)
- * Launch the daemon: `java -jar selenium-server-standalone-2.xx.xxx.jar`
+ * 1. Download [Selenium Server](http://docs.seleniumhq.org/download/)
+ * 2. Launch the daemon: `java -jar selenium-server-standalone-2.xx.xxx.jar`
+ *
  *
  * ## PhantomJS Installation
  *
- * PhantomJS is headless alternative to Selenium Server.
+ * PhantomJS is a headless alternative to Selenium Server that implements [the WebDriver protocol](https://code.google.com/p/selenium/wiki/JsonWireProtocol).
+ * It allows you to run Selenium tests on a server without a GUI installed.
  *
- * * Download [PhantomJS](http://phantomjs.org/download.html)
- * * Run PhantomJS in webdriver mode `phantomjs --webdriver=4444`
+ * 1. Download [PhantomJS](http://phantomjs.org/download.html)
+ * 2. Run PhantomJS in WebDriver mode: `phantomjs --webdriver=4444`
  *
  *
  * ## Status
@@ -37,17 +39,18 @@ use Codeception\PHPUnit\Constraint\Page as PageConstraint;
  * * Contact: davert.codecept@mailican.com
  * * Based on [facebook php-webdriver](https://github.com/facebook/php-webdriver)
  *
+ *
  * ## Configuration
  *
- * * url *required* - start url for your app
- * * browser *required* - browser that would be launched
- * * host  - Selenium server host (127.0.0.1 by default)
- * * port - Selenium server port (4444 by default)
- * * restart - set to false (default) to share browser sesssion between tests, or set to true to create a session per test
- * * window_size - initial window size. Values `maximize` or dimensions in format `640x480` are accepted.
- * * clear_cookies - set to false to keep cookies, or set to true (default) to delete all cookies between cases.
- * * wait - set the implicit wait (0 secs) by default.
- * * capabilities - sets Selenium2 [desired capabilities](http://code.google.com/p/selenium/wiki/DesiredCapabilities). Should be a key-value array.
+ * * url *required* - Starting URL for your app.
+ * * browser *required* - Browser to launch.
+ * * host - Selenium server host (127.0.0.1 by default).
+ * * port - Selenium server port (4444 by default).
+ * * restart - Set to false (default) to share browser session between tests, or set to true to create a separate session for each test.
+ * * window_size - Initial window size. Set to `maximize` or a dimension in the format `640x480`.
+ * * clear_cookies - Set to false to keep cookies, or set to true (default) to delete all cookies between tests.
+ * * wait - Implicit wait (default 0 seconds).
+ * * capabilities - Sets Selenium2 [desired capabilities](http://code.google.com/p/selenium/wiki/DesiredCapabilities). Should be a key-value array.
  *
  * ### Example (`acceptance.suite.yml`)
  *
@@ -63,10 +66,37 @@ use Codeception\PHPUnit\Constraint\Page as PageConstraint;
  *                  unexpectedAlertBehaviour: 'accept'
  *                  firefox_profile: '/Users/paul/Library/Application Support/Firefox/Profiles/codeception-profile.zip.b64' 
  *
+ *
+ * ## Locating Elements
+ * 
+ * Most methods in this module that operate on a DOM element (e.g. `click`) accept a locator as the first argument, which can be either a string or an array.
+ * 
+ * If the locator is an array, it should have a single element, with the key signifying the locator type (`id`, `name`, `css`, `xpath`, `link`, or `class`) and the value being the locator itself. This is called a "strict" locator. Examples:
+ * 
+ * * `['id' => 'foo']` matches `<div id="foo">`
+ * * `['name' => 'foo']` matches `<div name="foo">`
+ * * `['css' => 'input[type=input][value=foo]']` matches `<input type="input" value="foo">`
+ * * `['xpath' => "//input[@type='submit'][contains(@value, 'foo')]"]` matches `<input type="submit" value="foobar">`
+ * * `['link' => 'Click here']` matches `<a href="google.com">Click here</a>`
+ * * `['class' => 'foo']` matches `<div class="foo">`
+ * 
+ * Writing good locators can be tricky. The Mozilla team has written an excellent guide titled [Writing reliable locators for Selenium and WebDriver tests](https://blog.mozilla.org/webqa/2013/09/26/writing-reliable-locators-for-selenium-and-webdriver-tests/).
+ * 
+ * If you prefer, you may also pass a string for the locator. This is called a "fuzzy" locator. In this case, Codeception uses a a variety of heuristics (depending on the exact method called) to determine what element you're referring to. For example, here's the heuristic used for the `submitForm` method:
+ * 
+ * 1. Does the locator look like an ID selector (e.g. "#foo")? If so, try to find a form matching that ID.
+ * 2. If nothing found, check if locator looks like a CSS selector. If so, run it.
+ * 3. If nothing found, check if locator looks like an XPath expression. If so, run it.
+ * 4. Throw an `ElementNotFound` exception.
+ * 
+ * Be warned that fuzzy locators can be significantly slower than strict locators. If speed is a concern, it's recommended you stick with explicitly specifying the locator type via the array syntax.
+ *
  * ## Migration Guide (Selenium2 -> WebDriver)
  *
  * * `wait` method accepts seconds instead of milliseconds. All waits use second as parameter.
  *
+ *
+ * # Methods
  */
 class WebDriver extends \Codeception\Module implements WebInterface, RemoteInterface, MultiSessionInterface
 {
@@ -220,7 +250,7 @@ class WebDriver extends \Codeception\Module implements WebInterface, RemoteInter
     }
 
     /**
-     * Makes a screenshot of current window and saves it to `tests/_output/debug`.
+     * Takes a screenshot of the current window and saves it to `tests/_output/debug`.
      *
      * ``` php
      * <?php
@@ -244,9 +274,8 @@ class WebDriver extends \Codeception\Module implements WebInterface, RemoteInter
     }
 
     /**
-     * Resize current window
+     * Resize the current window.
      *
-     * Example:
      * ``` php
      * <?php
      * $I->resizeWindow(800, 600);
@@ -338,7 +367,7 @@ class WebDriver extends \Codeception\Module implements WebInterface, RemoteInter
     }
 
     /**
-     * Checks that page source contains text.
+     * Checks that the page source contains the given string.
      *
      * ```php
      * <?php
@@ -357,7 +386,7 @@ class WebDriver extends \Codeception\Module implements WebInterface, RemoteInter
     }
 
     /**
-     * Checks that page source does not contain text.
+     * Checks that the page source doesn't contain the given string.
      *
      * @param $text
      */
@@ -698,10 +727,11 @@ class WebDriver extends \Codeception\Module implements WebInterface, RemoteInter
     }
 
     /*
-        * Unselect an option in a select box
-        *
-        */
-
+     * Unselect an option in the given select box.
+     *
+     * @param $select
+     * @param $option
+     */
     public function unselectOption($select, $option)
     {
         $el = $this->findField($select);
@@ -841,6 +871,8 @@ class WebDriver extends \Codeception\Module implements WebInterface, RemoteInter
     }
 
     /**
+     * Grabs all visible text from the current page.
+     *
      * @return string
      */
     public function getVisibleText()
@@ -899,19 +931,6 @@ class WebDriver extends \Codeception\Module implements WebInterface, RemoteInter
         return $els;
     }
 
-
-    /**
-     * Checks for a visible element on a page, matching it by CSS or XPath
-     *
-     * ``` php
-     * <?php
-     * $I->seeElement('.error');
-     * $I->seeElement('//form/input[1]');
-     * ?>
-     * ```
-     * @param $selector
-     * @param array $attributes
-     */
     public function seeElement($selector, $attributes = array())
     {
         $els = $this->matchVisible($selector);
@@ -919,19 +938,6 @@ class WebDriver extends \Codeception\Module implements WebInterface, RemoteInter
         $this->assertNotEmpty($els);
     }
 
-    /**
-     * Checks that element is invisible or not present on page.
-     *
-     * ``` php
-     * <?php
-     * $I->dontSeeElement('.error');
-     * $I->dontSeeElement('//form/input[1]');
-     * ?>
-     * ```
-     *
-     * @param $selector
-     * @param array $attributes
-     */
     public function dontSeeElement($selector, $attributes = array())
     {
         $els = $this->matchVisible($selector);
@@ -940,7 +946,7 @@ class WebDriver extends \Codeception\Module implements WebInterface, RemoteInter
     }
 
     /**
-     * Checks if element exists on a page even it is invisible.
+     * Checks that the given element exists on the page, even it is invisible.
      *
      * ``` php
      * <?php
@@ -959,7 +965,7 @@ class WebDriver extends \Codeception\Module implements WebInterface, RemoteInter
 
 
     /**
-     * Opposite to `seeElementInDOM`.
+     * Opposite of `seeElementInDOM`.
      *
      * @param $selector
      */
@@ -1044,9 +1050,8 @@ class WebDriver extends \Codeception\Module implements WebInterface, RemoteInter
     }
 
     /**
-     * Accepts JavaScript native popup window created by `window.alert`|`window.confirm`|`window.prompt`.
-     * Don't confuse it with modal windows, created by [various libraries](http://jster.net/category/windows-modals-popups).
-     *
+     * Accepts the active JavaScript native popup window, as created by `window.alert`|`window.confirm`|`window.prompt`.
+     * Don't confuse popups with modal windows, as created by [various libraries](http://jster.net/category/windows-modals-popups).
      */
     public function acceptPopup()
     {
@@ -1054,7 +1059,7 @@ class WebDriver extends \Codeception\Module implements WebInterface, RemoteInter
     }
 
     /**
-     * Dismisses active JavaScript popup created by `window.alert`|`window.confirm`|`window.prompt`.
+     * Dismisses the active JavaScript popup, as created by `window.alert`|`window.confirm`|`window.prompt`.
      */
     public function cancelPopup()
     {
@@ -1062,7 +1067,7 @@ class WebDriver extends \Codeception\Module implements WebInterface, RemoteInter
     }
 
     /**
-     * Checks that active JavaScript popup created by `window.alert`|`window.confirm`|`window.prompt` contain text.
+     * Checks that the active JavaScript popup, as created by `window.alert`|`window.confirm`|`window.prompt`, contains the given string.
      *
      * @param $text
      */
@@ -1072,7 +1077,7 @@ class WebDriver extends \Codeception\Module implements WebInterface, RemoteInter
     }
 
     /**
-     * Enters text into native JavaScript prompt popup created by `window.prompt`.
+     * Enters text into a native JavaScript prompt popup, as created by `window.prompt`.
      *
      * @param $keys
      */
@@ -1082,7 +1087,7 @@ class WebDriver extends \Codeception\Module implements WebInterface, RemoteInter
     }
 
     /**
-     * Reloads current page
+     * Reloads the current page.
      */
     public function reloadPage()
     {
@@ -1090,7 +1095,7 @@ class WebDriver extends \Codeception\Module implements WebInterface, RemoteInter
     }
 
     /**
-     * Moves back in history
+     * Moves back in history.
      */
     public function moveBack()
     {
@@ -1099,7 +1104,7 @@ class WebDriver extends \Codeception\Module implements WebInterface, RemoteInter
     }
 
     /**
-     * Moves forward in history
+     * Moves forward in history.
      */
     public function moveForward()
     {
@@ -1108,12 +1113,18 @@ class WebDriver extends \Codeception\Module implements WebInterface, RemoteInter
     }
 
     /**
-     * Submits a form located on page.
-     * Specify the form by it's css or xpath selector.
-     * Fill the form fields values as array. Hidden fields can't be accessed.
+     * Submits the given form on the page, optionally with the given form values.
+     * Give the form fields values as an array. Note that hidden fields can't be accessed.
      *
+     * Skipped fields will be filled by their values from the page.
+     * You don't need to click the 'Submit' button afterwards.
      * This command itself triggers the request to form's action.
      *
+     * You can optionally specify what button's value to include
+     * in the request with the last parameter as an alternative to
+     * explicitly setting its value in the second parameter, as
+     * button values are not otherwise included in the request.
+     * 
      * Examples:
      *
      * ``` php
@@ -1124,7 +1135,7 @@ class WebDriver extends \Codeception\Module implements WebInterface, RemoteInter
      *
      * ```
      *
-     * For sample Sign Up form:
+     * For example, given this sample "Sign Up" form:
      *
      * ``` html
      * <form action="/sign_up">
@@ -1135,18 +1146,27 @@ class WebDriver extends \Codeception\Module implements WebInterface, RemoteInter
      *     <input type="submit" name="submitButton" value="Submit" />
      * </form>
      * ```
-     * You can write this:
+     *
+     * You could write the following to submit it:
      *
      * ``` php
      * <?php
      * $I->submitForm('#userForm', array('user' => array('login' => 'Davert', 'password' => '123456', 'agree' => true)), 'submitButton');
      *
      * ```
+     * Note that "2" will be the submitted value for the "plan" field, as it is the selected option.
+     * 
+     * You can also emulate a JavaScript submission by not specifying any buttons in the third parameter to submitForm.
+     * 
+     * ```php
+     * <?php
+     * $I->submitForm('#userForm', array('user' => array('login' => 'Davert', 'password' => '123456', 'agree' => true)));
+     * 
+     * ```
      *
      * @param $selector
      * @param $params
      * @param $button
-     * @throws \Codeception\Exception\ElementNotFound
      */
     public function submitForm($selector, $params, $button = null)
     {
@@ -1207,8 +1227,8 @@ class WebDriver extends \Codeception\Module implements WebInterface, RemoteInter
     }
 
     /**
-     * Waits for element to change or for $timeout seconds to pass. Element "change" is determined
-     * by a callback function which is called repeatedly until the return value evaluates to true.
+     * Waits up to $timeout seconds for the given element to change.
+     * Element "change" is determined by a callback function which is called repeatedly until the return value evaluates to true.
      *
      * ``` php
      * <?php
@@ -1237,8 +1257,8 @@ class WebDriver extends \Codeception\Module implements WebInterface, RemoteInter
     }
 
     /**
-     * Waits for element to appear on page for $timeout seconds to pass.
-     * If element not appears, timeout exception is thrown.
+     * Waits up to $timeout seconds for an element to appear on the page.
+     * If the element doesn't appear, a timeout exception is thrown.
      *
      * ``` php
      * <?php
@@ -1258,8 +1278,8 @@ class WebDriver extends \Codeception\Module implements WebInterface, RemoteInter
     }
 
     /**
-     * Waits for element to be visible on the page for $timeout seconds to pass.
-     * If element doesn't appear, timeout exception is thrown.
+     * Waits up to $timeout seconds for the given element to be visible on the page.
+     * If element doesn't appear, a timeout exception is thrown.
      *
      * ``` php
      * <?php
@@ -1279,8 +1299,8 @@ class WebDriver extends \Codeception\Module implements WebInterface, RemoteInter
     }
 
     /**
-     * Waits for element to not be visible on the page for $timeout seconds to pass.
-     * If element stays visible, timeout exception is thrown.
+     * Waits up to $timeout seconds for the given element to become invisible.
+     * If element stays visible, a timeout exception is thrown.
      *
      * ``` php
      * <?php
@@ -1299,9 +1319,9 @@ class WebDriver extends \Codeception\Module implements WebInterface, RemoteInter
     }
 
     /**
-     * Waits for text to appear on the page for a specific amount of time.
+     * Waits up to $timeout seconds for the given string to appear on the page.
      * Can also be passed a selector to search in.
-     * If text does not appear, timeout exception is thrown.
+     * If the given text doesn't appear, a timeout exception is thrown.
      *
      * ``` php
      * <?php
@@ -1329,7 +1349,7 @@ class WebDriver extends \Codeception\Module implements WebInterface, RemoteInter
     }
 
     /**
-     * Explicit wait.
+     * Wait for $timeout seconds.
      *
      * @param int $timeout secs
      * @throws \Codeception\Exception\TestRuntime
@@ -1348,7 +1368,7 @@ class WebDriver extends \Codeception\Module implements WebInterface, RemoteInter
 
     /**
      * Low-level API method.
-     * If Codeception commands are not enough, use Selenium WebDriver methods directly
+     * If Codeception commands are not enough, this allows you to use Selenium WebDriver methods directly:
      *
      * ``` php
      * $I->executeInSelenium(function(\WebDriver $webdriver) {
@@ -1356,9 +1376,9 @@ class WebDriver extends \Codeception\Module implements WebInterface, RemoteInter
      * });
      * ```
      *
-     * Use [WebDriver Session API](https://github.com/facebook/php-webdriver)
-     * Not recommended this command to be used on regular basis.
-     * If Codeception lacks important Selenium methods implement them and submit patches.
+     * This runs in the context of the [RemoteWebDriver class](https://github.com/facebook/php-webdriver/blob/master/lib/remote/RemoteWebDriver.php).
+     * Try not to use this command on a regular basis.
+     * If Codeception lacks a feature you need, please implement it and submit a patch.
      *
      * @param callable $function
      */
@@ -1368,9 +1388,9 @@ class WebDriver extends \Codeception\Module implements WebInterface, RemoteInter
     }
 
     /**
-     * Switch to another window identified by its name.
+     * Switch to another window identified by name.
      *
-     * The window can only be identified by its name. If the $name parameter is blank it will switch to the parent window.
+     * The window can only be identified by name. If the $name parameter is blank, the parent window will be used.
      *
      * Example:
      * ``` html
@@ -1387,7 +1407,7 @@ class WebDriver extends \Codeception\Module implements WebInterface, RemoteInter
      * ?>
      * ```
      *
-     * If the window has no name, the only way to access it is via the `executeInSelenium()` method like so:
+     * If the window has no name, the only way to access it is via the `executeInSelenium()` method, like so:
      *
      * ``` php
      * <?php
@@ -1407,7 +1427,7 @@ class WebDriver extends \Codeception\Module implements WebInterface, RemoteInter
     }
 
     /**
-     * Switch to another frame
+     * Switch to another frame on the page.
      *
      * Example:
      * ``` html
@@ -1436,9 +1456,9 @@ class WebDriver extends \Codeception\Module implements WebInterface, RemoteInter
     }
 
     /**
-     * Executes JavaScript and waits for it to return true or for the timeout.
+     * Executes JavaScript and waits up to $timeout seconds for it to return true.
      *
-     * In this example we will wait for all jQuery ajax requests are finished or 60 secs otherwise.
+     * In this example we will wait up to 60 seconds for all jQuery AJAX requests to finish.
      *
      * ``` php
      * <?php
@@ -1459,9 +1479,9 @@ class WebDriver extends \Codeception\Module implements WebInterface, RemoteInter
     }
 
     /**
-     * Executes custom JavaScript
+     * Executes custom JavaScript.
      *
-     * In this example we will use jQuery to get a value and assign this value to a variable.
+     * This example uses jQuery to get a value and assigns that value to a PHP variable:
      *
      * ```php
      * <?php
@@ -1478,7 +1498,7 @@ class WebDriver extends \Codeception\Module implements WebInterface, RemoteInter
     }
 
     /**
-     * Maximizes current window
+     * Maximizes the current window.
      */
     public function maximizeWindow()
     {
@@ -1486,7 +1506,7 @@ class WebDriver extends \Codeception\Module implements WebInterface, RemoteInter
     }
 
     /**
-     * Performs a simple mouse drag and drop operation.
+     * Performs a simple mouse drag-and-drop operation.
      *
      * ``` php
      * <?php
@@ -1507,16 +1527,21 @@ class WebDriver extends \Codeception\Module implements WebInterface, RemoteInter
     }
 
     /**
-     * Move mouse over the first element matched by css or xPath on page
+     * Move mouse over the first element matched by the given locator.
+     * If the second and third parameters are given, then the mouse is moved to an offset of the element's top-left corner.
+     * Otherwise, the mouse is moved to the center of the element.
      *
-     * https://code.google.com/p/selenium/wiki/JsonWireProtocol#/session/:sessionId/moveto
+     * ``` php
+     * <?php
+     * $I->moveMouseOver(['css' => '.checkout'], 20, 50);
+     * ?>
+     * ```
      *
      * @param string $cssOrXPath css or xpath of the web element
      * @param int $offsetX
      * @param int $offsetY
      *
      * @throws \Codeception\Exception\ElementNotFound
-     * @return null
      */
     public function moveMouseOver($cssOrXPath, $offsetX = null, $offsetY = null)
     {
@@ -1525,7 +1550,7 @@ class WebDriver extends \Codeception\Module implements WebInterface, RemoteInter
     }
 
     /**
-     * Performs contextual click with right mouse button on element matched by CSS or XPath.
+     * Performs contextual click with the right mouse button on an element.
      *
      * @param $cssOrXPath
      * @throws \Codeception\Exception\ElementNotFound
@@ -1540,7 +1565,7 @@ class WebDriver extends \Codeception\Module implements WebInterface, RemoteInter
      * Pauses test execution in debug mode.
      * To proceed test press "ENTER" in console.
      *
-     * This method is recommended to use in test development, for additional page analysis, locator searing, etc.
+     * This method is useful while writing tests, since it allows you to inspect the current page in the middle of a test case.
      */
     public function pauseExecution()
     {
@@ -1548,7 +1573,7 @@ class WebDriver extends \Codeception\Module implements WebInterface, RemoteInter
     }
 
     /**
-     * Performs a double click on element matched by CSS or XPath.
+     * Performs a double-click on an element matched by CSS or XPath.
      *
      * @param $cssOrXPath
      * @throws \Codeception\Exception\ElementNotFound
@@ -1638,11 +1663,10 @@ class WebDriver extends \Codeception\Module implements WebInterface, RemoteInter
     }
 
     /**
-     * Presses key on element found by css, xpath is focused
-     * A char and modifier (ctrl, alt, shift, meta) can be provided.
+     * Presses the given key on the given element. 
+     * To specify a character and modifier (e.g. ctrl, alt, shift, meta), pass an array for $char with 
+     * the modifier as the first element and the character as the second.
      * For special keys use key constants from \WebDriverKeys class.
-     *
-     * Example:
      *
      * ``` php
      * <?php
@@ -1656,7 +1680,7 @@ class WebDriver extends \Codeception\Module implements WebInterface, RemoteInter
      * ```
      *
      * @param $element
-     * @param $char can be char or array with modifier. You can provide several chars.
+     * @param $char Can be char or array with modifier. You can provide several chars.
      * @throws \Codeception\Exception\ElementNotFound
      */
     public function pressKey($element, $char)
@@ -1724,8 +1748,8 @@ class WebDriver extends \Codeception\Module implements WebInterface, RemoteInter
     }
 
     /**
-     * Append text to an element
-     * Can add another selection to a select box
+     * Append the given text to the given element.
+     * Can also add a selection to a select box.
      *
      * ``` php
      * <?php


### PR DESCRIPTION
I added a "Locating Elements" section to the docstring for WebDriver.php with details on how
locators are specified and processed. That was a stumbling point for me when I first learned how to
use this module. I introduced the term "fuzzy locator" to refer to plain-string locators.

I reworded a lot of the other method docstrings to read better and to correct grammatical errors. Also, I noticed a few methods (e.g. submitForm) duplicated the docstring for the corresponding interface method, so I removed those.
