### PR TITLE
Strip tags for see/dontSee in InnerBrowser

### DIFF
--- a/src/Codeception/Lib/InnerBrowser.php
+++ b/src/Codeception/Lib/InnerBrowser.php
@@ -1068,13 +1068,21 @@ class InnerBrowser extends Module implements Web
     protected function assertPageContains($needle, $message = '')
     {
         $constraint = new PageConstraint($needle, $this->_getCurrentUri());
-        $this->assertThat($this->client->getInternalResponse()->getContent(), $constraint,$message);
+        $this->assertThat(
+            htmlspecialchars_decode(strip_tags($this->client->getInternalResponse()->getContent())),
+            $constraint,
+            $message
+        );
     }
 
     protected function assertPageNotContains($needle, $message = '')
     {
         $constraint = new PageConstraint($needle, $this->_getCurrentUri());
-        $this->assertThatItsNot($this->client->getInternalResponse()->getContent(), $constraint,$message);
+        $this->assertThatItsNot(
+            htmlspecialchars_decode(strip_tags($this->client->getInternalResponse()->getContent())),
+            $constraint,
+            $message
+        );
     }
 
     /**

--- a/tests/data/app/view/index.php
+++ b/tests/data/app/view/index.php
@@ -21,7 +21,7 @@
     <a href="info">Document-Relative Link</a>
 </div>
 
-A wise man said: "debug!"
+A wise man said: <b>&quot;debug!&quot;</b>
 
 <?php print_r($_POST); ?>
 

--- a/tests/unit/Codeception/Module/TestsForWeb.php
+++ b/tests/unit/Codeception/Module/TestsForWeb.php
@@ -47,6 +47,7 @@ abstract class TestsForWeb extends \PHPUnit_Framework_TestCase
     {
         $this->module->amOnPage('/');
         $this->module->see('Welcome to test app!');
+        $this->module->see('A wise man said: "debug!"');
 
         $this->module->amOnPage('/');
         $this->module->see('Welcome to test app!', 'h1');


### PR DESCRIPTION
see/dontSee should test against text rather than HTML content.  Solution for #1873