### PR TITLE
Fix Codeception/Codeception#2185 when $$ not at line start ONLY

### DIFF
--- a/src/Codeception/Lib/Driver/PostgreSql.php
+++ b/src/Codeception/Lib/Driver/PostgreSql.php
@@ -26,8 +26,11 @@ class PostgreSql extends Db
                 continue;
             }
 
-            if (strpos(trim($sqlLine), '$$') === 0) {
-                $dollarsOpen = !$dollarsOpen;
+            if (!preg_match('/\'.*\$\$.*\'/', $sqlLine)) { // Ignore $$ inside SQL standard string syntax such as in INSERT statements.
+                $pos = strpos($sqlLine, '$$');
+                if (($pos !== false) && ($pos >= 0)) {
+                    $dollarsOpen = !$dollarsOpen;
+                }
             }
 
             $query .= "\n" . rtrim($sqlLine);

--- a/tests/data/dumps/postgres.sql
+++ b/tests/data/dumps/postgres.sql
@@ -294,6 +294,16 @@ BEGIN
 END;
   $$;
 
+-- Test $$ opening quote when is not at the beginning of the line.
+CREATE OR REPLACE FUNCTION upd_timestamp() RETURNS TRIGGER
+LANGUAGE plpgsql
+AS $$
+BEGIN
+    NEW.created_at = CURRENT_TIMESTAMP;
+    RETURN NEW;
+END;
+  $$;
+
 INSERT INTO users (name, email) VALUES ('This should work as well', 'user2@example.org');
 --
 -- end test for triggers with $$ syntax


### PR DESCRIPTION
This commit is to fix the the point of undetected dollar quoting when $$ is not at the beginning of the line. `trim` has been removed from `strpos(trim($sqlLine), '$$')` as it's no longer required.