### PR TITLE
Simplified module configuration format

### DIFF
--- a/docs/03-ModulesAndHelpers.md
+++ b/docs/03-ModulesAndHelpers.md
@@ -273,13 +273,10 @@ The host and port parameter can be redefined in the suite config. Values are set
 ```yaml
 modules:
     enabled:
-        - WebDriver
-        - Db
-    config:
-        WebDriver:
+        - WebDriver:
             url: 'http://mysite.com/'
             browser: 'firefox'
-        Db:
+        - Db:
             cleanup: false
             repopulate: false
 ```

--- a/docs/04-AcceptanceTests.md
+++ b/docs/04-AcceptanceTests.md
@@ -58,12 +58,10 @@ Before we start we need a local copy of the site running on your host. We need t
 class_name: AcceptanceTester
 modules:
     enabled:
-        - PhpBrowser
+        - PhpBrowser:
+            url: [your site's url]
         - AcceptanceHelper
         - Db
-    config:
-        PhpBrowser:
-            url: [your site's url]
 ```
 
 We should start by creating a 'Cept' file in the __tests/acceptance__ directory. Let's call it __SigninCept.php__. We will write the first lines into it.
@@ -378,12 +376,10 @@ Modify your `acceptance.suite.yml` file:
 class_name: AcceptanceTester
 modules:
     enabled:
-        - WebDriver
-        - AcceptanceHelper
-    config:
-        WebDriver:
+        - WebDriver:
             url: 'http://localhost/myapp/'
             browser: firefox            
+        - AcceptanceHelper
 ```
 
 In order to run Selenium tests you need to [download Selenium Server](http://seleniumhq.org/download/) and get it running (Alternatively you may use [PhantomJS](http://phantomjs.org/) headless browser in `ghostdriver` mode).

--- a/docs/10-WebServices.md
+++ b/docs/10-WebServices.md
@@ -19,12 +19,10 @@ Configure modules in `api.suite.yml`:
 ``` yaml
 class_name: ApiTester
 modules:
-    enabled: [PhpBrowser, REST, ApiHelper]
     config:
-		PhpBrowser:
-			url: http://serviceapp/
-		REST:
+		- REST:
 		    url: http://serviceapp/api/v1/
+		    depends: PhpBrowser
 ```
 
 The REST module will automatically connect to `PhpBrowser`. In case you provide it with Symfony2, Laravel4, Zend, or other framework module, it will connect to them as well. Don't forget to run the `build` command once you finished editing configuration.
@@ -78,11 +76,9 @@ Let's configure `SOAP` module to be used with `PhpBrowser`:
 ``` yaml
 class_name: ApiTester
 modules:
-    enabled: [PhpBrowser, SOAP, ApiHelper]
-    config:
-		PhpBrowser:
-			url: http://serviceapp/
-		SOAP:
+    enabled:
+		- SOAP:
+		    depends: PhpBrowser
 		    endpoint: http://serviceapp/api/v1/
 ```
 

--- a/src/Codeception/Command/Bootstrap.php
+++ b/src/Codeception/Command/Bootstrap.php
@@ -163,13 +163,11 @@ class Bootstrap extends Command
         $suiteConfig = [
             'class_name' => $actor . $this->actorSuffix,
             'modules'    => [
-                'enabled' => ['PhpBrowser', "\\{$this->namespace}Helper\\$actor"],
-                'config'  => [
-                    'PhpBrowser' => [
-                        'url' => 'http://localhost/myapp/'
-                    ],
+                'enabled' => [
+                    'PhpBrowser' =>
+                         ['url' => 'http://localhost/myapp/']
+                    , "\\{$this->namespace}Helper\\$actor"]
                 ]
-            ],
         ];
 
         $str = "# Codeception Test Suite Configuration\n\n";

--- a/src/Codeception/Configuration.php
+++ b/src/Codeception/Configuration.php
@@ -362,14 +362,15 @@ class Configuration
 
     /**
      * Return instances of enabled modules according suite config.
-     * Requires Guy class if it exists.
      *
      * @param array $settings suite settings
      * @return array|\Codeception\Module[]
      */
-    public static function modules(&$settings)
+    public static function modules($settings)
     {
-        return $settings['modules']['enabled'];
+        return array_map(function ($m, $key) {
+            return is_array($m) ? $key : $m;
+        }, $settings['modules']['enabled'], array_keys($settings['modules']['enabled']));
     }
 
     public static function isExtensionEnabled($extensionName)

--- a/src/Codeception/Lib/Console/Output.php
+++ b/src/Codeception/Lib/Console/Output.php
@@ -34,7 +34,8 @@ class Output extends ConsoleOutput
         $formatter->setStyle('ok', new OutputFormatterStyle('white', 'magenta'));
         $formatter->setStyle('error', new OutputFormatterStyle('white', 'red'));
         $formatter->setStyle('debug', new OutputFormatterStyle('cyan'));
-        $formatter->setStyle('info', new OutputFormatterStyle('yellow'));
+        $formatter->setStyle('comment', new OutputFormatterStyle('yellow'));
+        $formatter->setStyle('info', new OutputFormatterStyle('green'));
 
         $this->formatHelper = new FormatterHelper();
 

--- a/src/Codeception/Lib/ModuleContainer.php
+++ b/src/Codeception/Lib/ModuleContainer.php
@@ -69,7 +69,7 @@ class ModuleContainer
             return $this->instantiate($moduleName, $moduleClass, $config);
         }
 
-        throw new ConfigurationException($moduleName . ' could not be found and loaded');
+        throw new ConfigurationException("Module $moduleName could not be found and loaded");
     }
 
     public function hasModule($module)
@@ -205,7 +205,7 @@ class ModuleContainer
         if (!is_array($part)) {
             $part = [strtolower($part)];
         }
-        $part = array_map('strtolower', $part);
+        $part = array_map('strtoloower', $part);
         $parts = Annotation::forMethod($module, $action)->fetchAll('part');
         $usedParts = array_intersect($parts, $part);
         return !empty($usedParts);
@@ -232,7 +232,7 @@ class ModuleContainer
             if ($enabledModuleName !== $module) {
                 continue;
             }
-            $config = Configuration::mergeConfigs($config, $enabledModuleConfig);
+            $config = Configuration::mergeConfigs($enabledModuleConfig, $config);
         }
         return $config;
     }

