### PR TITLE
Issue #2052, changed checkOption method to check all options

### DIFF
--- a/src/Codeception/Lib/InnerBrowser.php
+++ b/src/Codeception/Lib/InnerBrowser.php
@@ -727,9 +727,26 @@ class InnerBrowser extends Module implements Web, PageSourceSaver, ElementLocato
         return $option;
     }
 
+    /**
+    * Checks all options matched by the variable $option
+    * @param $option
+    */
+
     public function checkOption($option)
     {
-        $this->proceedCheckOption($option)->tick();
+        $nodes = $this->match($option);
+        
+        foreach($nodes as $nodeIndex => $node){
+            if($node->hasAttribute('id')){
+                $nodeId = $node->getAttribute('id');
+                $this->proceedCheckOption('#'.$nodeId)->tick();
+                
+            }
+            elseif($node->hasAttribute('name')){
+                $nodeName = $node->getAttribute('name');
+                $this->proceedCheckOption($nodeName)->tick();
+            }       
+        }
     }
 
     public function uncheckOption($option)


### PR DESCRIPTION
This is a suggested enhancement for PhpBrowser's checkOption method, which retrieves all nodes matched by the $option parameter and then ticks each one individually. The checkOption method currently finds the first checkbox matched by $option and then ticks it. This method is intended to check all checkboxes matched by $option.