### PR TITLE
Updated coverage generation command

### DIFF
--- a/docs/11-Codecoverage.md
+++ b/docs/11-Codecoverage.md
@@ -66,10 +66,10 @@ The basic codecoverage can be collected for functional and unit tests.
 If you performed configuration steps from above, you are ready to go.
 All you need is to execute codeception with `--coverage` option.
 
-To generate a clover xml report or a tasty html report append also `--coverage-xml` and `--coverage-html` options.
+To generate a clover xml report or a tasty html report append also `--xml` &amp; `--html` and `--json` options.
 
 ``` yaml
-codecept run --coverage --coverage-xml --coverage-html
+codecept run --coverage --xml --html --json
 ```
 
 XML and HTML reports are stored to the `_output` directory. The best way to review report is to open `index.html` from `tests/_output/coverage` in your browser.


### PR DESCRIPTION
To run your coverage we should not use:
`codecept run --coverage --coverage-xml --coverage-html`

The correct command is:
`codecept run --coverage --xml --html --json`

Both the command and the description have been updated.
