### PR TITLE
Use 2.1 branch of zf1 and zf2 tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -48,10 +48,10 @@ install:
   - git clone -q -b 2.1 https://github.com/Codeception/symfony-demo.git frameworks-symfony
   - composer install -d frameworks-symfony --no-dev --prefer-dist
   # ZF1
-  - git clone -q --recursive https://github.com/Naktibalda/codeception-zf1-tests frameworks-zf1
+  - git clone -q -b 2.1 --recursive https://github.com/Naktibalda/codeception-zf1-tests frameworks-zf1
   - composer install -d frameworks-zf1 --no-dev  --prefer-dist
   # ZF2
-  - git clone -q --recursive https://github.com/Naktibalda/codeception-zf2-tests frameworks-zf2
+  - git clone -q -b 2.1 --recursive https://github.com/Naktibalda/codeception-zf2-tests frameworks-zf2
   - composer install -d frameworks-zf2 --no-dev  --prefer-dist
 
 before_script:


### PR DESCRIPTION
I created branches of zf1 and zf2 tests to test master.

3 ZF1 tests will fail, because 2 commits were lost by merging changes from 2.0 to master branch.

Commits:
https://github.com/Codeception/Codeception/commit/5546a506aaa4f7573bc16315d579afb72a225848
https://github.com/Codeception/Codeception/commit/1b343730376c4cf0b5008e99e0f04863e8a4374f

Merge which lost them:
https://github.com/Codeception/Codeception/commit/92106d051a6ee447393407a03ad516e7351f6f25
