### PR TITLE
REST methods can be used to inspect responses of other modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,9 @@
 
 #### 2.1.4
 
-* [PhpBrowser][Frameworks] Added moveBack method. By @Naktibalda
+* [REST] REST methods can be used to inspect result of the last request made by PhpBrowser or framework module. see #2507. By @Naktibalda
+* [PhpBrowser][Frameworks] Added `_getResponseContent` hidden method. By @Naktibalda
+* [PhpBrowser][Frameworks] Added `moveBack` method. By @Naktibalda
 * [Laravel5] Fixed fatal error in `seeCurrentRouteIs` and `seeCurrentActionIs` methods. See #2517. By @janhenkgerritsen
 * [Laravel5] Improved the error messages for several methods. See #2476. By @janhenkgerritsen
 * [Laravel5] Improved form error methods. See #2432. By @janhenkgerritsen

--- a/src/Codeception/Lib/InnerBrowser.php
+++ b/src/Codeception/Lib/InnerBrowser.php
@@ -105,10 +105,16 @@ class InnerBrowser extends Module implements Web, PageSourceSaver, ElementLocato
     public function _request($method, $uri, array $parameters = [],  array $files = [], array $server = [], $content = null)
     {
         $this->clientRequest($method, $uri, $parameters, $files, $server, $content, false);
-        return $this->_getLastResponse();
+        return $this->_getResponseContent();
     }
 
-    public function _getLastResponse()
+    /**
+     * Returns content of the last response
+     * 
+     * @return string
+     * @throws ModuleException
+     */
+    public function _getResponseContent()
     {
         return $this->getRunningClient()->getInternalResponse()->getContent();
     }
@@ -187,7 +193,7 @@ class InnerBrowser extends Module implements Web, PageSourceSaver, ElementLocato
 
     public function _savePageSource($filename)
     {
-        file_put_contents($filename, $this->_getLastResponse());
+        file_put_contents($filename, $this->_getResponseContent());
     }
 
     /**
@@ -1269,7 +1275,7 @@ class InnerBrowser extends Module implements Web, PageSourceSaver, ElementLocato
     {
         $constraint = new PageConstraint($needle, $this->_getCurrentUri());
         $this->assertThat(
-            html_entity_decode(strip_tags($this->_getLastResponse()), ENT_QUOTES),
+            html_entity_decode(strip_tags($this->_getResponseContent()), ENT_QUOTES),
             $constraint,
             $message
         );
@@ -1279,7 +1285,7 @@ class InnerBrowser extends Module implements Web, PageSourceSaver, ElementLocato
     {
         $constraint = new PageConstraint($needle, $this->_getCurrentUri());
         $this->assertThatItsNot(
-            html_entity_decode(strip_tags($this->_getLastResponse()), ENT_QUOTES),
+            html_entity_decode(strip_tags($this->_getResponseContent()), ENT_QUOTES),
             $constraint,
             $message
         );
@@ -1289,7 +1295,7 @@ class InnerBrowser extends Module implements Web, PageSourceSaver, ElementLocato
     {
         $constraint = new PageConstraint($needle, $this->_getCurrentUri());
         $this->assertThat(
-            $this->_getLastResponse(),
+            $this->_getResponseContent(),
             $constraint,
             $message
         );
@@ -1299,7 +1305,7 @@ class InnerBrowser extends Module implements Web, PageSourceSaver, ElementLocato
     {
         $constraint = new PageConstraint($needle, $this->_getCurrentUri());
         $this->assertThatItsNot(
-            $this->_getLastResponse(),
+            $this->_getResponseContent(),
             $constraint,
             $message
         );

--- a/src/Codeception/Lib/InnerBrowser.php
+++ b/src/Codeception/Lib/InnerBrowser.php
@@ -174,7 +174,7 @@ class InnerBrowser extends Module implements Web, PageSourceSaver, ElementLocato
 
     private function getRunningClient()
     {
-        if ($this->client->getHistory()->isEmpty()) {
+        if ($this->client->getInternalRequest() === null) {
             throw new ModuleException($this, "Page not loaded. Use `\$I->amOnPage` (or hidden API methods `_request` and `_loadPage`) to open it");
         }
         return $this->client;

--- a/src/Codeception/Lib/InnerBrowser.php
+++ b/src/Codeception/Lib/InnerBrowser.php
@@ -116,7 +116,7 @@ class InnerBrowser extends Module implements Web, PageSourceSaver, ElementLocato
      */
     public function _getResponseContent()
     {
-        return $this->getRunningClient()->getInternalResponse()->getContent();
+        return (string)$this->getRunningClient()->getInternalResponse()->getContent();
     }
 
     protected function clientRequest($method, $uri, array $parameters = [],  array $files = [], array $server = [], $content = null, $changeHistory = true)

