### PR TITLE
Symfony2: Fail when profile is not set.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 #### 2.1.3
 
+* [Symfony2] Fixed issue when accesing profiler when no request has been performed #652.
 * Fixed issue with trailing slashes in `seeCurrentUrlEquals` and `dontSeeCurrentUrlEquals` methods #2324. By @janhenkgerritsen
 * Warning is displayed once using unconfigured environment.
 * Fixed loading environment configurations for Cept files by @splinter89

--- a/src/Codeception/Module/Symfony2.php
+++ b/src/Codeception/Module/Symfony2.php
@@ -216,7 +216,11 @@ class Symfony2 extends Framework implements DoctrineProvider
             return null;
         }
         $profiler = $this->kernel->getContainer()->get('profiler');
-        return $profiler->loadProfileFromResponse($this->client->getResponse());
+        $response = $this->client->getResponse();
+        if (null === $response) {
+            $this->fail("You must perform a request before using this method.");
+        }
+        return $profiler->loadProfileFromResponse($response);
     }
 
     protected function debugResponse()


### PR DESCRIPTION
In Symfony2, when a method that need the profiler is called, it will fail instead of crashing.

Fixed #652