### PR TITLE
Add dontSeeResponseJsonMatchesJsonPath method to REST module.

### DIFF
--- a/src/Codeception/Module/REST.php
+++ b/src/Codeception/Module/REST.php
@@ -689,6 +689,19 @@ class REST extends \Codeception\Module
     }
 
     /**
+     * Checks if json structure does NOT match response [JsonPath](http://goessner.net/articles/JsonPath/).
+     * 
+     * @see seeResponseJsonMatchesJsonPath()
+     *
+     */
+    public function dontSeeResponseJsonMatchesJsonPath($jsonPath)
+    {
+        $jsonArray = (new JsonArray($this->response))->filterByJsonPath($jsonPath);
+        $this->assertEmpty($jsonArray,
+            "Received JSON did match the JsonPath provided\n".$this->response);
+    }
+
+    /**
      * Opposite to seeResponseContainsJson
      *
      * @param array $json

--- a/src/Codeception/Util/JsonArray.php
+++ b/src/Codeception/Util/JsonArray.php
@@ -52,7 +52,7 @@ class JsonArray
     public function filterByJsonPath($jsonPath)
     {
         if (!class_exists('Flow\JSONPath\JSONPath')) {
-            throw new \Exception('JSONPath library not installed. Please add `flow/jsonpath` to composer.json');
+            throw new \Exception('JSONPath library not installed. Please add `flow/jsonpath` `0.1.*` to composer.json');
         }
         return (new JSONPath($this->jsonArray))->find($jsonPath);
     }

--- a/tests/unit/Codeception/Module/RestTest.php
+++ b/tests/unit/Codeception/Module/RestTest.php
@@ -231,6 +231,8 @@ class RestTest extends \PHPUnit_Framework_TestCase
         $this->module->seeResponseJsonMatchesXpath('//user');
         $this->module->seeResponseJsonMatchesJsonPath('$[*].user');
         $this->module->seeResponseJsonMatchesJsonPath('$[1].tags');
+        $this->module->dontSeeResponseJsonMatchesJsonPath('$[*].user.badKey');
+        $this->module->dontSeeResponseJsonMatchesJsonPath('$[1].tags.badKey');
     }
 
     public function testStructuredJsonPathAndXPath()
@@ -240,6 +242,8 @@ class RestTest extends \PHPUnit_Framework_TestCase
         $this->module->seeResponseJsonMatchesXpath('//book/category');
         $this->module->seeResponseJsonMatchesJsonPath('$..book');
         $this->module->seeResponseJsonMatchesJsonPath('$.store.book[2].author');
+        $this->module->dontSeeResponseJsonMatchesJsonPath('$..book.badKey');
+        $this->module->dontSeeResponseJsonMatchesJsonPath('$.store.book[2].author.badKey');
     }
 
 


### PR DESCRIPTION
This is the inverse for `seeResponseJsonMatchesJsonPath`

This pull request also updates the comment to specify which version of `flow/jsonpath` to install since `0.2.*` returns an instance of `\Flow\JSONPath\JSONPath` instead of an array.