### PR TITLE
Reset leaves previous file uploads in UploadedFile

### DIFF
--- a/src/Codeception/Module/Yii2.php
+++ b/src/Codeception/Module/Yii2.php
@@ -93,6 +93,8 @@ class Yii2 extends Framework implements ActiveRecord, PartedModule, SupportsDoma
         if ($this->transaction && $this->config['cleanup']) {
             $this->transaction->rollback();
         }
+        
+        \yii\web\UploadedFile::reset();
 
         if (Yii::$app) {
             Yii::$app->session->destroy();


### PR DESCRIPTION
If `$_FILES` is emptied, `\yii\web\UploadedFile::reset()` must be also called. It has a static property `$_files` that keeps previous upload even if `$_FILES` is reset.