### PR TITLE
Fixed array to string conversion in InnerBroser commands.

### DIFF
--- a/src/Codeception/Lib/InnerBrowser.php
+++ b/src/Codeception/Lib/InnerBrowser.php
@@ -143,7 +143,7 @@ class InnerBrowser extends Module implements Web
             $this->assertPageContains($text);
         } else {
             $nodes = $this->match($selector);
-            $this->assertDomContains($nodes, $selector, $text);
+            $this->assertDomContains($nodes, $this->stringifySelector($selector), $text);
         }
     }
 
@@ -153,7 +153,7 @@ class InnerBrowser extends Module implements Web
             $this->assertPageNotContains($text);
         } else {
             $nodes = $this->match($selector);
-            $this->assertDomNotContains($nodes, $selector, $text);
+            $this->assertDomNotContains($nodes, $this->stringifySelector($selector), $text);
         }
     }
 
@@ -422,7 +422,7 @@ class InnerBrowser extends Module implements Web
     {
         $form = $this->match($selector)->first();
         if (!count($form)) {
-            throw new ElementNotFound($selector, 'Form');
+            throw new ElementNotFound($this->stringifySelector($selector), 'Form');
         }
         $this->proceedSubmitForm($form, $params, $button);
     }
@@ -954,9 +954,19 @@ class InnerBrowser extends Module implements Web
         $this->debugSection('Cookies', $this->client->getCookieJar()->all());
     }
 
+    public function stringifySelector($selector)
+    {
+      if (is_array($selector))
+      {
+          return trim(json_encode($selector), '{}');
+      }
+      return $selector;
+    }
+
     public function seeElement($selector, $attributes = array())
     {
         $nodes = $this->match($selector);
+        $selector = $this->stringifySelector($selector);
         if (!empty($attributes)) {
             $nodes = $this->filterByAttributes($nodes, $attributes);
             $selector .= "' with attribute(s) '" . trim(json_encode($attributes),'{}');
@@ -967,6 +977,7 @@ class InnerBrowser extends Module implements Web
     public function dontSeeElement($selector, $attributes = array())
     {
         $nodes = $this->match($selector);
+        $selector = $this->stringifySelector($selector);
         if (!empty($attributes)) {
             $nodes = $this->filterByAttributes($nodes, $attributes);
             $selector .= "' with attribute(s) '" . trim(json_encode($attributes),'{}');


### PR DESCRIPTION
Several commands in InnerBrowser have documentation about [array selectors](http://codeception.com/docs/modules/PhpBrowser#seeElement), however such selectors give you the **[ErrorException] Array to string conversion** exception.

I've fixed this and also added support of array selectors to other commands, which have $selector as optional parameter to make things more consistent.