### PR TITLE
More dynamic submitForm

### DIFF
--- a/src/Codeception/Lib/InnerBrowser.php
+++ b/src/Codeception/Lib/InnerBrowser.php
@@ -311,6 +311,14 @@ class InnerBrowser extends Module implements Web
         ];
     }
 
+    protected function getSubmissionFormFieldName($name)
+    {
+        if (substr($name, -2) === '[]') {
+            return substr($name, 0, -2);
+        }
+        return $name;
+    }
+
     public function submitForm($selector, $params, $button = null)
     {
         $form = $this->match($selector)->first();
@@ -318,49 +326,52 @@ class InnerBrowser extends Module implements Web
         if (!count($form)) {
             throw new ElementNotFound($selector, 'Form');
         }
-        
-        $url    = '';
+
+        $defaults = [];
         /** @var  \Symfony\Component\DomCrawler\Crawler|\DOMElement[] $fields */
-        $fields = $form->filter('input,button');
+        $fields = $form->filter('input:enabled,textarea:enabled,select:enabled,button:enabled,input[type=hidden]');
         foreach ($fields as $field) {
+            $fieldName = $this->getSubmissionFormFieldName($field->getAttribute('name'));
             if (($field->getAttribute('type') === 'checkbox' || $field->getAttribute('type') === 'radio') && !$field->hasAttribute('checked')) {
                 continue;
             } elseif ($field->getAttribute('type') === 'button') {
                 continue;
             } elseif (($field->getAttribute('type') === 'submit' || $field->tagName === 'button') && $field->getAttribute('name') !== $button) {
                 continue;
-            }
-            $url .= sprintf('%s=%s', $field->getAttribute('name'), $field->getAttribute('value')) . '&';
-        }
-
-        /** @var  \Symfony\Component\DomCrawler\Crawler|\DOMElement[] $fields */
-        $fields = $form->filter('textarea');
-        foreach ($fields as $field) {
-            $url .= sprintf('%s=%s', $field->getAttribute('name'), $field->nodeValue) . '&';
-        }
-        /** @var  \Symfony\Component\DomCrawler\Crawler|\DOMElement[] $fields */
-        $fields = $form->filter('select');
-        foreach ($fields as $field) {
-            /** @var  \DOMElement $option */
-            foreach ($field->childNodes as $option) {
-                if ($option->getAttribute('selected') == 'selected') {
-                    $url .= sprintf('%s=%s', $field->getAttribute('name'), $option->getAttribute('value')) . '&';
+            } elseif ($field->tagName === 'select') {
+                $values = [];
+                $select = new Crawler($field);
+                $options = $select->filter('option:enabled:selected');
+                foreach ($options as $option) {
+                    $values[] = $option->getAttribute('value');
+                    if (!$field->hasAttribute('multiple')) {
+                        break;
+                    }
                 }
+                if (count($values) > 1) {
+                    $defaults[$fieldName] = $values;
+                } elseif (count($values) === 1) {
+                    $defaults[$fieldName] = reset($values);
+                }
+                continue;
+            } elseif (!empty($field->nodeValue)) {
+                $defaults[$fieldName] = $field->nodeValue;
             }
+            $defaults[$fieldName] = $field->getAttribute('value');
         }
 
-        $url .= http_build_query($params);
-        parse_str($url, $params);
+        $requestParams = array_merge($defaults, $params);
+        
         $method = $form->attr('method') ? $form->attr('method') : 'GET';
-        $query  = '';
+        $query = '';
         if (strtoupper($method) == 'GET') {
-            $query = '?' . http_build_query($params);
+            $query = '?' . http_build_query($requestParams);
         }
         $this->debugSection('Uri', $this->getFormUrl($form));
         $this->debugSection('Method', $method);
-        $this->debugSection('Parameters', $params);
+        $this->debugSection('Parameters', $requestParams);
 
-        $this->crawler = $this->client->request($method, $this->getFormUrl($form) . $query, $params);
+        $this->crawler = $this->client->request($method, $this->getFormUrl($form) . $query, $requestParams);
         $this->debugResponse();
     }
 

--- a/tests/data/app/view/form/submitform_ampersands.php
+++ b/tests/data/app/view/form/submitform_ampersands.php
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>Testing submitForm with field values and ampersand</title>
+</head>
+<body>
+<form method="POST" action="/form/submitform_ampersands">
+    <input type="text" name="test" value="this &amp; that" />
+    <input type="submit" name="submit" value="Submit" />
+</form>
+</body>
+</html>

--- a/tests/data/app/view/form/submitform_multiple.php
+++ b/tests/data/app/view/form/submitform_multiple.php
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>Testing submitForm with select multiple</title>
+</head>
+<body>
+<form method="POST" action="/form/complex">
+    <select name="select[]" multiple>
+        <!-- a comment node here -->
+        <optgroup label="first part" disabled>
+            <option value="not seen one">Not selected</option>
+            <option value="not seen two" selected>Selected</option>
+        </optgroup>
+        <option value="not seen three" selected disabled>Not selected</option>
+        <option value="see test one" selected>Selected</option>
+        <option value="not seen four">Not selected</option>
+        <option value="see test two" selected>Selected</option>
+    </select>
+    <input type="submit" name="submit" value="Submit" />
+</form>
+</body>
+</html>

--- a/tests/unit/Codeception/Module/TestsForWeb.php
+++ b/tests/unit/Codeception/Module/TestsForWeb.php
@@ -758,8 +758,8 @@ abstract class TestsForWeb extends \PHPUnit_Framework_TestCase
         $form = data::get('form');
         $this->assertEquals('Davert', $form['name']);
         $this->assertEquals('Is Codeception maintainer', $form['description']);
-//        $this->assertFalse(isset($form['disabled_fieldset']));
-//        $this->assertFalse(isset($form['disabled_field']));
+        $this->assertFalse(isset($form['disabled_fieldset']));
+        $this->assertFalse(isset($form['disabled_field']));
         $this->assertEquals('kill_all', $form['action']);
     }
 
@@ -772,6 +772,24 @@ abstract class TestsForWeb extends \PHPUnit_Framework_TestCase
         $this->assertEquals('Hello!', $form['text']);
     }
     
+    public function testSubmitFormWithAmpersand()
+    {
+        $this->module->amOnPage('/form/submitform_ampersands');
+        $this->module->submitForm('form', []);
+        $form = data::get('form');
+        $this->assertEquals('this & that', $form['test']);
+    }
+    
+    public function testSubmitFormWithMultiSelect()
+    {
+        $this->module->amOnPage('/form/submitform_multiple');
+        $this->module->submitForm('form', []);
+        $form = data::get('form');
+        $this->assertCount(2, $form['select']);
+        $this->assertEquals('see test one', $form['select'][0]);
+        $this->assertEquals('see test two', $form['select'][1]);
+    }
+
     /**
      * https://github.com/Codeception/Codeception/issues/1381
      */


### PR DESCRIPTION
Removed submitForm's reliance on using parse_str and parse_url to
generate params (which caused unexpected side-effects like failing
for values with ampersands).

Modified the css selector for input elements so disabled input
elements don't get sent default values.

Modifications to ensure multiple values get sent correctly.