### PR TITLE
Allow selectOption() to select options not inside forms.

### DIFF
--- a/src/Codeception/Module/WebDriver.php
+++ b/src/Codeception/Module/WebDriver.php
@@ -837,7 +837,6 @@ class WebDriver extends \Codeception\Module implements WebInterface, RemoteInter
         /** @var $context \WebDriverElement  * */
         $noFormXpath = str_replace('ancestor::form', '', $xpath);
         foreach ([$xpath, $noFormXpath] as $testXpath) {
-            $this->debug("xpath is: $testXpath \n");
             $els = $context->findElements(\WebDriverBy::xpath($testXpath));
             if (count($els)) {
                 return reset($els);

--- a/src/Codeception/Module/WebDriver.php
+++ b/src/Codeception/Module/WebDriver.php
@@ -835,13 +835,17 @@ class WebDriver extends \Codeception\Module implements WebInterface, RemoteInter
             }
         }
         /** @var $context \WebDriverElement  * */
-        $els = $context->findElements(\WebDriverBy::xpath($xpath));
-        if (count($els)) {
-            return reset($els);
-        }
-        $els = $this->match($context, $radio_or_checkbox);
-        if (count($els)) {
-            return reset($els);
+        $noFormXpath = str_replace('ancestor::form', '', $xpath);
+        foreach ([$xpath, $noFormXpath] as $testXpath) {
+            $this->debug("xpath is: $testXpath \n");
+            $els = $context->findElements(\WebDriverBy::xpath($testXpath));
+            if (count($els)) {
+                return reset($els);
+            }
+            $els = $this->match($context, $radio_or_checkbox);
+            if (count($els)) {
+                return reset($els);
+            }
         }
         return null;
     }

--- a/tests/data/app/view/form/bug1637.php
+++ b/tests/data/app/view/form/bug1637.php
@@ -1,0 +1,10 @@
+<!doctype html>
+<html>
+    <head><title>hi</title></head>
+    <body>
+        TEST TEST
+            <label><input type="radio" name="first_test_radio" value="Yes"/>Yes</label>
+            <label><input type="radio" name="first_test_radio" value="No"/>No</label>
+            <br/>
+    </body>
+</html>

--- a/tests/unit/Codeception/Module/WebDriverTest.php
+++ b/tests/unit/Codeception/Module/WebDriverTest.php
@@ -496,4 +496,17 @@ class WebDriverTest extends TestsForBrowsers
         $this->module->amOnPage('/form/bug1598');
         $this->module->waitForText('12,345', 10, '#field');
     }
+
+    public function testBug1637()
+    {
+        $this->module->amOnPage('/form/bug1637');
+
+        // confirm that options outside a form are still selectable
+        $this->module->selectOption('input[name=first_test_radio]', 'Yes');
+
+        // confirm that it did what we expected and did not do anything else
+        $this->module->seeOptionIsSelected('input[name=first_test_radio]', 'Yes');
+        $this->module->dontSeeOptionIsSelected('input[name=first_test_radio]', 'No');
+    }
+
 }


### PR DESCRIPTION
This fixes a regression in behavior that was introduced in #1468.
It includes a new unit test to ensure that this behavior can be preserved
going forward in future modifications. I preform two sets of checks so that
if the ancestor::form is catching things we don't risk selecting the wrong
element. Confirmed this works for the tests for issue #1467 as well.