### PR TITLE
Move kernel booting and container set up into _initialize() method

### DIFF
--- a/src/Codeception/Module/Symfony2.php
+++ b/src/Codeception/Module/Symfony2.php
@@ -114,12 +114,13 @@ class Symfony2 extends Framework implements DoctrineProvider, SupportsDomainRout
         if (ini_get($xdebugMaxLevelKey) < $maxNestingLevel) {
             ini_set($xdebugMaxLevelKey, $maxNestingLevel);
         }
-    }
 
-    public function _before(\Codeception\TestCase $test) 
-    {
         $this->bootKernel();
         $this->container = $this->kernel->getContainer();
+    }
+
+    public function _before(\Codeception\TestCase $test)
+    {
         $this->client = new Symfony2Connector($this->kernel);
         $this->client->followRedirects(true);
     }


### PR DESCRIPTION
I faced a situation when I needed to load and use some of my Symfony2 project's services in _beforeSuite() to prepare some needed data, obviously, before suit is running. I couldn't do that because current implementation loads kernel and set up container only before a test (in the _beforeTest() method).
I also created an issue about that (according to https://github.com/Codeception/Codeception/wiki/Git-workflow-for-Codeception-contributors) - https://github.com/Codeception/Codeception/issues/2490
Tests passed with my changes.