### PR TITLE
Symfony2: Cache router

### DIFF
--- a/src/Codeception/Module/Symfony2.php
+++ b/src/Codeception/Module/Symfony2.php
@@ -144,10 +144,10 @@ class Symfony2 extends Framework implements DoctrineProvider, SupportsDomainRout
         $this->kernel = new $this->kernelClass($this->config['environment'], $this->config['debug']);
         $this->kernel->boot();
         if ($this->config['cache_router'] === true) {
-            if (null === $this->permanentServices['router']) {
-                $this->permanentServices['router'] = $this->getRouter();
-            } else {
+            if (isset($this->permanentServices['router'])) {
                 $this->kernel->getContainer()->set('router', $this->permanentServices['router']);
+            } else {
+                $this->permanentServices['router'] = $this->getRouter();
             }
         }
     }
@@ -196,7 +196,7 @@ class Symfony2 extends Framework implements DoctrineProvider, SupportsDomainRout
     }
 
     /**
-     * Invalidate previously cached router.
+     * Invalidate previously cached routes.
      */
     public function invalidateCachedRouter()
     {


### PR DESCRIPTION
Router can be cached on Symfony2 framework. This option is disabled by default.
It can be enabled with:
modules:
  - Symfony2:
    cache_router: true
    ...

It's also provided a method to force cache invalidation on desire named
'invalidateCachedRouter()', to be used on the rare cases you want router to be
cached but need to manually invalidate cache before of after certain tests.