### PR TITLE
Fix for undefined method Symfony\Component\HttpFoundation\Request::route()

### DIFF
--- a/src/Codeception/Lib/Connector/Laravel5.php
+++ b/src/Codeception/Lib/Connector/Laravel5.php
@@ -65,6 +65,7 @@ class Laravel5 extends Client implements HttpKernelInterface, TerminableInterfac
 	 */
 	public function terminate(DomRequest $request, Response $response)
 	{
-		$this->httpKernel->terminate($request, $response);
+		$this->httpKernel->terminate(Request::createFromBase($request), $response);
 	}
+
 }


### PR DESCRIPTION
This is a fix for #1748, based on the fix proposed in #1750 by @jedrzej. 

I confirmed the issue when I did a `composer update` on the sample application, and this commit fixes the issue.