### PR TITLE
Fixed Parser::validate to escape file paths

### DIFF
--- a/src/Codeception/Lib/Parser.php
+++ b/src/Codeception/Lib/Parser.php
@@ -126,7 +126,7 @@ class Parser
 
     public static function validate($file)
     {
-        exec("php -l $file 2>&1", $output, $code);
+        exec("php -l ".escapeshellarg($file)." 2>&1", $output, $code);
         if ($code !== 0) {
             throw new TestParseException($file, implode("\n", $output));
         }


### PR DESCRIPTION
Tests on file paths with spaces failed as the new Parser::validate() call wasn't escaping file paths.