### PR TITLE
Corected all instances of out to our in documentation

### DIFF
--- a/docs/modules/Laravel4.md
+++ b/docs/modules/Laravel4.md
@@ -1158,7 +1158,7 @@ For example, given this sample "Sign Up" form:
     <input type="text" name="user[login]" /><br/>
     Password:
     <input type="password" name="user[password]" /><br/>
-    Do you agree to out terms?
+    Do you agree to our terms?
     <input type="checkbox" name="user[agree]" /><br/>
     Select pricing plan:
     <select name="plan">

--- a/docs/modules/Laravel5.md
+++ b/docs/modules/Laravel5.md
@@ -1081,7 +1081,7 @@ For example, given this sample "Sign Up" form:
     <input type="text" name="user[login]" /><br/>
     Password:
     <input type="password" name="user[password]" /><br/>
-    Do you agree to out terms?
+    Do you agree to our terms?
     <input type="checkbox" name="user[agree]" /><br/>
     Select pricing plan:
     <select name="plan">

--- a/docs/modules/Lumen.md
+++ b/docs/modules/Lumen.md
@@ -959,7 +959,7 @@ For example, given this sample "Sign Up" form:
     <input type="text" name="user[login]" /><br/>
     Password:
     <input type="password" name="user[password]" /><br/>
-    Do you agree to out terms?
+    Do you agree to our terms?
     <input type="checkbox" name="user[agree]" /><br/>
     Select pricing plan:
     <select name="plan">

--- a/docs/modules/Phalcon1.md
+++ b/docs/modules/Phalcon1.md
@@ -944,7 +944,7 @@ For example, given this sample "Sign Up" form:
     <input type="text" name="user[login]" /><br/>
     Password:
     <input type="password" name="user[password]" /><br/>
-    Do you agree to out terms?
+    Do you agree to our terms?
     <input type="checkbox" name="user[agree]" /><br/>
     Select pricing plan:
     <select name="plan">

--- a/docs/modules/PhpBrowser.md
+++ b/docs/modules/PhpBrowser.md
@@ -929,7 +929,7 @@ For example, given this sample "Sign Up" form:
     <input type="text" name="user[login]" /><br/>
     Password:
     <input type="password" name="user[password]" /><br/>
-    Do you agree to out terms?
+    Do you agree to our terms?
     <input type="checkbox" name="user[agree]" /><br/>
     Select pricing plan:
     <select name="plan">

--- a/docs/modules/Silex.md
+++ b/docs/modules/Silex.md
@@ -845,7 +845,7 @@ For example, given this sample "Sign Up" form:
     <input type="text" name="user[login]" /><br/>
     Password:
     <input type="password" name="user[password]" /><br/>
-    Do you agree to out terms?
+    Do you agree to our terms?
     <input type="checkbox" name="user[agree]" /><br/>
     Select pricing plan:
     <select name="plan">

--- a/docs/modules/Symfony2.md
+++ b/docs/modules/Symfony2.md
@@ -868,7 +868,7 @@ For example, given this sample "Sign Up" form:
     <input type="text" name="user[login]" /><br/>
     Password:
     <input type="password" name="user[password]" /><br/>
-    Do you agree to out terms?
+    Do you agree to our terms?
     <input type="checkbox" name="user[agree]" /><br/>
     Select pricing plan:
     <select name="plan">

--- a/docs/modules/WebDriver.md
+++ b/docs/modules/WebDriver.md
@@ -1129,7 +1129,7 @@ For example, given this sample "Sign Up" form:
     <input type="text" name="user[login]" /><br/>
     Password:
     <input type="password" name="user[password]" /><br/>
-    Do you agree to out terms?
+    Do you agree to our terms?
     <input type="checkbox" name="user[agree]" /><br/>
     Select pricing plan:
     <select name="plan">

--- a/docs/modules/Yii1.md
+++ b/docs/modules/Yii1.md
@@ -855,7 +855,7 @@ For example, given this sample "Sign Up" form:
     <input type="text" name="user[login]" /><br/>
     Password:
     <input type="password" name="user[password]" /><br/>
-    Do you agree to out terms?
+    Do you agree to our terms?
     <input type="checkbox" name="user[agree]" /><br/>
     Select pricing plan:
     <select name="plan">

--- a/docs/modules/Yii2.md
+++ b/docs/modules/Yii2.md
@@ -874,7 +874,7 @@ For example, given this sample "Sign Up" form:
     <input type="text" name="user[login]" /><br/>
     Password:
     <input type="password" name="user[password]" /><br/>
