### PR TITLE
Implemented comparison for json structure by types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 #### 2.1.3
 
+* [REST] Added matching data types by with new methods `seeResponseMatchesJsonType` and `dontSeeResponseMatchesJsonType. See #2391
 * [Symfony2] Fixed issue when accessing profiler when no request has been performed #652.
 * [Symfony2] Added amOnRoute and seeCurrentRouteIs methods to Symfony2 module, by @raistlin
 * [ZF1] Added amOnRoute and seeCurrentRouteIs methods to ZF1 module, by @Naktibalda

--- a/RoboFile.php
+++ b/RoboFile.php
@@ -281,7 +281,7 @@ class RoboFile extends \Robo\Tasks
     public function buildDocsUtils()
     {
         $this->say("Util Classes");
-        $utils = ['Autoload', 'Fixtures', 'Stub', 'Locator', 'XmlBuilder'];
+        $utils = ['Autoload', 'Fixtures', 'Stub', 'Locator', 'XmlBuilder', 'JsonType'];
 
         foreach ($utils as $utilName) {
             $className = '\Codeception\Util\\' . $utilName;

--- a/src/Codeception/Module/REST.php
+++ b/src/Codeception/Module/REST.php
@@ -9,6 +9,7 @@ use Codeception\Lib\InnerBrowser;
 use Codeception\Lib\Interfaces\DependsOnModule;
 use Codeception\Lib\Interfaces\PartedModule;
 use Codeception\Util\JsonArray;
+use Codeception\Util\JsonType;
 use Codeception\Util\XmlStructure;
 use Symfony\Component\BrowserKit\Cookie;
 use Codeception\Util\Soap as XmlUtils;
@@ -755,12 +756,118 @@ EOF;
     public function dontSeeResponseContainsJson($json = [])
     {
         $jsonResponseArray = new JsonArray($this->response);
-        \PHPUnit_Framework_Assert::assertFalse(
+        $this->assertFalse(
             $jsonResponseArray->containsArray($json),
             "Response JSON does not contain JSON provided\n"
             . "- <info>" . var_export($json, true) . "</info>\n"
             . "+ " . var_export($jsonResponseArray->toArray(), true)
         );
+    }
+
+    /**
+     * Checks that Json matches provided types.
+     * In case you don't know the actual values of JSON data returned you can match them by type.
+     * Starts check with a root element. If JSON data is array it will check the first element of an array.
+     * You can specify the path in the json which should be checked with JsonPath
+     *
+     * Basic example:
+     *
+     * ```php
+     * <?php
+     * // {'user_id': 1, 'name': 'davert', 'is_active': false}
+     * $I->seeResponseIsJsonType([
+     *      'user_id' => 'integer',
+     *      'name' => 'string|null',
+     *      'is_active' => 'boolean'
+     * ]);
+     *
+     * // narrow down matching with JsonPath:
+     * // {"users": [{ "name": "davert"}, {"id": 1}]}
+     * $I->seeResponseMatchesJsonType(['name' => 'string'], '$.users[0]');
+     * ?>
+     * ```
+     *
+     * In this case you can match that record contains fields with data types you expected.
+     * The list of possible data types:
+     *
+     * * string
+     * * integer
+     * * float
+     * * array (json object is array as well)
+     * * boolean
+     *
+     * You can also use nested data type structures:
+     *
+     * ```php
+     * <?php
+     * // {'user_id': 1, 'name': 'davert', 'company': {'name': 'Codegyre'}}
+     * $I->seeResponseIsJsonType([
+     *      'user_id' => 'integer|string', // multiple types
+     *      'company' => ['name' => 'string']
+     * ]);
+     * ?>
+     * ```
+     *
+     * You can also apply filters to check values. Filter can be applied with `:` char after the type declatation.
+     *
+     * Here is the list of possible filters:
+     *
+     * * `integer:>{val}` - checks that integer is greater than {val} (works with float and string types too).
+     * * `integer:<{val}` - checks that integer is lower than {val} (works with float and string types too).
+     * * `string:url` - checks that value is valid url.
+     * * `string:regex({val})` - checks that string matches a regex provided with {val}
+     *
+     * This is how filters can be used:
+     *
+     * ```php
+     * <?php
+     * // {'user_id': 1, 'email' => 'davert@codeception.com'}
+     * $I->seeResponseIsJsonType([
+     *      'user_id' => 'string:>0:<1000', // multiple filters can be used
+     *      'email' => 'string:regex(~\@~)' // we just check that @ char is included
+     * ]);
+     *
+     * // {'user_id': '1'}
+     * $I->seeResponseIsJsonType([
+     *      'user_id' => 'string:>0', // works with strings as well
+     * }
+     * ?>
+     * ```
+     *
+     * You can also add custom filters y accessing `JsonType::addCustomFilter` method.
+     * See JsonType reference.
+     *
+     * @version 2.1.3
+     * @param array $jsonType
+     * @part json
+     */
+    public function seeResponseMatchesJsonType(array $jsonType, $jsonPath = null)
+    {
+        $jsonArray = new JsonArray($this->response);
+        if ($jsonPath) {
+            $jsonArray = $jsonArray->filterByJsonPath($jsonPath);
+        }
+        $matched = (new JsonType($jsonArray))->matches($jsonType);
+        $this->assertTrue($matched, $matched);
+    }
+
+    /**
+     * Opposite to `seeResponseMatchesJsonType`.
+     *
+     * @part json
+     * @see seeResponseMatchesJsonType
+     * @param $jsonType jsonType structure
+     * @param null $jsonPath optionally set specific path to structure with JsonPath
+     * @version 2.1.3
+     */
+    public function dontSeeResponseMatchesJsonType($jsonType, $jsonPath = null)
+    {
+        $jsonArray = new JsonArray($this->response);
+        if ($jsonPath) {
+            $jsonArray = $jsonArray->filterByJsonPath($jsonPath);
+        }
+        $matched = (new JsonType($jsonArray))->matches($jsonType);
+        $this->assertNotEquals(true, $matched, sprintf("Unexpectedly the response matched the %s data type", var_export($jsonType, true)));
     }
 
     /**

--- a/src/Codeception/Util/JsonType.php
+++ b/src/Codeception/Util/JsonType.php
@@ -154,10 +154,10 @@ class JsonType
 
         // apply custom filters
         foreach (static::$customFilters as $customFilter => $callable) {
-            if (strpos($customFilter,'/') === 0) {
+            if (strpos($customFilter, '/') === 0) {
                 if (preg_match($customFilter, $filter, $matches)) {
-                    $params = array_shift($matches);
-                    return call_user_func_array($callable, array_merge($value, $params));
+                    array_shift($matches);
+                    return call_user_func_array($callable, array_merge([$value], $matches));
                 }
             }
             if ($customFilter == $filter) {

--- a/src/Codeception/Util/JsonType.php
+++ b/src/Codeception/Util/JsonType.php
@@ -1,0 +1,191 @@
+<?php
+namespace Codeception\Util;
+
+/**
+ * JsonType matches JSON structures against templates.
+ * You can specify the type of fields in JSON or add additional validation rules.
+ *
+ * JsonType is used by REST module in `seeResponseMatchesJsonType` and `dontSeeResponseMatchesJsonType` methods.
+ *
+ * Usage example:
+ *
+ * ```php
+ * <?php
+ * $jsonType = new JsonType(['name' => 'davert', 'id' => 1]);
+ * $jsonType->matches([
+ *   'name' => 'string:!empty',
+ *   'id' => 'integer:>0|string:>0',
+ * ])); // => true
+ *
+ * $jsonType->matches([
+ *   'id' => 'string',
+ * ])); // => `id: 1` is not of type string
+ * ?>
+ * ```
+ *
+ * Class JsonType
+ * @package Codeception\Util
+ */
+class JsonType
+{
+    protected $jsonArray;
+
+    protected static $customFilters = [];
+
+    /**
+     * Creates instance of JsonType
+     * Pass an array or `\Codeception\Util\JsonArray` with data.
+     * If non-associative array is passed - the very first element of it will be used for matching.
+     *
+     * @param $jsonArray array|\Codeception\Util\JsonArray
+     */
+    public function __construct($jsonArray)
+    {
+        if ($jsonArray instanceof JsonArray) {
+            $jsonArray = $jsonArray->toArray();
+        }
+        $this->jsonArray = $jsonArray;
+    }
+
+    /**
+     * Adds custom filter to JsonType list.
+     * You should specify a name and parameters of a filter.
+     *
+     * Example:
+     *
+     * ```php
+     * <?php
+     * JsonType::addCustomFilter('email', function($value) {
+     *     return strpos('@', $value) !== false;
+     * });
+     * // => use it as 'string:email'
+
+     *
+     * // add custom function to matcher with `len($val)` syntax
+     * // parameter matching patterns should be valid regex and start with `/` char
+     * JsonType::addCustomFilter('/len\((.*?)\)/', function($value, $len) {
+     *   return strlen($value) == $len;
+     * });
+     * // use it as 'string:len(5)'
+     * ?>
+     * ```
+     *
+     * @param $name
+     * @param callable $callable
+     */
+    public static function addCustomFilter($name, callable $callable)
+    {
+        static::$customFilters[$name] = $callable;
+    }
+
+    /**
+     * Removes all custom filters
+     */
+    public static function cleanCustomFilters()
+    {
+        static::$customFilters = [];
+    }
+
+    /**
+     * Checks data against passed JsonType.
+     * If matching fails function returns a string with a message describing failure.
+     * On success returns `true`.
+     *
+     * @param array $jsonType
+     * @return bool|string
+     */
+    public function matches(array $jsonType)
+    {
+        $data = $this->jsonArray;
+        if (array_key_exists(0, $this->jsonArray)) {
+            // sequential array
+            $data = reset($this->jsonArray);
+        }
+        return $this->typeComparison($data, $jsonType);
+    }
+
+    protected function typeComparison($data, $jsonType)
+    {
+        foreach ($jsonType as $key => $type) {
+            if (!array_key_exists($key, $data)) {
+                return "Key `$key` doesn't exist in " . json_encode($data);
+            }
+            if (is_array($jsonType[$key])) {
+                $message = $this->typeComparison($data[$key], $jsonType[$key]);
+                if (is_string($message)) {
+                    return $message;
+                }
+                continue;
+            }
+            $matchTypes = explode('|', $type);
+            $matched = false;
+            foreach ($matchTypes as $matchType) {
+                $currentType = strtolower(gettype($data[$key]));
+                if ($currentType == 'double') {
+                    $currentType = 'float';
+                }
+                $filters = explode(':', $matchType);
+                $expectedType = trim(strtolower(array_shift($filters)));
+
+                if ($expectedType != $currentType) {
+                    break;
+                }
+                if (empty($filters)) {
+                    $matched = true;
+                    break;
+                }
+                foreach ($filters as $filter) {
+                    $matched = $this->matchFilter($filter, $data[$key]);
+                }
+            }
+            if (!$matched) {
+                return sprintf("`$key: %s` is not of type `$type`", var_export($data[$key], true));
+            }
+        }
+        return true;
+    }
+
+    protected function matchFilter($filter, $value)
+    {
+        $filter = trim($filter);
+        if (strpos($filter,'!') === 0) {
+            return !$this->matchFilter(substr($filter, 1), $value);
+        }
+
+        // apply custom filters
+        foreach (static::$customFilters as $customFilter => $callable) {
+            if (strpos($customFilter,'/') === 0) {
+                if (preg_match($customFilter, $filter, $matches)) {
+                    $params = array_shift($matches);
+                    return call_user_func_array($callable, array_merge($value, $params));
+                }
+            }
+            if ($customFilter == $filter) {
+                return $callable($value);
+            }
+        }
+
+        if (strpos($filter, '=') === 0) {
+            return $value == substr($filter, 1);
+        }
+        if ($filter === 'url') {
+            return preg_match('/^(https?:\/\/)?([\da-z\.-]+)\.([a-z\.]{2,6})([\/\w \.-]*)*\/?$/', $value);
+        }
+        if ($filter === 'date') {
+            return preg_match('/^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2})(?:Z|(\+|-)([\d|:]*))?$/', $value);
+        }
+        if ($filter === 'empty') {
+            return empty($value);
+        }
+        if (preg_match('~^regex\((.*?)\)$~', $filter, $matches)) {
+            return preg_match($matches[1], $value);
+        }
+        if (preg_match('~^>([\d\.]+)$~', $filter, $matches)) {
+            return (float)$value > (float)$matches[1];
+        }
+        if (preg_match('~^<([\d\.]+)$~', $filter, $matches)) {
+            return (float)$value < (float)$matches[1];
+        }
+    }
+
+}

--- a/tests/unit/Codeception/Module/RestTest.php
+++ b/tests/unit/Codeception/Module/RestTest.php
@@ -206,7 +206,6 @@ class RestTest extends \PHPUnit_Framework_TestCase
         $this->module->dontSeeHttpHeader('Content-Language','en-RU');
         $this->module->dontSeeHttpHeader('Content-Language1');
         $this->module->seeHttpHeaderOnce('Content-Language');
-        \Codeception\Util\Debug::debug($this->module->grabHttpHeader('Cache-Control', false));
         $this->assertEquals('en-US', $this->module->grabHttpHeader('Content-Language'));
         $this->assertEquals('no-cache', $this->module->grabHttpHeader('Cache-Control'));
         $this->assertEquals(['no-cache', 'no-store'], $this->module->grabHttpHeader('Cache-Control', false));
@@ -265,11 +264,26 @@ class RestTest extends \PHPUnit_Framework_TestCase
         $this->assertJson($request->getContent());
     }
 
+    public function testJsonTypeMatches()
+    {
+        $this->module->response = '{"xxx": "yyy", "user_id": 1}';
+        $this->module->seeResponseMatchesJsonType(['xxx' => 'string', 'user_id' => 'integer:<10']);
+        $this->module->dontSeeResponseMatchesJsonType(['xxx' => 'integer', 'user_id' => 'integer:<10']);
+    }
+
+    public function testJsonTypeMatchesWithJsonPath()
+    {
+        $this->module->response = '{"users": [{ "name": "davert"}, {"id": 1}]}';
+        $this->module->seeResponseMatchesJsonType(['name' => 'string'], '$.users[0]');
+        $this->module->seeResponseMatchesJsonType(['id' => 'integer'], '$.users[1]');
+        $this->module->dontSeeResponseMatchesJsonType(['id' => 'integer'], '$.users[0]');
+    }
+
+
     protected function shouldFail()
     {
         $this->setExpectedException('PHPUnit_Framework_AssertionFailedError');
     }
-
 
 }
 

--- a/tests/unit/Codeception/Util/JsonArrayTest.php
+++ b/tests/unit/Codeception/Util/JsonArrayTest.php
@@ -89,4 +89,5 @@ class JsonArrayTest extends \Codeception\TestCase\Test
         $expectedArray = ['foo', 'bar', 'foo'];
         $this->assertTrue($jsonArray->containsArray($expectedArray));       
     }
+
 }

--- a/tests/unit/Codeception/Util/JsonTypeTest.php
+++ b/tests/unit/Codeception/Util/JsonTypeTest.php
@@ -1,0 +1,111 @@
+<?php
+namespace Codeception\Util;
+
+
+class JsonTypeTest extends \Codeception\TestCase\Test
+{
+    protected $types = [
+        'id' => 'integer:>10',
+        'retweeted' => 'Boolean',
+        'in_reply_to_screen_name' => 'null|string',
+        'user' => [
+          'url' => 'String:url'
+        ]
+    ];
+    protected $data = [
+        'id' => 11,
+        'retweeted' => false,
+        'in_reply_to_screen_name' => null,
+        'user' => ['url' => 'http://davert.com']
+    ];
+
+    public function _after()
+    {
+        JsonType::cleanCustomFilters();
+    }
+
+    public function testMatchBasicTypes()
+    {
+        $jsonType = new JsonType($this->data);
+        $this->assertTrue($jsonType->matches($this->types));
+    }
+
+    public function testNotMatchesBasicType()
+    {
+        $this->data['in_reply_to_screen_name'] = true;
+        $jsonType = new JsonType($this->data);
+        $this->assertContains('`in_reply_to_screen_name: true` is not of type', $jsonType->matches($this->types));
+    }
+
+    public function testIntegerFilter()
+    {
+        $jsonType = new JsonType($this->data);
+        $this->assertContains('`id: 11` is not of type', $jsonType->matches(['id' => 'integer:<5']));
+        $this->assertContains('`id: 11` is not of type', $jsonType->matches(['id' => 'integer:>15']));
+        $this->assertTrue($jsonType->matches(['id' => 'integer:=111']));
+        $this->assertTrue($jsonType->matches(['id' => 'integer:>5']));
+        $this->assertTrue($jsonType->matches(['id' => 'integer:>5:<12']));
+        $this->assertNotTrue($jsonType->matches(['id' => 'integer:>5:<10']));
+    }
+
+    public function testUrlFilter()
+    {
+        $this->data['user']['url'] = 'invalid_url';
+        $jsonType = new JsonType($this->data);
+        $this->assertNotTrue($jsonType->matches($this->types));
+    }
+
+    public function testRegexFilter()
+    {
+        $jsonType = new JsonType(['numbers' => '1-2-3']);
+        $this->assertTrue($jsonType->matches(['numbers' => 'string:regex(~1-2-3~)']));
+        $this->assertTrue($jsonType->matches(['numbers' => 'string:regex(~\d-\d-\d~)']));
+        $this->assertNotTrue($jsonType->matches(['numbers' => 'string:regex(~^\d-\d$~)']));
+    }
+
+    public function testDateTimeFilter()
+    {
+        $jsonType = new JsonType(['date' => '2011-11-30T04:06:44Z']);
+        $this->assertTrue($jsonType->matches(['date' => 'string:date']));
+    }
+
+    public function testNegativeFilters()
+    {
+        $jsonType = new JsonType(['name' => 'davert', 'id' => 1]);
+        $this->assertTrue($jsonType->matches([
+            'date' => 'string:!date|string:!empty',
+            'id' => 'integer:!=0',
+        ]));
+    }
+
+    public function testCustomFilters()
+    {
+        JsonType::addCustomFilter('email', function($value) {
+            return strpos('@', $value) !== false;
+        });
+        $jsonType = new JsonType(['email' => 'davert@codeception.com', 'name' => 'davert']);
+        $this->assertTrue($jsonType->matches([
+            'email' => 'string:email'
+        ]));
+        $this->assertNotTrue($jsonType->matches([
+            'name' => 'string:email'
+        ]));
+
+        JsonType::addCustomFilter('/len\((.*?)\)/', function($value, $len) {
+            return strlen($value) == $len;
+        });
+        $this->assertTrue($jsonType->matches([
+            'email' => 'string:len(22)'
+        ]));
+        $this->assertNotTrue($jsonType->matches([
+            'email' => 'string:len(7)'
+        ]));
+    }
+
+    public function testArray()
+    {
+        $this->types['user'] = 'array';
+        $jsonType = new JsonType($this->data);
+        $this->assertTrue($jsonType->matches($this->types));
+    }
+}

--- a/tests/unit/Codeception/Util/JsonTypeTest.php
+++ b/tests/unit/Codeception/Util/JsonTypeTest.php
@@ -1,7 +1,6 @@
 <?php
 namespace Codeception\Util;
 
-
 class JsonTypeTest extends \Codeception\TestCase\Test
 {
     protected $types = [
@@ -42,7 +41,7 @@ class JsonTypeTest extends \Codeception\TestCase\Test
         $jsonType = new JsonType($this->data);
         $this->assertContains('`id: 11` is not of type', $jsonType->matches(['id' => 'integer:<5']));
         $this->assertContains('`id: 11` is not of type', $jsonType->matches(['id' => 'integer:>15']));
-        $this->assertTrue($jsonType->matches(['id' => 'integer:=111']));
+        $this->assertTrue($jsonType->matches(['id' => 'integer:=11']));
         $this->assertTrue($jsonType->matches(['id' => 'integer:>5']));
         $this->assertTrue($jsonType->matches(['id' => 'integer:>5:<12']));
         $this->assertNotTrue($jsonType->matches(['id' => 'integer:>5:<10']));
@@ -73,7 +72,7 @@ class JsonTypeTest extends \Codeception\TestCase\Test
     {
         $jsonType = new JsonType(['name' => 'davert', 'id' => 1]);
         $this->assertTrue($jsonType->matches([
-            'date' => 'string:!date|string:!empty',
+            'name' => 'string:!date|string:!empty',
             'id' => 'integer:!=0',
         ]));
     }
@@ -81,7 +80,7 @@ class JsonTypeTest extends \Codeception\TestCase\Test
     public function testCustomFilters()
     {
         JsonType::addCustomFilter('email', function($value) {
-            return strpos('@', $value) !== false;
+            return strpos($value, '@') !== false;
         });
         $jsonType = new JsonType(['email' => 'davert@codeception.com', 'name' => 'davert']);
         $this->assertTrue($jsonType->matches([


### PR DESCRIPTION
REST module can now also check JSON data by field types. 
Idea taken from #2373

Examples:

```json
"{\"id\":11,\"retweeted\":false,\"in_reply_to_screen_name\":null,\"user\":{\"url\":\"http:\\/\\/davert.com\"}}"
```
can be matched with

```php
<?php
$I->seeResponseMatchesJsonType(['id' => 'integer:>10',
        'retweeted' => 'Boolean',
        'in_reply_to_screen_name' => 'null|string',
        'user' => [
          'url' => 'String:url'
        ]
]);
?>
```

## ToDo

- [x] implement specifying JSON part to check with JSONPath
- [x] add DateTime type
- [x] add more filters: email, >=, <=, ... etc
- [x] implment custom filters
- [x] write JsonType reference