### PR TITLE
Alternative fix for regression #1923

### DIFF
--- a/tests/data/app/view/form/example17.php
+++ b/tests/data/app/view/form/example17.php
@@ -2,8 +2,9 @@
 <head>
 </head>
 <body>
-<form id="foo">
+<form id="foo" method="POST" action="/form/example17">
 <input type="text" value="baz" name="FooBar[bar]">
+<input type="text" value="mmhm" name="Food[beer][yum][yeah]">
 </form>
 </body>
 </html>

--- a/tests/unit/Codeception/Module/PhpBrowserTest.php
+++ b/tests/unit/Codeception/Module/PhpBrowserTest.php
@@ -280,4 +280,23 @@ class PhpBrowserTest extends TestsForBrowsers
         $this->setExpectedException("\\Codeception\\Exception\\TestRuntime");
         $this->module->fillField('#name', 'Nothing special');
     }
+    
+    public function testArrayFieldSubmitForm()
+    {
+        $this->module->amOnPage('/form/example17');
+        $this->module->submitForm(
+            'form',
+            [
+                'FooBar' => ['bar' => 'booze'],
+                'Food' => [
+                    'beer' => [
+                        'yum' => ['yeah' => 'crunked']
+                    ]
+                ]
+            ]
+        );
+        $data = data::get('form');
+        $this->assertEquals('booze', $data['FooBar']['bar']);
+        $this->assertEquals('crunked', $data['Food']['beer']['yum']['yeah']);
+    }
 }

--- a/tests/unit/Codeception/Module/TestsForWeb.php
+++ b/tests/unit/Codeception/Module/TestsForWeb.php
@@ -1215,5 +1215,6 @@ abstract class TestsForWeb extends \PHPUnit_Framework_TestCase
     {
         $this->module->amOnPage('/form/example17');
         $this->module->seeInField('input[name="FooBar[bar]"]', 'baz');
+        $this->module->seeInField('input[name="Food[beer][yum][yeah]"]', 'mmhm');
     }
 }


### PR DESCRIPTION
- Reverted changes to getFormValuesFor
- Created a different method to get the singular value for
  "seeInField" testing
- Added test for multi-dimensional array submission in
  PhpBrowserTest (functionality not yet implemented in WebDriver)

@DavertMik - I wanted to keep the getFormValuesFor function returning multi-dimensional arrays, so they can be overridden by calls to submitForm.  I plan to update seeInField so it accepts multi-dimensional arrays as well, so one can call submitForm/seeInFormFields using the same array (not quite there yet.)

Please have a quick look when you have a moment, and let me know if you have any concerns!

Thanks