### PR TITLE
Changed the oldest supported version of Guzzle to 4.1.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "ext-mbstring": "*",
         "phpunit/phpunit": "~4.8.0",
         "facebook/webdriver": ">=1.0.1",
-        "guzzlehttp/guzzle": ">=4.0|<7.0",
+        "guzzlehttp/guzzle": ">=4.1.4|<7.0",
         "guzzlehttp/psr7": "~1.0",
         "symfony/finder": "~2.4",
         "symfony/console": "~2.4",


### PR DESCRIPTION
I tested different versions of Guzzle 4 and discovered that 4.1.4 is the oldest version which passes all PhpBrowserTest tests.