### PR TITLE
Updated default value

### DIFF
--- a/src/Codeception/Lib/Generator/Actions.php
+++ b/src/Codeception/Lib/Generator/Actions.php
@@ -48,7 +48,7 @@ EOF;
 
     protected $name;
     protected $settings;
-    protected $modules;
+    protected $modules = [];
     protected $actions;
     protected $numMethods = 0;
 


### PR DESCRIPTION
When not using any module in configuration, `$modules` array doesn't filled in `__construct`, so this generating warning when iterating over this array in `produce()` method.