### PR TITLE
Print Selenium logs on failure

### DIFF
--- a/src/Codeception/Module/WebDriver.php
+++ b/src/Codeception/Module/WebDriver.php
@@ -24,6 +24,7 @@ use Codeception\Util\Locator;
 use Codeception\Util\Uri;
 use Facebook\WebDriver\Exception\InvalidSelectorException;
 use Facebook\WebDriver\Exception\NoSuchElementException;
+use Facebook\WebDriver\Exception\UnknownServerException;
 use Facebook\WebDriver\Exception\WebDriverCurlException;
 use Facebook\WebDriver\Interactions\WebDriverActions;
 use Facebook\WebDriver\Remote\LocalFileDetector;
@@ -263,11 +264,16 @@ class WebDriver extends CodeceptionModule implements
         $this->_savePageSource(codecept_output_dir() . $filename . '.html');
         $this->debug("Screenshot and page source were saved into '_output' dir");
 
-        // Dump out all available Selenium logs
-        foreach ($this->webDriver->manage()->getAvailableLogTypes() as $logType)
-        {
-           $logEntries = $this->webDriver->manage()->getLog($logType);
-           $this->debugSection("Selenium {$logType} logs", $this->formatLogEntries($logEntries));
+        try {
+           // Dump out all available Selenium logs
+           foreach ($this->webDriver->manage()->getAvailableLogTypes() as $logType) {
+              $logEntries = $this->webDriver->manage()->getLog($logType);
+              $this->debugSection("Selenium {$logType} logs", $this->formatLogEntries($logEntries));
+           }
+        } catch (UnknownServerException $e) {
+           // This only happens with the IE driver, which doesn't support retrieving logs yet:
+           // https://github.com/SeleniumHQ/selenium/issues/468
+           $this->debug("Unable to retrieve Selenium logs");
         }
     }
 

--- a/src/Codeception/Module/WebDriver.php
+++ b/src/Codeception/Module/WebDriver.php
@@ -262,6 +262,34 @@ class WebDriver extends CodeceptionModule implements
         $this->_saveScreenshot(codecept_output_dir() . $filename . '.png');
         $this->_savePageSource(codecept_output_dir() . $filename . '.html');
         $this->debug("Screenshot and page source were saved into '_output' dir");
+
+        // Dump out all available Selenium logs
+        foreach ($this->webDriver->manage()->getAvailableLogTypes() as $logType)
+        {
+           $logEntries = $this->webDriver->manage()->getLog($logType);
+           $this->debugSection("Selenium {$logType} logs", $this->formatLogEntries($logEntries));
+        }
+    }
+
+    /**
+     * Turns an array of log entries into a human-readable string.
+     * Each log entry is an array with the keys "timestamp", "level", and "message".
+     * See https://code.google.com/p/selenium/wiki/JsonWireProtocol#Log_Entry_JSON_Object
+     *
+     * @param array $logEntries
+     * @return string
+     */
+    protected function formatLogEntries(array $logEntries)
+    {
+       $formattedLogs = '';
+       foreach ($logEntries as $logEntry) {
+          // Timestamp is in milliseconds, but date() requires seconds. 
+          $time = date('H:i:s', $logEntry['timestamp'] / 1000) . 
+             // Append the milliseconds to the end of the time string
+             '.' . ($logEntry['timestamp'] % 1000);
+          $formattedLogs .= "{$time} {$logEntry['level']} - {$logEntry['message']}\n";
+       }
+       return $formattedLogs;
     }
 
     public function _afterSuite()

--- a/tests/unit/Codeception/Module/WebDriverTest.php
+++ b/tests/unit/Codeception/Module/WebDriverTest.php
@@ -419,8 +419,11 @@ class WebDriverTest extends TestsForBrowsers
     public function testCreateCeptScreenshotFail()
     {
         $fakeWd = Stub::make('\Facebook\WebDriver\Remote\RemoteWebDriver', [
-                'takeScreenshot' => Stub::once(function() {}),
-                'getPageSource' => Stub::once(function() {})
+            'takeScreenshot' => Stub::once(function() {}),
+            'getPageSource' => Stub::once(function() {}),
+            'manage' => Stub::make('\Facebook\WebDriver\WebDriverOptions', [
+                'getAvailableLogTypes' => Stub::atLeastOnce(function() { return []; }),
+            ]),
         ]);
         $this->module->webDriver = $fakeWd;
         $cept = (new \Codeception\TestCase\Cept())->configName('loginCept.php');
@@ -433,7 +436,10 @@ class WebDriverTest extends TestsForBrowsers
             'takeScreenshot' => Stub::once(function($filename) {
                 PHPUnit_Framework_Assert::assertEquals(codecept_log_dir('stdClass.login.fail.png'), $filename);
             }),
-            'getPageSource' => Stub::once(function() {})
+            'getPageSource' => Stub::once(function() {}),
+            'manage' => Stub::make('\Facebook\WebDriver\WebDriverOptions', [
+                'getAvailableLogTypes' => Stub::atLeastOnce(function() { return []; }),
+            ]),
         ]);
         $this->module->webDriver = $fakeWd;
         $cest = (new \Codeception\TestCase\Cest())
@@ -449,7 +455,10 @@ class WebDriverTest extends TestsForBrowsers
             'takeScreenshot' => Stub::once(function($filename) use ($test) {
                 PHPUnit_Framework_Assert::assertEquals(codecept_log_dir(get_class($test).'.testLogin.fail.png'), $filename);
             }),
-            'getPageSource' => Stub::once(function() {})
+            'getPageSource' => Stub::once(function() {}),
+            'manage' => Stub::make('\Facebook\WebDriver\WebDriverOptions', [
+                'getAvailableLogTypes' => Stub::atLeastOnce(function() { return []; }),
+            ]),
         ]);
         $this->module->webDriver = $fakeWd;
         $this->module->_failed($test, new PHPUnit_Framework_AssertionFailedError());


### PR DESCRIPTION
WebDriver provides access to the logs for both the client and server, which are sometimes necessary
to debug test failures. This commit modifies Codeception\Module\WebDriver->_failed() to grab all
available logs and print them in human-readable format. The format is identical to what Selenium
Server uses for displaying logs in the console.