### PR TITLE
Fixing the scalarizeArray to be aware of NULL fields, closing #2264

### DIFF
--- a/src/Codeception/Module.php
+++ b/src/Codeception/Module.php
@@ -200,7 +200,7 @@ abstract class Module
     protected function scalarizeArray($array)
     {
         foreach ($array as $k => $v) {
-            if (!is_scalar($v)) {
+            if (!is_null($v) && !is_scalar($v)) {
                 $array[$k] = (is_array($v) || $v instanceof \ArrayAccess)
                     ? $this->scalarizeArray($v)
                     : (string)$v;


### PR DESCRIPTION
The `is_scalar` method was causing issues when `$v` was `NULL` because, as said in [the docs](http://php.net/manual/en/function.is-scalar.php) it returns `false` on this case. The function so continued on and created an empty string, as reported on #2264 