### PR TITLE
Fix "Array to string conversion" errors

### DIFF
--- a/src/Codeception/Exception/ElementNotFound.php
+++ b/src/Codeception/Exception/ElementNotFound.php
@@ -1,25 +1,13 @@
 <?php
 namespace Codeception\Exception;
 
+use Codeception\Util\Locator;
+
 class ElementNotFound extends \PHPUnit_Framework_AssertionFailedError
 {
     public function __construct($selector, $message = null)
     {
-        if (is_array($selector)) {
-            $type = strtolower(key($selector));
-            $locator = $selector[$type];
-            parent::__construct("Element with $type '$locator' was not found.");
-            return;
-        }
-        if (class_exists('\Facebook\WebDriver\WebDriverBy')) {
-            if ($selector instanceof \Facebook\WebDriver\WebDriverBy) {
-                $type = $selector->getMechanism();
-                $locator = $selector->getValue();
-                parent::__construct("Element with $type '$locator' was not found.");
-                return;
-            }
-        }
-
-        parent::__construct($message . " '$selector' was not found.");
+        $selector = Locator::humanReadableString($selector);
+        parent::__construct($message . " element with $selector was not found.");
     }
 }

--- a/src/Codeception/PHPUnit/Constraint/WebDriver.php
+++ b/src/Codeception/PHPUnit/Constraint/WebDriver.php
@@ -3,6 +3,7 @@ namespace Codeception\PHPUnit\Constraint;
 
 use Codeception\Exception\ElementNotFound;
 use Codeception\Lib\Console\Message;
+use Codeception\Util\Locator;
 use SebastianBergmann\Comparator\ComparisonFailure;
 
 class WebDriver extends Page
@@ -35,7 +36,7 @@ class WebDriver extends Page
             throw new ElementNotFound($selector, 'Element located either by name, CSS or XPath');
         }
 
