### PR TITLE
support for log absolute path

### DIFF
--- a/src/Codeception/Configuration.php
+++ b/src/Codeception/Configuration.php
@@ -421,7 +421,11 @@ class Configuration
         if (!self::$logDir) {
             throw new ConfigurationException("Path for logs not specified. Please, set log path in global config");
         }
-        $dir = self::$dir . DIRECTORY_SEPARATOR . self::$logDir . DIRECTORY_SEPARATOR;
+
+        $dir = self::$logDir . DIRECTORY_SEPARATOR;
+        if(strcmp(self::$logDir[0], "/") !== 0){
+            $dir = self::$dir . DIRECTORY_SEPARATOR . $dir;
+        }
 
         if (!is_writable($dir)) {
             @mkdir($dir);


### PR DESCRIPTION
Currently log path is assumed as a sub-folder of the configuration folder which means codeception cannot be run when located in a readonly folder.