### PR TITLE
Remove unnecessary parameter from Webdriver PHPDoc

### DIFF
--- a/src/Codeception/Module/WebDriver.php
+++ b/src/Codeception/Module/WebDriver.php
@@ -1376,7 +1376,6 @@ class WebDriver extends \Codeception\Module implements WebInterface, RemoteInter
      * @param int $timeout seconds
      * @param null $selector
      * @throws \Exception
-     * @internal param string $element
      */
     public function waitForText($text, $timeout = 10, $selector = null)
     {


### PR DESCRIPTION
The tag `@internal` was causing PhpStorm to consider the method as internal. Additionally, it has no meaning for this method, since there is no variable `$element` used in the method the PhpDoc describes - `waitForText`