### PR TITLE
$_POST is now cleared among GET requests

### DIFF
--- a/src/Codeception/Lib/Connector/Yii1.php
+++ b/src/Codeception/Lib/Connector/Yii1.php
@@ -45,6 +45,7 @@ class Yii1 extends Client
         $_SERVER        = array_merge($_SERVER, $request->getServer());
         $_FILES         = $this->remapFiles($request->getFiles());
         $_REQUEST       = $this->remapRequestParameters($request->getParameters());
+        $_POST          = $_GET = array();
 
         if (strtoupper($request->getMethod()) == 'GET')
             $_GET = $_REQUEST;


### PR DESCRIPTION
Fixed issue #1933.
Based on [Yii2 code](https://github.com/Codeception/Codeception/blob/2.0.13/src/Codeception/Lib/Connector/Yii2.php#L51).