### PR TITLE
Reconnect option for Db module

### DIFF
--- a/tests/unit/Codeception/Module/DbTest.php
+++ b/tests/unit/Codeception/Module/DbTest.php
@@ -60,4 +60,26 @@ class DbTest extends \PHPUnit_Framework_TestCase
         self::$module->_after(\Codeception\Util\Stub::make('\Codeception\TestCase'));
         self::$module->dontSeeInDatabase('users', array('name' => 'john'));
     }
+    
+    public function testReconnectOption()
+    {
+        $testCase1 = \Codeception\Util\Stub::make('\Codeception\TestCase');
+        $testCase2 = \Codeception\Util\Stub::make('\Codeception\TestCase');
+
+        self::$module->_reconfigure(['reconnect' => true]);
+        $this->assertNotNull(self::$module->driver, 'driver is null before test');
+        $this->assertNotNull(self::$module->dbh, 'dbh is nullbefore test');
+        
+        self::$module->_after($testCase1);
+
+        $this->assertNull(self::$module->driver, 'driver is not unset by _after');
+        $this->assertNull(self::$module->dbh, 'dbh is not unset by _after');
+
+        self::$module->_before($testCase2);
+
+        $this->assertNotNull(self::$module->driver, 'driver is not set by _before');
+        $this->assertNotNull(self::$module->dbh, 'dbh is not set by _before');
+
+        self::$module->_reconfigure(['reconnect' => false]);
+    }
 }

--- a/tests/unit/Codeception/Module/DbTest.php
+++ b/tests/unit/Codeception/Module/DbTest.php
@@ -68,7 +68,7 @@ class DbTest extends \PHPUnit_Framework_TestCase
 
         self::$module->_reconfigure(['reconnect' => true]);
         $this->assertNotNull(self::$module->driver, 'driver is null before test');
-        $this->assertNotNull(self::$module->dbh, 'dbh is nullbefore test');
+        $this->assertNotNull(self::$module->dbh, 'dbh is null before test');
         
         self::$module->_after($testCase1);
 


### PR DESCRIPTION
Codeception 2.1 executes tests in random order.
If percentage of db tests is low and tests are being execute in slow environment, like Travis, database connection often gets lost.

To solve this issue, I implemented reconnect option which creates a new connection before each scenario and drops it after scenario.