### PR TITLE
FTP Passive Mode

### DIFF
--- a/src/Codeception/Module/FTP.php
+++ b/src/Codeception/Module/FTP.php
@@ -572,16 +572,16 @@ class FTP extends \Codeception\Module\Filesystem
                     \PHPUnit_Framework_Assert::fail('failed to connect to ftp server');
                 }
 
-                // Set passive mode option (ftp only option)
-                if (isset($this->config['passive']))
-                {
-                    ftp_pasv($this->ftp, strtolower($this->config['passive']) == 'enabled');
-                }
-
                 // Login using given access details
                 if (!@ftp_login($this->ftp, $user, $password))
                 {
                     \PHPUnit_Framework_Assert::fail('failed to authenticate user');
+                }
+                
+                // Set passive mode option (ftp only option)
+                if (isset($this->config['passive']))
+                {
+                    ftp_pasv($this->ftp, $this->config['passive']);
                 }
         }
         $pwd = $this->grabDirectory();


### PR DESCRIPTION
Hello Michael,

I found an issue of FTP module:

1. Passive mode do not get config value. Line 578 => You compare `$this->config['passive’]` with enabled instead of `true` or `1`
2. (Most important) You define passive mode before login, and you have to set it just after login.

I found the solution here :
- http://stackoverflow.com/a/1612323/3437153
- http://biostall.com/phps-ftp_nlist-returning-false-even-when-files-definitely-exist

With this pull request, FTP Module is fully operational.