### PR TITLE
HTML entity encode test "name" for HTML reports

### DIFF
--- a/src/Codeception/PHPUnit/ResultPrinter/HTML.php
+++ b/src/Codeception/PHPUnit/ResultPrinter/HTML.php
@@ -109,7 +109,7 @@ class HTML extends \Codeception\PHPUnit\ResultPrinter
         $scenarioTemplate->setVar(
           array(
             'id'             => ++$this->id,
-            'name'           => $name,
+            'name'           => htmlentities($name),
             'scenarioStatus' => $scenarioStatus,
             'steps'          => $stepsBuffer,
 	        'time' => round($time, 2)


### PR DESCRIPTION
Test "name" will render the method test name and any data provided as
an argument to the test method.  If that data is HTML, it can
influence the browser when viewing the HTML report, namely a chance
for XSS.

Fixes #1712