### PR TITLE
Fixes can/cant causing failure

### DIFF
--- a/src/Codeception/PHPUnit/Listener.php
+++ b/src/Codeception/PHPUnit/Listener.php
@@ -44,8 +44,6 @@ class Listener implements \PHPUnit_Framework_TestListener
         $this->unsuccessfulTests[] = spl_object_hash($test);
         $this->fire(Events::TEST_FAIL, new FailEvent($test, $e));
         if (!$e instanceof ConditionalAssertionFailed) {
-            //var_dump(get_class($e));
-            //exit;
             $this->fire(Events::TEST_AFTER, new TestEvent($test, $time));
         }
     }

--- a/src/Codeception/PHPUnit/Listener.php
+++ b/src/Codeception/PHPUnit/Listener.php
@@ -6,6 +6,7 @@ use Codeception\Event\SuiteEvent;
 use Codeception\Event\TestEvent;
 use Codeception\Events;
 use Codeception\TestCase;
+use Codeception\Exception\ConditionalAssertionFailed;
 use Exception;
 use PHPUnit_Framework_Test;
 use Symfony\Component\EventDispatcher\EventDispatcher;
@@ -42,7 +43,11 @@ class Listener implements \PHPUnit_Framework_TestListener
     {
         $this->unsuccessfulTests[] = spl_object_hash($test);
         $this->fire(Events::TEST_FAIL, new FailEvent($test, $e));
-        $this->fire(Events::TEST_AFTER, new TestEvent($test, $time));
+        if (!$e instanceof ConditionalAssertionFailed) {
+            //var_dump(get_class($e));
+            //exit;
+            $this->fire(Events::TEST_AFTER, new TestEvent($test, $time));
+        }
     }
 
     public function addError(\PHPUnit_Framework_Test $test, \Exception $e, $time)

--- a/tests/cli/OrderCest.php
+++ b/tests/cli/OrderCest.php
@@ -20,13 +20,21 @@ class OrderCest
         $I->seeFileContentsEqual("BIB([STF])");
     }
 
+    public function checkForCanCantFails(CliGuy $I)
+    {
+        $I->amInPath('tests/data/sandbox');
+        $I->executeCommand('run order CanCantFailCept.php --no-exit');
+        $I->seeFileFound('order.txt','tests/_output');
+        $I->expect('global bootstrap, initialization, beforeSuite, before, bootstrap, test, fail, fail, test, after, afterSuite');
+        $I->seeFileContentsEqual("BIB([STFFT])");
+    }
 
     public function checkSimpleFiles(CliGuy $I)
     {
         $I->amInPath('tests/data/sandbox');
         $I->executeCommand('run order --no-exit --group simple');
         $I->seeFileFound('order.txt','tests/_output');
-        $I->seeFileContentsEqual("BIB({{{[ST][STF][ST])}}}");
+        $I->seeFileContentsEqual("BIB({{{[ST][STFFT][STF][ST])}}}");
     }
 
     public function checkCestOrder(CliGuy $I)

--- a/tests/data/claypit/tests/_support/OrderHelper.php
+++ b/tests/data/claypit/tests/_support/OrderHelper.php
@@ -33,6 +33,16 @@ class OrderHelper extends Module
         $this->fail("intentionally");
     }
 
+    public function seeFailNow()
+    {
+        $this->fail("intentionally");
+    }
+
+    public function dontSeeFailNow()
+    {
+        $this->fail("intentionally");
+    }
+
     public function _beforeSuite($settings = array())
     {
         self::appendToFile('(');

--- a/tests/data/claypit/tests/order/CanCantFailCept.php
+++ b/tests/data/claypit/tests/order/CanCantFailCept.php
@@ -1,0 +1,10 @@
+<?php
+$scenario->group('simple');
+\Codeception\Module\OrderHelper::appendToFile('S');
+$I = new OrderGuy($scenario);
+$I->wantTo('write a marker, use can* functions and write a marker after the failures');
+$I->appendToFile('T');
+$I->canSeeFailNow();
+$I->cantSeeFailNow();
+$I->wantTo('ensure a second marker is written after failures');
+$I->appendToFile('T');


### PR DESCRIPTION
- Using can/cant causes cleanup code to be called, which causes an
  exception calling subsequent tests: for instance calling canSee()
  followed by amOnPage (or canSee twice).
- Fixes #1647 #1354 and #1111
- Same as pull request #1807 - but against master and with some added
  test code