### PR TITLE
Update 12-ParallelExecution.md

### DIFF
--- a/docs/12-ParallelExecution.md
+++ b/docs/12-ParallelExecution.md
@@ -146,7 +146,7 @@ In second case `Codeception\TestLoader` class will be used and test classes will
 Let's prepare group files:
 
 ```bash
-$ robo parallel:split-groups
+$ robo parallel:split-tests
 
  [Codeception\Task\SplitTestFilesByGroupsTask] Processing 33 files
  [Codeception\Task\SplitTestFilesByGroupsTask] Writing tests/_log/p1


### PR DESCRIPTION
The CLI command for splitting the tests is wrong
- it says: split-groups
- but this is not a valid command
