### PR TITLE
Ability to have another primary key then 'id'

### DIFF
--- a/src/Codeception/Lib/Driver/Db.php
+++ b/src/Codeception/Lib/Driver/Db.php
@@ -20,6 +20,8 @@ class Db
     public $sqlToRun;
 
     /**
+     * associative array with table name => primary-key
+     *
      * @var array
      */
     protected $primaryColumns = [];

--- a/src/Codeception/Lib/Driver/SqlSrv.php
+++ b/src/Codeception/Lib/Driver/SqlSrv.php
@@ -63,11 +63,11 @@ class SqlSrv extends Db
         return '[' . $name . ']';
     }
     
-    public function deleteQuery($table, $id)
+    public function deleteQuery($table, $id, $primaryKey = 'id')
     {
         $query = "delete from " 
             . $this->getQuotedName($table)
-            . " where " . $this->getQuotedName('id') . " = $id";
+            . " where " . $this->getQuotedName($primaryKey) . " = $id";
         
         $this->sqlQuery($query);
     }

--- a/src/Codeception/Lib/Driver/Sqlite.php
+++ b/src/Codeception/Lib/Driver/Sqlite.php
@@ -37,4 +37,15 @@ class Sqlite extends Db
             $this->hasSnapshot = true;
         }
     }
+
+    /**
+     * @param string $tableName
+     *
+     * @return string
+     */
+    public function getPrimaryColumn($tableName)
+    {
+        // @TODO: Implement this for SQLite later
+        return 'id';
+    }
 }

--- a/src/Codeception/Lib/Driver/SqliteGeneral.php
+++ b/src/Codeception/Lib/Driver/SqliteGeneral.php
@@ -30,4 +30,15 @@ class SqliteGeneral extends Db
         $this->dbh->exec('PRAGMA ignore_check_constraints = 0;');
         $this->dbh->exec('PRAGMA writable_schema = 0;');
     }
+
+    /**
+     * @param string $tableName
+     *
+     * @return string
+     */
+    public function getPrimaryColumn($tableName)
+    {
+        // @TODO: Implement this for SQLite later
+        return 'id';
+    }
 }

--- a/src/Codeception/Module/Db.php
+++ b/src/Codeception/Module/Db.php
@@ -117,7 +117,7 @@ class Db extends \Codeception\Module implements \Codeception\Lib\Interfaces\Db
      *
      * @var array
      */
-    protected $primaryKeys = [];
+    protected $primaryColumns = [];
 
     /**
      * @var array
@@ -269,39 +269,10 @@ class Db extends \Codeception\Module implements \Codeception\Lib\Interfaces\Db
         $this->insertedIds[] = [
           'table'   => $table,
           'id'      => $lastInsertId,
-          'primary' => $this->getPrimaryColumn($table)
+          'primary' => $this->driver->getPrimaryColumn($table)
         ];
 
         return $lastInsertId;
-    }
-
-    /**
-     * @param string $tableName
-     *
-     * @return string
-     * @throws \Exception
-     */
-    protected function getPrimaryColumn($tableName)
-    {
-        if ('sqlite' === $this->driver->getProvider($this->config['dsn'])) {
-            return 'id'; // @TODO: Fix this for SQLite because it can't use "SHOW KEYS"
-        }
-
-        if (false === isset($this->primaryKeys[$tableName])) {
-            $pdo  = $this->driver->getDbh();
-            $stmt = $pdo->prepare('SHOW KEYS FROM ' . $tableName . ' WHERE Key_name = ?');
-            $stmt->execute(['PRIMARY']);
-
-            $columnInformation = $stmt->fetch(\PDO::FETCH_ASSOC);
-
-            if (true === empty($columnInformation)) { // Need a primary key
-                throw new \Exception('Table ' . $tableName . ' is not valid or doesn\'t have no primary key');
-            }
-
-            $this->primaryKeys[$tableName] = $columnInformation['Column_name'];
-        }
-
-        return $this->primaryKeys[$tableName];
     }
 
     public function seeInDatabase($table, $criteria = [])

--- a/src/Codeception/Module/Db.php
+++ b/src/Codeception/Module/Db.php
@@ -84,17 +84,22 @@ class Db extends \Codeception\Module implements \Codeception\Lib\Interfaces\Db
     public $dbh;
 
     /**
-     * @var
+     * @var array
      */
+    protected $sql = [];
 
-    protected $sql = array();
-
-    protected $config = array(
+    /**
+     * @var array
+     */
+    protected $config = [
       'populate' => true,
       'cleanup'  => true,
       'dump'     => null
-    );
+    ];
 
