### PR TITLE
Fix quiet crash when crawler is null

### DIFF
--- a/src/Codeception/Lib/InnerBrowser.php
+++ b/src/Codeception/Lib/InnerBrowser.php
@@ -681,6 +681,10 @@ class InnerBrowser extends Module implements Web
      */
     protected function strictMatch(array $by)
     {
+        if (!$this->crawler) {
+            throw new TestRuntime('Crawler is null. Perhaps you forgot to call "amOnPage"?');
+        }
+
         $type = key($by);
         $locator = $by[$type];
         switch ($type) {

--- a/tests/unit/Codeception/Module/PhpBrowserTest.php
+++ b/tests/unit/Codeception/Module/PhpBrowserTest.php
@@ -259,4 +259,10 @@ class PhpBrowserTest extends TestsForBrowsers
         $formPath = parse_url($formUrl)['path'];
         $this->assertEquals($formPath, '/register');
     }
+
+    public function testFillFieldWithoutPage()
+    {
+        $this->setExpectedException("\\Codeception\\Exception\\TestRuntime");
+        $this->module->fillField('#name', 'Nothing special');
+    }
 }

--- a/tests/unit/Codeception/Module/TestsForWeb.php
+++ b/tests/unit/Codeception/Module/TestsForWeb.php
@@ -522,7 +522,6 @@ abstract class TestsForWeb extends \PHPUnit_Framework_TestCase
         $this->module->dontSeeElement('input[name=name]');
     }
 
-
 	public function testCookies()
 	{
 		$cookie_name = 'test_cookie';


### PR DESCRIPTION
When `amOnPage` is not called and try to call some function like fillField (with XPath-rule) the codeception quiet crashed without any errors.

It happened because `crawler->filterXPath` wrapped by "`@`".

This PR provide additional check on `crawler` exist