### PR TITLE
#1798 fix ugly output in unix terminals

### DIFF
--- a/src/Codeception/Lib/Console/Message.php
+++ b/src/Codeception/Lib/Console/Message.php
@@ -109,6 +109,20 @@ class Message
         return strlen($this->message);
     }
 
+    public function widthWithTerminalCorrection($width, $char = ' ')
+    {
+        $cols = 0;
+        if (strtoupper(substr(PHP_OS, 0, 3)) !== 'WIN') {
+            $cols = intval(`command -v tput >> /dev/null && tput cols`);
+        }
+        if ($cols > 0) {
+            $const = ($char == ' ') ? 6 : 1;
+            $width = ($cols <= $width) ? $cols - $const : $width;
+            $width = ($width < $const) ? $const : $width;
+        }
+        return $this->width($width, $char);
+    }
+
     public function __toString()
     {
         return $this->message;

--- a/src/Codeception/Subscriber/Console.php
+++ b/src/Codeception/Subscriber/Console.php
@@ -71,7 +71,7 @@ class Console implements EventSubscriberInterface
         $this->message("%s Tests (%d) ")
             ->with(ucfirst($e->getSuite()->getName()), count($e->getSuite()->tests()))
             ->style('bold')
-            ->width(array_sum($this->columns), '-')
+            ->widthWithTerminalCorrection(array_sum($this->columns), '-')
             ->prepend("\n")
             ->writeln();
 
@@ -201,7 +201,7 @@ class Console implements EventSubscriberInterface
 
     public function afterSuite(SuiteEvent $e)
     {
-        $this->message()->width(array_sum($this->columns), '-')->writeln();
+        $this->message()->widthWithTerminalCorrection(array_sum($this->columns), '-')->writeln();
     }
 
     public function printFail(FailEvent $e)
@@ -447,11 +447,11 @@ class Console implements EventSubscriberInterface
             return;
         }
         if ($this->output->isInteractive()) {
-            $this->getTestMessage($test)->prepend("\x0D")->width($this->columns[0])->write();
+            $this->getTestMessage($test)->prepend("\x0D")->widthWithTerminalCorrection($this->columns[0])->write();
             return;
         } 
         if ($this->message) {
-            $this->message('')->width($this->columns[0] - $this->message->apply('strip_tags')->getLength())->write();
+            $this->message('')->widthWithTerminalCorrection($this->columns[0] - $this->message->apply('strip_tags')->getLength())->write();
         }
     }
 


### PR DESCRIPTION
Fixed my own bug with ugly output when ```codeception run```. 
Works only for *nix terminals with ```tput```.