### PR TITLE
Partial patch for amOnSubdomain - wierdness #1757

### DIFF
--- a/src/Codeception/Module/PhpBrowser.php
+++ b/src/Codeception/Module/PhpBrowser.php
@@ -168,7 +168,7 @@ class PhpBrowser extends InnerBrowser implements Remote, MultiSession
     public function amOnSubdomain($subdomain)
     {
         $url = $this->config['url'];
-        $url = preg_replace('~(https?:\/\/)(.*\.)(.*\.)~', "$1$3", $url); // removing current subdomain
+        $url = preg_replace('~(https?:\/\/)(.*?\.)(.*\.)~', "$1$3", $url); // removing current subdomain
         $url = preg_replace('~(https?:\/\/)(.*)~', "$1$subdomain.$2", $url); // inserting new
         $this->_reconfigure(array('url' => $url));
     }

--- a/tests/unit/Codeception/Module/TestsForBrowsers.php
+++ b/tests/unit/Codeception/Module/TestsForBrowsers.php
@@ -22,6 +22,13 @@ abstract class TestsForBrowsers extends TestsForWeb
         $this->assertEquals('http://user.google.com', $this->module->_getUrl());
     }
 
+    public function testAmOnSecondLevelSubdomain()
+    {
+        $this->module->_reconfigure(array('url' => 'http://dev.mysite.co.uk'));
+        $this->module->amOnSubdomain('admin');
+        $this->assertEquals('http://admin.mysite.co.uk', $this->module->_getUrl());
+    }
+
     public function testOpenAbsoluteUrls()
     {
         $this->module->amOnUrl('http://localhost:8000/');

--- a/tests/unit/Codeception/Module/TestsForBrowsers.php
+++ b/tests/unit/Codeception/Module/TestsForBrowsers.php
@@ -22,11 +22,19 @@ abstract class TestsForBrowsers extends TestsForWeb
         $this->assertEquals('http://user.google.com', $this->module->_getUrl());
     }
 
+    /*
+     * https://github.com/Codeception/Codeception/issues/1757
+     * @todo implement special handling for .co.uk and similar top level domains 
+     */
     public function testAmOnSecondLevelSubdomain()
     {
         $this->module->_reconfigure(array('url' => 'http://dev.mysite.co.uk'));
         $this->module->amOnSubdomain('admin');
         $this->assertEquals('http://admin.mysite.co.uk', $this->module->_getUrl());
+
+//        $this->module->_reconfigure(array('url' => 'http://mysite.co.uk'));
+//        $this->module->amOnSubdomain('admin');
+//        $this->assertEquals('http://admin.mysite.co.uk', $this->module->_getUrl());
     }
 
     public function testOpenAbsoluteUrls()


### PR DESCRIPTION
Fixed #1757

I made subdomain removal ungreedy.

This patch enables transition from dev.mysite.co.uk to admin.mysite.co.uk

It doesn't enable transition from mysite.co.uk to admin.mysite.co.uk, because that functionality requires knowledge about all composite top level domains.