### PR TITLE
Make generate:suite respect bootstrap setting

### DIFF
--- a/src/Codeception/Command/GenerateSuite.php
+++ b/src/Codeception/Command/GenerateSuite.php
@@ -60,11 +60,11 @@ class GenerateSuite extends Command
             throw new \Exception("Suite configuration file '$suite.suite.yml' already exists.");
         }
 
-        $this->buildPath($dir . $suite . DIRECTORY_SEPARATOR, '_bootstrap.php');
+        $this->buildPath($dir . $suite . DIRECTORY_SEPARATOR, $config['settings']['bootstrap']);
 
         // generate bootstrap
         $this->save(
-            $dir . $suite . DIRECTORY_SEPARATOR . '_bootstrap.php',
+            $dir . $suite . DIRECTORY_SEPARATOR . $config['settings']['bootstrap'],
             "<?php\n// Here you can initialize variables that will be available to your tests\n",
             true
         );


### PR DESCRIPTION
Suite generation command always creates bootstrap script named `_bootstrap.php` regardless of user settings. Fortunately it's easy to fix.