### PR TITLE
Fixing matchOption to return the option value in case there is no value attribute

### DIFF
--- a/src/Codeception/Lib/InnerBrowser.php
+++ b/src/Codeception/Lib/InnerBrowser.php
@@ -525,7 +525,7 @@ class InnerBrowser extends Module implements Web
     {
         $options = $field->filterXPath(sprintf('//option[text()=normalize-space("%s")]', $option));
         if ($options->count()) {
-            return $options->first()->attr('value');
+            return $options->first()->text();
         }
         return $option;
     }


### PR DESCRIPTION
Sometimes HTML select element only has value <option>like this</option>, but not the "value" attribute. So we need to return the text, much like we match it initially.