### PR TITLE
Add Sqlsrv database type a primary column function

### DIFF
--- a/src/Codeception/Lib/Driver/SqlSrv.php
+++ b/src/Codeception/Lib/Driver/SqlSrv.php
@@ -76,4 +76,34 @@ class SqlSrv extends Db
         
         $this->sqlQuery($query);
     }
+    
+    /**
+     * Get a primary column name of a table.
+     *
+     * @param string $tableName
+     * @throws \Exception
+     * @return string of a primary column name.
+     */
+    public function getPrimaryColumn($tableName)
+    {
+    	if (false === isset($this->primaryColumns[$tableName])) {
+    		$stmt = $this->getDbh()->query("
+SELECT Col.Column_Name from
+	INFORMATION_SCHEMA.TABLE_CONSTRAINTS Tab,
+	INFORMATION_SCHEMA.CONSTRAINT_COLUMN_USAGE Col
+WHERE
+	Col.Constraint_Name = Tab.Constraint_Name
+    AND Col.Table_Name = Tab.Table_Name
+    AND Constraint_Type = 'PRIMARY KEY' AND Col.Table_Name = '" . $tableName . "'");
+    		$columnInformation = $stmt->fetch(\PDO::FETCH_ASSOC);
+    
+    		if (true === empty($columnInformation)) { // Need a primary key
+    			throw new \Exception('Table ' . $tableName . ' is not valid or doesn\'t have no primary key');
+    		}
+    
+    		$this->primaryColumns[$tableName] = $columnInformation['Column_Name'];
+    	}
+    
+    	return $this->primaryColumns[$tableName];
+    }
 }


### PR DESCRIPTION
Sqlsrv uses a different way to get primary column. This update add an override function to use a proper function in case of Sqlsrv database driver.