### PR TITLE
Allow Yii1 application to live without `log` component

### DIFF
--- a/src/Codeception/Lib/Connector/Yii1.php
+++ b/src/Codeception/Lib/Connector/Yii1.php
@@ -90,8 +90,10 @@ class Yii1 extends Client
         Yii::createApplication($this->appSettings['class'], $this->appSettings['config']);
 
         // disabling logging. Logs slow down test execution
-        foreach (Yii::app()->log->routes as $route) {
-            $route->enabled = false;
+        if(Yii::app()->hasComponent('log')) {
+            foreach (Yii::app()->getComponent('log')->routes as $route) {
+                $route->enabled = false;
+            }
         }
         Yii::app()->onEndRequest->add(array($this, 'setHeaders'));
         Yii::app()->run();

--- a/src/Codeception/Lib/Connector/Yii1.php
+++ b/src/Codeception/Lib/Connector/Yii1.php
@@ -90,7 +90,7 @@ class Yii1 extends Client
         Yii::createApplication($this->appSettings['class'], $this->appSettings['config']);
 
         // disabling logging. Logs slow down test execution
-        if(Yii::app()->hasComponent('log')) {
+        if (Yii::app()->hasComponent('log')) {
             foreach (Yii::app()->getComponent('log')->routes as $route) {
                 $route->enabled = false;
             }


### PR DESCRIPTION
Now Yii1 connector has checks to detect if Yii application actually *has* a `log` component. 

This patch fixes #1753 