### PR TITLE
Removing empty condition in proceedSeeInField

### DIFF
--- a/src/Codeception/Lib/InnerBrowser.php
+++ b/src/Codeception/Lib/InnerBrowser.php
@@ -298,10 +298,7 @@ class InnerBrowser extends Module implements Web
             $ident = reset($field);
             $strField = key($field) . '=>' . $ident;
         }
-        
-        if (is_bool($value)) {
-            
-        }
+
         return [
             'Contains',
             $value,


### PR DESCRIPTION
Mistakenly had an empty condition in there
