### PR TITLE
Pass raw body to ZF2 if it is present in request

### DIFF
--- a/src/Codeception/Lib/Connector/ZF2.php
+++ b/src/Codeception/Lib/Connector/ZF2.php
@@ -59,12 +59,12 @@ class ZF2 extends Client
             parse_str($queryString, $query);
             $zendRequest->setQuery(new Parameters($query));
         }
-
-        if ($method == HttpRequest::METHOD_POST) {
+        
+        if ($request->getContent() != null) {
+            $zendRequest->setContent($request->getContent());
+        } elseif ($method != HttpRequest::METHOD_GET) {
             $post = $request->getParameters();
             $zendRequest->setPost(new Parameters($post));
-        } elseif ($method == HttpRequest::METHOD_PUT) {
-            $zendRequest->setContent($request->getContent());
         }
 
         $zendRequest->setMethod($method);


### PR DESCRIPTION
Related to issue #1928

This change allows to use raw body in POST and other methods.

I haven't tested this change because I am not using ZF2, but I haven't introduced any new method calls and it should just work.