### PR TITLE
Added deleteHeader and docs for PhpBrowser

### DIFF
--- a/src/Codeception/Lib/Connector/Guzzle.php
+++ b/src/Codeception/Lib/Connector/Guzzle.php
@@ -49,9 +49,34 @@ class Guzzle extends Client
         $this->client = $client;
     }
 
-    public function setHeader($header, $value)
+    /**
+     * Sets the request header to the passed value.  The header will be
+     * sent along with the next request.
+     *
+     * Passing an empty value clears the header, which is the equivelant
+     * of calling deleteHeader.
+     *
+     * @param string $name the name of the header
+     * @param string $value the value of the header
+     */
+    public function setHeader($name, $value)
     {
-        $this->requestOptions['headers'][$header] = $value;
+        if (empty($value)) {
+            $this->deleteHeader($name);
+        } else {
+            $this->requestOptions['headers'][$name] = $value;
+        }
+    }
+
+    /**
+     * Deletes the header with the passed name from the list of headers
+     * that will be sent with the request.
+     *
+     * @param string $name the name of the header to delete.
+     */
+    public function deleteHeader($name)
+    {
+        unset($this->requestOptions['headers'][$name]);
     }
 
     public function setAuth($username, $password)

--- a/src/Codeception/Module/PhpBrowser.php
+++ b/src/Codeception/Module/PhpBrowser.php
@@ -134,9 +134,9 @@ class PhpBrowser extends InnerBrowser implements Remote, MultiSession
      * 
      * @param string $name the name of the header to delete.
      */
-    public function deleteHeader($header)
+    public function deleteHeader($name)
     {
-        $this->client->deleteHeader($header);
+        $this->client->deleteHeader($name);
     }
     
     public function amHttpAuthenticated($username, $password)

--- a/src/Codeception/Module/PhpBrowser.php
+++ b/src/Codeception/Module/PhpBrowser.php
@@ -96,9 +96,47 @@ class PhpBrowser extends InnerBrowser implements Remote, MultiSession
         return $this->config['url'];
     }
 
-    public function setHeader($header, $value)
+    /**
+     * Sets the HTTP header to the passed value - which is used on
+     * subsequent HTTP requests through PhpBrowser.
+     *
+     * Example:
+     * ```php
+     * <?php
+     * $I->setHeader('X-Requested-With', 'Codeception');
+     * $I->amOnPage('test-headers.php');
+     * ?>
+     * ```
+     *
+     * @param string $name the name of the request header
+     * @param string $value the value to set it to for subsequent
+     *        requests
+     */
+    public function setHeader($name, $value)
     {
-        $this->client->setHeader($header, $value);
+        $this->client->setHeader($name, $value);
+    }
+
+    /**
+     * Deletes the header with the passed name.  Subsequent requests
+     * will not have the deleted header in its request.
+     *
+     * Example:
+     * ```php
+     * <?php
+     * $I->setHeader('X-Requested-With', 'Codeception');
+     * $I->amOnPage('test-headers.php');
+     * // ...
+     * $I->deleteHeader('X-Requested-With');
+     * $I->amOnPage('some-other-page.php');
+     * ?>
+     * ```
+     * 
+     * @param string $name the name of the header to delete.
+     */
+    public function deleteHeader($header)
+    {
+        $this->client->deleteHeader($header);
     }
     
     public function amHttpAuthenticated($username, $password)

--- a/tests/unit/Codeception/Module/PhpBrowserTest.php
+++ b/tests/unit/Codeception/Module/PhpBrowserTest.php
@@ -182,6 +182,22 @@ class PhpBrowserTest extends TestsForBrowsers
         $this->assertTrue($this->history->getLastRequest()->hasHeader('xxx'));
     }
 
+    public function testDeleteHeaders()
+    {
+		$this->module->setHeader('xxx', 'yyyy');
+		$this->module->deleteHeader('xxx');
+        $this->module->amOnPage('/');
+        $this->assertFalse($this->history->getLastRequest()->hasHeader('xxx'));
+	}
+
+	public function testDeleteHeadersByEmptyValue()
+    {
+		$this->module->setHeader('xxx', 'yyyy');
+		$this->module->setHeader('xxx', '');
+        $this->module->amOnPage('/');
+        $this->assertFalse($this->history->getLastRequest()->hasHeader('xxx'));
+	}
+
     public function testCurlOptions()
     {
         $this->module->_setConfig(array('url' => 'http://google.com', 'curl' => array('CURLOPT_NOBODY' => true)));

--- a/tests/unit/Codeception/Module/PhpBrowserTest.php
+++ b/tests/unit/Codeception/Module/PhpBrowserTest.php
@@ -184,26 +184,25 @@ class PhpBrowserTest extends TestsForBrowsers
 
     public function testDeleteHeaders()
     {
-		$this->module->setHeader('xxx', 'yyyy');
-		$this->module->deleteHeader('xxx');
+        $this->module->setHeader('xxx', 'yyyy');
+        $this->module->deleteHeader('xxx');
         $this->module->amOnPage('/');
         $this->assertFalse($this->history->getLastRequest()->hasHeader('xxx'));
-	}
+    }
 
-	public function testDeleteHeadersByEmptyValue()
+    public function testDeleteHeadersByEmptyValue()
     {
-		$this->module->setHeader('xxx', 'yyyy');
-		$this->module->setHeader('xxx', '');
+        $this->module->setHeader('xxx', 'yyyy');
+        $this->module->setHeader('xxx', '');
         $this->module->amOnPage('/');
         $this->assertFalse($this->history->getLastRequest()->hasHeader('xxx'));
-	}
+    }
 
     public function testCurlOptions()
     {
         $this->module->_setConfig(array('url' => 'http://google.com', 'curl' => array('CURLOPT_NOBODY' => true)));
         $this->module->_initialize();
         $this->assertTrue($this->module->guzzle->getDefaultOption('config/curl/'.CURLOPT_NOBODY));
-
     }
 
     public function testHttpAuth()


### PR DESCRIPTION
- Created deleteHeader
- Allow deleting a header with an empty value when setting (since
  setting to an empty value doesn't make sense anyway)
- Added documentation for setHeader and deleteHeader
- Added simple test

Provides a solution for #1791 