### PR TITLE
Improved console log message for generated cept files.

### DIFF
--- a/src/Codeception/Command/GenerateCept.php
+++ b/src/Codeception/Command/GenerateCept.php
@@ -48,12 +48,13 @@ class GenerateCept extends Command
         $filename = $this->completeSuffix($filename, 'Cept');
         $gen = new Cept($config);
 
-        $res = $this->save($config['path'] . DIRECTORY_SEPARATOR . $filename, $gen->produce());
+        $full_path = rtrim( $config['path'], DIRECTORY_SEPARATOR ) . DIRECTORY_SEPARATOR . $filename;
+        $res = $this->save($full_path, $gen->produce());
         if (!$res) {
             $output->writeln("<error>Test $filename already exists</error>");
             return;
         }
-        $output->writeln("<info>Test was created in $filename</info>");
+        $output->writeln("<info>Test was created in $full_path</info>");
     }
 
 }


### PR DESCRIPTION
Currently when we generate cept file using `generate:cept` command we see following message in the terminal:

    Test was created in JustTestCept.php

This message looks less informative then `generate:cest` command's message which looks like this:

    Test was created in /path/to/the/project/folder/tests/acceptance/JustTestCest.php