### PR TITLE
Updating requestOptions generation

### DIFF
--- a/src/Codeception/Lib/Connector/Guzzle.php
+++ b/src/Codeception/Lib/Connector/Guzzle.php
@@ -183,7 +183,7 @@ class Guzzle extends Client
             'headers' => $this->extractHeaders($request)
         ];
 
-        $requestOptions = array_merge_recursive($requestOptions, $this->requestOptions);
+        $requestOptions = array_replace_recursive($requestOptions, $this->requestOptions);
 
         $guzzleRequest = $this->client->createRequest(
             $request->getMethod(),


### PR DESCRIPTION
Generally, array_merge_recursive($a, $b) does it's bad in case $a = ['key' => 'value1']; $b = ['key' => 'value2'];
array_replace_recursive prevents creation of arrays in case of same key=>value pairs are present in both arrays.

Detailed issue:
If someone tries to update USER_AGENT should be passed to server during request, the resulting USER_AGENT header receives comma separated value:
Symfony2 BrowserKit, <HERE COMES MY VALUE>
WURFL doesn't detect properly headers with such prepend for IOS devices.
By bad luck, for Android user agent header, WURFL does it's job correctly.