### PR TITLE
Adding instructions for contributing documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,3 +5,5 @@ At Codeception we are glad to receive contributions and patches from the communi
 Please check the guide for sending your contributions with Github at https://github.com/Codeception/Codeception/wiki/Git-workflow-for-Codeception-contributors
 
 All contributions must follow the coding standards described at: https://github.com/Codeception/Codeception/wiki/Codeception-coding-style-standard
+
+If you want to contribute documentation you are asked to send your changes to the /docs/ folder: https://github.com/Codeception/Codeception/tree/master/docs. This files are the source for the codeception website guides: http://codeception.com/docs/01-Introduction. Remind to send your documentation improvements to the right "repository branch" depending on the Codeception version you are working with: 2.0, master,...


### PR DESCRIPTION
This is a clone of #1948 done against `2.0` but this time against `master`