### PR TITLE
Create CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,6 @@
+# How to contribute
+At Codeception we are glad to receive contributions and patches from the community. There are a few guidelines that we need contributors to follow so that we can have a chance of keeping on top of things.
+
+Please check the guide for sending your contributions with Github at https://github.com/Codeception/Codeception/wiki/Git-workflow-for-Codeception-contributors
+
+All contributions must follow the coding standards described at: https://github.com/Codeception/Codeception/wiki/Codeception-coding-style-standard


### PR DESCRIPTION
I noticed that Codeception didn't had any contribution guidelines. This pull uses the Github feature for it, see details at https://github.com/blog/1184-contributing-guidelines

@DavertMik feel free to modify the content of the pull request. I just did a generic text.
