### PR TITLE
Message cut length fix

### DIFF
--- a/src/Codeception/Lib/Console/Message.php
+++ b/src/Codeception/Lib/Console/Message.php
@@ -41,7 +41,7 @@ class Message
 
     public function cut($length)
     {
-        $this->message = substr($this->message, 0, $length-1);
+        $this->message = substr($this->message, 0, $length);
         return $this;
     }
 

--- a/src/Codeception/Subscriber/Console.php
+++ b/src/Codeception/Subscriber/Console.php
@@ -429,7 +429,7 @@ class Console implements EventSubscriberInterface
             return $this->message = $this->message('%s::%s')
                 ->with(get_class($test), $test->getName(true))
                 ->apply(function ($str) { return str_replace('with data set', "|", $str); } )
-                ->cut($inProgress ? $this->columns[0]+$this->columns[1] - 15 : $this->columns[0]-1)
+                ->cut($inProgress ? $this->columns[0] + $this->columns[1] - 16 : $this->columns[0] - 2)
                 ->style('focus')
                 ->prepend($inProgress ? 'Running ' : '');
         }
@@ -439,7 +439,7 @@ class Console implements EventSubscriberInterface
         if ($feature) {
             return $this->message = $this->message($inProgress ? $feature : ucfirst($feature))
                 ->apply(function ($str) { return str_replace('with data set', "|", $str); } )
-                ->cut($inProgress ? $this->columns[0]+$this->columns[1] - 17 - strlen($filename): $this->columns[0]- 4 - strlen($filename))
+                ->cut($inProgress ? $this->columns[0] + $this->columns[1] - 18 - strlen($filename) : $this->columns[0] - 5 - strlen($filename))
                 ->style('focus')
                 ->prepend($inProgress ? 'Trying to ' : '')
                 ->append(" ($filename)");

--- a/tests/unit/Codeception/Lib/Console/MessageTest.php
+++ b/tests/unit/Codeception/Lib/Console/MessageTest.php
@@ -11,5 +11,8 @@ class MessageTest extends \Codeception\TestCase\Test
         $message = new Message('very long text');
         $this->assertEquals('very long ', $message->cut(10)->getMessage());
     }
+    
+    //test message cutting
+    public function testVeryLongTestNameVeryLongTestNameVeryLongTestNameVeryLongTestNameVeryLongTestNameVeryLongTestNameVeryLongTestName() {}
 }
  

--- a/tests/unit/Codeception/Lib/Console/MessageTest.php
+++ b/tests/unit/Codeception/Lib/Console/MessageTest.php
@@ -1,0 +1,15 @@
+<?php
+namespace Codeception\Lib\Console;
+
+
+class MessageTest extends \Codeception\TestCase\Test
+{
+
+    // tests
+    public function testCut()
+    {
+        $message = new Message('very long text');
+        $this->assertEquals('very long ', $message->cut(10)->getMessage());
+    }
+}
+ 


### PR DESCRIPTION
Modified Message::cut method to cut text at length specified in parameter.