### PR TITLE
 Anonymous function in PHP5.3 does not have $this

### DIFF
--- a/src/Codeception/TestCase.php
+++ b/src/Codeception/TestCase.php
@@ -78,10 +78,11 @@ abstract class TestCase extends \PHPUnit_Framework_TestCase implements \PHPUnit_
     {
         if (empty($this->dependencies)) return true;
 
-        $passed     = $this->getTestResultObject()->passed();
-        $testNames = array_map(function($testname) {
-            if ($this instanceof \Codeception\TestCase\Cest) {
-                $testname = str_replace('Codeception\TestCase\Cest::', get_class($this->getTestClass()).'::', $testname);
+        $passed = $this->getTestResultObject()->passed();
+        $that = $this;
+        $testNames = array_map(function($testname) use ($that) {
+            if ($that instanceof \Codeception\TestCase\Cest) {
+                $testname = str_replace('Codeception\TestCase\Cest::', get_class($that->getTestClass()).'::', $testname);
             }
             return preg_replace('~with data set (.*?)~','', $testname);
         }, array_keys($passed));


### PR DESCRIPTION
We had to write
@depends Codeception\TestCase\Cest::something
PHP Warning ("undefined variable this") was triggered when I changed the error reporting in the suite.

With this change @depends works as documented.