### PR TITLE
Added seeInFormFields for Web tests

### DIFF
--- a/src/Codeception/Lib/Interfaces/Web.php
+++ b/src/Codeception/Lib/Interfaces/Web.php
@@ -105,6 +105,22 @@ interface Web
      * $I->submitForm('#userForm', array('user' => array('login' => 'Davert', 'password' => '123456', 'agree' => true)));
      * 
      * ```
+     * 
+     * Pair this with seeInFormFields for quick testing magic.
+     * 
+     * ``` php
+     * <?php
+     * $form = [
+     *      'field1' => 'value',
+     *      'field2' => 'another value',
+     *      'checkbox1' => true,
+     *      // ...
+     * ];
+     * $I->submitForm('//form[@id=my-form]', $form, 'submitButton');
+     * // $I->amOnPage('/path/to/form-page') may be needed
+     * $I->seeInFormFields('//form[@id=my-form]', $form);
+     * ?>
+     * ```
      *
      * @param $selector
      * @param $params
@@ -350,6 +366,112 @@ interface Web
      * @param $value
      */
     public function dontSeeInField($field, $value);
+
+    /**
+     * Checks if the array of form parameters (name => value) are set on the form matched with the
+     * passed selector.
+     * 
+     * ``` php
+     * <?php
+     * $I->seeInFormFields('form[name=myform]', [
+     *      'input1' => 'value',
+     *      'input2' => 'other value',
+     * ]);
+     * ?>
+     * ```
+     * 
+     * For multi-select elements, or to check values of multiple elements with the same name, an
+     * array may be passed:
+     * 
+     * ``` php
+     * <?php
+     * $I->seeInFormFields('.form-class', [
+     *      'multiselect' => [
+     *          'value1',
+     *          'value2',
+     *      ],
+     *      'checkbox[]' => [
+     *          'a checked value',
+     *          'another checked value',
+     *      ],
+     * ]);
+     * ?>
+     * ```
+     *
+     * Additionally, checkbox values can be checked with a boolean.
+     * 
+     * ``` php
+     * <?php
+     * $I->seeInFormFields('#form-id', [
+     *      'checkbox1' => true,        // passes if checked
+     *      'checkbox2' => false,       // passes if unchecked
+     * ]);
+     * ?>
+     * ```
+     * 
+     * Pair this with submitForm for quick testing magic.
+     * 
+     * ``` php
+     * <?php
+     * $form = [
+     *      'field1' => 'value',
+     *      'field2' => 'another value',
+     *      'checkbox1' => true,
+     *      // ...
+     * ];
+     * $I->submitForm('//form[@id=my-form]', $form, 'submitButton');
+     * // $I->amOnPage('/path/to/form-page') may be needed
+     * $I->seeInFormFields('//form[@id=my-form]', $form);
+     * ?>
+     * ```
+     * 
+     * @param $formSelector
+     * @param $params
+     */
+    public function seeInFormFields($formSelector, array $params);
+
+    /**
+     * Checks if the array of form parameters (name => value) are not set on the form matched with
+     * the passed selector.
+     * 
+     * ``` php
+     * <?php
+     * $I->dontSeeInFormFields('form[name=myform]', [
+     *      'input1' => 'non-existent value',
+     *      'input2' => 'other non-existent value',
+     * ]);
+     * ?>
+     * ```
+     * 
+     * To check that an element hasn't been assigned any one of many values, an array can be passed
+     * as the value:
+     * 
+     * ``` php
+     * <?php
+     * $I->dontSeeInFormFields('.form-class', [
+     *      'fieldName' => [
+     *          'This value shouldn\'t be set',
+     *          'And this value shouldn\'t be set',
+     *      ],
+     * ]);
+     * ?>
+     * ```
+     *
+     * Additionally, checkbox values can be checked with a boolean.
+     * 
+     * ``` php
+     * <?php
+     * $I->dontSeeInFormFields('#form-id', [
+     *      'checkbox1' => true,        // fails if checked
+     *      'checkbox2' => false,       // fails if unchecked
+     * ]);
+     * ?>
+     * ```
+     * 
+     * @param $formSelector
+     * @param $params
+     */
+    public function dontSeeInFormFields($formSelector, array $params);
 
     /**
      * Selects an option in a select tag or in radio button group.

--- a/tests/data/app/view/form/field_values.php
+++ b/tests/data/app/view/form/field_values.php
@@ -45,6 +45,12 @@
             <option value="see test three" selected>Selected</option>
         </select>
         
+        <select name="select3">
+            <option value="not seen one">Nothing selected</option>
+            <option value="not seen two">Not selected</option>
+            <option value="not seen three">Not selected</option>
+        </select>
+        
         <input type="submit" name="submit" value="Submit" />
     </form>
 </body>

--- a/tests/unit/Codeception/Module/TestsForWeb.php
+++ b/tests/unit/Codeception/Module/TestsForWeb.php
@@ -401,6 +401,12 @@ abstract class TestsForWeb extends \PHPUnit_Framework_TestCase
         $this->module->dontSeeInField('select1', 'not seen three');
     }
     
+    public function testSeeInFieldEmptyValueForUnselectedSelect()
+    {
+        $this->module->amOnPage('/form/field_values');
+        $this->module->seeInField('select3', '');
+    }
+    
     public function testSeeInFieldOnSelectMultiple()
     {
         $this->module->amOnPage('/form/field_values');
@@ -432,6 +438,82 @@ abstract class TestsForWeb extends \PHPUnit_Framework_TestCase
         $this->module->dontSeeInField('Description','sunset');
         $this->module->dontSeeInField('textarea','sunset');
         $this->module->dontSeeInField('descendant-or-self::textarea[@id="description"]','sunset');
+    }
+    
+    public function testSeeInFormFields()
+    {
+        $this->module->amOnPage('/form/field_values');
+        $params = [
+            'checkbox[]' => [
+                'see test one',
+                'see test two',
+            ],
+            'radio1' => 'see test one',
+            'checkbox1' => true,
+            'checkbox2' => false,
+            'select1' => 'see test one',
+            'select2' => [
+                'see test one',
+                'see test two',
+                'see test three'
+            ]
+        ];
+        $this->module->seeInFormFields('form', $params);
+    }
+    
+    public function testSeeInFormFieldsFails()
+    {
+        $this->module->amOnPage('/form/field_values');
+        $this->setExpectedException("PHPUnit_Framework_AssertionFailedError");
+        $params = [
+            'radio1' => 'something I should not see',
+            'checkbox1' => true,
+            'checkbox2' => false,
+            'select1' => 'see test one',
+            'select2' => [
+                'see test one',
+                'see test two',
+                'see test three'
+            ]
+        ];
+        $this->module->seeInFormFields('form', $params);
+    }
+    
+    public function testDontSeeInFormFields()
+    {
+        $this->module->amOnPage('/form/field_values');
+        $params = [
+            'checkbox[]' => [
+                'not seen one',
+                'not seen two',
+            ],
+            'radio1' => 'not seen one',
+            'checkbox1' => false,
+            'checkbox2' => true,
+            'select1' => 'not seen one',
+            'select2' => [
+                'not seen one',
+                'No where to be seen'
+            ]
+        ];
+        $this->module->dontSeeInFormFields('form', $params);
+    }
+    
+    public function testDontSeeInFormFieldsFails()
+    {
+        $this->module->amOnPage('/form/field_values');
+        $this->setExpectedException("PHPUnit_Framework_AssertionFailedError");
+        $params = [
+            'checkbox[]' => [
+                'wont see this anyway',
+                'see test one',
+            ],
+            'select2' => [
+                'not seen one',
+                'No where to be seen'
+            ]
+        ];
+        $this->module->dontSeeInFormFields('form', $params);
     }
 
     public function testSeeInFieldWithNonLatin()


### PR DESCRIPTION
Allows quickly checking multiple form field values with an array with InnerBrowser and WebDriver.

Also updated seeInField functionality to allow comparing an empty value to an unselected combo box.

Created simple tests and updated documentation in Interfaces/Web.php (IIRC that's the only place needed? Let me know if otherwise.)

Example:

```php
$I->seeInFormFields('#myform', [
    'checkbox[]' => [
        'see test one',
        'see test two',
    ],
    'radio1' => 'see test one',
    'checkbox1' => true,
    'checkbox2' => false,
    'select1' => 'see test one',
    'select2' => [
        'see test one',
        'see test two',
        'see test three'
    ]
]);
```
Can be paired with submitForm for easy testing:

```php
$form = [
     'field1' => 'value',
     'field2' => 'another value',
     'checkbox1' => true,
     // ...
];
$I->submitForm('#my-form', $form, 'submitButton');
$I->seeInFormFields('#my-form', $form);
```