### PR TITLE
Replace backticks with double quotes for standard compatibility

### DIFF
--- a/src/Codeception/Lib/Driver/Db.php
+++ b/src/Codeception/Lib/Driver/Db.php
@@ -150,7 +150,7 @@ class Db
     public function select($column, $table, array &$criteria)
     {
         $where  = $criteria ? "where %s" : '';
-        $query  = "select %s from `%s` $where";
+        $query  = "select %s from \"%s\" $where";
         $params = [];
         foreach ($criteria as $k => $v) {
             $k = $this->getQuotedName($k);

--- a/src/Codeception/Lib/Driver/Db.php
+++ b/src/Codeception/Lib/Driver/Db.php
@@ -150,7 +150,7 @@ class Db
     public function select($column, $table, array &$criteria)
     {
         $where  = $criteria ? "where %s" : '';
-        $query  = "select %s from \"%s\" $where";
+        $query  = "select %s from %s $where";
         $params = [];
         foreach ($criteria as $k => $v) {
             $k = $this->getQuotedName($k);
@@ -162,7 +162,7 @@ class Db
         }
         $sparams = implode(' AND ', $params);
 
-        return sprintf($query, $column, $table, $sparams);
+        return sprintf($query, $column, $this->getQuotedName($table), $params);
     }
 
     public function deleteQuery($table, $id, $primaryKey = 'id')

--- a/src/Codeception/Lib/Driver/Db.php
+++ b/src/Codeception/Lib/Driver/Db.php
@@ -162,7 +162,7 @@ class Db
         }
         $sparams = implode(' AND ', $params);
 
-        return sprintf($query, $column, $this->getQuotedName($table), $params);
+        return sprintf($query, $column, $this->getQuotedName($table), $sparams);
     }
 
     public function deleteQuery($table, $id, $primaryKey = 'id')


### PR DESCRIPTION
Backticks are not compatible with SQL Server, using double quotes seems to be universally accepted.