-    Do you agree to out terms?
+    Do you agree to our terms?
     <input type="checkbox" name="user[agree]" /><br/>
     Select pricing plan:
     <select name="plan">

--- a/docs/modules/ZF1.md
+++ b/docs/modules/ZF1.md
@@ -847,7 +847,7 @@ For example, given this sample "Sign Up" form:
     <input type="text" name="user[login]" /><br/>
     Password:
     <input type="password" name="user[password]" /><br/>
-    Do you agree to out terms?
+    Do you agree to our terms?
     <input type="checkbox" name="user[agree]" /><br/>
     Select pricing plan:
     <select name="plan">

--- a/docs/modules/ZF2.md
+++ b/docs/modules/ZF2.md
@@ -814,7 +814,7 @@ For example, given this sample "Sign Up" form:
     <input type="text" name="user[login]" /><br/>
     Password:
     <input type="password" name="user[password]" /><br/>
-    Do you agree to out terms?
+    Do you agree to our terms?
     <input type="checkbox" name="user[agree]" /><br/>
     Select pricing plan:
     <select name="plan">

--- a/src/Codeception/Lib/Interfaces/Web.php
+++ b/src/Codeception/Lib/Interfaces/Web.php
@@ -90,7 +90,7 @@ interface Web
      *     <input type="text" name="user[login]" /><br/>
      *     Password:
      *     <input type="password" name="user[password]" /><br/>
-     *     Do you agree to out terms?
+     *     Do you agree to our terms?
      *     <input type="checkbox" name="user[agree]" /><br/>
      *     Select pricing plan:
      *     <select name="plan">

--- a/src/Codeception/Module/WebDriver.php
+++ b/src/Codeception/Module/WebDriver.php
@@ -1271,7 +1271,7 @@ class WebDriver extends CodeceptionModule implements
      *     <input type="text" name="user[login]" /><br/>
      *     Password:
      *     <input type="password" name="user[password]" /><br/>
-     *     Do you agree to out terms?
+     *     Do you agree to our terms?
      *     <input type="checkbox" name="user[agree]" /><br/>
      *     Select pricing plan:
      *     <select name="plan">

--- a/tests/data/claypit/tests/_support/_generated/AbsolutelyOtherGuyActions.php
+++ b/tests/data/claypit/tests/_support/_generated/AbsolutelyOtherGuyActions.php
@@ -1096,7 +1096,7 @@ trait AbsolutelyOtherGuyActions
      * <form action="/sign_up">
      *     Login: <input type="text" name="user[login]" /><br/>
      *     Password: <input type="password" name="user[password]" /><br/>
-     *     Do you agree to out terms? <input type="checkbox" name="user[agree]" /><br/>
+     *     Do you agree to our terms? <input type="checkbox" name="user[agree]" /><br/>
      *     Select pricing plan <select name="plan"><option value="1">Free</option><option value="2" selected="selected">Paid</option></select>
      *     <input type="submit" name="submitButton" value="Submit" />
      * </form>

--- a/tests/data/claypit/tests/_support/_generated/OtherGuyActions.php
+++ b/tests/data/claypit/tests/_support/_generated/OtherGuyActions.php
@@ -1096,7 +1096,7 @@ trait OtherGuyActions
      * <form action="/sign_up">
      *     Login: <input type="text" name="user[login]" /><br/>
      *     Password: <input type="password" name="user[password]" /><br/>
-     *     Do you agree to out terms? <input type="checkbox" name="user[agree]" /><br/>
+     *     Do you agree to our terms? <input type="checkbox" name="user[agree]" /><br/>
      *     Select pricing plan <select name="plan"><option value="1">Free</option><option value="2" selected="selected">Paid</option></select>
      *     <input type="submit" name="submitButton" value="Submit" />
      * </form>

--- a/tests/support/_generated/WebGuyActions.php
+++ b/tests/support/_generated/WebGuyActions.php
@@ -1929,7 +1929,7 @@ trait WebGuyActions
      *     <input type="text" name="user[login]" /><br/>
      *     Password:
      *     <input type="password" name="user[password]" /><br/>
-     *     Do you agree to out terms?
+     *     Do you agree to our terms?
      *     <input type="checkbox" name="user[agree]" /><br/>
      *     Select pricing plan:
      *     <select name="plan">


### PR DESCRIPTION
Corrected "Do you agree to **out** terms?" to "Do you agree to **our** terms?" where ever it showed up.

I wasn't 100% sure if some of these files were auto-generated, and if so, how to regenerate them. Figured I'd submit all the fixes for now.