### PR TITLE
Fix for fillField using values that contain ampersands

### DIFF
--- a/src/Codeception/Lib/InnerBrowser.php
+++ b/src/Codeception/Lib/InnerBrowser.php
@@ -290,17 +290,17 @@ class InnerBrowser extends Module implements Web, PageSourceSaver
         $crawler = $this->getFieldsByLabelOrCss($field);
         $this->assertNot($this->proceedSeeInField($crawler, $value));
     }
-    
+
     public function seeInFormFields($formSelector, array $params)
     {
         $this->proceedSeeInFormFields($formSelector, $params, false);
     }
-    
+
     public function dontSeeInFormFields($formSelector, array $params)
     {
         $this->proceedSeeInFormFields($formSelector, $params, true);
     }
-    
+
     protected function proceedSeeInFormFields($formSelector, array $params, $assertNot)
     {
         $form = $this->match($formSelector)->first();
@@ -332,7 +332,7 @@ class InnerBrowser extends Module implements Web, PageSourceSaver
     /**
      * Returns an array of values for the field with the passed name.  Usually
      * the array consists of a single value.  Used by proceedSeeInField
-     * 
+     *
      * @param Form $form
      * @param string $fieldName
      * @return array
@@ -357,7 +357,7 @@ class InnerBrowser extends Module implements Web, PageSourceSaver
         }
         return $values;
     }
-    
+
     protected function proceedSeeInField(Crawler $fields, $value)
     {
         $form = $this->getFormFor($fields);
@@ -508,7 +508,7 @@ class InnerBrowser extends Module implements Web, PageSourceSaver
 
     /**
      * Returns the form action's absolute URL.
-     * 
+     *
      * @param \Symfony\Component\DomCrawler\Crawler $form
      * @return string
      * @throws \Codeception\Exception\TestRuntimeException if either the current
@@ -563,7 +563,7 @@ class InnerBrowser extends Module implements Web, PageSourceSaver
     /**
      * Returns the DomCrawler\Form object for the form pointed to by
      * $node or its closes form parent.
-     * 
+     *
      * @param \Symfony\Component\DomCrawler\Crawler $node
      * @return \Symfony\Component\DomCrawler\Form
      */
@@ -583,7 +583,7 @@ class InnerBrowser extends Module implements Web, PageSourceSaver
         }
         return $this->forms[$action];
     }
