### PR TITLE
fix $I->am when User name starts with vowel

### DIFF
--- a/src/Codeception/Lib/Actor/Shared/Comment.php
+++ b/src/Codeception/Lib/Actor/Shared/Comment.php
@@ -18,14 +18,13 @@ trait Comment
         return $this->comment('I am going to ' . $argumentation);
     }
 
-    public function am($role) {
-	    $role = (string) trim($role);
-	    $firstLetter = $role[0];
+    public function am($role)
+    {
+        $role = trim($role);
 
-	    if(preg_match('/[aeiouAEIOU]/i', $firstLetter))
-	    {
+        if (stripos('aeiou', $role[0]) !== false) {
             return $this->comment('As an ' . $role);
-	    }
+        }
 
         return $this->comment('As a ' . $role);
     }
@@ -33,11 +32,5 @@ trait Comment
     public function lookForwardTo($achieveValue)
     {
         return $this->comment('So that I ' . $achieveValue);
-    }
-
-    public function comment($description)
-    {
-        $this->scenario->comment($description);
-        return $this;
     }
 }

--- a/src/Codeception/Lib/Actor/Shared/Comment.php
+++ b/src/Codeception/Lib/Actor/Shared/Comment.php
@@ -19,6 +19,14 @@ trait Comment
     }
 
     public function am($role) {
+	    $role = (string) trim($role);
+	    $firstLetter = $role[0];
+
+	    if(preg_match('/[aeiouAEIOU]/i', $firstLetter))
+	    {
+            return $this->comment('As an ' . $role);
+	    }
+
         return $this->comment('As a ' . $role);
     }
 


### PR DESCRIPTION
This is just a small fix for english output. 

Right now if you do:

```php
		$I->am(' Administrator');
```

You will get:

```
* As a Administrator
```

After the patch you will get:
```
* As an Administrator
```