### PR TITLE
Allow other HTTP_HOSTs then localhost

### DIFF
--- a/src/Codeception/Module/Yii1.php
+++ b/src/Codeception/Module/Yii1.php
@@ -145,6 +145,7 @@ class Yii1 extends Framework
     public function _createClient()
     {
         $this->client = new Yii1Connector();
+        $this->client->setServerParameter("HTTP_HOST", parse_url($this->config['url'], PHP_URL_HOST));
         $this->client->appPath = $this->config['appPath'];
         $this->client->url = $this->config['url'];
         $this->client->appSettings = [


### PR DESCRIPTION
It was not possible to change the host from localhost to something else.
I now use the URL config to extract the host and set the HTTP_HOST for the client.