### PR TITLE
WebDriver->seeNumberOfElements should only count visible elements

### DIFF
--- a/src/Codeception/Module/WebDriver.php
+++ b/src/Codeception/Module/WebDriver.php
@@ -1139,6 +1139,24 @@ class WebDriver extends CodeceptionModule implements
 
     public function seeNumberOfElements($selector, $expected)
     {
+        $counted = count($this->matchVisible($this->webDriver, $selector));
+        if (is_array($expected)) {
+            list($floor, $ceil) = $expected;
+            $this->assertTrue(
+                $floor <= $counted && $ceil >= $counted,
+                'Number of elements counted differs from expected range'
+            );
+        } else {
+            $this->assertEquals(
+                $expected,
+                $counted,
+                'Number of elements counted differs from expected number'
+            );
+        }
+    }
+
+    public function seeNumberOfElementsInDOM($selector, $expected)
+    {
         $counted = count($this->match($this->webDriver, $selector));
         if (is_array($expected)) {
             list($floor, $ceil) = $expected;


### PR DESCRIPTION
The behavior of seeNumberOfElements and seeElement is not the same
as seeNumberOfElements does also count invisible elements.
To check for elements in DOM there is a seperate method
seeElementInDOM.

The method `seeNumberOfElementsInDOM` has been added and the behavior
of `seeNumberOfElements` has been changed to not respect invisible
elements.

Fixes #2303