### PR TITLE
suggested fix for issue #1785: overloading and __set bug

### DIFF
--- a/src/Codeception/Util/Stub.php
+++ b/src/Codeception/Util/Stub.php
@@ -60,12 +60,22 @@ class Stub
         }
 
         self::bindParameters($mock, $params);
-        //only set __mocked if __set is not implemented
-        //to avoid __set implementations that error on overloading
-        if (!$reflection->hasMethod('__set')) {
-            $mock->__mocked = $class;
-        }
 
+        return self::markAsMock($mock, $reflection);
+    }
+
+    /**
+     * Set __mock flag, if at all possible
+     *
+     * @param object $mock
+     * @param \ReflectionClass $reflection
+     * @return object
+     */
+    private static function markAsMock($mock, \ReflectionClass $reflection)
+    {
+        if (!$reflection->hasMethod('__set')) {
+            $mock->__mocked = $reflection->getName();
+        }
         return $mock;
     }
 
@@ -156,11 +166,8 @@ class Stub
         $methods = count($methods) ? $methods : null;
         $mock    = self::generateMock($class, $methods, array(), '', false, $testCase);
         self::bindParameters($mock, $params);
-        if (!$reflectionClass->hasMethod('__set')) {
-            $mock->__mocked = $class;
-        }
 
