### PR TITLE
ZF2: empty form params and query params if new request does not set them

### DIFF
--- a/src/Codeception/Lib/Connector/ZF2.php
+++ b/src/Codeception/Lib/Connector/ZF2.php
@@ -51,14 +51,19 @@ class ZF2 extends Client
 
         if ($queryString) {
             parse_str($queryString, $query);
-            $zendRequest->setQuery(new Parameters($query));
+        } else {
+            $query = [];
         }
+        $zendRequest->setQuery(new Parameters($query));
         
         if ($request->getContent() !== null) {
+            $zendRequest->setPost(new Parameters([]));
             $zendRequest->setContent($request->getContent());
         } elseif ($method != HttpRequest::METHOD_GET) {
             $post = $request->getParameters();
             $zendRequest->setPost(new Parameters($post));
+        } else {
+            $zendRequest->setPost(new Parameters([]));
         }
 
         $zendRequest->setMethod($method);


### PR DESCRIPTION
ZF2 connector was setting GET and POST parameters inside ifs(), if these conditions weren't met, request object kept parameters from the previous request.

I changed it to clear parameters instead of keeping old parameters.