--- a/src/Codeception/Lib/ModuleContainer.php
+++ b/src/Codeception/Lib/ModuleContainer.php
@@ -205,7 +205,7 @@ class ModuleContainer
         if (!is_array($part)) {
             $part = [strtolower($part)];
         }
-        $part = array_map('strtoloower', $part);
+        $part = array_map('strtolower', $part);
         $parts = Annotation::forMethod($module, $action)->fetchAll('part');
         $usedParts = array_intersect($parts, $part);
         return !empty($usedParts);

--- a/src/Codeception/Module/AMQP.php
+++ b/src/Codeception/Module/AMQP.php
@@ -37,9 +37,8 @@ use PhpAmqpLib\Message\AMQPMessage;
  * ### Example
  *
  *     modules:
- *         enabled: [AMQP]
- *         config:
- *             AMQP:
+ *         enabled:
+ *             - AMQP:
  *                 host: 'localhost'
  *                 port: '5672'
  *                 username: 'guest'

--- a/src/Codeception/Module/Db.php
+++ b/src/Codeception/Module/Db.php
@@ -53,9 +53,8 @@ namespace Codeception\Module;
  * ### Example
  *
  *     modules:
- *        enabled: [Db]
- *        config:
- *           Db:
+ *        enabled:
+ *           - Db:
  *              dsn: 'mysql:host=localhost;dbname=testdb'
  *              user: 'root'
  *              password: ''

--- a/src/Codeception/Module/Doctrine2.php
+++ b/src/Codeception/Module/Doctrine2.php
@@ -48,19 +48,18 @@ class Doctrine2 extends \Codeception\Module implements DependsOnModule
 Provide connection_callback function to establish database connection and get Entity Manager:
 ```
 modules:
-    enabled: [Doctrine2]
-    config:
-        Doctrine2:
-            connection_callback: [My\ConnectionClass, getEntityManager]
+    enabled:
+        - Doctrine2:
+              connection_callback: [My\ConnectionClass, getEntityManager]
 ```
 
 Or set a dependent module, which can be either Symfony2 or ZF2 to get EM from service locator:
 
 ```
 modules:
-    enabled: [Doctrine2]
-    depends:
-        Doctrine2: Symfony2
+    enabled:
+        - Doctrine2:
+            depends: Symfony2
 ```
 EOF;
 

