### PR TITLE
Postgres driver: cleanup() delete all custom types

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,9 @@ matrix:
     - php: 5.6 # Symfony 2.8
       env: SYMFONY=2.8.0
 
+addons:
+  postgresql: "9.2"
+
 branches:
   except:
     - gh-pages
@@ -29,6 +32,7 @@ cache:
 services:
   - mongodb
   - rabbitmq
+  - postgresql
 
 sudo: false
 

--- a/src/Codeception/Lib/Driver/PostgreSql.php
+++ b/src/Codeception/Lib/Driver/PostgreSql.php
@@ -62,7 +62,7 @@ class PostgreSql extends Db
             ->fetchAll();
 
         $types = $this->dbh
-            ->query("SELECT 'DROP TYPE IF EXISTS \"' || pg_type.typname || '\" cascade;' FROM pg_type JOIN pg_enum ON pg_enum.enumtypid = pg_type.oid GROUP BY pg_type.typname;")
+            ->query("SELECT 'DROP TYPE IF EXISTS \"' || t.typname || '\" cascade;' FROM pg_catalog.pg_type t LEFT JOIN pg_catalog.pg_namespace n ON n.oid = t.typnamespace WHERE (t.typrelid = 0 OR (SELECT c.relkind = 'c' FROM pg_catalog.pg_class c WHERE c.oid = t.typrelid)) AND NOT EXISTS(SELECT 1 FROM pg_catalog.pg_type el WHERE el.oid = t.typelem AND el.typarray = t.oid) AND n.nspname <> 'pg_catalog' AND n.nspname <> 'information_schema' AND pg_catalog.pg_type_is_visible(t.oid);")
             ->fetchAll();
 
         $drops = array_merge($tables, $sequences, $types);

--- a/tests/data/dumps/postgres.sql
+++ b/tests/data/dumps/postgres.sql
@@ -408,6 +408,30 @@ CREATE TABLE "order" (
 
 insert  into "order"("id","name","status") values (1,'main', 'open');
 
+-- Custom Types
+DROP TYPE IF EXISTS composite_type;
+CREATE TYPE composite_type AS (
+    a decimal,
+    b decimal
+);
+
+DROP TYPE IF EXISTS enum_type;
+CREATE TYPE enum_type AS ENUM (
+    'Mon',
+    'Tue',
+    'Wed',
+    'Thu',
+    'Fri',
+    'Sat',
+    'Sun'
+);
+
+DROP TYPE IF EXISTS range_type;
+CREATE TYPE range_type AS range (subtype = time);
+
+DROP TYPE IF EXISTS base_type;
+CREATE TYPE base_type;
+
 -- --
 -- PostgreSQL database dump complete
 --

--- a/tests/unit/Codeception/Lib/Driver/PostgresTest.php
+++ b/tests/unit/Codeception/Lib/Driver/PostgresTest.php
@@ -59,6 +59,18 @@ class PostgresTest extends \PHPUnit_Framework_TestCase
         $this->assertEmpty($this->postgres->getDbh()->query("SELECT * FROM pg_tables where schemaname = 'public'")->fetchAll());
     }
 
+    public function testCleanupDatabaseDeletesTypes()
+    {
+        $customTypes = ['composite_type', 'enum_type', 'range_type', 'base_type'];
+        foreach ($customTypes as $customType) {
+            $this->assertNotEmpty($this->postgres->getDbh()->query("SELECT 1 FROM pg_type WHERE typname = '" . $customType . "';")->fetchAll());
+        }
+        $this->postgres->cleanup();
+        foreach ($customTypes as $customType) {
+            $this->assertEmpty($this->postgres->getDbh()->query("SELECT 1 FROM pg_type WHERE typname = '" . $customType . "';")->fetchAll());
+        }
+    }
+
     public function testLoadDump()
     {
         $res = $this->postgres->getDbh()->query("select * from users where name = 'davert'");


### PR DESCRIPTION
This is a PR to fix #2666. To test, I'm adding one of each kind of pgsql `type` and then individually checking that they exist before and don't exist after `cleanup()`. I'm doing the checks individually because it doesn't make sense to use the same query to check for type existence that I use to determine which types to delete (and that's the only query I have to list custom types).

Note that `range type`s aren't supported in pgsql below 9.2, so this will break the tests on pgsql 9.1 and below.