### PR TITLE
fix port number in WebDriverTest skip message

### DIFF
--- a/tests/unit/Codeception/Module/WebDriverTest.php
+++ b/tests/unit/Codeception/Module/WebDriverTest.php
@@ -62,7 +62,7 @@ class WebDriverTest extends TestsForBrowsers
             return true;
         }
         $this->markTestSkipped(
-            'Requires Selenium2 Server running on port 4455'
+            'Requires Selenium2 Server running on port 4444'
         );
         return false;
     }


### PR DESCRIPTION
In commit 002563602837195015ef1671154ed8775d382a78 @davert forgot to change port number to 4444 in WebDriverTest skip message.