### PR TITLE
Fix https support and verbose output

### DIFF
--- a/src/Codeception/Module/Yii2.php
+++ b/src/Codeception/Module/Yii2.php
@@ -55,8 +55,11 @@ class Yii2 extends Framework implements ActiveRecord
     {
         $this->client = new \Codeception\Lib\Connector\Yii2();
         $this->client->configFile = \Codeception\Configuration::projectDir().$this->config['configFile'];
-        $this->client->setServerParameter('HTTP_HOST', parse_url(\Codeception\Configuration::config()['config']['test_entry_url'], PHP_URL_HOST));
-        $this->client->setServerParameter('HTTPS', parse_url(\Codeception\Configuration::config()['config']['test_entry_url'], PHP_URL_SCHEME) === 'https');
+        $mainConfig = \Codeception\Configuration::config();
+        if (isset($mainConfig['config']) && isset($mainConfig['config']['test_entry_url'])){
+            $this->client->setServerParameter('HTTP_HOST', parse_url($mainConfig['config']['test_entry_url'], PHP_URL_HOST));
+            $this->client->setServerParameter('HTTPS', parse_url($mainConfig['config']['test_entry_url'], PHP_URL_SCHEME) === 'https');
+        }
         $this->app = $this->client->startApp();
 
         if ($this->config['cleanup'] and isset($this->app->db)) {
@@ -193,7 +196,7 @@ class Yii2 extends Framework implements ActiveRecord
      *  $I->amOnPage('http://localhost/index-test.php?site/index');
      */
     public function amOnPage($page) {
-                
+
         if(is_array($page)){
             $page = \Yii::$app->getUrlManager()->createUrl($page);
         }

--- a/src/Codeception/Module/Yii2.php
+++ b/src/Codeception/Module/Yii2.php
@@ -56,6 +56,7 @@ class Yii2 extends Framework implements ActiveRecord
         $this->client = new \Codeception\Lib\Connector\Yii2();
         $this->client->configFile = \Codeception\Configuration::projectDir().$this->config['configFile'];
         $this->client->setServerParameter('HTTP_HOST', parse_url(\Codeception\Configuration::config()['config']['test_entry_url'], PHP_URL_HOST));
+        $this->client->setServerParameter('HTTPS', parse_url(\Codeception\Configuration::config()['config']['test_entry_url'], PHP_URL_SCHEME) === 'https');
         $this->app = $this->client->startApp();
 
         if ($this->config['cleanup'] and isset($this->app->db)) {

--- a/src/Codeception/Module/Yii2.php
+++ b/src/Codeception/Module/Yii2.php
@@ -187,21 +187,19 @@ class Yii2 extends Framework implements ActiveRecord
         return $record;
     }
 
-
     /**
-     *  Converting $page to valid Yii2 url
-     *  Allows input like:
-     *  $I->amOnPage(['site/view','page'=>'about']);
-     *  $I->amOnPage('index-test.php?site/index');
-     *  $I->amOnPage('http://localhost/index-test.php?site/index');
+     * Converting $page to valid Yii2 url
+     * Allows input like:
+     * $I->amOnPage(['site/view','page'=>'about']);
+     * $I->amOnPage('index-test.php?site/index');
+     * $I->amOnPage('http://localhost/index-test.php?site/index');
+     * @param $page string|array parameter for \yii\web\UrlManager::createUrl()
      */
-    public function amOnPage($page) {
-
-        if(is_array($page)){
+    public function amOnPage($page)
+    {
+        if (is_array($page)) {
             $page = \Yii::$app->getUrlManager()->createUrl($page);
         }
-
         parent::amOnPage($page);
     }
-
 }

--- a/src/Codeception/Module/Yii2.php
+++ b/src/Codeception/Module/Yii2.php
@@ -55,6 +55,7 @@ class Yii2 extends Framework implements ActiveRecord
     {
         $this->client = new \Codeception\Lib\Connector\Yii2();
         $this->client->configFile = \Codeception\Configuration::projectDir().$this->config['configFile'];
+        $this->client->setServerParameter('HTTP_HOST', parse_url(\Codeception\Configuration::config()['config']['test_entry_url'], PHP_URL_HOST));
         $this->app = $this->client->startApp();
 
         if ($this->config['cleanup'] and isset($this->app->db)) {


### PR DESCRIPTION
This patch enables https support for functional suites.
Also this patch fix verbose output for functional suites.

E.g.: ../vendor/bin/codecept run functional -vvv

Was:

```
Scenario:
* I am on page "/index-test.php/site/login"
  [Response] 200
  [Page] http://localhost/index-test.php/site/login
```

After fix:

```
Scenario:
* I am on page "/index-test.php/site/login"
  [Response] 200
  [Page] http://YOURDOMAIN/index-test.php/site/login
```