### PR TITLE
fixed a problem with whitespaces in filenames when loading mongodb dumps

### DIFF
--- a/src/Codeception/Lib/Driver/MongoDb.php
+++ b/src/Codeception/Lib/Driver/MongoDb.php
@@ -111,10 +111,10 @@ class MongoDb
                 $this->host . '/' . $this->dbName,
                 $this->user,
                 $this->password,
-                $dumpFile
+                escapeshellarg($dumpFile)
             );
         } else {
-            $cmd = sprintf('mongo %s %s', $this->host . '/' . $this->dbName, $dumpFile);
+            $cmd = sprintf('mongo %s %s', $this->host . '/' . $this->dbName, escapeshellarg($dumpFile));
         }
         shell_exec($cmd);
     }


### PR DESCRIPTION
fixed a problem with whitespaces in filenames when loading mongodb dumps #1997