--- a/src/Codeception/Module/Facebook.php
+++ b/src/Codeception/Module/Facebook.php
@@ -34,17 +34,15 @@ use Codeception\Module as BaseModule;
  * ### Config example
  *
  *     modules:
- *         enabled: [Facebook]
- *         config:
- *             Facebook:
+ *         enabled:
+ *             - Facebook:
+ *                 depends: PhpBrowser
  *                 app_id: 412345678901234
  *                 secret: ccb79c1b0fdff54e4f7c928bf233aea5
  *                 test_user:
  *                     name: FacebookGuy
  *                     locale: uk_UA
  *                     permissions: [email, publish_stream]
- *         depends:
- *             Facebook: PhpBrowser
  *
  * ###  Test example:
  *

--- a/src/Codeception/Module/Laravel4.php
+++ b/src/Codeception/Module/Laravel4.php
@@ -25,11 +25,17 @@ use Illuminate\Support\MessageBag;
  *
  * <https://github.com/Codeception/sample-l4-app>
  *
+ * ## Example
+ *
+ *     modules:
+ *         enabled:
+ *             - Laravel4
+ *
  * ## Status
  *
- * * Maintainer: **Davert**
- * * Stability: **stable**
- * * Contact: davert.codeception@mailican.com
+ * * Maintainer: **Jan-Henk Gerritsen**
+ * * Stability: **dev**
+ * * Contact: janhenkgerritsen@gmail.com
  *
  * ## Config
  *

--- a/src/Codeception/Module/Laravel5.php
+++ b/src/Codeception/Module/Laravel5.php
@@ -26,6 +26,12 @@ use Illuminate\Http\Request;
  * * Stability: **dev**
  * * Contact: janhenkgerritsen@gmail.com
  *
+ * ## Example
+ *
+ *     modules:
+ *         enabled:
+ *             - Laravel5
+ *
  * ## Config
  *
  * * cleanup: `boolean`, default `true` - all db queries will be run in transaction, which will be rolled back at the end of test.

--- a/src/Codeception/Module/Phalcon1.php
+++ b/src/Codeception/Module/Phalcon1.php
@@ -40,9 +40,8 @@ use Codeception\Step;
  * <pre>
  * class_name: TestGuy
  * modules:
- *     enabled: [FileSystem, TestHelper, Phalcon1]
- *     config:
- *         Phalcon1
+ *     enabled:
+ *         - Phalcon1:
  *             bootstrap: 'app/config/bootstrap.php'
  *             cleanup: true
  *             savepoints: true

--- a/src/Codeception/Module/PhpBrowser.php
+++ b/src/Codeception/Module/PhpBrowser.php
@@ -41,9 +41,8 @@ use GuzzleHttp\Client;
  * ### Example (`acceptance.suite.yml`)
  *
  *     modules:
- *        enabled: [PhpBrowser]
- *        config:
- *           PhpBrowser:
+ *        enabled:
+ *           - PhpBrowser:
  *              url: 'http://localhost'
  *              auth: ['admin', '123345']
  *              curl:

--- a/src/Codeception/Module/REST.php
+++ b/src/Codeception/Module/REST.php
@@ -37,12 +37,10 @@ use Codeception\Util\Soap as XmlUtils;
  * ### Example
  *
  *     modules:
- *        enabled: [PhpBrowser, REST]
- *        config:
- *           PhpBrowser:
- * url: http://serviceapp/
- *           REST:
- *              url: 'http://serviceapp/api/v1/'
+ *        enabled:
+ *            - REST:
+ *                depends: PhpBrowser
+ *                url: 'http://serviceapp/api/v1/'
  *
  * ## Public Properties
  *
@@ -60,14 +58,14 @@ class REST extends \Codeception\Module implements DependsOnModule, PartedModule
     ];
 
     protected $dependencyMessage = <<<EOF
