### PR TITLE
Quoted table name in Db::select, removed identical methods from child classes

### DIFF
--- a/src/Codeception/Lib/Driver/Db.php
+++ b/src/Codeception/Lib/Driver/Db.php
@@ -153,12 +153,11 @@ class Db
         $query = "select %s from %s $where";
         $params = [];
         foreach ($criteria as $k => $v) {
-            $k = $this->getQuotedName($k);
             if ($v === null) {
-                $params[] = "$k IS NULL ";
+                $params[] = $this->getQuotedName($k) . " IS NULL ";
                 unset($criteria[$k]);
             } else {
-                $params[] = "$k = ? ";
+                $params[] = $this->getQuotedName($k) . " = ? ";
             }
         }
         $sparams = implode('AND ', $params);

--- a/src/Codeception/Lib/Driver/Db.php
+++ b/src/Codeception/Lib/Driver/Db.php
@@ -149,18 +149,19 @@ class Db
 
     public function select($column, $table, array &$criteria)
     {
-        $where  = $criteria ? "where %s" : '';
-        $query  = "select %s from %s $where";
+        $where = $criteria ? "where %s" : '';
+        $query = "select %s from %s $where";
         $params = [];
         foreach ($criteria as $k => $v) {
             $k = $this->getQuotedName($k);
             if ($v === null) {
-                $params[] = "$k IS ?";
+                $params[] = "$k IS NULL ";
+                unset($criteria[$k]);
             } else {
-                $params[] = "$k = ?";
+                $params[] = "$k = ? ";
             }
         }
-        $sparams = implode(' AND ', $params);
+        $sparams = implode('AND ', $params);
 
         return sprintf($query, $column, $this->getQuotedName($table), $sparams);
     }

--- a/src/Codeception/Lib/Driver/Db.php
+++ b/src/Codeception/Lib/Driver/Db.php
@@ -178,7 +178,7 @@ class Db
 
     public function getQuotedName($name)
     {
-        return $name;
+        return '"' . str_replace('.', '"."', $name) . '"';
     }
 
     protected function sqlLine($sql)

--- a/src/Codeception/Lib/Driver/Db.php
+++ b/src/Codeception/Lib/Driver/Db.php
@@ -150,7 +150,7 @@ class Db
     public function select($column, $table, array &$criteria)
     {
         $where  = $criteria ? "where %s" : '';
-        $query  = "select %s from `%s` $where";
+        $query  = "select %s from %s $where";
         $params = [];
         foreach ($criteria as $k => $v) {
             $k = $this->getQuotedName($k);
@@ -162,7 +162,7 @@ class Db
         }
         $sparams = implode(' AND ', $params);
 
-        return sprintf($query, $column, $table, $sparams);
+        return sprintf($query, $column, $this->getQuotedName($table), $sparams);
     }
 
     public function deleteQuery($table, $id, $primaryKey = 'id')

--- a/src/Codeception/Lib/Driver/MySql.php
+++ b/src/Codeception/Lib/Driver/MySql.php
@@ -20,25 +20,6 @@ class MySql extends Db
         $this->dbh->exec('SET FOREIGN_KEY_CHECKS=1;');
     }
 
-    public function select($column, $table, array &$criteria)
-    {
-        $where = $criteria ? "where %s" : '';
-        $table = $this->getQuotedName($table);
-        $query = "select %s from %s $where";
-        $params = [];
-        foreach ($criteria as $k => $v) {
-            $k = $this->getQuotedName($k);
-            if ($v === null) {
-                $params[] = "$k IS ?";
-            } else {
-                $params[] = "$k = ?";
-            }
-        }
-        $sparams = implode(' AND ', $params);
-
-        return sprintf($query, $column, $table, $sparams);
-    }
-
     public function getQuotedName($name)
     {
         return '`' . str_replace('.', '`.`', $name) . '`';

--- a/src/Codeception/Lib/Driver/Oci.php
+++ b/src/Codeception/Lib/Driver/Oci.php
@@ -3,24 +3,6 @@ namespace Codeception\Lib\Driver;
 
 class Oci extends Oracle
 {
-    public function select($column, $table, array &$criteria)
-    {
-        $where = $criteria ? "where %s" : '';
-        $query = "select %s from %s $where";
-        $params = [];
-        foreach ($criteria as $k => $v) {
-            if ($v === null) {
-                $params[] = "$k IS NULL ";
-                unset($criteria[$k]);
-            } else {
-                $params[] = "$k = ? ";
-            }
-        }
-        $sparams = implode('AND ', $params);
-
-        return sprintf($query, $column, $table, $sparams);
-    }
-
     /**
      * SQL commands should ends with `//` in the dump file
      * IF you want to load triggers too.

--- a/src/Codeception/Lib/Driver/PostgreSql.php
+++ b/src/Codeception/Lib/Driver/PostgreSql.php
@@ -101,24 +101,6 @@ class PostgreSql extends Db
         }
     }
 
-    public function select($column, $table, array &$criteria)
-    {
-        $where = $criteria ? "where %s" : '';
-        $query = 'select %s from "%s" ' . $where;
-        $params = [];
-        foreach ($criteria as $k => $v) {
-            if ($v === null) {
-                $params[] = "$k IS NULL ";
-                unset($criteria[$k]);
-            } else {
-                $params[] = "$k = ? ";
-            }
-        }
-        $sparams = implode('AND ', $params);
-
-        return sprintf($query, $column, $table, $sparams);
-    }
-
     public function lastInsertId($table)
     {
         /*We make an assumption that the sequence name for this table is based on how postgres names sequences for SERIAL columns */
@@ -137,7 +119,7 @@ class PostgreSql extends Db
         );
         return implode('.', $name);
     }
-    
+
     /**
      * @param string $tableName
      *

--- a/src/Codeception/Lib/Driver/SqlSrv.php
+++ b/src/Codeception/Lib/Driver/SqlSrv.php
@@ -67,16 +67,7 @@ class SqlSrv extends Db
     {
         return '[' . $name . ']';
     }
-    
-    public function deleteQuery($table, $id, $primaryKey = 'id')
-    {
-        $query = "delete from "
-            . $this->getQuotedName($table)
-            . " where " . $this->getQuotedName($primaryKey) . " = $id";
-        
-        $this->sqlQuery($query);
-    }
-    
+
     /**
      * Get a primary column name of a table.
      *


### PR DESCRIPTION
Use getQuotedName() for escaping table name in DB Driver's select().
Set default quotes to double quotes.
Select methods of some implementation classes became identical to DB::select after this change, so I removed them.
Also I removed deleteQuery from SqlSrv, because it became identical to DB::deleteQuery after earlier change.