+    /**
+     * @var bool
+     */
     protected $populated = false;
 
     /**
@@ -102,9 +107,15 @@ class Db extends \Codeception\Module implements \Codeception\Lib\Interfaces\Db
      */
     public $driver;
 
-    protected $insertedIds = array();
+    /**
+     * @var array
+     */
+    protected $insertedIds = [];
 
-    protected $requiredFields = array('dsn', 'user', 'password');
+    /**
+     * @var array
+     */
+    protected $requiredFields = ['dsn', 'user', 'password'];
 
     public function _initialize()
     {
@@ -165,7 +176,7 @@ class Db extends \Codeception\Module implements \Codeception\Lib\Interfaces\Db
                 $this->debug("coudn\'t delete record {$insertId['id']} from {$insertId['table']}");
             }
         }
-        $this->insertedIds = array();
+        $this->insertedIds = [];
     }
 
     protected function cleanup()
@@ -243,18 +254,18 @@ class Db extends \Codeception\Module implements \Codeception\Lib\Interfaces\Db
             // such as tables without _id_seq in PGSQL
             $lastInsertId = 0;
         }
-        $this->insertedIds[] = array('table' => $table, 'id' => $lastInsertId);
+        $this->insertedIds[] = ['table' => $table, 'id' => $lastInsertId];
 
         return $lastInsertId;
     }
 
-    public function seeInDatabase($table, $criteria = array())
+    public function seeInDatabase($table, $criteria = [])
     {
         $res = $this->proceedSeeInDatabase($table, 'count(*)', $criteria);
         \PHPUnit_Framework_Assert::assertGreaterThan(0, $res, 'No matching records found');
     }
 
-    public function dontSeeInDatabase($table, $criteria = array())
+    public function dontSeeInDatabase($table, $criteria = [])
     {
         $res = $this->proceedSeeInDatabase($table, 'count(*)', $criteria);
         \PHPUnit_Framework_Assert::assertLessThan(1, $res);
@@ -275,7 +286,7 @@ class Db extends \Codeception\Module implements \Codeception\Lib\Interfaces\Db
         return $sth->fetchColumn();
     }
 
-    public function grabFromDatabase($table, $column, $criteria = array())
+    public function grabFromDatabase($table, $column, $criteria = [])
     {
         return $this->proceedSeeInDatabase($table, $column, $criteria);
     }

