### PR TITLE
[dev-master] Fix Dependent Module Injection

### DIFF
--- a/src/Codeception/Lib/ModuleContainer.php
+++ b/src/Codeception/Lib/ModuleContainer.php
@@ -159,7 +159,7 @@ class ModuleContainer
                 "Please specify the dependent module inside module configuration section.\n" .
                 "\n\n$message");
         }
-        $dependentModule = $this->create($name, false);
+        $dependentModule = $this->create($this->config['modules']['depends'][$name], false);
         if (!method_exists($module, '_inject')) {
             throw new ModuleException($module, 'Module requires method _inject to be defined to accept dependencies');
         }

--- a/tests/unit/Codeception/Lib/ModuleContainerTest.php
+++ b/tests/unit/Codeception/Lib/ModuleContainerTest.php
@@ -253,7 +253,7 @@ class DependencyModule extends \Codeception\Module implements DependsOnModule
         return ['Codeception\Lib\ConflictedModule' => 'Error message'];
     }
 
-    public function _inject()
+    public function _inject(ConflictedModule $module)
     {
         
     }


### PR DESCRIPTION
Fixes #1818. With this update, we are changing the module being passed to the _inject method from the module itself ($name) to the correct 'depends' module as it is configured in the associated .yml file.