### PR TITLE
Type null converted to empty string

### DIFF
--- a/src/Codeception/Module.php
+++ b/src/Codeception/Module.php
@@ -176,7 +176,7 @@ abstract class Module extends AssertWrapper
     protected function scalarizeArray($array)
     {
         foreach ($array as $k => $v) {
-            if (!is_scalar($v)) {
+            if (!is_scalar($v) && $v !== null) {
                 $array[$k] = (is_array($v) || $v instanceof \ArrayAccess)
                     ? $this->scalarizeArray($v)
                     : (string)$v;


### PR DESCRIPTION
For examlpe: 
```php
$I->sendPATCH('/api/category/1', ['parent_id' => null]);
```
Encode to json:
```json
{"PARENT_CATEGORY_ID":""}
```