### PR TITLE
Only cleanup specified tables - MySQL

### DIFF
--- a/src/Codeception/Lib/Driver/Db.php
+++ b/src/Codeception/Lib/Driver/Db.php
@@ -102,6 +102,14 @@ class Db
     {
     }
 
+    protected function shouldCleanTable($table, array $cleanOnly=[])
+    {
+        if (empty($cleanOnly) || in_array($table, $cleanOnly)) {
+            return true;
+        }
+        return false;
+    }
+
     public function load($sql)
     {
         $query           = '';

--- a/src/Codeception/Lib/Driver/MySql.php
+++ b/src/Codeception/Lib/Driver/MySql.php
@@ -3,12 +3,14 @@ namespace Codeception\Lib\Driver;
 
 class MySql extends Db
 {
-    public function cleanup()
+    public function cleanup(array $cleanTables=[])
     {
         $this->dbh->exec('SET FOREIGN_KEY_CHECKS=0;');
         $res = $this->dbh->query("SHOW FULL TABLES WHERE TABLE_TYPE LIKE '%TABLE';")->fetchAll();
-        foreach ($res as $row) {
-            $this->dbh->exec('drop table `' . $row[0] . '`');
+        foreach ($res AS $row) {
+            if ($this->shouldCleanTable($row['0'], $cleanTables)) {
+                $this->dbh->exec('drop table `' . $row['0'] . '`');
+            }
         }
         $this->dbh->exec('SET FOREIGN_KEY_CHECKS=1;');
     }

--- a/src/Codeception/Module/Db.php
+++ b/src/Codeception/Module/Db.php
@@ -92,9 +92,10 @@ class Db extends \Codeception\Module implements \Codeception\Lib\Interfaces\Db
      * @var array
      */
     protected $config = [
-      'populate' => true,
-      'cleanup'  => true,
-      'dump'     => null
+      'populate'     => true,
+      'cleanup'      => true,
+      'dump'         => null,
+      'clean_tables' => [],
     ];
 
     /**
@@ -193,7 +194,7 @@ class Db extends \Codeception\Module implements \Codeception\Lib\Interfaces\Db
             if (!count($this->sql)) {
                 return;
             }
-            $this->driver->cleanup();
+            $this->driver->cleanup($this->config['clean_tables']);
         } catch (\Exception $e) {
             throw new ModuleException(__CLASS__, $e->getMessage());
         }


### PR DESCRIPTION
Refs #1827 @DavertMik 

Config can now contain a `clean_tables` sequence of tables that will be cleaned during `cleanup()`. If this list is missing/empty then all tables will be cleaned. If it is not missing/empty then only tables in this sequence will be cleaned up. Other tables will be completely ignored unless also included in a provided dump. **This first implementation is ONLY for MySQL**

Example:
```yaml
modules:
    config:
        Db:
            dsn: 'mysql:host=myhostname;dbname=dbname'
            user: 'username'
            password: 'Pa5Sw0Rd!'
            dump: tests/_data/dump.sql
            populate: true
            cleanup: true
            clean_tables:
                - clean_me_one
                - clean_me_two
```

I've only implemented this in MySQL at the moment because the `cleanup()` methods for other DB drivers are quite different:

* The MySQL driver will get a list of tables that are available and iterate over them and check that either `clean_tables` is missing or that the current table is in the `clean_tables` array. This is checked by `Db::shouldCleanTable()`, which returns `true` if the table should be dropped, and `false` if not.
* The MsSQL and SqlSrv drivers create a cursor that moves through all tables dropping as it goes. This would need that query updating to say something like `if @tablename NOT IN(table1, table2 ...) EXEC('DROP TABLE ' + @tablename) ... ` but I don't know enough about this engine to be able to write suitable SQL.
* The PostgreSQL driver runs three queries, each of which returns a complete DROP statement that can be executed later. That means that `Db::shouldCleanTable()` could not check a simple table name and would instead need to compare against the entire query, else we'll need to regex the query to get the table out and pass that through to `Db::shouldCleanTable()`. That's relatively straightforward, but a bit ugly.
* The Oracle driver also runs `cleanup()` similar to MsSQL where it loops through all triggers, tables and sequences and and drops immediately, never returning anything to PHP for us to process. This will mean that `Db::shouldCleanTable()` can't work.

So I'm submitting this actually as a work-in-progress for further feedback. I'm undecided about what the best solution is. I like this idea because we can easily configure in Codeception which tables we actually want to clean and disregard the rest, but it's difficult to implement in the other engines. I also like the previous idea (on #1827) because I can set the permissions on MySQL and just catch a `\PDOException` in PHP and continue as I was. If you like this solution then we'd need to find people who know a lot more about the various RDBMS engines in order to implement properly in each, or make it a MySQL only implementation for now, which I know you don't like.

Before I go any further, please let me know your thoughts.

Thanks