### PR TITLE
Added support of dblib PDO driver

### DIFF
--- a/src/Codeception/Lib/Driver/Db.php
+++ b/src/Codeception/Lib/Driver/Db.php
@@ -57,6 +57,7 @@ class Db
             case 'pgsql':
                 return new PostgreSql($dsn, $user, $password);
             case 'mssql':
+            case 'dblib':
             case 'sqlsrv':
                 return new SqlSrv($dsn, $user, $password);
             case 'oci':


### PR DESCRIPTION
Db module should handle "dblib" PDO driver as well. 
I tested it and figured out that populate and cleanup works well (without taking into account the fact that sql dump from mssql should be converted to appropriate fromat first).