### PR TITLE
Update ZF2.php

### DIFF
--- a/src/Codeception/Lib/Connector/ZF2.php
+++ b/src/Codeception/Lib/Connector/ZF2.php
@@ -39,7 +39,14 @@ class ZF2 extends Client
     {
         $zendRequest  = $this->application->getRequest();
         $zendResponse = $this->application->getResponse();
+        $zendHeaders  = $zendRequest->getHeaders();
 
+        if (!$zendHeaders->has('Content-Type')) {
+            $server = $request->getServer();
+            if (isset($server['CONTENT_TYPE'])) {
+                $zendHeaders->addHeaderLine('Content-Type', $server['CONTENT_TYPE']);}
+        }
+        
         $zendResponse->setStatusCode(200);
 
         $uri         = new HttpUri($request->getUri());


### PR DESCRIPTION
I added fix the setting header with key "Content-type" 
That header is ignored during request to Zend if you set its  via
```
$I->haveHttpHeader('Content-Type', 'application/json');
```
It makes problem in Zend\Mvc\Controller\AbstractRestfulController because it checks content type and without right header that class doesn't decode content 
