### PR TITLE
Add Interface DependsOnModule to SOAP module

### DIFF
--- a/src/Codeception/Module/SOAP.php
+++ b/src/Codeception/Module/SOAP.php
@@ -1,6 +1,7 @@
 <?php
 namespace Codeception\Module;
 
+use Codeception\Lib\Interfaces\DependsOnModule;
 use Codeception\Module as CodeceptionModule;
 use Codeception\TestCase;
 use Codeception\Exception\ModuleException;
@@ -40,7 +41,7 @@ use Codeception\Util\XmlStructure;
  * * response - last soap response (DOMDocument)
  *
  */
-class SOAP extends CodeceptionModule
+class SOAP extends CodeceptionModule implements DependsOnModule
 {
     protected $config = [
         'schema' => "",


### PR DESCRIPTION
I hope it will be in 2.1, because SOAP is broken without DependsOnModule interface.