### PR TITLE
Bug fix for Guzzle Connector headers

### DIFF
--- a/src/Codeception/Lib/Connector/Guzzle.php
+++ b/src/Codeception/Lib/Connector/Guzzle.php
@@ -210,7 +210,7 @@ class Guzzle extends Client
 
         foreach ($server as $header => $val) {
             $header = implode('-', array_map('ucfirst', explode('-', strtolower(str_replace('_', '-', $header)))));
-            $contentHeaders = ['Content-length' => true, 'Content-md5' => true, 'Content-type' => true];
+            $contentHeaders = ['Content-Length' => true, 'Content-Md5' => true, 'Content-Type' => true];
             if (strpos($header, 'Http-') === 0) {
                 $headers[substr($header, 5)] = $val;
             } elseif (isset($contentHeaders[$header])) {


### PR DESCRIPTION
For now it is impossible to send Content-Type Http request header