-        $output = new Message("Failed asserting that any element by '$selector'");
+        $output = "Failed asserting that any element by " . Locator::humanReadableString($selector);
         $output .= $this->uriMessage('on page');
 
         if (count($nodes) < 5) {

--- a/src/Codeception/PHPUnit/Constraint/WebDriverNot.php
+++ b/src/Codeception/PHPUnit/Constraint/WebDriverNot.php
@@ -2,6 +2,7 @@
 namespace Codeception\PHPUnit\Constraint;
 
 use SebastianBergmann\Comparator\ComparisonFailure;
+use Codeception\Util\Locator;
 
 class WebDriverNot extends WebDriver
 {
@@ -12,11 +13,12 @@ class WebDriverNot extends WebDriver
 
     protected function fail($nodes, $selector, ComparisonFailure $comparisonFailure = null)
     {
+        $selectorString = Locator::humanReadableString($selector);
         if (!$this->string) {
-            throw new \PHPUnit_Framework_ExpectationFailedException("Element '$selector' was found", $comparisonFailure);
+            throw new \PHPUnit_Framework_ExpectationFailedException("Element $selectorString was found", $comparisonFailure);
         }
 
-        $output = "There was '$selector' element";
+        $output = "There was $selectorString element";
         $output .= $this->uriMessage("on page");
         $output .= str_replace($this->string, "<bold>{$this->string}</bold>", $this->nodesList($nodes, $this->string));
         $output .= "\ncontaining '{$this->string}'";

--- a/src/Codeception/Util/Locator.php
+++ b/src/Codeception/Util/Locator.php
@@ -181,4 +181,24 @@ class Locator
     {
         return (bool)preg_match('~^#[\w\.\-\[\]\=\^\~\:]+$~', $id);
     }
+
+    public static function humanReadableString($selector)
+    {
+       if (is_string($selector)) {
+          return "'$selector'";
+       }
+       if (is_array($selector)) {
+          $type = strtolower(key($selector));
+          $locator = $selector[$type];
+          return "$type '$locator'";
+       }
+       if (class_exists('\Facebook\WebDriver\WebDriverBy')) {
+          if ($selector instanceof \Facebook\WebDriver\WebDriverBy) {
+             $type = $selector->getMechanism();
+             $locator = $selector->getValue();
+             return "$type '$locator'";
+          }
+       }
+       throw new \InvalidArgumentException("Unrecognized selector");
+    }
 }

--- a/tests/unit/Codeception/Constraints/WebDriverConstraintTest.php
+++ b/tests/unit/Codeception/Constraints/WebDriverConstraintTest.php
@@ -19,7 +19,7 @@ class WebDriverConstraintTest extends PHPUnit_Framework_TestCase {
         $this->constraint->evaluate($nodes);
     }
 
-    public function testFailMessageResponse()
+    public function testFailMessageResponseWithStringSelector()
     {
         $nodes = array(new TestedWebElement('Bye warcraft'), new TestedWebElement('Bye world'));
         try {
@@ -27,6 +27,19 @@ class WebDriverConstraintTest extends PHPUnit_Framework_TestCase {
         } catch (PHPUnit_Framework_AssertionFailedError $fail) {
             $this->assertContains("Failed asserting that any element by 'selector' on page <bold>/user</bold>", $fail->getMessage());
             $this->assertContains('+ <info><p> Bye world</info>',$fail->getMessage());
+            $this->assertContains('+ <info><p> Bye warcraft</info>',$fail->getMessage());
+            return;
+        }
+        $this->fail("should have failed, but not");
+    }
+
+    public function testFailMessageResponseWithArraySelector()
+    {
+        $nodes = array(new TestedWebElement('Bye warcraft'));
+        try {
+            $this->constraint->evaluate($nodes, ['css' => 'p.mocked']);
+        } catch (PHPUnit_Framework_AssertionFailedError $fail) {
+            $this->assertContains("Failed asserting that any element by css 'p.mocked' on page <bold>/user</bold>", $fail->getMessage());
             $this->assertContains('+ <info><p> Bye warcraft</info>',$fail->getMessage());
             return;
         }

--- a/tests/unit/Codeception/Constraints/WebDriverNotConstraintTest.php
+++ b/tests/unit/Codeception/Constraints/WebDriverNotConstraintTest.php
@@ -19,7 +19,7 @@ class WebDriverConstraintNotTest extends PHPUnit_Framework_TestCase {
         $this->constraint->evaluate($nodes);
     }
 
-    public function testFailMessageResponse()
+    public function testFailMessageResponseWithStringSelector()
     {
         $nodes = array(new TestedWebElement('Bye warcraft'), new TestedWebElement('Bye world'));
         try {
@@ -27,6 +27,19 @@ class WebDriverConstraintNotTest extends PHPUnit_Framework_TestCase {
         } catch (PHPUnit_Framework_AssertionFailedError $fail) {
             $this->assertContains("There was 'selector' element on page <bold>/user</bold>", $fail->getMessage());
             $this->assertNotContains('+ <info><p> Bye world</info>',$fail->getMessage());
+            $this->assertContains('+ <info><p> Bye <bold>warcraft</bold></info>',$fail->getMessage());
+            return;
+        }
+        $this->fail("should have failed, but not");
+    }
+
+    public function testFailMessageResponseWithArraySelector()
+    {
+        $nodes = array(new TestedWebElement('Bye warcraft'));
+        try {
+            $this->constraint->evaluate($nodes, ['css' => 'p.mocked']);
+        } catch (PHPUnit_Framework_AssertionFailedError $fail) {
+            $this->assertContains("There was css 'p.mocked' element on page <bold>/user</bold>", $fail->getMessage());
             $this->assertContains('+ <info><p> Bye <bold>warcraft</bold></info>',$fail->getMessage());
             return;
         }

--- a/tests/unit/Codeception/Util/LocatorTest.php
+++ b/tests/unit/Codeception/Util/LocatorTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use Codeception\Util\Locator;
+use Facebook\WebDriver\WebDriverBy;
 
 class LocatorTest extends PHPUnit_Framework_TestCase
 {
@@ -52,4 +53,15 @@ class LocatorTest extends PHPUnit_Framework_TestCase
         $this->assertFalse(Locator::isID('hello'));
     }
 
+    public function testHumanReadableString()
+    {
+       $this->assertEquals("'string selector'", Locator::humanReadableString("string selector"));
+       $this->assertEquals("css '.something'", Locator::humanReadableString(['css' => '.something']));
+       $this->assertEquals("css selector '.something'", Locator::humanReadableString(WebDriverBy::cssSelector('.something')));
+
+       try {
+          Locator::humanReadableString(null);
+          $this->fail("Expected exception when calling humanReadableString() with invalid selector");
+       } catch (\InvalidArgumentException $e) {}
+    }
 }


### PR DESCRIPTION
The "fail" method of both Codeception\PHPUnit\Constraint\WebDriver and WebDriverNot takes in a
$selector for error reporting purposes. The $selector is assumed to be a string and interpolated
into the error message, but there are cases where the $selector is actually an array or WebDriverBy
object. When that's the case, this method triggers a "Array to string conversion" PHP notice.

I noticed this in a test case I have that calls Codeception\Module\WebDriver->see():

    $I->see('Reviewers', ["css" => ".submission_nav .box.current"])

This test failed because the ".submission_nav" element disappeared, but instead of a descriptive
failure message I got "[PHPUnit_Framework_Exception] Array to string conversion".

To reduce code duplication, I extracted the logic used in ElementNotFound for converting a
selector into a string and put it in a new method, Codeception\Util\Locator->humanReadableString().