### PR TITLE
fix put method in Yii2 connector

### DIFF
--- a/src/Codeception/Lib/Connector/Yii2.php
+++ b/src/Codeception/Lib/Connector/Yii2.php
@@ -54,6 +54,7 @@ class Yii2 extends Client
             $_GET = $_REQUEST;
         } else {
             $_POST = $_REQUEST;
+            $_POST[Yii::$app->getRequest()->methodParam] = $request->getMethod();
         }
 
         $uri = $request->getUri();


### PR DESCRIPTION
Hi.
There is a problem:
When i'm using ```sendPut``` in functional tests, ```Yii::$app->getRequest()->getBodyParams()``` is empty in controller.
It's happens because Yii2 connector is not putting ```methodParam``` field into POST array.