### PR TITLE
added HTTPS to server parameters only when it required

### DIFF
--- a/src/Codeception/Module/Yii2.php
+++ b/src/Codeception/Module/Yii2.php
@@ -76,13 +76,11 @@ class Yii2 extends Framework implements ActiveRecord, PartedModule
                     PHP_URL_HOST
                 )
             );
-            $this->client->setServerParameter(
-                'HTTPS',
-                ((string) parse_url(
-                    $mainConfig['config']['test_entry_url'],
-                    PHP_URL_SCHEME
-                )) === 'https'
-            );
+
+	        $scheme = (string) parse_url($mainConfig['config']['test_entry_url'], PHP_URL_SCHEME);
+	        if ($scheme === 'https') {
+		        $this->client->setServerParameter('HTTPS', true);
+	        }
         }
         $this->app = $this->client->startApp();
 


### PR DESCRIPTION
https://github.com/symfony/BrowserKit/blob/master/Client.php#L557 symfony check if HTTPS is isset. Not true or false.

Also, may be make check if HTTP_HOST is not empty? For backward compatibility in this config case:
```
config:
    # the entry script URL (without host info) for functional and acceptance tests
    # PLEASE ADJUST IT TO THE ACTUAL ENTRY SCRIPT URL
    test_entry_url: /frontend/web/index-test.php
```