### PR TITLE
In fact, only properties may be updated using Stub::update :(

### DIFF
--- a/src/Codeception/Util/Stub.php
+++ b/src/Codeception/Util/Stub.php
@@ -453,7 +453,7 @@ class Stub
     }
 
     /**
-     * Replaces properties and methods of current stub
+     * Replaces properties of current stub
      *
      * @param \PHPUnit_Framework_MockObject_MockObject $mock
      * @param array                                    $params


### PR DESCRIPTION
This is so because method replaced only on stage of mock generation
