### PR TITLE
humanize WebDriverBy step arguments

### DIFF
--- a/src/Codeception/Step.php
+++ b/src/Codeception/Step.php
@@ -3,6 +3,7 @@ namespace Codeception;
 
 use Codeception\Lib\ModuleContainer;
 use Codeception\Step\Meta;
+use Codeception\Util\Locator;
 
 abstract class Step
 {
@@ -106,8 +107,13 @@ abstract class Step
 
     protected function parseArgumentAsString($argument)
     {
-        if (is_object($argument) && method_exists($argument, '__toString')) {
-            return (string)$argument;
+        if (is_object($argument)) {
+            if (method_exists($argument, '__toString')) {
+                return (string)$argument;
+            }
+            if (get_class($argument) == 'Facebook\WebDriver\WebDriverBy') {
+                return Locator::humanReadableString($argument);
+            }
         }
         if (is_callable($argument, true)) {
             return 'lambda function';

--- a/tests/unit/Codeception/StepTest.php
+++ b/tests/unit/Codeception/StepTest.php
@@ -1,0 +1,14 @@
+<?php
+
+use Facebook\WebDriver\WebDriverBy;
+use Codeception\Util\Locator;
+
+class StepTest extends \PHPUnit_Framework_TestCase
+{
+    public function testGetArguments()
+    {
+        $by = WebDriverBy::cssSelector('.something');
+        $step = $this->getMockBuilder('\Codeception\Step')->setConstructorArgs([null, [$by]])->setMethods(null)->getMock();
+        $this->assertEquals('"' . Locator::humanReadableString($by) . '"', $step->getArguments(true));
+    }
+}


### PR DESCRIPTION
Although WebDriverBy are acceptable arguments to many of the WebDriver module steps taken by the AcceptanceTester, the arguments are not very human-readable when output during test execution:

* I click "Facebook\WebDriver\WebDriverBy"
* I click "Facebook\WebDriver\WebDriverBy"

This change uses the Locator util to humanize the arguments, making them more readable:

* I click "css selector '.something'"

A unit test (StepTest::testGetArguments()) asserting correctness is also included.
 