### PR TITLE
ZF1 connector improvements

### DIFF
--- a/src/Codeception/Lib/Connector/ZF1.php
+++ b/src/Codeception/Lib/Connector/ZF1.php
@@ -64,7 +64,12 @@ class ZF1 extends Client
         $this->front->setRequest($zendRequest)->setResponse($zendResponse);
 
         ob_start();
-        $this->bootstrap->run();
+        try {
+            $this->bootstrap->run();
+        } catch (\Exception $e) {
+            ob_end_clean();
+            throw $e;
+        }
         ob_end_clean();
 
         $this->zendRequest = $zendRequest;

--- a/src/Codeception/Lib/Connector/ZF1.php
+++ b/src/Codeception/Lib/Connector/ZF1.php
@@ -54,6 +54,7 @@ class ZF1 extends Client
         // so we set all parameters in ZF's request here to not break apps
         // relying on $request->getPost()
         $zendRequest->setPost($request->getParameters());
+        $zendRequest->setRawBody($request->getContent());
         $zendRequest->setRequestUri(str_replace('http://localhost', '', $request->getUri()));
         $zendRequest->setHeaders($request->getServer());
         $_FILES = $this->remapFiles($request->getFiles());


### PR DESCRIPTION
1. Set raw request body, it is particularly necessary when using REST module with application/json content-type.
2. Catch exception and close output buffer to avoid 'risky test' mark, allows testing exceptions thrown by controllers.