### PR TITLE
Refactor Laravel modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,9 @@
 
 #### 2.1.5
 
-* [Laravel5] Fix bug for `seeCurrentRouteIs` when routes don't match. See #2593. By @maddhatter.
+* [Laravel5] Removed `enableMiddleware` and `enableEvents` methods. See #2602. By @janhenkgerritsen
+* [Laravel] Refactored modules. See #2602. By @janhenkgerritsen
+* [Laravel5] Fix bug for `seeCurrentRouteIs` when routes don't match. See #2593. By @maddhatter
 * [PhpBrowser][WebDriver] Unifies `expires` parameter for `setCookie`. Fixes #2582 By @davertmik
 * [REST] Fixes validation of several types with filters. See #2581 By @davertmik
 * [REST] JsonType improved URL filter to use `filter_var($value, FILTER_VALIDATE_URL)`

--- a/src/Codeception/Lib/Connector/Laravel5.php
+++ b/src/Codeception/Lib/Connector/Laravel5.php
@@ -9,7 +9,6 @@ use Symfony\Component\HttpKernel\Client;
 
 class Laravel5 extends Client
 {
-
     /**
      * @var Application
      */
@@ -21,9 +20,24 @@ class Laravel5 extends Client
     private $module;
 
     /**
+     * @var bool
+     */
+    private $firstRequest = true;
+
+    /**
      * @var array
      */
     private $triggeredEvents = [];
+
+    /**
+     * @var bool
+     */
+    private $middlewareDisabled = false;
+
+    /**
+     * @var bool
+     */
+    private $eventsDisabled = false;
 
     /**
      * @var object
@@ -32,6 +46,7 @@ class Laravel5 extends Client
 
     /**
      * Constructor.
+     *
      * @param \Codeception\Module\Laravel5 $module
      */
     public function __construct($module)
@@ -49,12 +64,17 @@ class Laravel5 extends Client
     }
 
     /**
+     * Execute a request.
+     *
      * @param SymfonyRequest $request
      * @return Response
      */
     protected function doRequest($request)
     {
-        $this->initialize($request);
+        if (!$this->firstRequest) {
+            $this->initialize($request);
+        }
+        $this->firstRequest = false;
 
         $request = Request::createFromBase($request);
         $response = $this->kernel->handle($request);
@@ -65,6 +85,7 @@ class Laravel5 extends Client
 
     /**
      * Initialize the Laravel framework.
+     *
      * @param SymfonyRequest $request
      */
     private function initialize($request = null)
@@ -76,25 +97,14 @@ class Laravel5 extends Client
             $this->oldDb = $this->app['db'];
         }
 
-        // The module can login a user with the $I->amLoggedAs() method,
-        // but this is not persisted between requests. Store a reference
-        // to the logged in user to simulate this.
-        $loggedInUser = null;
-        if ($this->app['auth'] && $this->app['auth']->check()) {
-            $loggedInUser = $this->app['auth']->user();
-        }
-
-        // Load the application object
         $this->app = $this->kernel = $this->loadApplication();
 
-        // Set the request instance for the application
+        // Set the request instance for the application,
         if (is_null($request)) {
             $appConfig = require $this->module->config['project_dir'] . 'config/app.php';
             $request = SymfonyRequest::create($appConfig['url']);
         }
-
         $this->app->instance('request', Request::createFromBase($request));
-        $this->app->instance('middleware.disable', $this->module->config['disable_middleware']);
 
         // Reset the old database after the DatabaseServiceProvider ran.
         // This way other service providers that rely on the $app['db'] entry
@@ -109,19 +119,17 @@ class Laravel5 extends Client
 
         $this->app->make('Illuminate\Contracts\Http\Kernel')->bootstrap();
 
