### PR TITLE
Cleanup should happen only if enabled

### DIFF
--- a/src/Codeception/Module/Db.php
+++ b/src/Codeception/Module/Db.php
@@ -143,7 +143,9 @@ class Db extends CodeceptionModule implements DbInterface
 
         // starting with loading dump
         if ($this->config['populate']) {
-            $this->cleanup();
+            if ($this->config['cleanup']) {
+                $this->cleanup();
+            }
             $this->loadDump();
             $this->populated = true;
         }


### PR DESCRIPTION
The `Db::_initialize()` method calls `$this->cleanup()` regardless of the value of `$this->config['cleanup']`.

I added a check to see if `cleanup` is set to `true`.