### PR TITLE
implements PartedModule in Symfony2 module with services part

### DIFF
--- a/src/Codeception/Module/Symfony2.php
+++ b/src/Codeception/Module/Symfony2.php
@@ -7,6 +7,7 @@ use Codeception\Lib\Framework;
 use Codeception\Exception\ModuleRequireException;
 use Codeception\Lib\Connector\Symfony2 as Symfony2Connector;
 use Codeception\Lib\Interfaces\DoctrineProvider;
+use Codeception\Lib\Interfaces\PartedModule;
 use Symfony\Component\Finder\Finder;
 
 /**
@@ -65,7 +66,7 @@ use Symfony\Component\Finder\Finder;
  * * container - dependency injection container instance
  *
  */
-class Symfony2 extends Framework implements DoctrineProvider
+class Symfony2 extends Framework implements DoctrineProvider, PartedModule
 {
     /**
      * @var \Symfony\Component\HttpKernel\Kernel
@@ -84,6 +85,14 @@ class Symfony2 extends Framework implements DoctrineProvider
         'debug' => true,
         'em_service' => 'doctrine.orm.entity_manager'
     ];
+
+    /**
+     * @return array
+     */
+    public function _parts()
+    {
+        return ['serives'];
+    }
 
     /**
      * @var
@@ -252,6 +261,7 @@ class Symfony2 extends Framework implements DoctrineProvider
      *
      * @param $service
      * @return mixed
+     * @part services
      */
     public function grabServiceFromContainer($service)
     {

--- a/src/Codeception/Module/Symfony2.php
+++ b/src/Codeception/Module/Symfony2.php
@@ -91,7 +91,7 @@ class Symfony2 extends Framework implements DoctrineProvider, PartedModule
      */
     public function _parts()
     {
-        return ['serives'];
+        return ['services'];
     }
 
     /**


### PR DESCRIPTION
Codeception/Codeception#2435

Codeception/Codeception#2470

Usage example:

```yaml
class_name: AcceptanceTester
modules:
    enabled:
        - Symfony2:
            part: SERVICES
            app_path: '../../../app'
            var_path: '../../../app'
        - Doctrine2:
            depends: Symfony2
            cleanup: false
        - Asserts:
        - WebDriver:
            url: http://your-url.com
            host: '127.0.0.1'
            browser: phantomjs
            window_size: 1280x800
            request_timeout: 30
            debug_log_entries: 100
            wait: 1
            capabilities:
                webStorageEnabled: true
                handlesAlerts: true
        - \FrontendAdminBundle\Helper\Acceptance
```