-        return $mock;
+        return self::markAsMock($mock, $reflectionClass);
     }
 
     /**
@@ -213,11 +220,8 @@ class Stub
         );
         $mock    = self::generateMock($class, $methods, array(), '', false, $testCase);
         self::bindParameters($mock, $params);
-        if (!$reflection->hasMethod('__set')) {
-            $mock->__mocked = $class;
-        }
 
-        return $mock;
+        return self::markAsMock($mock, $reflection);
     }
 
     /**
@@ -283,11 +287,8 @@ class Stub
         $arguments = empty($callables) ? null : array_keys($callables);
         $mock      = self::generateMock($class, $arguments, $constructorParams, $testCase);
         self::bindParameters($mock, $params);
-        if (!$reflection->hasMethod('__set')) {
-            $mock->__mocked = $class;
-        }
 
-        return $mock;
+        return self::markAsMock($mock, $reflection);
     }
 
     /**
@@ -341,11 +342,8 @@ class Stub
         );
         $mock    = self::generateMock($class, $methods, $constructorParams, $testCase);
         self::bindParameters($mock, $params);
-        if (!$reflection->hasMethod('__set')) {
-            $mock->__mocked = $class;
-        }
 
-        return $mock;
+        return self::markAsMock($mock, $reflection);
     }
 
     /**
@@ -417,10 +415,8 @@ class Stub
         $methods         = count($methods) ? $methods : null;
         $mock            = self::generateMock($class, $methods, $constructorParams, $testCase);
         self::bindParameters($mock, $params);
-        if (!$reflectionClass->hasMethod('__set')) {
-            $mock->__mocked = $class;
-        }
-        return $mock;
+
+        return self::markAsMock($mock, $reflectionClass);
     }
 
     private static function generateMock()
@@ -571,6 +567,11 @@ class Stub
         return $object;
     }
 
+    /**
+     * @param \ReflectionClass $reflection
+     * @param $params
+     * @return array
+     */
     protected static function getMethodsToReplace(\ReflectionClass $reflection, $params)
     {
         $callables = array();

--- a/src/Codeception/Util/Stub.php
+++ b/src/Codeception/Util/Stub.php
@@ -593,7 +593,15 @@ class Stub
                     try {
                         $mock->{$param} = $value;
                     } catch (\Exception $e) {
-                        //silence exception, decide what is best -> trigger error, let exception fly, or...
+                        throw new \PHPUnit_Framework_Exception(
+                            sprintf(
+                                'Could not add property %s, class %s implements __set method, and no %s property exists',
+                                $param,
+                                $reflectionClass->getName()
+                            ),
+                            $e->getCode(),
+                            $e
+                        );
                     }
                 } else {
                     $mock->{$param} = $value;

--- a/src/Codeception/Util/Stub.php
+++ b/src/Codeception/Util/Stub.php
@@ -70,62 +70,6 @@ class Stub
     }
 
     /**
-     *
-     * Works exactly the same as Stub::make, but doesn't fail when the mocked class implements __set
-     * In some extensions, the __set method is implemented and triggers errors when an undefined property is set
-     * Stub::makeNative checks the errors, and will return the mocked object regardless
-     *
-     * ``` php
-     * <?php
-     * Stub::makeNative('\CouchbaseBucket');
-     * ?>
-     * ```
-     * @param                                  $class - A class to be mocked
-     * @param array                            $params - properties and methods to set
-     * @param bool|\PHPUnit_Framework_TestCase $testCase
-     *
-     * @return object - mock
-     * @throws \RuntimeException when class not exists
-     */
-    public static function makeNative($class, $params = [], $testCase = false)
-    {
-        $class = self::getClassname($class);
-        if (!class_exists($class)) {
-            throw new \RuntimeException(
-                sprintf(
-                    'Stubbed extension class %s does not exist',
-                    $class
-                )
-            );
-        }
-        $reflection = new \ReflectionClass($class);
-        $callables  = self::getMethodsToReplace($reflection, $params);
-        if ($reflection->isAbstract()) {
-            $arguments = empty($callables) ? [] : array_keys($callables);
-            $mock      = self::generateMockForAbstractClass($class, $arguments, '', false, $testCase);
-        } else {
-            $arguments = empty($callables) ? null : array_keys($callables);
-            $mock = self::generateMock($class, $arguments, [], '', false, $testCase);
-        }
-
-        self::bindParameters($mock, $params);
-        try {
-            $mock->__mocked = $class;
-        } catch (\PHPUnit_Framework_Exception $e) {
-            if (
-                strstr($e->getMessage(), 'property via __set(): __mocked') === false
-                ||
-                strstr($e->getTraceAsString(), 'Native]') === false
-            ) {
-                throw $e;
-            }
-        }
-
-        return $mock;
-
-    }
-
-    /**
      * Creates $num instances of class through `Stub::make`.
      *
      * @param       $class

--- a/tests/data/DummyOverloadableClass.php
+++ b/tests/data/DummyOverloadableClass.php
@@ -1,0 +1,68 @@
+<?php
+
+class DummyOverloadableClass
+{
+    protected $checkMe = 1;
+    protected $properties = array('checkMeToo' => 1);
+
+    function __construct($checkMe = 1)
+    {
+        $this->checkMe = "constructed: ".$checkMe;
+    }
+
+    public function helloWorld() {
+        return "hello";
+    }
+
+    public function goodByeWorld() {
+        return "good bye";
+    }
+
+    protected function notYourBusinessWorld()
+    {
+        return "goAway";
+    }
+
+    public function getCheckMe() {
+        return $this->checkMe;
+    }
+
+    public function getCheckMeToo() {
+        return $this->checkMeToo;
+    }
+
+    public function call() {
+        $this->targetMethod();
+        return true;
+    }
+
+    public function targetMethod() {
+        return true;
+    }
+
+    public function exceptionalMethod() {
+        throw new Exception('Catch it!');
+    }
+
+    public function __get($name) {
+        //seeing as we're not implementing __set here, add check for __mocked
+        $return = null;
+        if ($name === '__mocked') {
+            $return = isset($this->__mocked) ? $this->__mocked : null;
+        } else {
+            if ($this->__isset($name)) {
+                $return = $this->properties[$name];
+            }
+        }
+        return $return;
+    }
+
+    public function __isset($name) {
+        return $this->isMagical($name) && isset($this->properties[$name]);
+    }
+
+    private function isMagical($name) {
+        $reflectionClass = new \ReflectionClass($this);
+        return !$reflectionClass->hasProperty($name);
+    }
+}

--- a/tests/data/claypit/tests/dummy/_bootstrap.php
+++ b/tests/data/claypit/tests/dummy/_bootstrap.php
@@ -1,4 +1,8 @@
 <?php
 // Here you can initialize variables that will for your tests
 require_once \Codeception\Configuration::dataDir().'DummyClass.php';
+$overload = \Codeception\Configuration::dataDir().'DummyOverloadableClass.php';
+if (file_exists($overload)) {
+    require_once($overload);
+}
 $codeception = 'codeception.yml';

--- a/tests/unit/Codeception/Util/StubTest.php
+++ b/tests/unit/Codeception/Util/StubTest.php
@@ -129,16 +129,46 @@ class StubTest extends \PHPUnit_Framework_TestCase
     public function testStubsFromObject()
     {
         $dummy = Stub::make(new \DummyClass());
+        $this->assertInstanceOf(
+            '\PHPUnit_Framework_MockObject_MockObject',
+            $dummy
+        );
+        $dummy = Stub::make(new \DummyOverloadableClass());
         $this->assertTrue(isset($dummy->__mocked));
         $dummy = Stub::makeEmpty(new \DummyClass());
+        $this->assertInstanceOf(
+            '\PHPUnit_Framework_MockObject_MockObject',
+            $dummy
+        );
+        $dummy = Stub::makeEmpty(new \DummyOverloadableClass());
         $this->assertTrue(isset($dummy->__mocked));
         $dummy = Stub::makeEmptyExcept(new \DummyClass(),'helloWorld');
+        $this->assertInstanceOf(
+            '\PHPUnit_Framework_MockObject_MockObject',
+            $dummy
+        );
+        $dummy = Stub::makeEmptyExcept(new \DummyOverloadableClass(), 'helloWorld');
         $this->assertTrue(isset($dummy->__mocked));
         $dummy = Stub::construct(new \DummyClass());
+        $this->assertInstanceOf(
+            '\PHPUnit_Framework_MockObject_MockObject',
+            $dummy
+        );
+        $dummy = Stub::construct(new \DummyOverloadableClass());
         $this->assertTrue(isset($dummy->__mocked));
         $dummy = Stub::constructEmpty(new \DummyClass());
+        $this->assertInstanceOf(
+            '\PHPUnit_Framework_MockObject_MockObject',
+            $dummy
+        );
+        $dummy = Stub::constructEmpty(new \DummyOverloadableClass());
         $this->assertTrue(isset($dummy->__mocked));
         $dummy = Stub::constructEmptyExcept(new \DummyClass(),'helloWorld');
+        $this->assertInstanceOf(
+            '\PHPUnit_Framework_MockObject_MockObject',
+            $dummy
+        );
+        $dummy = Stub::constructEmptyExcept(new \DummyOverloadableClass(), 'helloWorld');
         $this->assertTrue(isset($dummy->__mocked));
     }
 


### PR DESCRIPTION
The `Stub::*` methods all tend to set a `__mocked` property on the mocked classes. When attempting to mock a class that implements a `__set` method that doesn't allow (as PHP calls it) _"overloading"_, this results in a PHPUnit exception.

This PR addresses this issue by checking the class for an existing `__set` method. If such a method exists, the `__mocked` flag is not set.
This check is also used when attempting to add a non-existent property to classes with a `__set` method. These properties will be added, but a `PHPUnit_Framework_Exception` will be thrown if this fails.

The `__mocked` flag was primarily (only?) used in the `Stub::update` call (to change the mock's behavior on the fly). the `__mocked` property check has been replaced with an `instanceof PHPUnit_Framework_MockObject_MockObject` check. If this check fails, the behavior remains unchanged: calling `Stub::update` on anything that is not an instance of the `MockObject` class cause a `LogicException` to be thrown.