### PR TITLE
Allow following symlinks when searching for tests

### DIFF
--- a/src/Codeception/TestLoader.php
+++ b/src/Codeception/TestLoader.php
@@ -109,7 +109,7 @@ class TestLoader {
 
     public function loadTests()
     {
-        $finder = Finder::create()->files()->sortByName()->in($this->path);
+        $finder = Finder::create()->files()->sortByName()->in($this->path)->followLinks();
 
         foreach (self::$formats as $format) {
             $formatFinder = clone($finder);


### PR DESCRIPTION
Hello,

in our projects we have separated modules packed with tests.
When deploying to Linux server, automated scripts create
symlinks, instead of copying these tests to a directory and
run them. Symphony Finder doesnt follow these
symlinks by default, so I suggest a change to allow such behavior.

(Moved from master to branch 2.0 based on #1860)