### PR TITLE
Fixes REST module when POST a JsonSerializable.

### DIFF
--- a/src/Codeception/Module/REST.php
+++ b/src/Codeception/Module/REST.php
@@ -390,7 +390,7 @@ class REST extends \Codeception\Module
                 $this->client->request($method, $url, $parameters, $files);
             } else {
                 $this->debugSection("Request", "$method $url ".json_encode($parameters));
-                $this->client->request($method, $url, array(), $files, array(), $parameters);
+                $this->client->request($method, $url, array(), $files, array(), json_encode($parameters));
             }
         } else {
             $this->debugSection("Request", "$method $url " . $parameters);

--- a/src/Codeception/Module/REST.php
+++ b/src/Codeception/Module/REST.php
@@ -387,11 +387,11 @@ class REST extends \Codeception\Module
             }
             if($method == 'GET') {
                 $this->debugSection("Request", "$method $url");
+                $this->client->request($method, $url, $parameters, $files);
             } else {
                 $this->debugSection("Request", "$method $url ".json_encode($parameters));
+                $this->client->request($method, $url, array(), $files, array(), $parameters);
             }
-            $this->client->request($method, $url, $parameters, $files);
-
         } else {
             $this->debugSection("Request", "$method $url " . $parameters);
             $this->client->request($method, $url, array(), $files, array(), $parameters);


### PR DESCRIPTION
Because of https://github.com/Codeception/Codeception/commit/dcfc8e303b1260a9b6937448be991620d20e5a64#diff-d8e5babfee3fd0e8675337cf8ff58b50, when I post/put/patch a `JsonSerializable` object, is always sending a request without body.