### PR TITLE
PhpBrowser: Fixed cookies option by setting cookies to BrowserKit's CookieJar #2653

### DIFF
--- a/src/Codeception/Lib/InnerBrowser.php
+++ b/src/Codeception/Lib/InnerBrowser.php
@@ -1501,4 +1501,35 @@ class InnerBrowser extends Module implements Web, PageSourceSaver, ElementLocato
         $cookieStrings = array_map('strval', $cookies);
         $this->debugSection('Cookie Jar', $cookieStrings);
     }
+
+    protected function setCookiesFromOptions()
+    {
+        if (isset($this->config['cookies']) && is_array($this->config['cookies']) && !empty($this->config['cookies'])) {
+
+            $domain = parse_url($this->config['url'], PHP_URL_HOST);
+            $cookieJar = $this->client->getCookieJar();
+            foreach ($this->config['cookies'] as &$cookie) {
+                if (!is_array($cookie) || !array_key_exists('Name', $cookie) || !array_key_exists('Value', $cookie)) {
+                    throw new \InvalidArgumentException('Cookies must have at least Name and Value attributes');
+                }
+                if (!isset($cookie['Domain'])) {
+                    $cookie['Domain'] = $domain;
+                }
+                if (!isset($cookie['Expires'])) {
+                    $cookie['Expires'] = null;
+                }
+                if (!isset($cookie['Path'])) {
+                    $cookie['Path'] = '/';
+                }
+                if (!isset($cookie['Secure'])) {
+                    $cookie['Secure'] = false;
+                }
+                if (!isset($cookie['HttpOnly'])) {
+                    $cookie['HttpOnly'] = false;
+                }
+                $cookieJar->set(new \Symfony\Component\BrowserKit\Cookie($cookie['Name'], $cookie['Value'],
+                    $cookie['Expires'], $cookie['Path'], $cookie['Domain'], $cookie['Secure'], $cookie['HttpOnly']));
+            }
+        }
+    }
 }

--- a/src/Codeception/Module/PhpBrowser.php
+++ b/src/Codeception/Module/PhpBrowser.php
@@ -91,7 +91,6 @@ class PhpBrowser extends InnerBrowser implements Remote, MultiSession
         'proxy',
         'expect',
         'version',
-        'cookies',
         'timeout',
         'connect_timeout'
     ];
@@ -248,6 +247,8 @@ class PhpBrowser extends InnerBrowser implements Remote, MultiSession
                 $curlOptions[constant($key)] = $val;
             }
         }
+
+        $this->setCookiesFromOptions();
 
         if ($this->isGuzzlePsr7) {
             $defaults['base_uri'] = $this->config['url'];

--- a/src/Codeception/Module/PhpBrowser.php
+++ b/src/Codeception/Module/PhpBrowser.php
@@ -46,6 +46,18 @@ use GuzzleHttp\Client as GuzzleClient;
  *                auth: ['admin', '123345']
  *                curl:
  *                    CURLOPT_RETURNTRANSFER: true
+ *                cookies:
+ *                    cookie-1:
+ *                        Name: userName
+ *                        Value: john.doe
+ *                    cookie-2:
+ *                        Name: authToken
+ *                        Value: 1abcd2345
+ *                        Domain: subdomain.domain.com
+ *                        Path: /admin/
+ *                        Expires: 1292177455
+ *                        Secure: true
+ *                        HttpOnly: false
  *
  *
  * All SSL certification checks are disabled by default.

--- a/tests/unit/Codeception/Module/PhpBrowserTest.php
+++ b/tests/unit/Codeception/Module/PhpBrowserTest.php
@@ -450,6 +450,28 @@ class PhpBrowserTest extends TestsForBrowsers
         $this->assertEquals('codeception.com', $cookie['Domain']);
     }
 
+    /**
+     * @issue https://github.com/Codeception/Codeception/issues/2653
+     */
+    public function testSetCookiesByOptions()
+    {
+        $config = $this->module->_getConfig();
+        $config['cookies'] = [
+            [
+                'Name' => 'foo',
+                'Value' => 'bar1',
+            ],
+            [
+                'Name' => 'baz',
+                'Value' => 'bar2',
+            ],
+        ];
+        $this->module->_reconfigure($config);
+        // this url redirects if cookies are present
+        $this->module->amOnPage('/cookies');
+        $this->module->seeCurrentUrlEquals('/info');
+    }
+
     private function skipForOldGuzzle()
     {
         if (class_exists('GuzzleHttp\Url')) {


### PR DESCRIPTION
BrowserKit's CookieJar overrides Guzzle's, so I decided to use it instead of passing `cookies` option to Guzzle.

`setCookiesFromOptions` method can be used in framework modules, if there is a wish to add `cookies` option to them.