### PR TITLE
Interface SupportsDomainRouting is for modules, not for connectors

### DIFF
--- a/src/Codeception/Lib/Connector/Lumen.php
+++ b/src/Codeception/Lib/Connector/Lumen.php
@@ -1,7 +1,6 @@
 <?php
 namespace Codeception\Lib\Connector;
 
-use Codeception\Lib\Interfaces\SupportsDomainRouting;
 use Illuminate\Http\Request;
 use Laravel\Lumen\Application;
 use Symfony\Component\HttpFoundation\Request as SymfonyRequest;
@@ -9,7 +8,7 @@ use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Client;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
 
-class Lumen extends Client implements HttpKernelInterface, SupportsDomainRouting
+class Lumen extends Client implements HttpKernelInterface
 {
 
     /**

--- a/src/Codeception/Lib/Connector/Symfony2.php
+++ b/src/Codeception/Lib/Connector/Symfony2.php
@@ -1,9 +1,7 @@
 <?php
 namespace Codeception\Lib\Connector;
 
-use Codeception\Lib\Interfaces\SupportsDomainRouting;
-
-class Symfony2 extends \Symfony\Component\HttpKernel\Client implements SupportsDomainRouting
+class Symfony2 extends \Symfony\Component\HttpKernel\Client
 {
     
     /**

--- a/src/Codeception/Lib/Connector/Yii1.php
+++ b/src/Codeception/Lib/Connector/Yii1.php
@@ -1,12 +1,11 @@
 <?php
 namespace Codeception\Lib\Connector;
 
-use Codeception\Lib\Interfaces\SupportsDomainRouting;
 use Symfony\Component\BrowserKit\Client;
 use Symfony\Component\BrowserKit\Response;
 use Yii;
 
-class Yii1 extends Client implements SupportsDomainRouting
+class Yii1 extends Client
 {
     use Shared\PhpSuperGlobalsConverter;
     /**

--- a/src/Codeception/Lib/Connector/Yii2.php
+++ b/src/Codeception/Lib/Connector/Yii2.php
@@ -1,7 +1,6 @@
 <?php
 namespace Codeception\Lib\Connector;
 
-use Codeception\Lib\Interfaces\SupportsDomainRouting;
 use Codeception\Util\Debug;
 use Symfony\Component\BrowserKit\Client;
 use Symfony\Component\BrowserKit\Cookie;
@@ -11,7 +10,7 @@ use yii\base\ExitException;
 use yii\web\HttpException;
 use yii\web\Response as YiiResponse;
 
-class Yii2 extends Client implements SupportsDomainRouting
+class Yii2 extends Client
 {
     use Shared\PhpSuperGlobalsConverter;
 

--- a/src/Codeception/Module/Lumen.php
+++ b/src/Codeception/Module/Lumen.php
@@ -5,6 +5,7 @@ use Codeception\Exception\ModuleConfig;
 use Codeception\Lib\Connector\Lumen as LumenConnector;
 use Codeception\Lib\Framework;
 use Codeception\Lib\Interfaces\ActiveRecord;
+use Codeception\Lib\Interfaces\SupportsDomainRouting;
 use Codeception\TestCase;
 use Codeception\Step;
 use Codeception\Configuration;

--- a/src/Codeception/Module/Lumen.php
+++ b/src/Codeception/Module/Lumen.php
@@ -41,7 +41,7 @@ use Illuminate\Support\Facades\Facade;
  * * client - `BrowserKit` client
  *
  */
-class Lumen extends Framework implements ActiveRecord
+class Lumen extends Framework implements ActiveRecord, SupportsDomainRouting
 {
 
     /**

--- a/src/Codeception/Module/Silex.php
+++ b/src/Codeception/Module/Silex.php
@@ -4,6 +4,7 @@ namespace Codeception\Module;
 use Codeception\Configuration;
 use Codeception\Exception\ModuleConfigException;
 use Codeception\Lib\Framework;
+use Codeception\Lib\Interfaces\SupportsDomainRouting;
 use Codeception\TestCase;
 use Symfony\Component\HttpKernel\Client;
 
@@ -47,7 +48,7 @@ use Symfony\Component\HttpKernel\Client;
  * Class Silex
  * @package Codeception\Module
  */
-class Silex extends Framework
+class Silex extends Framework implements SupportsDomainRouting
 {
 
     protected $app;

--- a/src/Codeception/Module/Symfony2.php
+++ b/src/Codeception/Module/Symfony2.php
@@ -7,6 +7,7 @@ use Codeception\Lib\Framework;
 use Codeception\Exception\ModuleRequireException;
 use Codeception\Lib\Connector\Symfony2 as Symfony2Connector;
 use Codeception\Lib\Interfaces\DoctrineProvider;
+use Codeception\Lib\Interfaces\SupportsDomainRouting;
 use Symfony\Component\Finder\Finder;
 
 /**

--- a/src/Codeception/Module/Symfony2.php
+++ b/src/Codeception/Module/Symfony2.php
@@ -65,7 +65,7 @@ use Symfony\Component\Finder\Finder;
  * * container - dependency injection container instance
  *
  */
-class Symfony2 extends Framework implements DoctrineProvider
+class Symfony2 extends Framework implements DoctrineProvider, SupportsDomainRouting
 {
     /**
      * @var \Symfony\Component\HttpKernel\Kernel

--- a/src/Codeception/Module/Yii1.php
+++ b/src/Codeception/Module/Yii1.php
@@ -71,7 +71,7 @@ use Yii;
  *
  * @property Codeception\Lib\Connector\Yii1 $client
  */
-class Yii1 extends Framework
+class Yii1 extends Framework implements SupportsDomainRouting
 {
 
     /**

--- a/src/Codeception/Module/Yii1.php
+++ b/src/Codeception/Module/Yii1.php
@@ -2,6 +2,7 @@
 namespace Codeception\Module;
 
 use Codeception\Lib\Framework;
+use Codeception\Lib\Interfaces\SupportsDomainRouting;
 use Codeception\Exception\ModuleConfigException;
 use Codeception\TestCase;
 use Codeception\Lib\Connector\Yii1 as Yii1Connector;

--- a/src/Codeception/Module/Yii2.php
+++ b/src/Codeception/Module/Yii2.php
@@ -7,6 +7,7 @@ use Codeception\Configuration;
 use Codeception\TestCase;
 use Codeception\Lib\Interfaces\ActiveRecord;
 use Codeception\Lib\Interfaces\PartedModule;
+use Codeception\Lib\Interfaces\SupportsDomainRouting;
 use Codeception\Lib\Connector\Yii2 as Yii2Connector;
 use yii\db\ActiveRecordInterface;
 use Yii;

--- a/src/Codeception/Module/Yii2.php
+++ b/src/Codeception/Module/Yii2.php
@@ -41,7 +41,7 @@ use Yii;
  * Stability: **stable**
  *
  */
-class Yii2 extends Framework implements ActiveRecord, PartedModule
+class Yii2 extends Framework implements ActiveRecord, PartedModule, SupportsDomainRouting
 {
     /**
      * Application config file must be set.


### PR DESCRIPTION
I made a blunder in a previous pull request #2371 