### PR TITLE
Issue #668 – REST Module : grabResponseStatus

### DIFF
--- a/src/Codeception/Module/REST.php
+++ b/src/Codeception/Module/REST.php
@@ -94,6 +94,32 @@ class REST extends \Codeception\Module
     }
 
     /**
+     * Returns current response status code so that it can be used in next scenario steps.
+     *
+     * Example:
+     *
+     * ``` php
+     * <?php
+     * $status = $I->grabResponseStatus();
+     * switch($status) {
+     *     case 201:
+     *         $I->seeResponseIsJson();
+     *     break;
+     *     case 202:
+     *         // "Accepted" Response Handling
+     *     break;
+     * }
+     * ?>
+     * ```
+     *
+     * @return integer
+     */
+    public function grabResponseStatus()
+    {
+        return $this->client->getInternalResponse()->getStatus();
+    }
+
+    /**
      * Sets HTTP header
      *
      * @param $name

--- a/tests/unit/Codeception/Module/RestTest.php
+++ b/tests/unit/Codeception/Module/RestTest.php
@@ -263,6 +263,11 @@ class RestTest extends \PHPUnit_Framework_TestCase
         $this->setExpectedException('PHPUnit_Framework_AssertionFailedError');
     }
 
+    public function testGrabResponseStatus()
+    {
+        $this->module->sendGET('/');
+        $this->assertEquals(200, $this->module->grabResponseStatus());
+    }
 
 }
 


### PR DESCRIPTION
Adds `grabResponseStatus` method to the REST module for obtaining the
request's HTTP status code.

Although issue #668 was closed, this seems like it should be available to Scenarios; related to the following quote:

> P.S. also @DavertMik what about to add method to REST module grabResponseCode so people can handle this situations?

Implemented as `getResponseStatus` to match the module's `client` method for retrieving the status code.




