### PR TITLE
Find also environment files without `.dist` in its name

### DIFF
--- a/src/Codeception/Configuration.php
+++ b/src/Codeception/Configuration.php
@@ -288,7 +288,7 @@ class Configuration
 
         $envFiles = Finder::create()
             ->files()
-            ->name('*{.dist}.yml')
+            ->name('*.yml')
             ->in($path)
             ->depth('< 1');
 


### PR DESCRIPTION
Files in the '_envs' folder are currently only recognized
if they are ending with `.dist.yml`.
The environment builder creates those files without the
`.dist` in its name wich is very confusing.

Fixes Codeception/Codeception#1944