### PR TITLE
fixes #2163

### DIFF
--- a/src/Codeception/Lib/Generator/Cest.php
+++ b/src/Codeception/Lib/Generator/Cest.php
@@ -45,7 +45,7 @@ EOF;
         $actor = $this->settings['class_name'];
         $namespace = rtrim( $this->settings['namespace'], '\\' );
         $ns = $this->getNamespaceHeader($namespace.'\\'.$this->name);
-        $ns .= "use ".$this->settings['namespace'].'\\'.$actor.";";
+        $ns .= "use ".$namespace.'\\'.$actor.";";
 
         return (new Template($this->template))
             ->place('name', $this->getShortClassName($this->name))


### PR DESCRIPTION
by using the --namespace option, ```$this->settings['namespace']``` contains a trailing backslash.