### PR TITLE
[WIP] Strip the cookie domain in session snapshots

### DIFF
--- a/src/Codeception/Module/WebDriver.php
+++ b/src/Codeception/Module/WebDriver.php
@@ -2167,6 +2167,9 @@ class WebDriver extends CodeceptionModule implements
 
         foreach ($this->webDriver->manage()->getCookies() as $cookie) {
             if ($this->cookieDomainMatchesConfigUrl($cookie)) {
+                // strip the domain since it matches the config url and may cause problems with the selenium webdriver
+                unset($cookie['domain']);
+
                 $this->sessionSnapshots[$name][] = $cookie;
             }
         }

--- a/tests/unit/Codeception/Module/WebDriverTest.php
+++ b/tests/unit/Codeception/Module/WebDriverTest.php
@@ -541,6 +541,8 @@ class WebDriverTest extends TestsForBrowsers
     {
         $fakeWdOptions = Stub::make('\Facebook\WebDriver\WebDriverOptions', [
             'getCookies' => Stub::atLeastOnce(function() {
+                $sameCookieDomain = parse_url($this->module->_getUrl(), PHP_URL_HOST);
+
                 return [
                     [
                         'name' => 'PHPSESSID',
@@ -548,11 +550,23 @@ class WebDriverTest extends TestsForBrowsers
                         'path' => '/',
                     ],
                     [
+                        'name' => 'SameDomain',
+                        'value' => '654321',
+                        'path' => '/',
+                        'domain' => $sameCookieDomain,
+                    ],
+                    [
+                        'name' => 'SameDomainWildcard',
+                        'value' => '291784',
+                        'path' => '/',
+                        'domain' => '.'.$sameCookieDomain,
+                    ],
+                    [
                         'name' => '3rdParty',
                         'value' => '_value_',
                         'path' => '/',
                         'domain' => '.3rd-party.net',
-                    ]
+                    ],
                 ];
             }),
         ]);
@@ -569,6 +583,8 @@ class WebDriverTest extends TestsForBrowsers
         $this->module->webDriver = $fakeWd;
 
         $this->module->seeCookie('PHPSESSID');
+        $this->module->seeCookie('SameDomain');
+        $this->module->seeCookie('SameDomainWildcard');
         $this->module->seeCookie('3rdParty');
         $this->module->saveSessionSnapshot('login');
 
@@ -577,9 +593,13 @@ class WebDriverTest extends TestsForBrowsers
 
         $this->webDriver->manage()->deleteAllCookies();
         $this->module->dontSeeCookie('PHPSESSID');
+        $this->module->dontSeeCookie('SameDomain');
+        $this->module->dontSeeCookie('SameDomainWildcard');
         $this->module->dontSeeCookie('3rdParty');
         $this->module->loadSessionSnapshot('login');
         $this->module->seeCookie('PHPSESSID');
+        $this->module->seeCookie('SameDomain');
+        $this->module->seeCookie('SameDomainWildcard');
         $this->module->dontSeeCookie('3rdParty');
     }
 }


### PR DESCRIPTION
This came up while I was testing #2250 

Sending a cookie with a domain `.foo.bar.com` will cause a selenium exception
if the current domain is `http://foo.bar.com` (which should match). The test `testSaveSessionSnapshotsExcludeInvalidCookieDomains` will fail without this fix.

Removing the cookie domain should not cause any problems since it matches the
configured url.