### PR TITLE
Add optional `message` parameter to seeInDatabase and dontSeeInDatabase

### DIFF
--- a/src/Codeception/Module/Db.php
+++ b/src/Codeception/Module/Db.php
@@ -270,16 +270,16 @@ class Db extends \Codeception\Module implements \Codeception\Lib\Interfaces\Db
         return $lastInsertId;
     }
 
-    public function seeInDatabase($table, $criteria = [])
+    public function seeInDatabase($table, $criteria = [], $message = 'No matching records found')
     {
         $res = $this->proceedSeeInDatabase($table, 'count(*)', $criteria);
-        $this->assertGreaterThan(0, $res, 'No matching records found');
+        $this->assertGreaterThan(0, $res, $message);
     }
 
-    public function dontSeeInDatabase($table, $criteria = [])
+    public function dontSeeInDatabase($table, $criteria = [], $message = '')
     {
         $res = $this->proceedSeeInDatabase($table, 'count(*)', $criteria);
-        $this->assertLessThan(1, $res);
+        $this->assertLessThan(1, $res, $message);
     }
 
     protected function proceedSeeInDatabase($table, $column, $criteria)


### PR DESCRIPTION
I was writing a batch of tests for several objects having the same interface and would have needed a way to know which object failed the test. This change does not alter the current behavior. If there's a better way, I'd be happy to know about it! :-)