### PR TITLE
Phalcon1: Fixed getting fields

### DIFF
--- a/src/Codeception/Module/Phalcon1.php
+++ b/src/Codeception/Module/Phalcon1.php
@@ -241,11 +241,19 @@ class Phalcon1 extends Framework implements ActiveRecord
     {
         $record = $this->getModelRecord($model);
         $res = $record->save($attributes);
+        $field = function($field) {
+            if (is_array($field)) {
+                return implode(', ', $field);
+            }
+
+            return $field;
+        };
+
         if (!$res) {
             $messages = $record->getMessages();
             $errors = [];
             foreach ($messages as $message) {
-                $errors[] = sprintf('[%s] %s: %s', $message->getType(), $message->getField(), $message->getMessage());
+                $errors[] = sprintf('[%s] %s: %s', $message->getType(), $field($message->getField()), $message->getMessage());
             }
 
             $this->fail(sprintf("Record %s was not saved. Messages: \n%s", $model, implode(PHP_EOL, $errors)));


### PR DESCRIPTION
In some cases Phalcon's model message has more than one field.
For example:

```php
    public function validation()
    {
        $this->validate(new Uniqueness(
            [
                'field' => ['phone', 'email'],
                'message' => 'User already exists!'
            ]
        ));

        if ($this->validationHasFailed() == true) {
            return false;
        }

        return true;
    }
```

In this case `$message->getField()` returns:

```
Array
(
    [0] => phone
    [1] => email
)

```