### PR TITLE
Check if value is set with empty() instead of !isset()

### DIFF
--- a/src/Codeception/Configuration.php
+++ b/src/Codeception/Configuration.php
@@ -341,7 +341,7 @@ class Configuration
     {
         $settings = self::suiteSettings($suite, self::config());
 
-        if (!isset($settings['env']) || !is_array($settings['env'])) {
+        if (empty($settings['env']) || !is_array($settings['env'])) {
             return [];
         }
 


### PR DESCRIPTION
empty() should be used instead of isset() if a value should be checked
for an array as isset() returns also true if only the array key is set.