### PR TITLE
Fixed "Call to undefined method Symfony\Component\HttpFoundation\Request::route()"

### DIFF
--- a/src/Codeception/Lib/Connector/Laravel5.php
+++ b/src/Codeception/Lib/Connector/Laravel5.php
@@ -67,4 +67,16 @@ class Laravel5 extends Client implements HttpKernelInterface, TerminableInterfac
 	{
 		$this->httpKernel->terminate($request, $response);
 	}
+
+    /**
+     * Build Laravel5 request based on provided request instance
+     *
+     * @param DomRequest $request A DomRequest instance
+     *
+     * @return Response A Response instance
+     */
+    protected function doRequest($request)
+    {
+        return parent::doRequest(Request::createFromBase($request));
+    }
 }


### PR DESCRIPTION
This is a fix to #1748.

