### PR TITLE
seeInSource method for InnerBrowser/WebDriver

### DIFF
--- a/src/Codeception/Lib/InnerBrowser.php
+++ b/src/Codeception/Lib/InnerBrowser.php
@@ -292,6 +292,16 @@ class InnerBrowser extends Module implements Web, PageSourceSaver, ElementLocato
         }
     }
 
+    public function seeInSource($raw)
+    {
+        $this->assertPageSourceContains($raw);
+    }
+
+    public function dontSeeInSource($raw)
+    {
+        $this->assertPageSourceNotContains($raw);
+    }
+
     public function seeLink($text, $url = null)
     {
         $links = $this->getCrawler()->selectLink($text);
@@ -1265,6 +1275,26 @@ class InnerBrowser extends Module implements Web, PageSourceSaver, ElementLocato
         $constraint = new PageConstraint($needle, $this->_getCurrentUri());
         $this->assertThatItsNot(
             html_entity_decode(strip_tags($this->getRunningClient()->getInternalResponse()->getContent()), ENT_QUOTES),
+            $constraint,
+            $message
+        );
+    }
+
+    protected function assertPageSourceContains($needle, $message = '')
+    {
+        $constraint = new PageConstraint($needle, $this->_getCurrentUri());
+        $this->assertThat(
+            $this->getRunningClient()->getInternalResponse()->getContent(),
+            $constraint,
+            $message
+        );
+    }
+
+    protected function assertPageSourceNotContains($needle, $message = '')
+    {
+        $constraint = new PageConstraint($needle, $this->_getCurrentUri());
+        $this->assertThatItsNot(
+            $this->getRunningClient()->getInternalResponse()->getContent(),
             $constraint,
             $message
         );

--- a/src/Codeception/Lib/Interfaces/Web.php
+++ b/src/Codeception/Lib/Interfaces/Web.php
@@ -52,6 +52,34 @@ interface Web
      * @param null $selector
      */
     public function dontSee($text, $selector = null);
+    
+    /**
+     * Checks that the current page contains the given string in its
+     * raw source code.
+     *
+     * ``` php
+     * <?php
+     * $I->seeInSource('<h1>Green eggs &amp; ham</h1>');
+     * ?>
+     * ```
+     *
+     * @param      $raw
+     */
+    public function seeInSource($raw);
+
+    /**
+     * Checks that the current page contains the given string in its
+     * raw source code.
+     *
+     * ```php
+     * <?php
+     * $I->dontSeeInSource('<h1>Green eggs &amp; ham</h1>');
+     * ?>
+     * ```
+     *
+     * @param      $raw
+     */
+    public function dontSeeInSource($raw);
 
     /**
      * Submits the given form on the page, optionally with the given form

--- a/src/Codeception/Module/WebDriver.php
+++ b/src/Codeception/Module/WebDriver.php
@@ -476,6 +476,16 @@ class WebDriver extends CodeceptionModule implements
         $this->assertNodesNotContain($text, $nodes, $selector);
     }
 
+    public function seeInSource($raw)
+    {
+        $this->assertPageSourceContains($raw);
+    }
+
+    public function dontSeeInSource($raw)
+    {
+        $this->assertPageSourceNotContains($raw);
+    }
+
     /**
      * Checks that the page source contains the given string.
      *
@@ -2052,6 +2062,24 @@ class WebDriver extends CodeceptionModule implements
     {
         $this->assertThatItsNot(
             htmlspecialchars_decode($this->getVisibleText()),
+            new PageConstraint($needle, $this->_getCurrentUri()),
+            $message
+        );
+    }
+
+    protected function assertPageSourceContains($needle, $message = '')
+    {
+        $this->assertThat(
+            $this->webDriver->getPageSource(),
+            new PageConstraint($needle, $this->_getCurrentUri()),
+            $message
+        );
+    }
+
+    protected function assertPageSourceNotContains($needle, $message = '')
+    {
+        $this->assertThatItsNot(
+            $this->webDriver->getPageSource(),
             new PageConstraint($needle, $this->_getCurrentUri()),
             $message
         );

--- a/tests/unit/Codeception/Module/TestsForWeb.php
+++ b/tests/unit/Codeception/Module/TestsForWeb.php
@@ -61,6 +61,14 @@ abstract class TestsForWeb extends \PHPUnit_Framework_TestCase
         $this->module->dontSee('Welcome','h6');
     }
 
+    public function testSeeInSource()
+    {
+        $this->module->amOnPage('/');
+        $this->module->seeInSource('<h1>Welcome to test app!</h1>');
+        $this->module->seeInSource('A wise man said: "debug!"');
+        $this->module->dontSeeInSource('John Cleese');
+    }
+
     public function testSeeInCurrentUrl()
     {
         $this->module->amOnPage('/info');


### PR DESCRIPTION
Checks the raw response rather than the tag stripped/html decoded
result.