--- a/src/Codeception/Module/Db.php
+++ b/src/Codeception/Module/Db.php
@@ -283,6 +283,10 @@ class Db extends \Codeception\Module implements \Codeception\Lib\Interfaces\Db
      */
     protected function getPrimaryColumn($tableName)
     {
+        if ('sqlite' === $this->driver->getProvider($this->config['dsn'])) {
+            return 'id'; // @TODO: Fix this for SQLite because it can't use "SHOW KEYS"
+        }
+
         if (false === isset($this->primaryKeys[$tableName])) {
             $pdo  = $this->driver->getDbh();
             $stmt = $pdo->prepare('SHOW KEYS FROM ' . $tableName . ' WHERE Key_name = ?');

--- a/src/Codeception/Module/Db.php
+++ b/src/Codeception/Module/Db.php
@@ -113,13 +113,6 @@ class Db extends \Codeception\Module implements \Codeception\Lib\Interfaces\Db
     protected $insertedIds = [];
 
     /**
-     * associative array with table name => primary-key
-     *
-     * @var array
-     */
-    protected $primaryColumns = [];
-
-    /**
      * @var array
      */
     protected $requiredFields = ['dsn', 'user', 'password'];
@@ -178,11 +171,7 @@ class Db extends \Codeception\Module implements \Codeception\Lib\Interfaces\Db
     {
         foreach ($this->insertedIds as $insertId) {
             try {
-                $pdo  = $this->driver->getDbh();
-                $stmt = $pdo->prepare(
-                  'DELETE FROM `' . $insertId['table'] . '` WHERE `' . $insertId['primary'] . '` = ?'
-                );
-                $stmt->execute([$insertId['id']]);
+                $this->driver->deleteQuery($insertId['table'], $insertId['id'], $insertId['primary']);
             } catch (\Exception $e) {
                 $this->debug("coudn\'t delete record {$insertId['id']} from {$insertId['table']}");
             }

--- a/src/Codeception/Module/Db.php
+++ b/src/Codeception/Module/Db.php
@@ -89,16 +89,19 @@ class Db extends \Codeception\Module implements \Codeception\Lib\Interfaces\Db
 
     protected $sql = array();
 
-    protected $config = array('populate' => true,
-                              'cleanup'  => true,
-                              'dump'     => null);
+    protected $config = array(
+      'populate' => true,
+      'cleanup'  => true,
+      'dump'     => null
+    );
 
-	protected $populated = false;
+    protected $populated = false;
 
     /**
      * @var \Codeception\Lib\Driver\Db
      */
     public $driver;
+
     protected $insertedIds = array();
 
     protected $requiredFields = array('dsn', 'user', 'password');
@@ -109,14 +112,14 @@ class Db extends \Codeception\Module implements \Codeception\Lib\Interfaces\Db
 
             if (!file_exists(Configuration::projectDir() . $this->config['dump'])) {
                 throw new ModuleConfigException(
-                    __CLASS__,
-                    "\nFile with dump doesn't exist.
+                  __CLASS__,
+                  "\nFile with dump doesn't exist.
                     Please, check path for sql file: " . $this->config['dump']
                 );
             }
             $sql = file_get_contents(Configuration::projectDir() . $this->config['dump']);
             $sql = preg_replace('%/\*(?!!\d+)(?:(?!\*/).)*\*/%s', "", $sql);
-            if( ! empty($sql)) {
+            if (!empty($sql)) {
                 $this->sql = explode("\n", $sql);
             }
         }
@@ -157,7 +160,7 @@ class Db extends \Codeception\Module implements \Codeception\Lib\Interfaces\Db
     {
         foreach ($this->insertedIds as $insertId) {
             try {
-            $this->driver->deleteQuery($insertId['table'], $insertId['id']);
+                $this->driver->deleteQuery($insertId['table'], $insertId['id']);
             } catch (\Exception $e) {
                 $this->debug("coudn\'t delete record {$insertId['id']} from {$insertId['table']}");
             }
@@ -168,15 +171,15 @@ class Db extends \Codeception\Module implements \Codeception\Lib\Interfaces\Db
     protected function cleanup()
     {
         $dbh = $this->driver->getDbh();
-        if (! $dbh) {
+        if (!$dbh) {
             throw new ModuleConfigException(
-                __CLASS__,
-                "No connection to database. Remove this module from config if you don't need database repopulation"
+              __CLASS__,
+              "No connection to database. Remove this module from config if you don't need database repopulation"
             );
         }
         try {
             // don't clear database for empty dump
-            if (! count($this->sql)) {
+            if (!count($this->sql)) {
                 return;
             }
             $this->driver->cleanup();
@@ -187,15 +190,15 @@ class Db extends \Codeception\Module implements \Codeception\Lib\Interfaces\Db
 
     protected function loadDump()
     {
-        if (! $this->sql) {
+        if (!$this->sql) {
             return;
         }
         try {
             $this->driver->load($this->sql);
         } catch (\PDOException $e) {
             throw new ModuleException(
-                __CLASS__,
-                $e->getMessage() . "\nSQL query being executed: " . $this->driver->sqlToRun
+              __CLASS__,
+              $e->getMessage() . "\nSQL query being executed: " . $this->driver->sqlToRun
             );
         }
     }
@@ -209,8 +212,9 @@ class Db extends \Codeception\Module implements \Codeception\Lib\Interfaces\Db
      * ?>
      * ```
      *
-     * @param $table
+     * @param       $table
      * @param array $data
+     *
      * @return integer $id
      */
     public function haveInDatabase($table, array $data)
@@ -222,7 +226,7 @@ class Db extends \Codeception\Module implements \Codeception\Lib\Interfaces\Db
         if (!$sth) {
             $this->fail("Query '$query' can't be executed.");
         }
-	    $i = 1;
+        $i = 1;
         foreach ($data as $val) {
             $sth->bindValue($i, $val);
             $i++;
@@ -252,7 +256,7 @@ class Db extends \Codeception\Module implements \Codeception\Lib\Interfaces\Db
 
     public function dontSeeInDatabase($table, $criteria = array())
     {
-        $res = $this->proceedSeeInDatabase($table, 'count(*)',$criteria);
+        $res = $this->proceedSeeInDatabase($table, 'count(*)', $criteria);
         \PHPUnit_Framework_Assert::assertLessThan(1, $res);
     }
 
@@ -267,11 +271,12 @@ class Db extends \Codeception\Module implements \Codeception\Lib\Interfaces\Db
         }
 
         $sth->execute(array_values($criteria));
+
         return $sth->fetchColumn();
     }
 
-    public function grabFromDatabase($table, $column, $criteria = array()) {
+    public function grabFromDatabase($table, $column, $criteria = array())
+    {
         return $this->proceedSeeInDatabase($table, $column, $criteria);
     }
-
 }


### PR DESCRIPTION
We have the problem that the primary key isn't named 'id'. That means that the cleanup of the Module 'Db' not delete our entries. This fix helped us and should help everyone else who have the same problem.