### PR TITLE
Fix a root cause hiding error when Symfony2 is configured wrong

### DIFF
--- a/src/Codeception/Module/Symfony2.php
+++ b/src/Codeception/Module/Symfony2.php
@@ -109,7 +109,11 @@ class Symfony2 extends Framework implements DoctrineProvider, SupportsDomainRout
         }
         require_once $cache;
         $this->kernelClass = $this->getKernelClass();
-        ini_set('xdebug.max_nesting_level', 200); // Symfony may have very long nesting level
+        $maxNestingLevel = 200; // Symfony may have very long nesting level
+        $xdebugMaxLevelKey = 'xdebug.max_nesting_level';
+        if (ini_get($xdebugMaxLevelKey) < $maxNestingLevel) {
+            ini_set($xdebugMaxLevelKey, $maxNestingLevel);
+        }
     }
 
     public function _before(\Codeception\TestCase $test) 


### PR DESCRIPTION
@todo Should leave it up to the user to update the php.ini instead of
setting it in code. This overwrote my correct settings.

This ini change caused an error when I used Codeception/Specify library.