### PR TITLE
Suppress console coverage report with `--quiet`

### DIFF
--- a/src/Codeception/Codecept.php
+++ b/src/Codeception/Codecept.php
@@ -52,7 +52,8 @@ class Codecept
         'fail-fast'     => false,
         'verbosity'     => 1,
         'interactive'   => true,
-        'no-rebuild'    => false
+        'no-rebuild'    => false,
+        'quiet'         => false,
     ];
 
     protected $config = [];

--- a/src/Codeception/Coverage/Subscriber/Printer.php
+++ b/src/Codeception/Coverage/Subscriber/Printer.php
@@ -61,7 +61,9 @@ class Printer implements EventSubscriberInterface
             return;
         }
 
-        $this->printConsole($printer);
+        if (!$this->options['quiet']) {
+            $this->printConsole($printer);
+        }
         $printer->write("Remote CodeCoverage reports are not printed to console\n");
         $this->printPHP();
         $printer->write("\n");


### PR DESCRIPTION
PR for #1592 

This should work as-is, although I'm not sure it's the 'right' way of doing it. When `--quiet` is used it also suppresses the progress of the tests, which isn't really what I would find useful, ideally I'd like to see the test progress but just hide the report. That would require a new option (something like `--no-coverage-console` or `--coverage-quiet`) and I wasn't sure if that would be okay so I thought I'd check first.