### PR TITLE
Fix undefined field in generated Actions trait

### DIFF
--- a/src/Codeception/Actor.php
+++ b/src/Codeception/Actor.php
@@ -19,6 +19,13 @@ abstract class Actor
         $this->scenario = $scenario;
     }
 
+    /**
+     * @return \Codeception\Scenario
+     */
+    protected function getScenario()
+    {
+        return $this->scenario;
+    }
 
     public function wantToTest($text)
     {

--- a/src/Codeception/Lib/Generator/Actions.php
+++ b/src/Codeception/Lib/Generator/Actions.php
@@ -22,7 +22,12 @@ namespace {{namespace}}_generated;
 
 trait {{name}}Actions
 {
-   {{methods}}
+    /**
+     * @return \Codeception\Scenario
+     */
+    abstract protected function getScenario();
+
+    {{methods}}
 }
 EOF;
 
@@ -36,7 +41,7 @@ EOF;
      * @see \{{module}}::{{method}}()
      */
     public function {{action}}({{params}}) {
-        return \$this->scenario->runStep(new \Codeception\Step\{{step}}('{{method}}', func_get_args()));
+        return \$this->getScenario()->runStep(new \Codeception\Step\{{step}}('{{method}}', func_get_args()));
     }
 EOF;
 


### PR DESCRIPTION
PhpStorm IDE reports an undefined field `scenario` in generated *Actions trait.
For example here:
```
public function canSee($text, $selector = null) {
    return $this->scenario->runStep(new \Codeception\Step\ConditionalAssertion('see', func_get_args()));
}
```
I think it makes sense, because there is no such field defined in the trait and you can't be sure that the trait will always be inserted into a class that has the field defined.

There is a possibility to define a field in the trait itself, but if it conflicts with the field of same name in the imported class PHP issues either E_STRICT (if the definition is the same) or E_FATAL (if it's not the same) - see http://php.net/manual/en/language.oop5.traits.php#language.oop5.traits.properties .

Therefore I suggest to declare an abstract method `getScenario()` which is basically like specifying  the interface of the class importing the trait (it imposes the importing class to have such method - see http://php.net/manual/en/language.oop5.traits.php#language.oop5.traits.abstract ).