### PR TITLE
Guzzle connector override status code to 302 if a meta refresh exists in body

### DIFF
--- a/src/Codeception/Lib/Connector/Guzzle.php
+++ b/src/Codeception/Lib/Connector/Guzzle.php
@@ -28,16 +28,16 @@ class Guzzle extends Client
     {
         $this->baseUri = $uri;
     }
-    
+
     /**
      * Sets the maximum allowable timeout interval for a meta tag refresh to
      * automatically redirect a request.
-     * 
+     *
      * A meta tag detected with an interval equal to or greater than $seconds
      * would not result in a redirect.  A meta tag without a specified interval
      * or one with a value less than $seconds would result in the client
      * automatically redirecting to the specified URL
-     * 
+     *
      * @param int $seconds Number of seconds
      */
     public function setRefreshMaxInterval($seconds)
@@ -107,38 +107,40 @@ class Guzzle extends Client
             }
             $response->setHeader('Content-Type', $contentType);
         }
-        
+
         $headers = $response->getHeaders();
         $status = $response->getStatusCode();
-        $matches = [];
+        if ($status < 300 || $status >= 400) {
+            $matches = [];
 
-        $matchesMeta = preg_match(
-            '/\<meta[^\>]+http-equiv="refresh" content="(\d*)\s*;?\s*url=(.*?)"/i',
-            $response->getBody(true),
-            $matches
-        );
-
-        if (!$matchesMeta) {
-            // match by header
-            preg_match(
-                '~(\d*);?url=(.*)~',
-                (string)$response->getHeader('Refresh'),
+            $matchesMeta = preg_match(
+                '/\<meta[^\>]+http-equiv="refresh" content="(\d*)\s*;?\s*url=(.*?)"/i',
+                $response->getBody(true),
                 $matches
             );
-        }
 
-        if ((!empty($matches)) && (empty($matches[1]) || $matches[1] < $this->refreshMaxInterval)) {
-            $uri = $this->getAbsoluteUri($matches[2]);
-            $partsUri = parse_url($uri);
-            $partsCur = parse_url($this->getHistory()->current()->getUri());
-            foreach ($partsCur as $key => $part) {
-                if ($key === 'fragment') {
-                    continue;
-                }
-                if (!isset($partsUri[$key]) || $partsUri[$key] !== $part) {
-                    $status = 302;
-                    $headers['Location'] = $matchesMeta ? htmlspecialchars_decode($uri) : $uri;
-                    break;
+            if (!$matchesMeta) {
+                // match by header
+                preg_match(
+                    '~(\d*);?url=(.*)~',
+                    (string)$response->getHeader('Refresh'),
+                    $matches
+                );
+            }
+
+            if ((!empty($matches)) && (empty($matches[1]) || $matches[1] < $this->refreshMaxInterval)) {
+                $uri = $this->getAbsoluteUri($matches[2]);
+                $partsUri = parse_url($uri);
+                $partsCur = parse_url($this->getHistory()->current()->getUri());
+                foreach ($partsCur as $key => $part) {
+                    if ($key === 'fragment') {
+                        continue;
+                    }
+                    if (!isset($partsUri[$key]) || $partsUri[$key] !== $part) {
+                        $status = 302;
+                        $headers['Location'] = $matchesMeta ? htmlspecialchars_decode($uri) : $uri;
+                        break;
+                    }
                 }
             }
         }

--- a/src/Codeception/Lib/Connector/Guzzle6.php
+++ b/src/Codeception/Lib/Connector/Guzzle6.php
@@ -112,30 +112,32 @@ class Guzzle6 extends Client
         }
 
         $status = $response->getStatusCode();
-        $matches = [];
+        if ($status < 300 || $status >= 400) {
+            $matches = [];
 
-        $matchesMeta = preg_match(
-            '/\<meta[^\>]+http-equiv="refresh" content="(\d*)\s*;?\s*url=(.*?)"/i',
-            $body,
-            $matches
-        );
-
-        if (!$matchesMeta && isset($headers['Refresh'])) {
-            // match by header
-            preg_match(
-                '~(\d*);?url=(.*)~',
-                (string) reset($headers['Refresh']),
+            $matchesMeta = preg_match(
+                '/\<meta[^\>]+http-equiv="refresh" content="(\d*)\s*;?\s*url=(.*?)"/i',
+                $body,
                 $matches
             );
-        }
 
-        if ((!empty($matches)) && (empty($matches[1]) || $matches[1] < $this->refreshMaxInterval)) {
-            $uri = new Psr7Uri($this->getAbsoluteUri($matches[2]));
-            $currentUri = new Psr7Uri($this->getHistory()->current()->getUri());
+            if (!$matchesMeta && isset($headers['Refresh'])) {
+                // match by header
+                preg_match(
+                    '~(\d*);?url=(.*)~',
+                    (string) reset($headers['Refresh']),
+                    $matches
+                );
+            }
 
-            if ($uri->withFragment('') != $currentUri->withFragment('')) {
-                $status = 302;
-                $headers['Location'] = $matchesMeta ? htmlspecialchars_decode($uri) : $uri;
+            if ((!empty($matches)) && (empty($matches[1]) || $matches[1] < $this->refreshMaxInterval)) {
+                $uri = new Psr7Uri($this->getAbsoluteUri($matches[2]));
+                $currentUri = new Psr7Uri($this->getHistory()->current()->getUri());
+
+                if ($uri->withFragment('') != $currentUri->withFragment('')) {
+                    $status = 302;
+                    $headers['Location'] = $matchesMeta ? htmlspecialchars_decode($uri) : $uri;
+                }
             }
         }
 
@@ -287,7 +289,7 @@ class Guzzle6 extends Client
                 }
             } else {
                 $files[] = [
-                    'name' => $name, 
+                    'name' => $name,
                     'contents' => fopen($info, 'r')
                 ];
             }
@@ -295,7 +297,7 @@ class Guzzle6 extends Client
 
         return $files;
     }
-    
+
     protected function extractCookies($host)
     {
         $jar = [];


### PR DESCRIPTION
I disabled followRedirect in PhpBrowser (`$this->getModule('PhpBrowser')->client->followRedirects(false)`) to test 301 response with REST module like:

    $I->seeResponseCodeIs(301);

But the endpoind I want to test returns a 301 response with `<meta http-equiv="refresh" />` in body (the Symfony2 way).
So Guzzle recode the status code to 302 and my test fails.