### PR TITLE
Fix an erroneous cookie behavior of functional tests

### DIFF
--- a/src/Codeception/Module/Yii2.php
+++ b/src/Codeception/Module/Yii2.php
@@ -55,6 +55,7 @@ class Yii2 extends Framework implements ActiveRecord
     {
         $this->client = new \Codeception\Lib\Connector\Yii2();
         $this->client->configFile = \Codeception\Configuration::projectDir().$this->config['configFile'];
+        $this->client->setServerParameter('HTTP_HOST', parse_url(\Codeception\Configuration::config()['config']['test_entry_url'], PHP_URL_HOST));
         $this->app = $this->client->startApp();
 
         if ($this->config['cleanup'] and isset($this->app->db)) {


### PR DESCRIPTION
This is something that hard to catch. But it is.

To reproduce you can run any functional test for Yii2 advanced app (installed as an application skeleton not as yii dev playground and having different domains for the frontend and the backend) and run something like `../vendor/bin/codecept run functional -vvv`
You will see a lot of such messages:

```
Scenario:
* I am on page "/index-test.php/site/login"
  [Response] 200
  [Page] http://localhost/index-test.php/site/login
  [Cookies] []
```

You will notice, that your domain is something different then `localhost`

It is hard to achieve an example code that will do a false negative pass.
But I have one in my application and this fix helps me to solve it.