### PR TITLE
Allow subfolders for environments grouping

### DIFF
--- a/src/Codeception/Configuration.php
+++ b/src/Codeception/Configuration.php
@@ -293,7 +293,7 @@ class Configuration
             ->files()
             ->name('*.yml')
             ->in($path)
-            ->depth('< 1');
+            ->depth('< 2');
 
         $envs = [];
         /** @var SplFileInfo $envFile */


### PR DESCRIPTION
This should allow having something like:

 _envs
&nbsp;&nbsp;&nbsp;&nbsp;browsers
&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;firefox.yml
&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&hellip;
&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;chrome.yml