### PR TITLE
Improvement to the unit test case examples

### DIFF
--- a/docs/06-UnitTests.md
+++ b/docs/06-UnitTests.md
@@ -177,7 +177,8 @@ function testSavingUser()
 ?>
 ```
 
-Database will be cleaned and populated after each test, as it happens for acceptance and functional tests.
+To enable the database functionality in the unit tests please make sure the `Db` module is part of the enabled module list in the unit.suite.yml configuration file. 
+The database will be cleaned and populated after each test, as it happens for acceptance and functional tests.
 If it's not your required behavior, please change the settings of `Db` module for the current suite.
 
 ### Accessing Module


### PR DESCRIPTION
The unit test examples that use database functionality like the seeInDatabase() method call need to have the Db module listed in the unit suite configuration file. The module was not enabled by default after running bootstrap and generate:test, so I think it would be very helpful to mention this detail on the guide for Unit Tests. It took me a while to figure out why the test run failed with an exception about the missing function in the UnitTester class.

Thank you, Markus