### PR TITLE
Support for multiple databases

### DIFF
--- a/src/Codeception/Lib/Driver/Db.php
+++ b/src/Codeception/Lib/Driver/Db.php
@@ -208,7 +208,7 @@ class Db
     public function getPrimaryColumn($tableName)
     {
         if (false === isset($this->primaryColumns[$tableName])) {
-            $stmt = $this->getDbh()->query('SHOW KEYS FROM `' . $tableName . '` WHERE Key_name = "PRIMARY"');
+            $stmt = $this->getDbh()->query('SHOW KEYS FROM ' . $tableName . ' WHERE Key_name = "PRIMARY"');
             $columnInformation = $stmt->fetch(\PDO::FETCH_ASSOC);
 
             if (true === empty($columnInformation)) { // Need a primary key


### PR DESCRIPTION
Only a small change to #1727 .
If the table is in another database the string is like \`other_database.table_name`. Removing the backtick works well:

I know that ideally should escape the string, but there are [plenty](https://github.com/Codeception/Codeception/blob/2.0/src/Codeception/Lib/Driver/MySql.php#L26) of [lines](https://github.com/Codeception/Codeception/blob/2.0/src/Codeception/Lib/Driver/Db.php#L168) [where](https://github.com/Codeception/Codeception/blob/2.0/src/Codeception/Lib/Driver/Oci.php#L8) is [not covered](https://github.com/Codeception/Codeception/blob/2.0/src/Codeception/Module/Dbh.php#L91) 

```php
$I->haveInDatabase('other_db.my_table', $data); //was working until 2.0.10
$I->haveInDatabase('my-speçial-table-ñame', $data); //never worked
```
So I think that escaping table name should be fixed in another patch.