### PR TITLE
Add ability to control redirect following in the REST module

### DIFF
--- a/src/Codeception/Module/REST.php
+++ b/src/Codeception/Module/REST.php
@@ -1087,4 +1087,21 @@ EOF;
     {
         throw new ModuleException($this, "This action was deprecated in Codeception 2.0.9 and removed in 2.1. Please use `grabDataFromResponseByJsonPath` instead");
     }
+
+    /**
+     * Prevents automatic redirects to be followed by the client
+     */
+    public function stopFollowingRedirects()
+    {
+        $this->client->followRedirects(false);
+    }
+
+    /**
+     * Enables automatic redirects to be followed by the client
+     */
+    public function startFollowingRedirects()
+    {
+        $this->client->followRedirects(true);
+    }
+
 }


### PR DESCRIPTION
Enables a pair of methods to control automatic redirection following by the REST client, like so:

```php
$I->stopFollowingRedirects();
// ...
$I->startFollowingRedirects();
```