### PR TITLE
fixed issue1788: removed strict check

### DIFF
--- a/src/Codeception/Util/JsonArray.php
+++ b/src/Codeception/Util/JsonArray.php
@@ -145,7 +145,7 @@ class JsonArray
                     continue;
                 }
 
-                if ($value1 === $value2 && !isset($matchedKeys[$key2])) {
+                if ($value1 == $value2 && !isset($matchedKeys[$key2])) {
                     $ret[$key1] = $value1;
                     $matchedKeys[$key2] = true;
                     break;
@@ -173,8 +173,7 @@ class JsonArray
                 $ret[$key] = $return;
                 continue;
             }
-
-            if ($arr1[$key] === $arr2[$key]) {
+            if ($arr1[$key] == $arr2[$key]) {
                 $ret[$key] = $arr1[$key];
             }
         }

--- a/src/Codeception/Util/JsonArray.php
+++ b/src/Codeception/Util/JsonArray.php
@@ -145,7 +145,7 @@ class JsonArray
                     continue;
                 }
 
-                if ($value1 == $value2 && !isset($matchedKeys[$key2])) {
+                if ($this->isEqualValue($value1, $value2) && !isset($matchedKeys[$key2])) {
                     $ret[$key1] = $value1;
                     $matchedKeys[$key2] = true;
                     break;
@@ -173,7 +173,7 @@ class JsonArray
                 $ret[$key] = $return;
                 continue;
             }
-            if ($arr1[$key] == $arr2[$key]) {
+            if ($this->isEqualValue($arr1[$key], $arr2[$key])) {
                 $ret[$key] = $arr1[$key];
             }
         }
@@ -210,5 +210,18 @@ class JsonArray
                 $subNode->nodeValue = (string)$value;
             }
         }
+    }
+
+    private function isEqualValue($val1, $val2)
+    {
+        if (is_numeric($val1)) {
+            $val1 = (string) $val1;
+        }
+
+        if (is_numeric($val2)) {
+            $val2 = (string) $val2;
+        }
+
+        return $val1 === $val2;
     }
 }

--- a/tests/unit/Codeception/Module/RestTest.php
+++ b/tests/unit/Codeception/Module/RestTest.php
@@ -128,12 +128,12 @@ class RestTest extends \PHPUnit_Framework_TestCase
 
     public function testSeeInJsonCollection()
     {
-        $this->module->response = '[{"user":"Blacknoir","age":27,"tags":["wed-dev","php"]},{"user":"John Doe","age":27,"tags":["web-dev","java"]}]';
+        $this->module->response = '[{"user":"Blacknoir","age":"42","tags":["wed-dev","php"]},{"user":"John Doe","age":27,"tags":["web-dev","java"]}]';
         $this->module->seeResponseIsJson();
         $this->module->seeResponseContainsJson(['tags' => ['web-dev', 'java']]);
         $this->module->seeResponseContainsJson(['user' => 'John Doe', 'age' => 27]);
         $this->module->seeResponseContainsJson([['user' => 'John Doe', 'age' => 27]]);
-        $this->module->seeResponseContainsJson([['user' => 'Blacknoir', 'age' => 27], ['user' => 'John Doe', 'age' => 27]]);
+        $this->module->seeResponseContainsJson([['user' => 'Blacknoir', 'age' => 42], ['user' => 'John Doe', 'age' => "27"]]);
     }
 
     public function testArrayJson()


### PR DESCRIPTION
Issue: https://github.com/Codeception/Codeception/issues/1788
i've investigated a bit more and found out that it would be better be go with php way - make it array_diff does http://php.net/manual/ru/function.array-diff.php

    Note:

    Two elements are considered equal if and only if (string) $elem1 === (string) $elem2. In words: when the string representation is the same.


but with current code it will look like simple non-strict check.
So i've changed that condition and applied tests, to proof new behaviour. 
Please verify.