### PR TITLE
allow redirects for guzzle connector

### DIFF
--- a/src/Codeception/Lib/Connector/Guzzle.php
+++ b/src/Codeception/Lib/Connector/Guzzle.php
@@ -14,7 +14,7 @@ class Guzzle extends Client
 {
     protected $baseUri;
     protected $requestOptions = [
-        'allow_redirects' => false,
+        'allow_redirects' => true,
         'headers' => [],
     ];
     protected $refreshMaxInterval = 0;


### PR DESCRIPTION
This allows phpbrowser, which relies on guzzle, to follow redirects correctly.