### PR TITLE
Allow CLI module to handle nonzero response codes without failing

### DIFF
--- a/src/Codeception/Module/Cli.php
+++ b/src/Codeception/Module/Cli.php
@@ -25,12 +25,12 @@ class Cli extends \Codeception\Module
      *
      * @param $command
      */
-    public function runShellCommand($command) {
+    public function runShellCommand($command, $failNonZero = true) {
         $data = array();
         exec("$command", $data, $resultCode);
         $this->output = implode("\n", $data);
         if ($this->output === null) \PHPUnit_Framework_Assert::fail("$command can't be executed");
-        if ($resultCode !== 0) {
+        if ($resultCode !== 0 && $failNonZero) {
             \PHPUnit_Framework_Assert::fail("Result code was $resultCode.\n\n".$this->output);
         }
         $this->debug(preg_replace('~s/\e\[\d+(?>(;\d+)*)m//g~', '',$this->output));


### PR DESCRIPTION
Fixes https://github.com/Codeception/Codeception/issues/1603.

As explained in the issue, I wanted to test the output of a command that would return a nonzero result code. 

This change allows the `runShellCommand` function to take an optional parameter to disable the auto-failure of a test for instances where the resultcode is expected to be nonzero.
