### PR TITLE
syntax highlighting fix by adding missing "<?php"

### DIFF
--- a/docs/modules/MongoDb.md
+++ b/docs/modules/MongoDb.md
@@ -86,6 +86,7 @@ $cursor = $I->grabFromCollection('users', array('name' => 'miles'));
 Inserts data into collection
 
 ``` php
+<?php
 $I->haveInCollection('users', array('name' => 'John', 'email' => 'john@coltrane.com'));
 $user_id = $I->haveInCollection('users', array('email' => 'john@coltrane.com'));
 ```


### PR DESCRIPTION
The highlighting is slightly broke on the site. for "haveInCollection"
![screen shot 2015-05-28 at 14 10 15](https://cloud.githubusercontent.com/assets/1612186/7859667/57a9a53e-0543-11e5-98cc-be16954116c3.png)
