### PR TITLE
add a function that lets you provide additional headers before making an...

### DIFF
--- a/src/Codeception/Module/REST.php
+++ b/src/Codeception/Module/REST.php
@@ -94,6 +94,18 @@ class REST extends \Codeception\Module
     }
 
     /**
+     * Adds HTTP headers
+     *
+     * @param $headers
+     */
+    public function addHeaders($headers)
+    {
+        if (!empty($headers) && is_array($headers)) {
+            $this->headers = array_merge($this->headers, $headers);
+        }
+    }
+
+    /**
      * Sets HTTP header
      *
      * @param $name


### PR DESCRIPTION
... HTTP Request.

I noticed you have $this->headers but there's no way to set those. This function lets me say

$I->addHeaders(array("Content-Type"=>"application/jsonp"));

Or add any other headers I may need to test my application.