### PR TITLE
MongoDb. Remove not necessary config fields 'user' and 'password'.

### DIFF
--- a/docs/modules/MongoDb.md
+++ b/docs/modules/MongoDb.md
@@ -30,8 +30,8 @@ Check out the driver if you get problems loading dumps and cleaning databases.
 ## Config
 
 * dsn *required* - MongoDb DSN with the db name specified at the end of the host after slash
-* user *required* - user to access database
-* password *required* - password
+* user - user to access database
+* password - password
 * dump - path to database dump
 * populate: true - should the dump be loaded before test suite is started.
 * cleanup: true - should the dump be reloaded after each test

--- a/src/Codeception/Module/MongoDb.php
+++ b/src/Codeception/Module/MongoDb.php
@@ -58,7 +58,10 @@ class MongoDb extends \Codeception\Module
     protected $config = array(
         'populate' => true,
         'cleanup'  => true,
-        'dump'     => null);
+        'dump'     => null,
+        'user'     => null,
+        'password' => null
+    );
 
     protected $populated = false;
 
@@ -67,7 +70,7 @@ class MongoDb extends \Codeception\Module
      */
     public $driver;
 
-    protected $requiredFields = array('dsn', 'user', 'password');
+    protected $requiredFields = array('dsn');
 
     public function _initialize()
     {

--- a/tests/unit/Codeception/Module/MongoDbTest.php
+++ b/tests/unit/Codeception/Module/MongoDbTest.php
@@ -8,9 +8,7 @@ class MongoDbTest extends \PHPUnit_Framework_TestCase
      * @var array 
      */
     private $mongoConfig = array(
-        'dsn' => 'mongodb://localhost:27017/test',
-        'user' => '',
-        'password' => ''
+        'dsn' => 'mongodb://localhost:27017/test'
     );
     
     /**


### PR DESCRIPTION
No one is using authentication in MongoDb on dev machine.
Sorry, I don't read 'CONTRIBUTING GUIDE'.