### PR TITLE
Typo change in example

### DIFF
--- a/docs/modules/REST.md
+++ b/docs/modules/REST.md
@@ -182,7 +182,7 @@ Example:
 ``` php
 <?php
 // match the first `user.id` in json
-$firstUser = $I->grabDataFromJsonResponse('$..users[0].id');
+$firstUser = $I->grabDataFromResponseByJsonPath('$..users[0].id');
 $I->sendPUT('/user', array('id' => $firstUser[0], 'name' => 'davert'));
 ?>
 ```


### PR DESCRIPTION
Typo used deprecated function instead of actul grabDataFromResponseByJsonPath