### PR TITLE
Suppressing E_USER_DEPRECATED errors thrown by vendor packages

### DIFF
--- a/codecept
+++ b/codecept
@@ -8,6 +8,20 @@ require_once dirname(__FILE__).'/autoload.php';
 
 use Symfony\Component\Console\Application;
 
+/**
+ * Suppressing E_USER_DEPRECATED errors thrown by vendor packages
+ */
+set_error_handler(function ($errno, $errstr, $errfile, $errline, $errcontext) {
+    foreach (Codeception\Configuration::$silenceVendorDeprecatedFiles as $file) {
+        // Suppress error for matched file
+        if (preg_match('#'.$file.'$#', $errfile)) {
+            return true;
+        }
+    }
+    // Continue to default error handling
+    return false;
+}, E_USER_DEPRECATED);
+
 $app = new Application('Codeception', Codeception\Codecept::VERSION);
 $app->add(new Codeception\Command\Build('build'));
 $app->add(new Codeception\Command\Run('run'));

--- a/src/Codeception/Configuration.php
+++ b/src/Codeception/Configuration.php
@@ -82,6 +82,15 @@ class Configuration
     );
 
     /**
+     * List of vendor files with suppressed E_USER_DEPRECATED error
+     *
+     * @var array
+     */
+    public static $silenceVendorDeprecatedFiles = array(
+        'Symfony/Component/Yaml/Deprecated/Unescaper.php',
+    );
+
+    /**
      * Loads global config file which is `codeception.yml` by default.
      * When config is already loaded - returns it.
      *


### PR DESCRIPTION
This should fix problem with Symfony packages throwing E_USER_DEPRECATED errors from functions or classes which are used just inside Symfony functions and not used or extended directly by Codeception.
Solves issues #1628 #1571