### PR TITLE
Fixed removing dots from path and temp file, causing errors in html coverage generation

### DIFF
--- a/src/Codeception/Coverage/Subscriber/RemoteServer.php
+++ b/src/Codeception/Coverage/Subscriber/RemoteServer.php
@@ -36,7 +36,7 @@ class RemoteServer extends LocalServer
 
     protected function retrieveAndPrintHtml($suite)
     {
-        $tempFile = str_replace('.', '', tempnam(sys_get_temp_dir(), 'C3')) . '.tar';
+        $tempFile = tempnam(sys_get_temp_dir(), 'C3') . '.tar';
         file_put_contents($tempFile, $this->c3Request('html'));
 
         $destDir = Configuration::outputDir() . $suite . '.remote.coverage';


### PR DESCRIPTION
find_put_contents couldn't open stream because of wrong path. Problems appeared only for those having temp dirs with dots like for users of EasyPHP default installation.

Fixes issue: #2244