### PR TITLE
Documenting format of dump.sql

### DIFF
--- a/docs/modules/Db.md
+++ b/docs/modules/Db.md
@@ -65,6 +65,22 @@ Check out drivers if you get problems loading dumps and cleaning databases.
              cleanup: false
              reconnect: true
 
+### SQL data dump
+
+ * Comments are permitted.
+ * The `dump.sql` may contain multiline statements.
+  * The delimiter, a semi-colon in this case, must be on the same line as the last statement:
+ 
+```sql
+-- Add a few contacts to the table.
+REPLACE INTO `Contacts` (`created`, `modified`, `status`, `contact`, `first`, `last`) VALUES
+(NOW(), NOW(), 1, 'Bob Ross', 'Bob', 'Ross'),
+(NOW(), NOW(), 1, 'Fred Flintstone', 'Fred', 'Flintstone');
+
+-- Remove existing orders for testing.
+DELETE FROM `Order`;
+```
+
 ## Public Properties
 * dbh - contains PDO connection.
 * driver - contains Connection Driver. See [list all available drivers](https://github.com/Codeception/Codeception/tree/master/src/Codeception/Util/Driver)


### PR DESCRIPTION
Updated docs to show how to use data dump file. See issue https://github.com/Codeception/Codeception/issues/1245

NOTE: This section should also note that if `cleanup` is set to `true`, then the entire schema could/should be placed in this file.

Likewise, if `cleanup` is set to `false`, then the schema is not required.

The pull request https://github.com/Codeception/Codeception/pull/2148 affects this configuration.