### PR TITLE
Save the search path when importing Postgres dumps

### DIFF
--- a/src/Codeception/Lib/Driver/PostgreSql.php
+++ b/src/Codeception/Lib/Driver/PostgreSql.php
@@ -9,6 +9,8 @@ class PostgreSql extends Db
 
     protected $connection = null;
 
+    protected $searchPath = null;
+
     public function load($sql)
     {
         $query = '';
@@ -33,6 +35,10 @@ class PostgreSql extends Db
                 if (($pos !== false) && ($pos >= 0)) {
                     $dollarsOpen = !$dollarsOpen;
                 }
+            }
+
+            if (preg_match('/SET search_path = .*/i', $sqlLine, $match)) {
+                $this->searchPath = $match[0];
             }
 
             $query .= "\n" . rtrim($sqlLine);
@@ -97,6 +103,11 @@ class PostgreSql extends Db
             $constring .= ' user=' . $this->user;
             $constring .= ' password=' . $this->password;
             $this->connection = pg_connect($constring);
+
+            if ($this->searchPath !== null) {
+                pg_query($this->connection, $this->searchPath);
+            }
+
             pg_query($this->connection, $query);
             $this->putline = true;
         } else {

--- a/tests/data/dumps/postgres.sql
+++ b/tests/data/dumps/postgres.sql
@@ -2,8 +2,6 @@
 -- PostgreSQL database dump
 --
 
--- Started on 2012-02-03 00:00:32
-
 SET statement_timeout = 0;
 SET client_encoding = 'UTF8';
 SET standard_conforming_strings = off;
@@ -11,11 +9,51 @@ SET check_function_bodies = false;
 SET client_min_messages = warning;
 SET escape_string_warning = off;
 
-SET search_path = public, pg_catalog;
+--
+-- Name: anotherschema; Type: SCHEMA; Schema: -; Owner: -
+--
+
+DROP SCHEMA IF EXISTS anotherschema CASCADE;
+CREATE SCHEMA anotherschema;
+
+SET search_path = anotherschema, pg_catalog;
 
 SET default_tablespace = '';
 
 SET default_with_oids = false;
+
+--
+-- Name: users; Type: TABLE; Schema: anotherschema; Owner: -; Tablespace:
+--
+DROP TABLE IF EXISTS users CASCADE;
+CREATE TABLE users (
+    name character varying(30),
+    email character varying(50),
+    created_at timestamp without time zone DEFAULT now(),
+    id integer NOT NULL
+);
+
+
+--
+-- Name: users_id_seq; Type: SEQUENCE; Schema: anotherschema; Owner: -
+--
+
+CREATE SEQUENCE users_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: users_id_seq; Type: SEQUENCE OWNED BY; Schema: anotherschema; Owner: -
+--
+
+ALTER SEQUENCE users_id_seq OWNED BY users.id;
+
+SET search_path = public, pg_catalog;
+
 
 --
 -- Name: empty_table; Type: TABLE; Schema: public; Owner: -; Tablespace:
@@ -142,6 +180,17 @@ CREATE SEQUENCE users_id_seq
 ALTER SEQUENCE users_id_seq OWNED BY users.id;
 
 
+SET search_path = anotherschema, pg_catalog;
+
+--
+-- Name: id; Type: DEFAULT; Schema: anotherschema; Owner: -
+--
+
+ALTER TABLE ONLY users ALTER COLUMN id SET DEFAULT nextval('users_id_seq'::regclass);
+
+
+SET search_path = public, pg_catalog;
+
 --
 -- Name: id; Type: DEFAULT; Schema: public; Owner: -
 --
@@ -169,6 +218,25 @@ ALTER TABLE ONLY permissions ALTER COLUMN id SET DEFAULT nextval('permissions_id
 
 ALTER TABLE ONLY users ALTER COLUMN id SET DEFAULT nextval('users_id_seq'::regclass);
 
+
+SET search_path = anotherschema, pg_catalog;
+
+--
+-- Data for Name: users; Type: TABLE DATA; Schema: anotherschema; Owner: -
+--
+
+COPY users (name, email, created_at, id) FROM stdin;
+andrew	schemauser@example.org	2015-10-13 07:26:51.398693	1
+\.
+
+--
+-- Name: users_id_seq; Type: SEQUENCE SET; Schema: anotherschema; Owner: -
+--
+
+SELECT pg_catalog.setval('users_id_seq', 1, true);
+
+
+SET search_path = public, pg_catalog;
 
 --
 -- Data for Name: empty_table; Type: TABLE DATA; Schema: public; Owner: -
@@ -239,6 +307,18 @@ bird	charlie@parker.com	2012-02-02 22:32:13.107	4
 
 SELECT pg_catalog.setval('users_id_seq', 4, true);
 
+
+SET search_path = anotherschema, pg_catalog;
+
+--
+-- Name: u1; Type: CONSTRAINT; Schema: anotherschema; Owner: -; Tablespace:
+--
+
+ALTER TABLE ONLY users
+    ADD CONSTRAINT u1 PRIMARY KEY (id);
+
+
+SET search_path = public, pg_catalog;
 
 --
 -- Name: g1; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace:

--- a/tests/unit/Codeception/Lib/Driver/PostgresTest.php
+++ b/tests/unit/Codeception/Lib/Driver/PostgresTest.php
@@ -72,6 +72,9 @@ class PostgresTest extends \PHPUnit_Framework_TestCase
         $res = $this->postgres->getDbh()->query("select * from users where email = 'user2@example.org'");
         $this->assertNotEquals(false, $res);
         $this->assertGreaterThan(0, $res->rowCount());
+
+        $res = $this->postgres->getDbh()->query("select * from anotherschema.users where email = 'schemauser@example.org'");
+        $this->assertEquals(1, $res->rowCount());
     }
 
     public function testSelectWithEmptyCriteria()


### PR DESCRIPTION
Currently the search path isn't saved when importing a PostgreSQL dump
which causes problems when trying to fill a database table using `COPY`.
If the search_path isn't reset for the new connection then the import
will try to `COPY` the data into the default schema (usually `public`)
and cause the import to fail with
`pg_query(): Query failed: ERROR:  relation "..." does not exist`

I would consider this a bug fix since my imports are currently failing
without the patch, but it could change some behaviour for badly created
database dumps that always assume the search path for `COPY`s
will be set to the `public` schema. If you'd prefer I could change the
base for the merge to be `master` and not the `2.1` branch.