### PR TITLE
proceedSubmitForm clear forms array after submit

### DIFF
--- a/src/Codeception/Lib/InnerBrowser.php
+++ b/src/Codeception/Lib/InnerBrowser.php
@@ -459,6 +459,7 @@ class InnerBrowser extends Module implements Web
             $requestParams,
             $form->getPhpFiles()
         );
+        $this->forms = [];
         $this->debugResponse();
     }
 


### PR DESCRIPTION
After submitting a form, proceedSubmitForm should set $this->forms to an empty array.

Fixes #2087