### PR TITLE
Add support for nested helpers

### DIFF
--- a/src/Codeception/Command/GenerateHelper.php
+++ b/src/Codeception/Command/GenerateHelper.php
@@ -13,6 +13,7 @@ use Symfony\Component\Console\Output\OutputInterface;
  * Creates empty Helper class.
  *
  * * `codecept g:helper MyHelper`
+ * * `codecept g:helper "My\Helper"`
  *
  */
 class GenerateHelper extends Command
@@ -23,7 +24,7 @@ class GenerateHelper extends Command
     protected function configure()
     {
         $this->setDefinition([
-            new InputArgument('name', InputArgument::REQUIRED, 'suite to be generated'),
+            new InputArgument('name', InputArgument::REQUIRED, 'helper name'),
             new InputOption('config', 'c', InputOption::VALUE_OPTIONAL, 'Use custom path for config'),
         ]);
     }
@@ -48,6 +49,4 @@ class GenerateHelper extends Command
             $output->writeln("<error>Error creating helper $filename</error>");
         }
     }
-
-
 }

--- a/src/Codeception/Lib/Generator/Helper.php
+++ b/src/Codeception/Lib/Generator/Helper.php
@@ -1,14 +1,16 @@
 <?php
 namespace Codeception\Lib\Generator;
 
+use Codeception\Util\Shared\Namespaces;
 use Codeception\Util\Template;
 
 class Helper
 {
+    use Namespaces;
 
     protected $template = <<<EOF
 <?php
-namespace {{namespace}}Helper;
+{{namespace}}
 // here you can define custom actions
 // all public methods declared in helper class will be available in \$I
 
@@ -24,15 +26,15 @@ EOF;
 
     public function __construct($name, $namespace = '')
     {
-        $this->namespace = $namespace ? "$namespace\\" : $namespace;
+        $this->namespace = $namespace;
         $this->name = $name;
     }
 
     public function produce()
     {
         return (new Template($this->template))
-            ->place('namespace', $this->namespace)
-            ->place('name', $this->name)
+            ->place('namespace', $this->getNamespaceHeader($this->namespace . '\\Helper\\' . $this->name))
+            ->place('name', $this->getShortClassName($this->name))
             ->produce();
     }
 


### PR DESCRIPTION
My team uses nested helpers. What running `codecept g:helper "A\B"` creates is tests/_support/Helper/A/B.php with the following content

```php
<?php
namespace Helper;
// here you can define custom actions
// all public methods declared in helper class will be available in $I

class A\B extends \Codeception\Module
{

}
```
It would be good if it could read like this instead,

```php
<?php
namespace Helper\A;
// here you can define custom actions
// all public methods declared in helper class will be available in $I

class B extends \Codeception\Module
{

}
```