### PR TITLE
WebDriver submitForm allows array parameter values

### DIFF
--- a/src/Codeception/Lib/InnerBrowser.php
+++ b/src/Codeception/Lib/InnerBrowser.php
@@ -347,12 +347,63 @@ class InnerBrowser extends Module implements Web
         ];
     }
 
+    /**
+     * Strips out one pair of trailing square brackets from a field's
+     * name.
+     *
+     * @param string $name the field name
+     * @return string the name after stripping trailing square brackets
+     */
     protected function getSubmissionFormFieldName($name)
     {
         if (substr($name, -2) === '[]') {
             return substr($name, 0, -2);
         }
         return $name;
+    }
+
+    /**
+     * Replaces boolean values in $params with the corresponding field's
+     * value for checkbox form fields.
+     *
+     * The function loops over all input checkbox fields, checking if a
+     * corresponding key is set in $params.  If it is, and the value is
+     * boolean or an array containing booleans, the value(s) are
+     * replaced in the array with the real value of the checkbox, and
+     * the array is returned.
+     *
+     * @param Crawler $form the form to find checkbox elements
+     * @param array $params the parameters to be submitted
+     * @return array the $params array after replacing bool values
+     */
+    protected function setCheckboxBoolValues(Crawler $form, array $params)
+    {
+        $checkboxes = $form->filter('input[type=checkbox]');
+        $chFoundByName = [];
+        foreach ($checkboxes as $box) {
+            $fieldName = $this->getSubmissionFormFieldName($box->getAttribute('name'));
+            $pos = (!isset($chFoundByName[$fieldName])) ? 0 : $chFoundByName[$fieldName];
+            $skip = (!isset($params[$fieldName]))
+                || (!is_array($params[$fieldName]) && !is_bool($params[$fieldName]))
+                || ($pos >= count($params[$fieldName])
+                || (is_array($params[$fieldName]) && !is_bool($params[$fieldName][$pos])));
+            if ($skip) {
+                continue;
+            }
+            $values = $params[$fieldName];
+            if ($values === true) {
+                $params[$fieldName] = $box->getAttribute('value');
+                $chFoundByName[$fieldName] = $pos + 1;
+            } elseif ($values[$pos] === true) {
+                $params[$fieldName][$pos] = $box->getAttribute('value');
+                $chFoundByName[$fieldName] = $pos + 1;
+            } elseif (is_array($values)) {
+                array_splice($params[$fieldName], $pos, 1);
+            } else {
+                unset($params[$fieldName]);
+            }
+        }
+        return $params;
     }
 
     public function submitForm($selector, $params, $button = null)
@@ -396,21 +447,9 @@ class InnerBrowser extends Module implements Web
             $defaults[$fieldName] = $field->getAttribute('value');
         }
 
