### PR TITLE
Update Phalcon.php

### DIFF
--- a/src/Codeception/Lib/Connector/Phalcon.php
+++ b/src/Codeception/Lib/Connector/Phalcon.php
@@ -193,7 +193,7 @@ class PhalconMemorySession implements SessionInterface
      *
      * @param array $options
      */
-    public function setOptions(array $options)
+    public function setOptions($options = array())
     {
         if (isset($options['uniqueId'])) {
             $this->sessionId = $options['uniqueId'];


### PR DESCRIPTION
Fixes this error:

PHP Fatal error:  Declaration of Codeception\Lib\Connector\PhalconMemorySession::setOptions() must be compatible with Phalcon\Session\AdapterInterface::setOptions($options) in /srv/web/pc.vm/tests/vendor/codeception/codeception/src/Codeception/Lib/Connector/Phalcon.php on line 141