### PR TITLE
Yii2 cookie handling issue

### DIFF
--- a/src/Codeception/Lib/Connector/Yii2.php
+++ b/src/Codeception/Lib/Connector/Yii2.php
@@ -127,7 +127,8 @@ class Yii2 extends Client
             /** @var \yii\web\Cookie $cookie */
             $value = $cookie->value;
             if ($cookie->expire != 1 && isset($validationKey)) {
-                $value = Yii::$app->security->hashData(serialize($value), $validationKey);
+                $data = version_compare(Yii::getVersion(), '2.0.2', '>') ? [$cookie->name, $cookie->value] : $cookie->value;
+                $value = Yii::$app->security->hashData(serialize($data), $validationKey);
             }
             $c = new Cookie($cookie->name, $value, $cookie->expire, $cookie->path, $cookie->domain, $cookie->secure, $cookie->httpOnly);
             $this->getCookieJar()->set($c);


### PR DESCRIPTION
I have a project using Yii 2.0.2 version, but when I upgraded to 2.0.5, all my tests that contains CSRF validation starts to failed. I investigated and figured out that there was a changed in cookie handling on this commit which is part of 2.0.3 update. https://github.com/yiisoft/yii2/commit/0a6cd6190b851db89120572259ae8ca0ade9c2cb#diff-d87d70b11324cad0f14e3077c0f2c847

