### PR TITLE
Improves performance of getClassesFromFile method of the parser

### DIFF
--- a/src/Codeception/Lib/Parser.php
+++ b/src/Codeception/Lib/Parser.php
@@ -131,12 +131,13 @@ class Parser
         $sourceCode = file_get_contents($file);
         $classes = [];
         $tokens = token_get_all($sourceCode);
+        $tokenCount = count($tokens);
         $namespace = '';
 
-        for ($i = 0; $i < count($tokens); $i++) {
+        for ($i = 0; $i < $tokenCount; $i++) {
             if ($tokens[$i][0] === T_NAMESPACE) {
                 $namespace = '';
-                for ($j = $i + 1; $j < count($tokens); $j++) {
+                for ($j = $i + 1; $j < $tokenCount; $j++) {
                     if ($tokens[$j][0] === T_STRING) {
                         $namespace .= $tokens[$j][1] . '\\';
                     } else {


### PR DESCRIPTION
Due to the way for loops are implemented in php, the count function will run every iteration of the loop. Therefore, moving the count to a variable, calculated before the start of the loop, improves performance (less function calls).