### PR TITLE
Fix Symfony2 bug #1656 where kernel is not shutdown before next test

### DIFF
--- a/src/Codeception/Lib/Connector/Symfony2.php
+++ b/src/Codeception/Lib/Connector/Symfony2.php
@@ -3,18 +3,18 @@ namespace Codeception\Lib\Connector;
 
 class Symfony2 extends \Symfony\Component\HttpKernel\Client
 {
-    private $hasPerformedRequest = false;
+    private static $hasPerformedRequest;
 
     public $persistentServices = [];
 
     protected function doRequest($request)
     {
         $services = [];
-        if ($this->hasPerformedRequest) {
+        if (static::$hasPerformedRequest) {
             $services = $this->persistServices();
             $this->kernel->shutdown();
         } else {
-            $this->hasPerformedRequest = true;
+            static::$hasPerformedRequest = true;
         }
         $this->kernel->boot();
 


### PR DESCRIPTION
Explanation:
A new `Codeception\Lib\Connector\Symfony2` object is initiated for every test (see https://github.com/Codeception/Codeception/blob/2.0/src/Codeception/Module/Symfony2.php#L104) resetting the hasPerformedRequest property but reusing the old kernel.

In my case that resulted in a user being logged in on the first request of a new test..see #1656 .

