### PR TITLE
Fix for InnerBrowser setting values multiple times

### DIFF
--- a/src/Codeception/Lib/InnerBrowser.php
+++ b/src/Codeception/Lib/InnerBrowser.php
@@ -631,12 +631,13 @@ class InnerBrowser extends Module implements Web
         $input = $this->getFieldByLabelOrCss($field);
         $form = $this->getFormFor($input);
         $name = $input->attr('name');
-
+        
         $dynamicField = $input->getNode(0)->tagName == 'textarea'
             ? new TextareaFormField($input->getNode(0))
             : new InputFormField($input->getNode(0));
         $formField = $this->matchFormField($name, $form, $dynamicField);
         $formField->setValue($value);
+        $input->getNode(0)->nodeValue = $value;
     }
 
     /**
@@ -691,7 +692,7 @@ class InnerBrowser extends Module implements Web
         $field = $this->getFieldByLabelOrCss($select);
         $form = $this->getFormFor($field);
         $fieldName = $this->getSubmissionFormFieldName($field->attr('name'));
-
+        
         if (is_array($option)) {
             $options = [];
             foreach ($option as $opt) {
@@ -700,14 +701,36 @@ class InnerBrowser extends Module implements Web
             $form[$fieldName]->select($options);
             return;
         }
-
-        $form[$fieldName]->select($this->matchOption($field, $option));
+        
+        $dynamicField = new ChoiceFormField($field->getNode(0));
+        $formField = $this->matchFormField($fieldName, $form, $dynamicField);
+        $selValue = $this->matchOption($field, $option);
+        
+        if (is_array($formField)) {
+            foreach ($formField as $field) {
+                $values = $field->availableOptionValues();
+                foreach ($values as $val) {
+                    if ($val === $option) {
+                        $field->select($selValue);
+                        return;
+                    }
+                }
+            }
+            return;
+        }
+        
+        $formField->select($this->matchOption($field, $option));
     }
 
     protected function matchOption(Crawler $field, $option)
     {
-        $options = $field->filterXPath(sprintf('//option[text()=normalize-space("%s")]', $option));
+        $options = $field->filterXPath(sprintf('//option[text()=normalize-space("%s")]|//input[@type="radio" and @value=normalize-space("%s")]', $option, $option));
         if ($options->count()) {
+            if ($options->getNode(0)->tagName === 'option') {
+                $options->getNode(0)->setAttribute('selected', 'selected');
+            } else {
+                $options->getNode(0)->setAttribute('checked', 'checked');
+            }
             if ($options->first()->attr('value')) {
                 return $options->first()->attr('value');
             }
@@ -740,6 +763,7 @@ class InnerBrowser extends Module implements Web
         }
         // If the name is an array than we compare objects to find right checkbox
         $formField = $this->matchFormField($name, $form, new ChoiceFormField($field->getNode(0)));
+        $field->getNode(0)->setAttribute('checked', 'checked');
         if (!$formField instanceof ChoiceFormField) {
             throw new TestRuntime("Form field $name is not a checkable");
         }

--- a/tests/data/app/view/form/names-sq-brackets.php
+++ b/tests/data/app/view/form/names-sq-brackets.php
@@ -1,0 +1,40 @@
+<html>
+<head><title>Daison tests</title>
+</head>
+<body>
+    <form>
+        <input type="text" name="input_text">
+        <input type="text" name="input[text][]">
+
+        <textarea name="textarea_name"></textarea>
+        <textarea name="textarea[name][]"></textarea>
+
+        <input type="radio" name="input_radio_name" value="1">
+        <input type="radio" name="input_radio_name" value="2">
+
+        <input type="radio" name="input[radio][name][]" value="1">
+        <input type="radio" name="input[radio][name][]" value="2">
+
+        <input type="checkbox" name="input_checkbox_name" value="1">
+        <input type="checkbox" name="input_checkbox_name" value="2">
+
+        <input type="checkbox" name="input[checkbox][name][]" value="1">
+        <input type="checkbox" name="input[checkbox][name][]" value="2">
+
+        <select name="select_name">
+            <option value="1">Select 1</option>
+            <option value="2">Select 2</option>
+            <option value="3">Select 3</option>
+            <option value="4">Select 4</option>
+            <option value="5">Select 5</option>
+        </select>
+        <select name="select[name][]">
+            <option value="1">Select 1</option>
+            <option value="2">Select 2</option>
+            <option value="3">Select 3</option>
+            <option value="4">Select 4</option>
+            <option value="5">Select 5</option>
+        </select>
+    </form>
+</body>
+</html>

--- a/tests/unit/Codeception/Module/TestsForWeb.php
+++ b/tests/unit/Codeception/Module/TestsForWeb.php
@@ -1217,4 +1217,41 @@ abstract class TestsForWeb extends \PHPUnit_Framework_TestCase
         $this->module->seeInField('input[name="FooBar[bar]"]', 'baz');
         $this->module->seeInField('input[name="Food[beer][yum][yeah]"]', 'mmhm');
     }
+    
+    public function testFillFieldSquareBracketNames()
+    {
+        $this->module->amOnPage('/form/names-sq-brackets');
+        $this->module->fillField('//input[@name="input_text"]', 'filling this input');
+        $this->module->fillField('//input[@name="input[text][]"]', 'filling this input');
+
+        $this->module->fillField('//textarea[@name="textarea_name"]', 'filling this textarea');
+        $this->module->fillField('//textarea[@name="textarea[name][]"]', 'filling this textarea');
+        $this->module->fillField('//textarea[@name="textarea[name][]"]', 'filling this textarea once again');
+
+        $this->module->fillField('//textarea[@name="textarea_name"]', 'filling this textarea');
+        $this->module->fillField('//textarea[@name="textarea[name][]"]', 'filling this textarea more');
+        $this->module->fillField('//textarea[@name="textarea[name][]"]', 'filling this textarea most');
+    }
+    
+    public function testSelectAndCheckOptionSquareBracketNames()
+    {
+        $this->module->amOnPage('/form/names-sq-brackets');
+        $this->module->selectOption('//input[@name="input_radio_name"]', '1');
+        $this->module->selectOption('//input[@name="input_radio_name"]', '2');
+
+        $this->module->checkOption('//input[@name="input_checkbox_name"]', '1');
+        $this->module->checkOption('//input[@name="input_checkbox_name"]', '2');
+
+        $this->module->checkOption('//input[@name="input[checkbox][name][]"]', '1');
+        $this->module->checkOption('//input[@name="input[checkbox][name][]"]', '2');
+        $this->module->checkOption('//input[@name="input[checkbox][name][]"]', '1');
+
+        $this->module->selectOption('//select[@name="select_name"]', '1');
+
+        $this->module->selectOption('//input[@name="input[radio][name][]"]', '1');
+        $this->module->selectOption('//input[@name="input[radio][name][]"]', '2');
+        $this->module->selectOption('//input[@name="input[radio][name][]"]', '1');
+
+        $this->module->selectOption('//select[@name="select[name][]"]', '1');
+    }
 }


### PR DESCRIPTION
Setting values multiple times on fields with square brackets in their names resulted in the Field not being matched in matchFormField.

Radio input fields were not being set correctly in selectOptions.

Should fix #2062 