### PR TITLE
Fix for submitForm default value for a textarea

### DIFF
--- a/src/Codeception/Lib/InnerBrowser.php
+++ b/src/Codeception/Lib/InnerBrowser.php
@@ -441,10 +441,13 @@ class InnerBrowser extends Module implements Web
                     $defaults[$fieldName] = reset($values);
                 }
                 continue;
-            } elseif (!empty($field->nodeValue)) {
+            }
+            // <button> tags have both, nodeValue is set to the content of the <button> tag, so preference is for "value" first
+            if ($field->hasAttribute('value')) {
+                $defaults[$fieldName] = $field->getAttribute('value');
+            } else {
                 $defaults[$fieldName] = $field->nodeValue;
             }
-            $defaults[$fieldName] = $field->getAttribute('value');
         }
 
         $merged = array_merge($defaults, $params);

--- a/tests/unit/Codeception/Module/TestsForWeb.php
+++ b/tests/unit/Codeception/Module/TestsForWeb.php
@@ -830,7 +830,6 @@ abstract class TestsForWeb extends \PHPUnit_Framework_TestCase
 
     }
 
-
     public function testSubmitForm() {
         $this->module->amOnPage('/form/complex');
         $this->module->submitForm('form', array(
@@ -927,6 +926,14 @@ abstract class TestsForWeb extends \PHPUnit_Framework_TestCase
     {
         $this->module->amOnPage('/form/empty_fill');
         $this->module->fillField('test', 'value');
+    }
+    
+    public function testSubmitFormWithDefaultTextareaValue()
+    {
+        $this->module->amOnPage('/form/textarea');
+        $this->module->submitForm('form', []);
+        $form = data::get('form');
+        $this->assertEquals('sunrise', $form['description']);
     }
 
     /**


### PR DESCRIPTION
Textarea node doesn't have 'value' attribute, and an issue with conditions meant it wasn't working correctly.