--- a/src/Codeception/Lib/InnerBrowser.php
+++ b/src/Codeception/Lib/InnerBrowser.php
@@ -105,6 +105,11 @@ class InnerBrowser extends Module implements Web, PageSourceSaver, ElementLocato
     public function _request($method, $uri, array $parameters = [],  array $files = [], array $server = [], $content = null)
     {
         $this->clientRequest($method, $uri, $parameters, $files, $server, $content, false);
+        return $this->_getLastResponse();
+    }
+
+    public function _getLastResponse()
+    {
         return $this->getRunningClient()->getInternalResponse()->getContent();
     }
 
@@ -182,7 +187,7 @@ class InnerBrowser extends Module implements Web, PageSourceSaver, ElementLocato
 
     public function _savePageSource($filename)
     {
-        file_put_contents($filename, $this->getRunningClient()->getInternalResponse()->getContent());
+        file_put_contents($filename, $this->_getLastResponse());
     }
 
     /**
@@ -1264,7 +1269,7 @@ class InnerBrowser extends Module implements Web, PageSourceSaver, ElementLocato
     {
         $constraint = new PageConstraint($needle, $this->_getCurrentUri());
         $this->assertThat(
-            html_entity_decode(strip_tags($this->getRunningClient()->getInternalResponse()->getContent()), ENT_QUOTES),
+            html_entity_decode(strip_tags($this->_getLastResponse()), ENT_QUOTES),
             $constraint,
             $message
         );
@@ -1274,7 +1279,7 @@ class InnerBrowser extends Module implements Web, PageSourceSaver, ElementLocato
     {
         $constraint = new PageConstraint($needle, $this->_getCurrentUri());
         $this->assertThatItsNot(
-            html_entity_decode(strip_tags($this->getRunningClient()->getInternalResponse()->getContent()), ENT_QUOTES),
+            html_entity_decode(strip_tags($this->_getLastResponse()), ENT_QUOTES),
             $constraint,
             $message
         );
@@ -1284,7 +1289,7 @@ class InnerBrowser extends Module implements Web, PageSourceSaver, ElementLocato
     {
         $constraint = new PageConstraint($needle, $this->_getCurrentUri());
         $this->assertThat(
-            $this->getRunningClient()->getInternalResponse()->getContent(),
+            $this->_getLastResponse(),
             $constraint,
             $message
         );
@@ -1294,7 +1299,7 @@ class InnerBrowser extends Module implements Web, PageSourceSaver, ElementLocato
     {
         $constraint = new PageConstraint($needle, $this->_getCurrentUri());
         $this->assertThatItsNot(
-            $this->getRunningClient()->getInternalResponse()->getContent(),
+            $this->_getLastResponse(),
             $constraint,
             $message
         );

--- a/src/Codeception/Lib/InnerBrowser.php
+++ b/src/Codeception/Lib/InnerBrowser.php
@@ -110,7 +110,19 @@ class InnerBrowser extends Module implements Web, PageSourceSaver, ElementLocato
 
     /**
      * Returns content of the last response
-     * 
+     * Use it in Helpers when you want to retrieve response of request performed by another module.
+     *
+     * ```php
+     * <?php
+     * // in Helper class
+     * public function seeResponseContains($text)
+     * {
+     *    $this->assertContains($text, $this->getModule('{{MODULE_NAME}}')->_getResponseContent(), "response contains");
+     * }
+     * ?>
+     * ```
+     *
+     * @api
      * @return string
      * @throws ModuleException
      */

