### PR TITLE
Remote context options fix

### DIFF
--- a/src/Codeception/Coverage/Subscriber/LocalServer.php
+++ b/src/Codeception/Coverage/Subscriber/LocalServer.php
@@ -165,7 +165,10 @@ class LocalServer extends SuiteSubscriber
 
      protected function addC3AccessHeader($header, $value)
      {
-         $this->c3Access['http']['header'] .= "$header: $value\r\n";
+         $headerString = "$header: $value\r\n";
+         if (strpos($this->c3Access['http']['header'], $headerString) === false) {
+             $this->c3Access['http']['header'] .= $headerString;
+         }
      }
 
     protected function applySettings($settings)

--- a/src/Codeception/Coverage/Subscriber/LocalServer.php
+++ b/src/Codeception/Coverage/Subscriber/LocalServer.php
@@ -172,7 +172,7 @@ class LocalServer extends SuiteSubscriber
     {
         parent::applySettings($settings);
         if (isset($settings['coverage']['remote_context_options'])) {
-            $this->c3Access = array_merge_recursive($settings['coverage']['remote_context_options'], $this->c3Access);
+            $this->c3Access = array_replace_recursive($this->c3Access, $settings['coverage']['remote_context_options']);
         }
     }
 


### PR DESCRIPTION
When running remote coverage with multiple test suites, Coverage class gets multiple calls to *beforeSuite*, hence *applySettings* triggers *$this->c3Access* to be merged over and over again with yaml config. *array_merge_recursive* behaviour for duplicates is to create an array with two or more values, so the result is e.g 
```php
['http' => 'timeout' => [300, 300, ...]
```
, which is invalid http_stream_context options.

Same goes for *addC3AccessHeader*, which concatenates headers over and over again. While there's no harm in that, it's kind of wrong.

The whole remote coverage client would be better off by using a proper symfony http client, but this would be a bigger refactoring.