### PR TITLE
Missing HTTPS when trying to access protected pages

### DIFF
--- a/src/Codeception/Util/Uri.php
+++ b/src/Codeception/Util/Uri.php
@@ -43,6 +43,9 @@ class Uri
             }
             $base = $base->withPath($path);
         }
+        if (isset($parts['scheme'])) {
+            $base = $base->withScheme($parts['scheme']);
+        }
         if (isset($parts['query'])) {
             $base = $base->withQuery($parts['query']);
         }


### PR DESCRIPTION
So, in config main site's URL is http://google.com/
Some of my pages are https://
But trying to access them, I get errors.
When dig into, found that all new URLs are build based on base_uri, adding path, query, if any.
Adding also scheme solved the issue.

Actual:
Uri::mergeUrls('http://google.com/';, 'https://google.com/account/')  === 'http://google.com/account/';

Expecting:
Uri::mergeUrls('http://google.com/';, 'https://google.com/account/')  === 'https://google.com/account/';