### PR TITLE
Fix Laravel5 module seeCurrentRouteIs crash

### DIFF
--- a/src/Codeception/Module/Laravel5.php
+++ b/src/Codeception/Module/Laravel5.php
@@ -381,7 +381,7 @@ class Laravel5 extends Framework implements ActiveRecord, PartedModule, Supports
         $currentRouteName = $currentRoute ? $currentRoute->getName() : '';
 
         if ($currentRouteName != $routeName) {
-            $message = empty($currentRouteName) ? "Current route has no name" : "Current route is \"$currentRoute\"";
+            $message = empty($currentRouteName) ? "Current route has no name" : "Current route is \"$currentRouteName\"";
             $this->fail($message);
         }
     }


### PR DESCRIPTION
`seeCurrentRouteIs()` will throw an exception if the routes don't match:

`[ErrorException] Object of class Illuminate\Routing\Route could not be converted to string`

It should use the `$currentRouteName` instead of the route object when creating the error message.