### PR TITLE
Refactoring to merge fillField/submitForm

### DIFF
--- a/src/Codeception/Lib/InnerBrowser.php
+++ b/src/Codeception/Lib/InnerBrowser.php
@@ -539,9 +539,13 @@ class InnerBrowser extends Module implements Web
      */
     protected function getFormFor(Crawler $node)
     {
-        $form = $node->parents()->filter('form')->first();
+        if (strcasecmp($node->first()->getNode(0)->tagName, 'form') === 0) {
+            $form = $node->first();
+        } else {
+            $form = $node->parents()->filter('form')->first();
+        }
         if (!$form) {
-            $this->fail('The selected node does not have a form ancestor.');
+            $this->fail('The selected node is not a form and does not have a form ancestor.');
         }
         $action = $this->getFormUrl($form);
         if (!isset($this->forms[$action])) {

--- a/src/Codeception/Lib/InnerBrowser.php
+++ b/src/Codeception/Lib/InnerBrowser.php
@@ -553,28 +553,22 @@ class InnerBrowser extends Module implements Web
     /**
      * Returns an array of name => value pairs for the passed form.
      *
-     * For form fields containing a name ending in [], an array is
-     * created out of all field values with the given name.
+     * The function calls getPhpValues on the passed form object, then
+     * resets numeric array indexes for array field names without array
+     * keys specified (i.e. 'fieldname[]' but not 'fieldname[keyname]')
+     * as expected by setCheckboxBoolValues.
      *
      * @param \Symfony\Component\DomCrawler\Form the form
      * @return array an array of name => value pairs
      */
     protected function getFormValuesFor(Form $form)
     {
-        $values = [];
+        $values = $form->getPhpValues();
         $fields = $form->all();
         foreach ($fields as $field) {
-            $fieldName = $this->getSubmissionFormFieldName($field->getName());
-            if (!$field->hasValue()) {
-                continue;
-            }
-            if (substr($field->getName(), -2) === '[]') {
-                if (!isset($values[$fieldName])) {
-                    $values[$fieldName] = [];
-                }
-                $values[$fieldName][] = $field->getValue();
-            } else {
-                $values[$fieldName] = $field->getValue();
+            $name = $this->getSubmissionFormFieldName($field->getName());
+            if (!empty($values[$name]) && substr($field->getName(), -2) === '[]') {
+                $values[$name] = array_values($values[$name]);
             }
         }
         return $values;

--- a/src/Codeception/Lib/Interfaces/Web.php
+++ b/src/Codeception/Lib/Interfaces/Web.php
@@ -155,7 +155,7 @@ interface Web
      * @param $params
      * @param $button
      */
-    public function submitForm($selector, $params, $button = null);
+    public function submitForm($selector, array $params, $button = null);
 
     /**
      * Perform a click on a link or a button, given by a locator.

--- a/src/Codeception/Module/WebDriver.php
+++ b/src/Codeception/Module/WebDriver.php
@@ -1253,7 +1253,7 @@ class WebDriver extends \Codeception\Module implements WebInterface, RemoteInter
      * @param $params
      * @param $button
      */
-    public function submitForm($selector, $params, $button = null)
+    public function submitForm($selector, array $params, $button = null)
     {
         $form = $this->match($this->webDriver, $selector);
         if (empty($form)) {

--- a/tests/data/app/view/form/submit_adjacentforms.php
+++ b/tests/data/app/view/form/submit_adjacentforms.php
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>Testing submitForm with an adjacent form</title>
+</head>
+<body>
+<form id="form-1" method="POST" action="/form/complex">
+    <input type="text" name="first-field" value="Ptitsa" />
+    <input type="button" type="submit" value="submit" />
+</form>    
+<form id="form-2" method="POST" action="/form/complex">
+    <input type="text" name="second-field" value="Killgore Trout" />
+    <input type="submit" value="submit" />
+</form>
+</body>
+</html>

--- a/tests/unit/Codeception/Module/TestsForWeb.php
+++ b/tests/unit/Codeception/Module/TestsForWeb.php
@@ -1183,4 +1183,14 @@ abstract class TestsForWeb extends \PHPUnit_Framework_TestCase
         $this->assertContains('test2', $data['captions']);
         $this->assertContains('davert', $data['users']);
     }
+    
+    public function testSubmitAdjacentForms()
+    {
+        $this->module->amOnPage('/form/submit_adjacentforms');
+        $this->module->submitForm('#form-2', []);
+        $data = data::get('form');
+        $this->assertTrue(isset($data['second-field']));
+        $this->assertFalse(isset($data['first-field']));
+        $this->assertEquals('Killgore Trout', $data['second-field']);
+    }
 }

--- a/tests/unit/Codeception/Module/TestsForWeb.php
+++ b/tests/unit/Codeception/Module/TestsForWeb.php
@@ -844,6 +844,19 @@ abstract class TestsForWeb extends \PHPUnit_Framework_TestCase
         $this->assertEquals('kill_all', $form['action']);
     }
 
+    public function testSubmitFormWithFillField()
+    {
+        $this->module->amOnPage('/form/complex');
+        $this->module->fillField('name', 'Kilgore Trout');
+        $this->module->fillField('description', 'Is a fish');
+        $this->module->submitForm('form', [
+            'description' => 'Is from Iliyum, NY'
+        ]);
+        $form = data::get('form');
+        $this->assertEquals('Kilgore Trout', $form['name']);
+        $this->assertEquals('Is from Iliyum, NY', $form['description']);
+    }
+
     public function testSubmitFormWithoutButton() {
         $this->module->amOnPage('/form/empty');
         $this->module->submitForm('form', array(
@@ -1169,7 +1182,5 @@ abstract class TestsForWeb extends \PHPUnit_Framework_TestCase
         $this->assertContains('test3', $data['items'][1]);
         $this->assertContains('test2', $data['captions']);
         $this->assertContains('davert', $data['users']);
-
     }
-
 }


### PR DESCRIPTION
- submitForm refactored to use DomCrawler's Form object, and grab
  defualt values from it instead of filtering the crawler for
  fields manually.
- getFormFor refactored so it creates its own crawler.  Needed so
  input fields in disabled fieldsets aren't submitted
- Created getFormValuesFor to get an array of values as expected by
  submitForm
- Created proceedSubmitForm which is called instead of the deleted
  submitFormWithButton
- Refactored getFormUrl into getFormUrl, getAbsoluteUrlFor and
  mergeUrl methods
- More docblock comments for protected/private methods
- Minor cleanup