-Example using PhpBrowser as backend for REST module.
+Example configuring PhpBrowser as backend for REST module.
 --
 modules:
-    enabled: [REST, ApiHelper]
-    depends:
-        REST: PhpBrowser
+    enabled: REST:
+        depends: PhpBrowser
+        url: http://localhost/api/
 --
-Framework modules can be used as well for functional testing of API.
+Framework modules can be used for testing of API as well.
 EOF;
 
     /**

--- a/src/Codeception/Module/Silex.php
+++ b/src/Codeception/Module/Silex.php
@@ -39,9 +39,8 @@ use Codeception\TestCase;
  * ### Example (`functional.suite.yml`)
  *
  *     modules:
- *        enabled: [Silex]
- *        config:
- *           Silex:
+ *        enabled:
+ *           - Silex:
  *              app: 'app/bootstrap.php'
  *
  * Class Silex

--- a/src/Codeception/Module/Symfony2.php
+++ b/src/Codeception/Module/Symfony2.php
@@ -50,12 +50,11 @@ use Symfony\Component\HttpKernel\Exception\HttpException;
  * ### Example (`functional.suite.yml`) - Symfony 3 Directory Structure
  *
  *     modules:
- *        enabled: [Symfony2]
- *        config:
- *           Symfony2:
- *              app_path: 'app/front'
- *              var_path: 'var'
- *              environment: 'local_test'
+ *        enabled:
+ *           - Symfony2:
+ *               app_path: 'app/front'
+ *               var_path: 'var'
+ *               environment: 'local_test'
  *
  *
  * ## Public Properties

--- a/src/Codeception/Module/WebDriver.php
+++ b/src/Codeception/Module/WebDriver.php
@@ -60,9 +60,8 @@ use Symfony\Component\DomCrawler\Crawler;
  * ### Example (`acceptance.suite.yml`)
  *
  *     modules:
- *        enabled: [WebDriver]
- *        config:
- *           WebDriver:
+ *        enabled:
+ *           - WebDriver:
  *              url: 'http://localhost/'
  *              browser: firefox
  *              window_size: 1024x768

--- a/src/Codeception/Module/Yii2.php
+++ b/src/Codeception/Module/Yii2.php
@@ -21,9 +21,8 @@ use Yii;
  * <pre>
  * class_name: TestGuy
  * modules:
- *     enabled: [Yii2, TestHelper]
- *     config:
- *         Yii2:
+ *     enabled:
+ *         - Yii2:
  *             configFile: '/path/to/config.php'
  * </pre>
  *

--- a/src/Codeception/Subscriber/Console.php
+++ b/src/Codeception/Subscriber/Console.php
@@ -216,13 +216,15 @@ class Console implements EventSubscriberInterface
     {
         $failedTest = $e->getTest();
         $fail = $e->getFail();
+        
+        $this->output->write($e->getCount() . ") ");
 
-        $this->getTestMessage($failedTest)->prepend($e->getCount() . ") ")->write();
 
         if ($failedTest instanceof ScenarioDriven) {
             $this->printScenarioFail($failedTest, $fail);
             return;
         }
+        $this->getTestMessage($failedTest)->write();
 
         $this->printException($fail);
         $this->printExceptionTrace($fail);
@@ -372,18 +374,18 @@ class Console implements EventSubscriberInterface
 
         if (!$length) return;
 
-        $this->output->writeln("\nScenario Steps:\n");
+        $this->message("\nScenario Steps:\n")->style('comment')->writeln();
 
         foreach ($trace as $step) {
             $message = $this->message($i)->prepend(' ')->width(strlen($length))->append(". ".$step->getPhpCode());
 
             if ($step->hasFailed()) {
-                $message->append(' ')->style('bold');
+                $message->append('')->style('bold');
             }
 
             $line = $step->getLineNumber();
             if ($line) {
-                $message->append(' <info>'.codecept_relative_path($failedTest->getFileName().":$line</info>"));
+                $message->append(' at <info>'.codecept_relative_path($failedTest->getFileName().":$line</info>"));
             }
 
             $i--;

--- a/src/Codeception/Subscriber/Console.php
+++ b/src/Codeception/Subscriber/Console.php
@@ -216,9 +216,10 @@ class Console implements EventSubscriberInterface
     {
         $failedTest = $e->getTest();
         $fail = $e->getFail();
-        $this->output->write($e->getCount() . ") ");
 
-        if ($e->getTest() instanceof ScenarioDriven) {
+        $this->getTestMessage($failedTest)->prepend($e->getCount() . ") ")->write();
+
+        if ($failedTest instanceof ScenarioDriven) {
             $this->printScenarioFail($failedTest, $fail);
             return;
         }

--- a/tests/unit/Codeception/Lib/ModuleContainerTest.php
+++ b/tests/unit/Codeception/Lib/ModuleContainerTest.php
@@ -111,7 +111,7 @@ class ModuleContainerTest extends \PHPUnit_Framework_TestCase
     public function testCreateModuleWithoutRequiredFields()
     {
         $this->setExpectedException('\Codeception\Exception\ModuleConfigException');
-        $this->moduleContainer->create('Codeception\Lib\StubModule', ['secondField' => 'none']);
+        $this->moduleContainer->create('Codeception\Lib\StubModule');
     }
 
     /**
@@ -193,8 +193,10 @@ class ModuleContainerTest extends \PHPUnit_Framework_TestCase
     {
         $config = ['modules' => [
             'enabled' => ['Codeception\Lib\DependencyModule'],
-            'depends' => [
-                'Codeception\Lib\DependencyModule' => 'Codeception\Lib\ConflictedModule'
+            'config' => [
+                'Codeception\Lib\DependencyModule' => [
+                    'depends' => 'Codeception\Lib\ConflictedModule'
+                ]
             ]
         ]];
         $this->moduleContainer = new ModuleContainer(Stub::make('Codeception\Lib\Di'), $config);
@@ -234,6 +236,53 @@ class ModuleContainerTest extends \PHPUnit_Framework_TestCase
         $actions = $this->moduleContainer->getActions();
         $this->assertArrayHasKey('partTwo', $actions);
         $this->assertArrayNotHasKey('partOne', $actions);
+    }
+
+    public function testShortConfigParts()
+    {
+        $config = ['modules' => [
+            'enabled' => ['\Codeception\Lib\PartedModule' => [
+                'part' => 'one'
+            ]],
+        ]];
+        $this->moduleContainer = new ModuleContainer(Stub::make('Codeception\Lib\Di'), $config);
+        $this->moduleContainer->create('\Codeception\Lib\PartedModule');
+        $actions = $this->moduleContainer->getActions();
+        $this->assertArrayHasKey('partOne', $actions);
+        $this->assertArrayNotHasKey('partTwo', $actions);
+
+
+    }
+
+    public function testShortConfigFormat()
+    {
+        $config = ['modules' =>
+            ['enabled' => [
+                'Codeception\Lib\StubModule' => [
+                    'firstField' => 'firstValue',
+                    'secondField' => 'secondValue',
+                ]
+            ]
+        ]];
+
+        $this->moduleContainer = new ModuleContainer(Stub::make('Codeception\Lib\Di'), $config);
+        $module = $this->moduleContainer->create('Codeception\Lib\StubModule');
+
+        $this->assertEquals('firstValue', $module->_getFirstField());
+        $this->assertEquals('secondValue', $module->_getSecondField());
+
+    }
+
+    public function testShortConfigDependencies()
+    {
+        $config = ['modules' => [
+            'enabled' => ['Codeception\Lib\DependencyModule' => [
+                'depends' => 'Codeception\Lib\ConflictedModule'
+            ]],
+        ]];
+        $this->moduleContainer = new ModuleContainer(Stub::make('Codeception\Lib\Di'), $config);
+        $this->moduleContainer->create('Codeception\Lib\DependencyModule');
+        $this->moduleContainer->hasModule('\Codeception\Lib\DependencyModule');
     }
 
 }


### PR DESCRIPTION
Module configuration can be set while lising module in `enabled` sections like here:

``` yaml
modules:
    enabled:
        - WebDriver:
            browser: firefox
        - \Helper\Acceptance
```

Other examples:

https://gist.github.com/DavertMik/79a540dce15a7a0d81bd