### PR TITLE
Typo: Remove semicolon from XMLBuilder block

### DIFF
--- a/docs/reference/XmlBuilder.md
+++ b/docs/reference/XmlBuilder.md
@@ -21,7 +21,7 @@ $xml->users
            ->attr('empty','false')
            ->items
                ->item
-                   ->val('useful item');
+                   ->val('useful item')
                ->parents('user')
        ->active
            ->val(1);


### PR DESCRIPTION
Semi colon at the end of the line causes XML builder to break.