### PR TITLE
Fix issue #2060 - Too many connections error

### DIFF
--- a/src/Codeception/Module/Doctrine2.php
+++ b/src/Codeception/Module/Doctrine2.php
@@ -157,7 +157,7 @@ EOF;
 
         $this->em->getConnection()->connect();
     }
-    
+
     public function _after(TestCase $test)
     {
         if (!$this->em instanceof \Doctrine\ORM\EntityManager) {
@@ -170,6 +170,7 @@ EOF;
             }
         }
         $this->clean();
+        $this->em->getConnection()->close();
     }
 
     protected function clean()


### PR DESCRIPTION
Close Doctrine2 connection after each test to prevent throwing an
exception "[Doctrine\DBAL\Exception\DriverException] An exception occured
in driver: SQLSTATE[08004] [1040] Too many connections" with a large
test suite