### PR TITLE
Allow bool values for checkboxes in submitForm

### DIFF
--- a/src/Codeception/Lib/InnerBrowser.php
+++ b/src/Codeception/Lib/InnerBrowser.php
@@ -362,6 +362,19 @@ class InnerBrowser extends Module implements Web
 
         $requestParams = array_merge($defaults, $params);
         
+        // set boolean values of checkboxes to the input field's actual value
+        $checkboxes = $form->filter('input[type=checkbox]');
+        foreach ($checkboxes as $box) {
+            $fieldName = $this->getSubmissionFormFieldName($box->getAttribute('name'));
+            if (isset($requestParams[$fieldName]) && is_bool($requestParams[$fieldName])) {
+                if ($requestParams[$fieldName] === true) {
+                    $requestParams[$fieldName] = $box->getAttribute('value');
+                } else {
+                    unset($requestParams[$fieldName]);
+                }
+            }
+        }
+        
         $method = $form->attr('method') ? $form->attr('method') : 'GET';
         $query = '';
         if (strtoupper($method) == 'GET') {

--- a/src/Codeception/Module/WebDriver.php
+++ b/src/Codeception/Module/WebDriver.php
@@ -1226,20 +1226,23 @@ class WebDriver extends \Codeception\Module implements WebInterface, RemoteInter
             $el = reset($els);
             if ($el->getTagName() == 'textarea') {
                 $this->fillField($el, $value);
-            }
-            if ($el->getTagName() == 'select') {
+            } elseif ($el->getTagName() == 'select') {
                 $this->selectOption($el, $value);
-            }
-            if ($el->getTagName() == 'input') {
+            } elseif ($el->getTagName() == 'input') {
                 $type = $el->getAttribute('type');
-                if ($type == 'text' or $type == 'password') {
+                if ($type == 'text' || $type == 'password') {
                     $this->fillField($el, $value);
-                }
-                if ($type == 'radio' or $type == 'checkbox') {
+                } elseif ($type == 'radio') {
                     foreach ($els as $radio) {
                         if ($radio->getAttribute('value') == $value) {
                             $this->checkOption($radio);
                         }
+                    }
+                } elseif ($type == 'checkbox') {
+                    if ($value === true || $value == $el->getAttribute('value')) {
+                        $this->checkOption($el);
+                    } else {
+                        $this->uncheckOption($el);
                     }
                 }
             }

--- a/tests/unit/Codeception/Module/TestsForWeb.php
+++ b/tests/unit/Codeception/Module/TestsForWeb.php
@@ -909,6 +909,24 @@ abstract class TestsForWeb extends \PHPUnit_Framework_TestCase
         $this->assertEquals($form['radio1'], 'to be sent');
     }
     
+    public function testSubmitFormCheckboxWithBoolean()
+    {
+        $this->module->amOnPage('/form/example16');
+        $this->module->submitForm('form', array(
+            'checkbox1' => true
+        ));
+        $form = data::get('form');
+        $this->assertTrue(isset($form['checkbox1']), 'Checkbox value not sent');
+        $this->assertEquals($form['checkbox1'], 'testing');
+        
+        $this->module->amOnPage('/form/example16');
+        $this->module->submitForm('form', array(
+            'checkbox1' => false
+        ));
+        $form = data::get('form');
+        $this->assertFalse(isset($form['checkbox1']), 'Checkbox value sent');
+    }
+    
     public function testSubmitFormWithButtons()
     {
         $this->module->amOnPage('/form/form_with_buttons');


### PR DESCRIPTION
submitForm now accepts boolean values for checkbox fields, mapping them to the actual checkbox field value if found.

Also minor cleanup of conditionals in WebDriver's submitForm.