### PR TITLE
Fix double slashes in certain forms submitted by InnerBrowser::submitForm

### DIFF
--- a/src/Codeception/Lib/InnerBrowser.php
+++ b/src/Codeception/Lib/InnerBrowser.php
@@ -393,7 +393,13 @@ class InnerBrowser extends Module implements Web
                     $build[$part] = $build[$part] . $value;
                     continue;
                 }
-                $build[$part] = dirname($build[$part]) . '/' . $value;
+                $dir = dirname($build[$part]);
+                
+                // Do not double the slashes and guard against the Windows backslash
+                if ($dir === '/' || $dir === '\\') {
+                    $dir = '';
+                }
+                $build[$part] =  $dir . '/' . $value;
                 continue;
             }
             $build[$part] = $value;

--- a/tests/data/app/controllers.php
+++ b/tests/data/app/controllers.php
@@ -162,3 +162,13 @@ class httpAuth {
         echo "Forbidden";
     }
 }
+
+class register {
+    function GET() {
+        include __DIR__.'/view/register.php';
+    }
+    
+    function POST() {
+        $this->GET();
+    }
+}

--- a/tests/data/app/index.php
+++ b/tests/data/app/index.php
@@ -29,7 +29,8 @@ $urls = array(
     '/facebook\??.*' => 'facebookController',
     '/form/(.*?)(#|\?.*?)?' => 'form',
     '/articles\??.*' => 'articles',
-    '/auth' => 'httpAuth'
+    '/auth' => 'httpAuth',
+    '/register' => 'register'
 );
 
 glue::stick($urls);

--- a/tests/data/app/view/register.php
+++ b/tests/data/app/view/register.php
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html>
+<head>
+<base href="http://127.0.0.1:8000">
+<meta charset="utf-8">
+<title>Test submitting a form with a relative URL without a leading slash as its action from a URI in the root directory</title>
+</head>
+<body>
+<form method="post" action="register">
+<input type="text" name="test" value="" />
+<input type="submit" name="submit" value="Submit" />
+</form>
+</body>
+</html>

--- a/tests/unit/Codeception/Module/PhpBrowserTest.php
+++ b/tests/unit/Codeception/Module/PhpBrowserTest.php
@@ -249,5 +249,14 @@ class PhpBrowserTest extends TestsForBrowsers
         $this->module->attachFile('foo[bar]', 'app/avatar.jpg');
         $this->module->click('Submit');
     }
-
+    
+    public function testDoubleSlash()
+    {
+        $I = $this->module;
+        $I->amOnPage('/register');
+        $I->submitForm('form', array('test' => 'test'));
+        $formUrl = $this->module->client->getHistory()->current()->getUri();
+        $formPath = parse_url($formUrl)['path'];
+        $this->assertEquals($formPath, '/register');
+    }
 }


### PR DESCRIPTION
The Codeception\Lib\InnerBrowser method getFormUrl() can under certain
conditions create a form URL where the path begins with double slashes.

Conditions for the error:
1. The page with the form lies on a first-level path, e.g.
example.com/register
2. The form has an action without a leading slash, e.g.
<form action="login">

This is valid and browsers understand what is meant.

On Unix the malformed action URL will look like this:
http://example.com//form-target

On Windows this is even worse because dirname() of a first-level directory
returns a backslash (\) instead of a forward slash.

See http://www.webmasterworld.com/php/3752500.htm

Thus a form URL with Codeception run on Windows will look like this:
http://example.com/\/form-target

Both malformed URLs can cause server errors, depending on the server
configuration mostly 404 or 500.

This commit adds a test that confirms the error and fixes it
in a localized way that shouldn't regress anything else.