### PR TITLE
Allow following symlinks when searching for tests

### DIFF
--- a/src/Codeception/TestLoader.php
+++ b/src/Codeception/TestLoader.php
@@ -112,7 +112,7 @@ class TestLoader
 
     public function loadTests()
     {
-        $finder = Finder::create()->files()->sortByName()->in($this->path);
+        $finder = Finder::create()->files()->sortByName()->in($this->path)->followLinks();
 
         foreach (self::$formats as $format) {
             $formatFinder = clone($finder);


### PR DESCRIPTION
Hello,

in our projects  we have in separated modules packed with tests. When deploying to Linux server automated scripts make symlinks instead of copy of this tests to one directory and run them. Symphony Finderdoesnt follow these symlinks by default, so I'm suggesting this change to allow this behavior. 