### PR TITLE
Laravel5: Mocked events shouls also return an array

### DIFF
--- a/src/Codeception/Lib/Connector/Laravel5.php
+++ b/src/Codeception/Lib/Connector/Laravel5.php
@@ -162,6 +162,7 @@ class Laravel5 extends Client
         // So to record the triggered events we have to catch the calls to the fire method of the event dispatcher mock.
         $callback = function ($event) {
             $this->triggeredEvents[] = $this->normalizeEvent($event);
+            return [];
         };
         $mock->expects(new \PHPUnit_Framework_MockObject_Matcher_AnyInvokedCount)
             ->method('fire')


### PR DESCRIPTION
"Normal" events in Laravel return an array of listeners responses. Mocked events should also return an array so that application code does not have to account for the possibility of null being returned instead.