### PR TITLE
Closes issue #2264

### DIFF
--- a/src/Codeception/Module.php
+++ b/src/Codeception/Module.php
@@ -201,7 +201,7 @@ abstract class Module
     protected function scalarizeArray($array)
     {
         foreach ($array as $k => $v) {
-            if (!is_scalar($v)) {
+            if (!is_null($v) && !is_scalar($v)) {
                 $array[$k] = (is_array($v) || $v instanceof \ArrayAccess)
                     ? $this->scalarizeArray($v)
                     : (string)$v;


### PR DESCRIPTION
This commit fixes the issue #2264 

PHP's `is_scalar` takes `NULL` as a non scalar. The current state of the code returns an empty string