### PR TITLE
BugFix: string|null as well as null|string can be used to specify the value type

### DIFF
--- a/src/Codeception/Util/JsonType.php
+++ b/src/Codeception/Util/JsonType.php
@@ -119,16 +119,16 @@ class JsonType
             }
             $matchTypes = explode('|', $type);
             $matched = false;
+            $currentType = strtolower(gettype($data[$key]));
+            if ($currentType == 'double') {
+                $currentType = 'float';
+            }
             foreach ($matchTypes as $matchType) {
-                $currentType = strtolower(gettype($data[$key]));
-                if ($currentType == 'double') {
-                    $currentType = 'float';
-                }
                 $filters = explode(':', $matchType);
                 $expectedType = trim(strtolower(array_shift($filters)));
 
                 if ($expectedType != $currentType) {
-                    break;
+                    continue;
                 }
                 if (empty($filters)) {
                     $matched = true;

--- a/tests/unit/Codeception/Util/JsonTypeTest.php
+++ b/tests/unit/Codeception/Util/JsonTypeTest.php
@@ -7,14 +7,16 @@ class JsonTypeTest extends \Codeception\TestCase\Test
         'id' => 'integer:>10',
         'retweeted' => 'Boolean',
         'in_reply_to_screen_name' => 'null|string',
+        'name' => 'string|null', // http://codeception.com/docs/modules/REST#seeResponseMatchesJsonType
         'user' => [
-          'url' => 'String:url'
+            'url' => 'String:url'
         ]
     ];
     protected $data = [
         'id' => 11,
         'retweeted' => false,
         'in_reply_to_screen_name' => null,
+        'name' => null,
         'user' => ['url' => 'http://davert.com']
     ];
 


### PR DESCRIPTION
BugFix: In \Codeception\Module\REST::seeResponseMatchesJsonType now can be used 'string|null' as well as 'null|string' to specify the type