### PR TITLE
When Tests has NS, throws class not found for actor.

### DIFF
--- a/src/Codeception/TestCase/Test.php
+++ b/src/Codeception/TestCase/Test.php
@@ -19,8 +19,12 @@ class Test extends TestCase implements
     protected function setUp()
     {
         $actor = $this->actor;
-        if ($actor) {
+     if ($actor) {
             $property = lcfirst(Configuration::config()['actor']);
+            if (class_exists($actor) === false && strrpos($actor, '\\') !== false) {
+                $actor = str_replace('\\\\', '\\', $actor);
+            }
+
             $this->$property = new $actor($this->scenario);
 
             // BC compatibility hook


### PR DESCRIPTION
When i create a tests with own NS:
php codecept bootstrap --namespace "Project\Test"
php codecept run throws fatal error:

Class 'Project\Tests\\UnitTester' not found.

This fix can solve problem.

Or you can navigate me, where is correct point to fix it ;)