### PR TITLE
Configure the client host for the laravel5 module

### DIFF
--- a/src/Codeception/Lib/Connector/Laravel5.php
+++ b/src/Codeception/Lib/Connector/Laravel5.php
@@ -33,8 +33,9 @@ class Laravel5 extends Client implements HttpKernelInterface, TerminableInterfac
         $this->httpKernel = $this->app->make('Illuminate\Contracts\Http\Kernel');
         $this->httpKernel->bootstrap();
         $this->app->boot();
+        $url = preg_replace('/https?:\/\//', '', $this->app->config->get('app.url', 'localhost'));
 
-        parent::__construct($this);
+        parent::__construct($this, ['HTTP_HOST' => $url]);
     }
 
     /**


### PR DESCRIPTION
This will set the correct base url of the application which resolves
issues when routing, and provides better error outputs as the URL
will be the correct application URL and not localhost or empty