### PR TITLE
Fix a bug where blank lines in a groups file would run every test in the project

### DIFF
--- a/src/Codeception/Lib/GroupManager.php
+++ b/src/Codeception/Lib/GroupManager.php
@@ -68,6 +68,11 @@ class GroupManager
                 $handle = @fopen(Configuration::projectDir() . $tests, "r");
                 if ($handle) {
                     while (($test = fgets($handle, 4096)) !== false) {
+                        // if the current line is blank then we need to move to the next line
+                        // otherwise the current codeception directory becomes part of the group
+                        // which causes every single test to run
+                        if (trim($test) === '') continue;
+
                         $file = trim(Configuration::projectDir() . $test);
                         $file = str_replace(['/', '\\'], [DIRECTORY_SEPARATOR, DIRECTORY_SEPARATOR], $file);
                         $this->testsInGroups[$group][] = $file;

--- a/tests/data/whitespace_group_test
+++ b/tests/data/whitespace_group_test
@@ -1,0 +1,4 @@
+
+
+tests/WhitespaceTest.php
+

--- a/tests/unit/Codeception/Lib/GroupManagerTest.php
+++ b/tests/unit/Codeception/Lib/GroupManagerTest.php
@@ -1,6 +1,7 @@
 <?php
 namespace Codeception\Lib;
 
+use Codeception\Configuration;
 use Codeception\TestCase\Interfaces\Reported;
 use Codeception\Util\Stub;
 
@@ -66,6 +67,15 @@ class GroupManagerTest extends \Codeception\TestCase\Test
         $this->assertContains('g_2', $this->manager->groupsForTest($test2));
     }
 
+    public function testGroupsFileHandlesWhitespace()
+    {
+        $this->manager = new GroupManager(['whitespace_group_test' => 'tests/data/whitespace_group_test']);
+        $goodTest = $this->makeTestCase('tests/WhitespaceTest.php');
+        $badTest = $this->makeTestCase('');
+
+        $this->assertContains('whitespace_group_test', $this->manager->groupsForTest($goodTest));
+        $this->assertEmpty($this->manager->groupsForTest($badTest));
+    }
 
     protected function makeTestCase($file, $name = '')
     {


### PR DESCRIPTION
Hi,

Recently we had an issue where Codeception was running all of our acceptance tests when trying to use our group files. We discovered this was because there where extra blank lines at the end of some of them.

This happens because Configuration::projectDir() was appended to the file name, but the filename would be blank if there was a blank line. Codeception would then interpret the group as containing the entire project and so would run every test.

If you need anymore information to reproduce, just let me know.

Thanks!