### PR TITLE
Do not error if unable to drop table during cleanup()

### DIFF
--- a/src/Codeception/Lib/Driver/MySql.php
+++ b/src/Codeception/Lib/Driver/MySql.php
@@ -12,7 +12,7 @@ class MySql extends Db
                 $this->dbh->exec('drop table `' . $row[0] . '`');
             } catch (\PDOException $e) {
                 if ($ignoreDrop) {
-                    trigger_error('Unable to drop table '.$row[0].' during cleanup', E_WARNING);
+                    trigger_error('Unable to drop table '.$row[0].' during cleanup', E_USER_WARNING);
                 } else {
                     throw $e;
                 }

--- a/src/Codeception/Lib/Driver/MySql.php
+++ b/src/Codeception/Lib/Driver/MySql.php
@@ -11,9 +11,7 @@ class MySql extends Db
             try {
                 $this->dbh->exec('drop table `' . $row[0] . '`');
             } catch (\PDOException $e) {
-                if ($ignoreDrop) {
-                    trigger_error('Unable to drop table '.$row[0].' during cleanup', E_USER_WARNING);
-                } else {
+                if (!$ignoreDrop) {
                     throw $e;
                 }
             }

--- a/src/Codeception/Lib/Driver/MySql.php
+++ b/src/Codeception/Lib/Driver/MySql.php
@@ -3,12 +3,20 @@ namespace Codeception\Lib\Driver;
 
 class MySql extends Db
 {
-    public function cleanup()
+    public function cleanup($ignoreDrop=false)
     {
         $this->dbh->exec('SET FOREIGN_KEY_CHECKS=0;');
         $res = $this->dbh->query("SHOW FULL TABLES WHERE TABLE_TYPE LIKE '%TABLE';")->fetchAll();
         foreach ($res as $row) {
-            $this->dbh->exec('drop table `' . $row[0] . '`');
+            try {
+                $this->dbh->exec('drop table `' . $row[0] . '`');
+            } catch (\PDOException $e) {
+                if ($ignoreDrop) {
+                    trigger_error('Unable to drop table '.$row[0].' during cleanup', E_WARNING);
+                } else {
+                    throw $e;
+                }
+            }
         }
         $this->dbh->exec('SET FOREIGN_KEY_CHECKS=1;');
     }

--- a/src/Codeception/Module/Db.php
+++ b/src/Codeception/Module/Db.php
@@ -92,10 +92,11 @@ class Db extends \Codeception\Module implements \Codeception\Lib\Interfaces\Db
      * @var array
      */
     protected $config = [
-      'populate' => true,
-      'cleanup'  => true,
-      'dump'     => null
-    ];
+      'populate'   => true,
+      'cleanup'    => true,
+      'dump'       => null,
+      'ignoredrop' => false,
+    ]
 
     /**
      * @var bool
@@ -193,7 +194,7 @@ class Db extends \Codeception\Module implements \Codeception\Lib\Interfaces\Db
             if (!count($this->sql)) {
                 return;
             }
-            $this->driver->cleanup();
+            $this->driver->cleanup($this->config['ignoredrop']);
         } catch (\Exception $e) {
             throw new ModuleException(__CLASS__, $e->getMessage());
         }

--- a/src/Codeception/Module/Db.php
+++ b/src/Codeception/Module/Db.php
@@ -96,7 +96,7 @@ class Db extends \Codeception\Module implements \Codeception\Lib\Interfaces\Db
       'cleanup'    => true,
       'dump'       => null,
       'ignoredrop' => false,
-    ]
+    ];
 
     /**
      * @var bool


### PR DESCRIPTION
By adding `ignoredrop: true` to the MySQL DB module config, I can use MySQL permissions to prevent tables that I don't want to be dropped from actually being dropped. Previously this would've thrown an exception that would've failed my build. Now I can create a user for the test that has a drop privilege on the tables in my dump.sql, but not on the other tables.

I've not added to the other drivers since I don't have working installs for them, but presumably it would work in a similar fashion.

See #1826