### PR TITLE
Add seeCurrentRouteMatches function to the symfony2 module

### DIFF
--- a/src/Codeception/Module/Symfony2.php
+++ b/src/Codeception/Module/Symfony2.php
@@ -281,6 +281,36 @@ class Symfony2 extends Framework implements DoctrineProvider, PartedModule
     }
 
     /**
+     * Checks that current url matches route. 
+     * Unlike seeCurrentRouteIs, this can matches without exact route parameters
+     * 
+     * ``` php
+     * <?php
+     * $I->seeCurrentRouteMatches(my_blog_pages);
+     * ?>
+     * ```
+     *
+     * @param $routeName
+     */
+    public function seeCurrentRouteMatches($routeName)
+    {
+        $router = $this->grabServiceFromContainer('router');
+        
+        $route = $router->getRouteCollection()->get($routeName);
+        if (!$route) {
+            $this->fail(sprintf('Route with name "%s" does not exists.', $routeName));
+        }
+        
+        try {
+            $matchedRouteName = $router->match($this->grabFromCurrentUrl())['_route'];
+        } catch(\Exception\ResourceNotFoundException $e) {
+            $this->fail(sprintf('The "%s" url does not match with any route', $routeName));
+        }
+        
+        $this->assertEquals($matchedRouteName, $routeName);
+    }
+
+    /**
      * Checks if any email were sent by last request
      *
      * @throws \LogicException

--- a/src/Codeception/Module/Symfony2.php
+++ b/src/Codeception/Module/Symfony2.php
@@ -281,12 +281,12 @@ class Symfony2 extends Framework implements DoctrineProvider, PartedModule
     }
 
     /**
-     * Checks that current url matches route. 
+     * Checks that current url matches route.
      * Unlike seeCurrentRouteIs, this can matches without exact route parameters
-     * 
+     *
      * ``` php
      * <?php
-     * $I->seeCurrentRouteMatches(my_blog_pages);
+     * $I->seeCurrentRouteMatches('my_blog_pages');
      * ?>
      * ```
      *
@@ -303,7 +303,7 @@ class Symfony2 extends Framework implements DoctrineProvider, PartedModule
         
         try {
             $matchedRouteName = $router->match($this->grabFromCurrentUrl())['_route'];
-        } catch(\Exception\ResourceNotFoundException $e) {
+        } catch (\Exception\ResourceNotFoundException $e) {
             $this->fail(sprintf('The "%s" url does not match with any route', $routeName));
         }
         

--- a/src/Codeception/Module/Symfony2.php
+++ b/src/Codeception/Module/Symfony2.php
@@ -292,7 +292,7 @@ class Symfony2 extends Framework implements DoctrineProvider, PartedModule
      *
      * @param $routeName
      */
-    public function seeCurrentRouteMatches($routeName)
+    public function seeInCurrentRoute($routeName)
     {
         $router = $this->grabServiceFromContainer('router');
         


### PR DESCRIPTION
#2664

Unlike seeCurrentRouteIs, this can matches without exact route parameters.

Usage example: 
```php
$I->amOnRoute('posts.create');    # admin/posts/create
$I->fillField(['name' => 'title'],  "Hello World!");
$I->click('Save');
$I->seeCurrentRouteMatches('posts.edit');    # admin/posts/123/edit
```