### PR TITLE
Fixed handling multiple cookies

### DIFF
--- a/src/Codeception/Lib/Connector/Guzzle6.php
+++ b/src/Codeception/Lib/Connector/Guzzle6.php
@@ -94,17 +94,17 @@ class Guzzle6 extends Client
     protected function createResponse(Psr7Response $response)
     {
         $body = (string) $response->getBody();
-        $headers = $this->flattenHeaders($response->getHeaders());
+        $headers = $response->getHeaders();
 
         $contentType = null;
-        if (isset($headers['Content-Type'])) {
-            $contentType = $headers['Content-Type'];
-        }
-        if (!$contentType or strpos($contentType, 'charset=') === false) {
-            if (preg_match('/\<meta[^\>]+charset *= *["\']?([a-zA-Z\-0-9]+)/i', $body, $matches)) {
-                $contentType .= ';charset=' . $matches[1];
+        if (isset($headers['Content-Type']) && count($headers['Content-Type']) === 1) {
+            $contentType = reset($headers['Content-Type']);
+            if (strpos($contentType, 'charset=') === false) {
+                if (preg_match('/\<meta[^\>]+charset *= *["\']?([a-zA-Z\-0-9]+)/i', $body, $matches)) {
+                    $contentType .= ';charset=' . $matches[1];
+                }
+                $headers['Content-Type'] = $contentType;
             }
-            $headers['Content-Type'] = $contentType;
         }
 
         $status = $response->getStatusCode();
@@ -120,7 +120,7 @@ class Guzzle6 extends Client
             // match by header
             preg_match(
                 '~(\d*);?url=(.*)~',
-                (string) $headers['Refresh'],
+                (string) reset($headers['Refresh']),
                 $matches
             );
         }
@@ -136,14 +136,6 @@ class Guzzle6 extends Client
         }
 
         return new BrowserKitResponse($body, $status, $headers);
-    }
-
-    protected function flattenHeaders($headers)
-    {
-        return array_map(function ($header) {
-            return reset($header);
-        }, $headers);
-
     }
 
     public function getAbsoluteUri($uri)


### PR DESCRIPTION
My god, which idiot wrote the Guzzle6 class???

The flattenHeaders method completely broke my tests because it threw away every cookie except the first and since PHPSESSID was the second cookie in response, session did not work at all.

Then there is #2104 because of which setCookie did not work at all so I couldn't set PHPSESSID manually either. The bug is again in Guzzle6 class.

Oh and by the way there are problems with cookies even when using WebDriver instead of PhpBrowser. I was not able to fix that. https://github.com/Codeception/Codeception/issues/766#issuecomment-115005827