-        // If events should be disabled mock the event dispatcher instance
-        if ($this->module->config['disable_events']) {
-            $this->mockEventDispatcher();
+        // Record all triggered events by adding a wildcard event listener
+        $this->app['events']->listen('*', function () {
+            $this->triggeredEvents[] = $this->normalizeEvent($this->app['events']->firing());
+        });
+
+        if ($this->module->config['disable_middleware'] || $this->middlewareDisabled) {
+            $this->app->instance('middleware.disable', true);
         }
 
-        // Setup an event listener to listen for all events that are triggered
-        $this->setupEventListener();
-
-        // If there was a user logged in restore this user.
-        // Also reload the user object from the user provider to prevent stale user data.
-        if ($loggedInUser) {
-            $refreshed = $this->app['auth']->getProvider()->retrieveById($loggedInUser->getAuthIdentifier());
-            $this->app['auth']->setUser($refreshed ?: $loggedInUser);
+        if ($this->module->config['disable_events'] || $this->eventsDisabled) {
+            $this->mockEventDispatcher();
         }
 
         $this->module->setApplication($this->app);
@@ -148,32 +156,18 @@ class Laravel5 extends Client
     {
         $mockGenerator = new \PHPUnit_Framework_MockObject_Generator;
         $mock = $mockGenerator->getMock('Illuminate\Contracts\Events\Dispatcher');
+
+        // Even if events are disabled we still want to record the triggered events.
+        // But by mocking the event dispatcher the wildcard listener registered in the initialize method is removed.
+        // So to record the triggered events we have to catch the calls to the fire method of the event dispatcher mock.
+        $callback = function ($event) {
+            $this->triggeredEvents[] = $this->normalizeEvent($event);
+        };
+        $mock->expects(new \PHPUnit_Framework_MockObject_Matcher_AnyInvokedCount)
+            ->method('fire')
+            ->will(new \PHPUnit_Framework_MockObject_Stub_ReturnCallback($callback));
+
         $this->app->instance('events', $mock);
-    }
-
-    /**
-     * Listen for events.
-     * Even works when events are disabled.
-     */
-    private function setupEventListener()
-    {
-        if ($this->module->config['disable_events']) {
-            // Events are disabled so we should listen for events through the mocked event dispatcher
-            $mock = $this->app['events'];
-            $callback = function ($event) {
-                $this->triggeredEvents[] = $this->normalizeEvent($event);
-            };
-
-            $mock->expects(new \PHPUnit_Framework_MockObject_Matcher_AnyInvokedCount)
-                ->method('fire')
-                ->will(new \PHPUnit_Framework_MockObject_Stub_ReturnCallback($callback));
-        } else {
-            // Listen for all events by registering a wildcard event listener
-            $callback = function () {
-                $this->triggeredEvents[] = $this->normalizeEvent($this->app['events']->firing());
-            };
-            $this->app['events']->listen('*', $callback);
-        }
     }
 
     /**
@@ -198,6 +192,10 @@ class Laravel5 extends Client
         return $segments[0];
     }
 
+    //======================================================================
+    // Public methods called by module
+    //======================================================================
+
     /**
      * Did an event trigger?
      *
@@ -218,12 +216,20 @@ class Laravel5 extends Client
     }
 
     /**
-     * Clear all expected events.
-     * Should be called before each test.
+     * Disable events.
      */
-    public function clearTriggeredEvents()
+    public function disableEvents()
     {
-        $this->triggeredEvents = [];
+        $this->eventsDisabled = true;
+        $this->mockEventDispatcher();
     }
 
+    /*
+     * Disable middleware.
+     */
+    public function disableMiddleware()
+    {
+        $this->middlewareDisabled = true;
+        $this->app->instance('middleware.disable', true);
+    }
 }


### PR DESCRIPTION
I refactored the Laravel modules due to the results of the discussion in #2596. Besides implementing the fix mentioned in that issue I also implemented several other improvements to the internals of the modules.

I also removed the `enableMiddleware` and `enableEvents` methods from the Laravel 5 module, because I think it is not necessary to be able to enable the middleware/events again in the same test after disabling them. And the implementation of `enableEvents` will not be simple due to the refactoring in this PR.