### PR TITLE
Fix output cept file path

### DIFF
--- a/src/Codeception/Command/GenerateCept.php
+++ b/src/Codeception/Command/GenerateCept.php
@@ -40,12 +40,13 @@ class GenerateCept extends Command
         $filename = $input->getArgument('test');
 
         $config = $this->getSuiteConfig($suite, $input->getOption('config'));
-        $this->buildPath($config['path'], $filename);
+        $path = $this->buildPath($config['path'], $filename);
 
         $filename = $this->completeSuffix($filename, 'Cept');
         $gen = new Cept($config);
 
         $res = $this->save($config['path'].DIRECTORY_SEPARATOR . $filename, $gen->produce());
+        $filename = $path.$filename;
         if (!$res) {
             $output->writeln("<error>Test $filename already exists</error>");
             return;

--- a/tests/unit/Codeception/Command/GenerateCeptTest.php
+++ b/tests/unit/Codeception/Command/GenerateCeptTest.php
@@ -17,7 +17,7 @@ class GenerateCeptTest extends BaseCommandRunner {
         $this->execute(array('suite' => 'shire', 'test' => 'HomeCanInclude12Dwarfs'));
         $this->assertEquals($this->filename, 'tests/shire/HomeCanInclude12DwarfsCept.php');
         $this->assertContains('$I = new HobbitGuy($scenario);', $this->content);
-        $this->assertContains('Test was created in HomeCanInclude12DwarfsCept.php', $this->output);
+        $this->assertContains('Test was created in tests/shire/HomeCanInclude12DwarfsCept.php', $this->output);
         $this->assertIsValidPhp($this->content);
     }
 


### PR DESCRIPTION
Change to the same format as the others(test, phpunit, cest) because there is a difference in output when we run generate commands.

- test, phpunit, cest : full file path
- cept : not full file path

e.g.
```
$ codecept generate:test suite Foo
Test was created in /home/junichi/Projects/myproject/tests/suite/FooTest.php
$ codecept generate:cept suite Foo
Test was created in FooCept.php
```