-        $requestParams = array_merge($defaults, $params);
-        
-        // set boolean values of checkboxes to the input field's actual value
-        $checkboxes = $form->filter('input[type=checkbox]');
-        foreach ($checkboxes as $box) {
-            $fieldName = $this->getSubmissionFormFieldName($box->getAttribute('name'));
-            if (isset($requestParams[$fieldName]) && is_bool($requestParams[$fieldName])) {
-                if ($requestParams[$fieldName] === true) {
-                    $requestParams[$fieldName] = $box->getAttribute('value');
-                } else {
-                    unset($requestParams[$fieldName]);
-                }
-            }
-        }
-        
+        $merged = array_merge($defaults, $params);
+        $requestParams = $this->setCheckboxBoolValues($form, $merged);
+
         $method = $form->attr('method') ? $form->attr('method') : 'GET';
         $query = '';
         if (strtoupper($method) == 'GET') {

--- a/src/Codeception/Lib/Interfaces/Web.php
+++ b/src/Codeception/Lib/Interfaces/Web.php
@@ -122,6 +122,35 @@ interface Web
      * ?>
      * ```
      *
+     * Parameter values can be set to arrays for multiple input fields
+     * of the same name, or multi-select combo boxes.  For checkboxes,
+     * either the string value can be used, or boolean values which will
+     * be replaced by the checkbox's value in the DOM.
+     *
+     * ``` php
+     * <?php
+     * $I->submitForm('#my-form', [
+     *      'field1' => 'value',
+     *      'checkbox' => [
+     *          'value of first checkbox',
+     *          'value of second checkbox,
+     *      ],
+     *      'otherCheckboxes' => [
+     *          true,
+     *          false,
+     *          false
+     *      ],
+     *      'multiselect' => [
+     *          'first option value',
+     *          'second option value'
+     *      ]
+     * ]);
+     * ?>
+     * ```
+     *
+     * Mixing string and boolean values for a checkbox's value is not
+     * supported and may produce unexpected results.
+     * 
      * @param $selector
      * @param $params
      * @param $button

--- a/tests/unit/Codeception/Module/TestsForWeb.php
+++ b/tests/unit/Codeception/Module/TestsForWeb.php
@@ -861,7 +861,22 @@ abstract class TestsForWeb extends \PHPUnit_Framework_TestCase
         $form = data::get('form');
         $this->assertEquals('this & that', $form['test']);
     }
-    
+
+    public function testSubmitFormMultiSelectWithArrayParameter()
+    {
+        $this->module->amOnPage('/form/submitform_multiple');
+        $this->module->submitForm('form', [
+            'select' => [
+                'see test one',
+                'not seen four'
+            ]
+        ]);
+        $form = data::get('form');
+        $this->assertCount(2, $form['select']);
+        $this->assertEquals('see test one', $form['select'][0]);
+        $this->assertEquals('not seen four', $form['select'][1]);
+    }
+
     public function testSubmitFormWithMultiSelect()
     {
         $this->module->amOnPage('/form/submitform_multiple');
@@ -870,6 +885,39 @@ abstract class TestsForWeb extends \PHPUnit_Framework_TestCase
         $this->assertCount(2, $form['select']);
         $this->assertEquals('see test one', $form['select'][0]);
         $this->assertEquals('see test two', $form['select'][1]);
+    }
+    
+    public function testSubmitFormCheckboxWithArrayParameter()
+    {
+        $this->module->amOnPage('/form/field_values');
+        $this->module->submitForm('form', [
+            'checkbox' => [
+                'not seen one',
+                'see test two',
+                'not seen three'
+            ]
+        ]);
+        $form = data::get('form');
+        $this->assertCount(3, $form['checkbox']);
+        $this->assertEquals('not seen one', $form['checkbox'][0]);
+        $this->assertEquals('see test two', $form['checkbox'][1]);
+        $this->assertEquals('not seen three', $form['checkbox'][2]);
+    }
+    
+    public function testSubmitFormCheckboxWithBooleanArrayParameter()
+    {
+        $this->module->amOnPage('/form/field_values');
+        $this->module->submitForm('form', [
+            'checkbox' => [
+                true,
+                false,
+                true
+            ]
+        ]);
+        $form = data::get('form');
+        $this->assertCount(2, $form['checkbox']);
+        $this->assertEquals('not seen one', $form['checkbox'][0]);
+        $this->assertEquals('not seen two', $form['checkbox'][1]);
     }
 
     /**
@@ -987,8 +1035,8 @@ abstract class TestsForWeb extends \PHPUnit_Framework_TestCase
         $form = data::get('form');
         $this->assertTrue(isset($form['checkbox1']), 'Checkbox value not sent');
         $this->assertTrue(isset($form['radio1']), 'Radio button value not sent');
-        $this->assertEquals($form['checkbox1'], 'testing');
-        $this->assertEquals($form['radio1'], 'to be sent');
+        $this->assertEquals('testing', $form['checkbox1']);
+        $this->assertEquals('to be sent', $form['radio1']);
     }
     
     public function testSubmitFormCheckboxWithBoolean()
@@ -999,7 +1047,7 @@ abstract class TestsForWeb extends \PHPUnit_Framework_TestCase
         ));
         $form = data::get('form');
         $this->assertTrue(isset($form['checkbox1']), 'Checkbox value not sent');
-        $this->assertEquals($form['checkbox1'], 'testing');
+        $this->assertEquals('testing', $form['checkbox1']);
         
         $this->module->amOnPage('/form/example16');
         $this->module->submitForm('form', array(


### PR DESCRIPTION
- Fixes #1797
- Updated function to allow submitting array parameter values like
  for PhpBrowser
- Updated PhpBrowser so array of booleans could be sent - separated
  into separate function
- Cleaned up WebDriver's submitForm a bit
- Added some documentation
- Added a few more tests