-    
+
     /**
      * Returns an array of name => value pairs for the passed form.
      *
@@ -613,13 +613,13 @@ class InnerBrowser extends Module implements Web, PageSourceSaver
         $input = $this->getFieldByLabelOrCss($field);
         $form = $this->getFormFor($input);
         $name = $input->attr('name');
-        
+
         $dynamicField = $input->getNode(0)->tagName == 'textarea'
             ? new TextareaFormField($input->getNode(0))
             : new InputFormField($input->getNode(0));
         $formField = $this->matchFormField($name, $form, $dynamicField);
         $formField->setValue($value);
-        $input->getNode(0)->nodeValue = $value;
+        $input->getNode(0)->nodeValue = htmlspecialchars($value);
     }
 
     /**
@@ -674,7 +674,7 @@ class InnerBrowser extends Module implements Web, PageSourceSaver
         $field = $this->getFieldByLabelOrCss($select);
         $form = $this->getFormFor($field);
         $fieldName = $this->getSubmissionFormFieldName($field->attr('name'));
-        
+
         if (is_array($option)) {
             $options = [];
             foreach ($option as $opt) {
@@ -683,11 +683,11 @@ class InnerBrowser extends Module implements Web, PageSourceSaver
             $form[$fieldName]->select($options);
             return;
         }
-        
+
         $dynamicField = new ChoiceFormField($field->getNode(0));
         $formField = $this->matchFormField($fieldName, $form, $dynamicField);
         $selValue = $this->matchOption($field, $option);
-        
+
         if (is_array($formField)) {
             foreach ($formField as $field) {
                 $values = $field->availableOptionValues();
@@ -700,7 +700,7 @@ class InnerBrowser extends Module implements Web, PageSourceSaver
             }
             return;
         }
-        
+
         $formField->select($this->matchOption($field, $option));
     }
 

--- a/tests/unit/Codeception/Module/TestsForWeb.php
+++ b/tests/unit/Codeception/Module/TestsForWeb.php
@@ -88,7 +88,7 @@ abstract class TestsForWeb extends \PHPUnit_Framework_TestCase
 
         $this->module->amOnPage('/');
         $this->module->click("descendant-or-self::a[@id = 'link']");
-        $this->module->seeInCurrentUrl('/info');               
+        $this->module->seeInCurrentUrl('/info');
     }
 
     public function testClickByName()
@@ -370,7 +370,7 @@ abstract class TestsForWeb extends \PHPUnit_Framework_TestCase
         $this->module->dontSeeInField('checkbox[]', 'not seen three');
         $this->module->seeInField('checkbox[]', 'see test three');
     }
-    
+
     public function testSeeInFieldWithBoolean()
     {
         $this->module->amOnPage('/form/field_values');
@@ -383,7 +383,7 @@ abstract class TestsForWeb extends \PHPUnit_Framework_TestCase
         $this->module->seeInField('radio3', false);
         $this->module->dontSeeInField('radio3', true);
     }
-    
+
     public function testSeeInFieldOnRadio()
     {
         $this->module->amOnPage('/form/field_values');
@@ -392,7 +392,7 @@ abstract class TestsForWeb extends \PHPUnit_Framework_TestCase
         $this->module->dontSeeInField('radio1', 'not seen two');
         $this->module->dontSeeInField('radio1', 'not seen three');
     }
-    
+
     public function testSeeInFieldOnSelect()
     {
         $this->module->amOnPage('/form/field_values');
@@ -401,13 +401,13 @@ abstract class TestsForWeb extends \PHPUnit_Framework_TestCase
         $this->module->dontSeeInField('select1', 'not seen two');
         $this->module->dontSeeInField('select1', 'not seen three');
     }
-    
+
     public function testSeeInFieldEmptyValueForUnselectedSelect()
     {
         $this->module->amOnPage('/form/field_values');
         $this->module->seeInField('select3', '');
     }
-    
+
     public function testSeeInFieldOnSelectMultiple()
     {
         $this->module->amOnPage('/form/field_values');
@@ -418,7 +418,7 @@ abstract class TestsForWeb extends \PHPUnit_Framework_TestCase
         $this->module->dontSeeInField('select2', 'not seen three');
         $this->module->seeInField('select2', 'see test three');
     }
-    
+
     public function testSeeInFieldWithExactMatch()
     {
         $this->module->amOnPage('/form/field_values');
@@ -440,7 +440,7 @@ abstract class TestsForWeb extends \PHPUnit_Framework_TestCase
         $this->module->dontSeeInField('textarea','sunset');
         $this->module->dontSeeInField('descendant-or-self::textarea[@id="description"]','sunset');
     }
-    
+
     public function testSeeInFormFields()
     {
         $this->module->amOnPage('/form/field_values');
@@ -461,7 +461,7 @@ abstract class TestsForWeb extends \PHPUnit_Framework_TestCase
         ];
         $this->module->seeInFormFields('form', $params);
     }
-    
+
     public function testSeeInFormFieldsFails()
     {
         $this->module->amOnPage('/form/field_values');
@@ -479,7 +479,7 @@ abstract class TestsForWeb extends \PHPUnit_Framework_TestCase
         ];
         $this->module->seeInFormFields('form', $params);
     }
-    
+
     public function testDontSeeInFormFields()
     {
         $this->module->amOnPage('/form/field_values');
@@ -499,7 +499,7 @@ abstract class TestsForWeb extends \PHPUnit_Framework_TestCase
         ];
         $this->module->dontSeeInFormFields('form', $params);
     }
-    
+
     public function testDontSeeInFormFieldsFails()
     {
         $this->module->amOnPage('/form/field_values');
@@ -819,7 +819,7 @@ abstract class TestsForWeb extends \PHPUnit_Framework_TestCase
         $this->module->submitForm('form', ['username' => 'John', 'password' => '1234']);
         $this->module->seeCurrentUrlEquals('/form/example5?username=John&password=1234');
     }
-    
+
     public function testExample5WithParams()
     {
         $this->module->amOnPage('/form/example5?a=b');
@@ -890,7 +890,7 @@ abstract class TestsForWeb extends \PHPUnit_Framework_TestCase
         $form = data::get('form');
         $this->assertEquals('Hello!', $form['text']);
     }
-    
+
     public function testSubmitFormWithAmpersand()
     {
         $this->module->amOnPage('/form/submitform_ampersands');
@@ -923,7 +923,7 @@ abstract class TestsForWeb extends \PHPUnit_Framework_TestCase
         $this->assertEquals('see test one', $form['select'][0]);
         $this->assertEquals('see test two', $form['select'][1]);
     }
-    
+
     public function testSubmitFormCheckboxWithArrayParameter()
     {
         $this->module->amOnPage('/form/field_values');
@@ -940,7 +940,7 @@ abstract class TestsForWeb extends \PHPUnit_Framework_TestCase
         $this->assertEquals('see test two', $form['checkbox'][1]);
         $this->assertEquals('not seen three', $form['checkbox'][2]);
     }
-    
+
     public function testSubmitFormCheckboxWithBooleanArrayParameter()
     {
         $this->module->amOnPage('/form/field_values');
@@ -965,7 +965,7 @@ abstract class TestsForWeb extends \PHPUnit_Framework_TestCase
         $this->module->amOnPage('/form/empty_fill');
         $this->module->fillField('test', 'value');
     }
-    
+
     public function testSubmitFormWithDefaultTextareaValue()
     {
         $this->module->amOnPage('/form/textarea');
@@ -1051,7 +1051,7 @@ abstract class TestsForWeb extends \PHPUnit_Framework_TestCase
         ));
         $this->module->seeCurrentUrlEquals('/form/example11');
     }
-    
+
     public function testSubmitFormWithDocRelativePathForActionFromDefaultPage()
     {
         $this->module->amOnPage('/form/');
@@ -1060,7 +1060,7 @@ abstract class TestsForWeb extends \PHPUnit_Framework_TestCase
         ));
         $this->module->seeCurrentUrlEquals('/form/example11');
     }
-    
+
     public function testLinkWithDocRelativeURLFromDefaultPage()
     {
         $this->module->amOnPage('/form/');
@@ -1083,7 +1083,7 @@ abstract class TestsForWeb extends \PHPUnit_Framework_TestCase
         $this->assertEquals('testing', $form['checkbox1']);
         $this->assertEquals('to be sent', $form['radio1']);
     }
-    
+
     public function testSubmitFormCheckboxWithBoolean()
     {
         $this->module->amOnPage('/form/example16');
@@ -1093,7 +1093,7 @@ abstract class TestsForWeb extends \PHPUnit_Framework_TestCase
         $form = data::get('form');
         $this->assertTrue(isset($form['checkbox1']), 'Checkbox value not sent');
         $this->assertEquals('testing', $form['checkbox1']);
-        
+
         $this->module->amOnPage('/form/example16');
         $this->module->submitForm('form', array(
             'checkbox1' => false
@@ -1101,7 +1101,7 @@ abstract class TestsForWeb extends \PHPUnit_Framework_TestCase
         $form = data::get('form');
         $this->assertFalse(isset($form['checkbox1']), 'Checkbox value sent');
     }
-    
+
     public function testSubmitFormWithButtons()
     {
         $this->module->amOnPage('/form/form_with_buttons');
@@ -1110,7 +1110,7 @@ abstract class TestsForWeb extends \PHPUnit_Framework_TestCase
         ));
         $form = data::get('form');
         $this->assertFalse(isset($form['button1']) || isset($form['button2']) || isset($form['button3']) || isset($form['button4']), 'Button values should not be set');
-        
+
         $this->module->amOnPage('/form/form_with_buttons');
         $this->module->submitForm('form', array(
             'test' => 'value',
@@ -1119,7 +1119,7 @@ abstract class TestsForWeb extends \PHPUnit_Framework_TestCase
         $this->assertFalse(isset($form['button1']) || isset($form['button2']) || isset($form['button4']), 'Button values for buttons 1, 2 and 4 should not be set');
         $this->assertTrue(isset($form['button3']), 'Button value for button3 should be set');
         $this->assertEquals($form['button3'], 'third', 'Button value for button3 should equal third');
-        
+
         $this->module->amOnPage('/form/form_with_buttons');
         $this->module->submitForm('form', array(
             'test' => 'value',
@@ -1229,7 +1229,7 @@ abstract class TestsForWeb extends \PHPUnit_Framework_TestCase
         $this->assertContains('test2', $data['captions']);
         $this->assertContains('davert', $data['users']);
     }
-    
+
     public function testSubmitAdjacentForms()
     {
         $this->module->amOnPage('/form/submit_adjacentforms');
@@ -1246,7 +1246,7 @@ abstract class TestsForWeb extends \PHPUnit_Framework_TestCase
         $this->module->seeInField('input[name="FooBar[bar]"]', 'baz');
         $this->module->seeInField('input[name="Food[beer][yum][yeah]"]', 'mmhm');
     }
-    
+
     public function testFillFieldSquareBracketNames()
     {
         $this->module->amOnPage('/form/names-sq-brackets');
@@ -1261,7 +1261,7 @@ abstract class TestsForWeb extends \PHPUnit_Framework_TestCase
         $this->module->fillField('//textarea[@name="textarea[name][]"]', 'filling this textarea more');
         $this->module->fillField('//textarea[@name="textarea[name][]"]', 'filling this textarea most');
     }
-    
+
     public function testSelectAndCheckOptionSquareBracketNames()
     {
         $this->module->amOnPage('/form/names-sq-brackets');
@@ -1282,5 +1282,14 @@ abstract class TestsForWeb extends \PHPUnit_Framework_TestCase
         $this->module->selectOption('//input[@name="input[radio][name][]"]', '1');
 
         $this->module->selectOption('//select[@name="select[name][]"]', '1');
+    }
+
+    public function testFillFieldWithAmpersand()
+    {
+        $this->module->amOnPage('/form/field');
+        $this->module->fillField('Name', 'this & that');
+        $this->module->click('Submit');
+        $form = data::get('form');
+        $this->assertEquals('this & that', $form['name']);
     }
 }


### PR DESCRIPTION
Text fields, such as passwords or fields that contain free text, can use
ampersands and DOMNode property textContent should be set instead of
nodeValue to prevent "unterminated entity reference" errors