### PR TITLE
ZF1: Clear $_POST and $_GET after each request

### DIFF
--- a/src/Codeception/Lib/Connector/ZF1.php
+++ b/src/Codeception/Lib/Connector/ZF1.php
@@ -68,8 +68,10 @@ class ZF1 extends Client
         ob_start();
         try {
             $this->bootstrap->run();
+            $_GET = $_POST = [];
         } catch (\Exception $e) {
             ob_end_clean();
+            $_GET = $_POST = [];
             throw $e;
         }
         ob_end_clean();


### PR DESCRIPTION
I spent 2 hours trying to figure out why parameters persist between requests in the same scenario, here is the fix.