### PR TITLE
Added disconnecting from DB to prevent "Too many connections" issue

### DIFF
--- a/src/Codeception/Module/Laravel4.php
+++ b/src/Codeception/Module/Laravel4.php
@@ -122,8 +122,8 @@ class Laravel4 extends Framework implements ActiveRecord
         }
 
         // disconnect from DB to prevent "Too many connections" issue
-        if ($this->app['db']) {
-            $this->app['db']->disconnect();
+        if ($this->kernel['db']) {
+            $this->kernel['db']->disconnect();
         }
     }
 

--- a/src/Codeception/Module/Laravel4.php
+++ b/src/Codeception/Module/Laravel4.php
@@ -120,6 +120,11 @@ class Laravel4 extends Framework implements ActiveRecord
         if ($this->kernel['session']) {
             $this->kernel['session']->flush();
         }
+
+        // disconnect from DB to prevent "Too many connections" issue
+        if ($this->app['db']) {
+            $this->app['db']->disconnect();
+        }
     }
 
     /**


### PR DESCRIPTION
If this line is not present for 170 tests I get (tested on Laravel 5 but it will be the same on Laravel 4):

````
 [PDOException]                               
 SQLSTATE[08004] [1040] Too many connections
````

For lower number of tests there is no problem of course and I don't want to increase my database connections limit.

As far as I know it's impossible to disconnect in test in ```__after``` method because in that case you will get fatal error ```Call to a member function rollBack() on null```