### PR TITLE
Update SqlSrv.php

### DIFF
--- a/src/Codeception/Lib/Driver/SqlSrv.php
+++ b/src/Codeception/Lib/Driver/SqlSrv.php
@@ -43,7 +43,7 @@ class SqlSrv extends Db
             DEALLOCATE tables_cursor;");
     }
     
-    public function select($column, $table, array $criteria)
+    public function select($column, $table, array &$criteria)
     {
         $where  = $criteria ? "where %s" : '';
         $query  = "select %s from " . $this->getQuotedName('%s') . " $where";


### PR DESCRIPTION
select() needs the $criteria parameter to be passed by reference to be compatible with Db::select()