### PR TITLE
Add details about required var_path configuration parameter for Symfony2 module

### DIFF
--- a/docs/modules/Symfony2.md
+++ b/docs/modules/Symfony2.md
@@ -19,7 +19,8 @@ This module uses Symfony2 Crawler and HttpKernel to emulate requests and test re
 
 ### Symfony 2.x
 
-* app_path: 'app' - specify custom path to your app dir, where bootstrap cache and kernel interface is located.
+* app_path: 'app' - specify custom path to your app dir, where the kernel interface is located.
+* var_path: 'var' - specify custom path to your var dir, where the bootstrap cache is located.
 * environment: 'local' - environment used for load kernel
 * debug: true - turn on/off debug mode
 
@@ -31,6 +32,7 @@ This module uses Symfony2 Crawler and HttpKernel to emulate requests and test re
        config:
           Symfony2:
              app_path: 'app/front'
+             var_path: 'app'
              environment: 'local_test'
 
 ### Symfony 3.x Directory Structure

--- a/src/Codeception/Module/Symfony2.php
+++ b/src/Codeception/Module/Symfony2.php
@@ -25,7 +25,8 @@ use Codeception\Lib\Connector\Symfony2 as Symfony2Connector;
  *
  * ### Symfony 2.x
  *
- * * app_path: 'app' - specify custom path to your app dir, where bootstrap cache and kernel interface is located.
+ * * app_path: 'app' - specify custom path to your app dir, where the kernel interface is located.
+ * * var_path: 'var' - specify custom path to your var dir, where the bootstrap cache is located.
  * * environment: 'local' - environment used for load kernel
  * * debug: true - turn on/off debug mode
  * 
@@ -37,6 +38,7 @@ use Codeception\Lib\Connector\Symfony2 as Symfony2Connector;
  *        config:
  *           Symfony2:
  *              app_path: 'app/front'
+ *              var_path: 'app'
  *              environment: 'local_test'
  *
  * ### Symfony 3.x Directory Structure


### PR DESCRIPTION
The description of var_path is also required for symfony2 applications.

As a generic good practice tests are located in symfony2 bundles under src. Thus it is required to specify var_path too so the Symfony2 module is aware of where the bootstrap cache is loaded from. app_path alone just tells where the AppKernel is supposed to be loaded from.