--- a/src/Codeception/Module/REST.php
+++ b/src/Codeception/Module/REST.php
@@ -81,6 +81,10 @@ EOF;
      */
     public $client = null;
     public $isFunctional = false;
+
+    /**
+     * @var InnerBrowser
+     */
     protected $connectionModule;
 
     public $headers = [];
@@ -137,7 +141,7 @@ EOF;
 
     private function getRunningClient()
     {
-        if ($this->client->getHistory()->isEmpty()) {
+        if ($this->client->getInternalRequest() === null) {
             throw new ModuleException($this, "Response is empty. Use `\$I->sendXXX()` methods to send HTTP request");
         }
         return $this->client;

--- a/src/Codeception/Module/REST.php
+++ b/src/Codeception/Module/REST.php
@@ -483,7 +483,7 @@ EOF;
             $this->debugSection("Request", "$method $url " . $parameters);
             $this->client->request($method, $url, [], $files, [], $parameters);
         }
-        $this->response = (string)$this->connectionModule->_getLastResponse();
+        $this->response = (string)$this->connectionModule->_getResponseContent();
         $this->debugSection("Response", $this->response);
 
         if (count($this->client->getInternalRequest()->getCookies())) {
@@ -519,7 +519,7 @@ EOF;
      */
     public function seeResponseIsJson()
     {
-        json_decode($this->connectionModule->_getLastResponse());
+        json_decode($this->connectionModule->_getResponseContent());
         $errorCode = json_last_error();
         \PHPUnit_Framework_Assert::assertEquals(
             JSON_ERROR_NONE,
@@ -537,7 +537,7 @@ EOF;
      */
     public function seeResponseContains($text)
     {
-        $this->assertContains($text, $this->connectionModule->_getLastResponse(), "REST response contains");
+        $this->assertContains($text, $this->connectionModule->_getResponseContent(), "REST response contains");
     }
 
     /**
@@ -549,7 +549,7 @@ EOF;
      */
     public function dontSeeResponseContains($text)
     {
-        $this->assertNotContains($text, $this->connectionModule->_getLastResponse(), "REST response contains");
+        $this->assertNotContains($text, $this->connectionModule->_getResponseContent(), "REST response contains");
     }
 
     /**
@@ -578,7 +578,7 @@ EOF;
      */
     public function seeResponseContainsJson($json = [])
     {
-        $jsonResponseArray = new JsonArray($this->connectionModule->_getLastResponse());
+        $jsonResponseArray = new JsonArray($this->connectionModule->_getResponseContent());
         \PHPUnit_Framework_Assert::assertTrue(
             $jsonResponseArray->containsArray($json),
             "Response JSON contains provided\n"
@@ -606,7 +606,7 @@ EOF;
      */
     public function grabResponse()
     {
-        return $this->connectionModule->_getLastResponse();
+        return $this->connectionModule->_getResponseContent();
     }
 
     /**
@@ -634,7 +634,7 @@ EOF;
      */
     public function grabDataFromResponseByJsonPath($jsonPath)
     {
-        return (new JsonArray($this->connectionModule->_getLastResponse()))->filterByJsonPath($jsonPath);
+        return (new JsonArray($this->connectionModule->_getResponseContent()))->filterByJsonPath($jsonPath);
     }
 
     /**
@@ -679,7 +679,7 @@ EOF;
      */
     public function seeResponseJsonMatchesXpath($xpath)
     {
-        $response = $this->connectionModule->_getLastResponse();
+        $response = $this->connectionModule->_getResponseContent();
         $this->assertGreaterThan(
             0, (new JsonArray($response))->filterByXPath($xpath)->length,
             "Received JSON did not match the XPath `$xpath`.\nJson Response: \n" . $response
@@ -731,7 +731,7 @@ EOF;
      */
     public function seeResponseJsonMatchesJsonPath($jsonPath)
     {
-        $response = $this->connectionModule->_getLastResponse();
+        $response = $this->connectionModule->_getResponseContent();
         $this->assertNotEmpty(
             (new JsonArray($response))->filterByJsonPath($jsonPath),
             "Received JSON did not match the JsonPath provided\n" . $response
@@ -746,7 +746,7 @@ EOF;
      */
     public function dontSeeResponseJsonMatchesJsonPath($jsonPath)
     {
-        $response = $this->connectionModule->_getLastResponse();
+        $response = $this->connectionModule->_getResponseContent();
         $this->assertEmpty(
             (new JsonArray($response))->filterByJsonPath($jsonPath),
             "Received JSON did (but should not) match the JsonPath provided\n" . $response
@@ -761,7 +761,7 @@ EOF;
      */
     public function dontSeeResponseContainsJson($json = [])
     {
-        $jsonResponseArray = new JsonArray($this->connectionModule->_getLastResponse());
+        $jsonResponseArray = new JsonArray($this->connectionModule->_getResponseContent());
         $this->assertFalse(
             $jsonResponseArray->containsArray($json),
             "Response JSON does not contain JSON provided\n"
@@ -849,7 +849,7 @@ EOF;
      */
     public function seeResponseMatchesJsonType(array $jsonType, $jsonPath = null)
     {
-        $jsonArray = new JsonArray($this->connectionModule->_getLastResponse());
+        $jsonArray = new JsonArray($this->connectionModule->_getResponseContent());
         if ($jsonPath) {
             $jsonArray = $jsonArray->filterByJsonPath($jsonPath);
         }
@@ -868,7 +868,7 @@ EOF;
      */
     public function dontSeeResponseMatchesJsonType($jsonType, $jsonPath = null)
     {
-        $jsonArray = new JsonArray($this->connectionModule->_getLastResponse());
+        $jsonArray = new JsonArray($this->connectionModule->_getResponseContent());
         if ($jsonPath) {
             $jsonArray = $jsonArray->filterByJsonPath($jsonPath);
         }
@@ -885,7 +885,7 @@ EOF;
      */
     public function seeResponseEquals($expected)
     {
-        $this->assertEquals($expected, $this->connectionModule->_getLastResponse());
+        $this->assertEquals($expected, $this->connectionModule->_getResponseContent());
     }
 
     /**
@@ -921,7 +921,7 @@ EOF;
     public function seeResponseIsXml()
     {
         libxml_use_internal_errors(true);
-        $doc = simplexml_load_string($this->connectionModule->_getLastResponse());
+        $doc = simplexml_load_string($this->connectionModule->_getResponseContent());
         $num = "";
         $title = "";
         if ($doc === false) {
@@ -950,7 +950,7 @@ EOF;
      */
     public function seeXmlResponseMatchesXpath($xpath)
     {
-        $structure = new XmlStructure($this->connectionModule->_getLastResponse());
+        $structure = new XmlStructure($this->connectionModule->_getResponseContent());
         $this->assertTrue($structure->matchesXpath($xpath), 'xpath not matched');
     }
 
@@ -966,7 +966,7 @@ EOF;
      */
     public function dontSeeXmlResponseMatchesXpath($xpath)
     {
-        $structure = new XmlStructure($this->connectionModule->_getLastResponse());
+        $structure = new XmlStructure($this->connectionModule->_getResponseContent());
         $this->assertTrue($structure->matchesXpath($xpath), 'accidentally matched xpath');
     }
 
@@ -980,7 +980,7 @@ EOF;
      */
     public function grabTextContentFromXmlElement($cssOrXPath)
     {
-        $el = (new XmlStructure($this->connectionModule->_getLastResponse()))->matchElement($cssOrXPath);
+        $el = (new XmlStructure($this->connectionModule->_getResponseContent()))->matchElement($cssOrXPath);
         return $el->textContent;
     }
 
@@ -995,7 +995,7 @@ EOF;
      */
     public function grabAttributeFrom($cssOrXPath, $attribute)
     {
-        $el = (new XmlStructure($this->connectionModule->_getLastResponse()))->matchElement($cssOrXPath);
+        $el = (new XmlStructure($this->connectionModule->_getResponseContent()))->matchElement($cssOrXPath);
         if (!$el->hasAttribute($attribute)) {
             $this->fail("Attribute not found in element matched by '$cssOrXPath'");
         }
@@ -1013,7 +1013,7 @@ EOF;
      */
     public function seeXmlResponseEquals($xml)
     {
-        \PHPUnit_Framework_Assert::assertXmlStringEqualsXmlString($this->connectionModule->_getLastResponse(), $xml);
+        \PHPUnit_Framework_Assert::assertXmlStringEqualsXmlString($this->connectionModule->_getResponseContent(), $xml);
     }
 
 
@@ -1028,7 +1028,7 @@ EOF;
      */
     public function dontSeeXmlResponseEquals($xml)
     {
-        \PHPUnit_Framework_Assert::assertXmlStringNotEqualsXmlString($this->connectionModule->_getLastResponse(), $xml);
+        \PHPUnit_Framework_Assert::assertXmlStringNotEqualsXmlString($this->connectionModule->_getResponseContent(), $xml);
     }
 
     /**
@@ -1048,7 +1048,7 @@ EOF;
      */
     public function seeXmlResponseIncludes($xml)
     {
-        $this->assertContains(XmlUtils::toXml($xml)->C14N(), XmlUtils::toXml($this->connectionModule->_getLastResponse())->C14N(), "found in XML Response");
+        $this->assertContains(XmlUtils::toXml($xml)->C14N(), XmlUtils::toXml($this->connectionModule->_getResponseContent())->C14N(), "found in XML Response");
     }
 
     /**
@@ -1061,7 +1061,7 @@ EOF;
      */
     public function dontSeeXmlResponseIncludes($xml)
     {
-        $this->assertNotContains(XmlUtils::toXml($xml)->C14N(), XmlUtils::toXml($this->connectionModule->_getLastResponse())->C14N(), "found in XML Response");
+        $this->assertNotContains(XmlUtils::toXml($xml)->C14N(), XmlUtils::toXml($this->connectionModule->_getResponseContent())->C14N(), "found in XML Response");
     }
 
     /**

--- a/src/Codeception/Module/REST.php
+++ b/src/Codeception/Module/REST.php
@@ -516,6 +516,9 @@ EOF;
      */
     public function seeResponseIsJson()
     {
+        if ($this->response === '') {
+            throw new ModuleException($this, "Response is empty. Use `\$I->sendXXX()` methods to send HTTP request");
+        }
         json_decode($this->response);
         $errorCode = json_last_error();
         \PHPUnit_Framework_Assert::assertEquals(
@@ -914,6 +917,9 @@ EOF;
      */
     public function seeResponseIsXml()
     {
+        if ($this->response === '') {
+            throw new ModuleException($this, "Response is empty. Use `\$I->sendXXX()` methods to send HTTP request");
+        }
         libxml_use_internal_errors(true);
         $doc = simplexml_load_string($this->response);
         $num = "";

--- a/tests/unit/Codeception/Module/PhpBrowserRestTest.php
+++ b/tests/unit/Codeception/Module/PhpBrowserRestTest.php
@@ -31,7 +31,7 @@ class PhpBrowserRestTest extends \PHPUnit_Framework_TestCase
 
     private function setStubResponse($response)
     {
-        $this->phpBrowser = Stub::make('\Codeception\Module\PhpBrowser', ['_getLastResponse' => $response]);
+        $this->phpBrowser = Stub::make('\Codeception\Module\PhpBrowser', ['_getResponseContent' => $response]);
         $this->module->_inject($this->phpBrowser);
         $this->module->_initialize();
         $this->module->_before(Stub::makeEmpty('\Codeception\TestCase\Cest'));


### PR DESCRIPTION
Introduced `_getResponseContent` helper method to InnerBrowser.
Used it in all REST response methods to enable tests like this.
```
$I->amOnPage('/rest/user/');
$I->seeResponseCodeIs(200);
$I->seeResponseIsJson();
```

Related ticket #2496