### PR TITLE
fix the namespace to RemoteWebDriver in the executeInSelenium() references

### DIFF
--- a/docs/modules/WebDriver.md
+++ b/docs/modules/WebDriver.md
@@ -561,7 +561,7 @@ Low-level API method.
 If Codeception commands are not enough, this allows you to use Selenium WebDriver methods directly:
 
 ``` php
-$I->executeInSelenium(function(\Facebook\WebDriver\RemoteWebDriver $webdriver) {
+$I->executeInSelenium(function(\Facebook\WebDriver\Remote\RemoteWebDriver $webdriver) {
   $webdriver->get('http://google.com');
 });
 ```
@@ -1360,7 +1360,7 @@ If the window has no name, the only way to access it is via the `executeInSeleni
 
 ``` php
 <?php
-$I->executeInSelenium(function (\Facebook\WebDriver\RemoteWebDriver $webdriver) {
+$I->executeInSelenium(function (\Facebook\WebDriver\Remote\RemoteWebDriver $webdriver) {
      $handles=$webdriver->getWindowHandles();
      $last_window = end($handles);
      $webdriver->switchTo()->window($last_window);

--- a/src/Codeception/Module/WebDriver.php
+++ b/src/Codeception/Module/WebDriver.php
@@ -1763,7 +1763,7 @@ class WebDriver extends CodeceptionModule implements
      * If Codeception commands are not enough, this allows you to use Selenium WebDriver methods directly:
      *
      * ``` php
-     * $I->executeInSelenium(function(\Facebook\WebDriver\RemoteWebDriver $webdriver) {
+     * $I->executeInSelenium(function(\Facebook\WebDriver\Remote\RemoteWebDriver $webdriver) {
      *   $webdriver->get('http://google.com');
      * });
      * ```
@@ -1803,7 +1803,7 @@ class WebDriver extends CodeceptionModule implements
      *
      * ``` php
      * <?php
-     * $I->executeInSelenium(function (\Facebook\WebDriver\RemoteWebDriver $webdriver) {
+     * $I->executeInSelenium(function (\Facebook\WebDriver\Remote\RemoteWebDriver $webdriver) {
      *      $handles=$webdriver->getWindowHandles();
      *      $last_window = end($handles);
      *      $webdriver->switchTo()->window($last_window);

--- a/tests/support/_generated/WebGuyActions.php
+++ b/tests/support/_generated/WebGuyActions.php
@@ -2359,7 +2359,7 @@ trait WebGuyActions
      * If Codeception commands are not enough, this allows you to use Selenium WebDriver methods directly:
      *
      * ``` php
-     * $I->executeInSelenium(function(\Facebook\WebDriver\RemoteWebDriver $webdriver) {
+     * $I->executeInSelenium(function(\Facebook\WebDriver\Remote\RemoteWebDriver $webdriver) {
      *   $webdriver->get('http://google.com');
      * });
      * ```
@@ -2402,7 +2402,7 @@ trait WebGuyActions
      *
      * ``` php
      * <?php
-     * $I->executeInSelenium(function (\Facebook\WebDriver\RemoteWebDriver $webdriver) {
+     * $I->executeInSelenium(function (\Facebook\WebDriver\Remote\RemoteWebDriver $webdriver) {
      *      $handles=$webdriver->getWindowHandles();
      *      $last_window = end($handles);
      *      $webdriver->switchTo()->window($last_window);


### PR DESCRIPTION
The old pre2.1 docs showed usage of either `\Facebook\WebDriver\RemoteWebDriver` or just `\WebDriver`, so my custom `switchToPreviousWindow()` method utilized an `executeInSelenium(\WebDriver $webdriver)` call.  Although this worked up to 2.1.0 (with facebook/webdriver up to 0.6.0 underneath), it broke on 2.1.1 (when webdriver jumped to 1.0.0+).  Changing the signature from `\WebDriver` to `\Facebook\WebDriver\RemoteWebDriver` made no difference.

The broken behavior I witnessed was that Chrome would hang on this step, and only a timeout would break it.  On IE, there was no hang... just a `[Facebook\WebDriver\Exception\NoSuchWindowException]`.

I debugged the problem down to `Argument 1 passed to Codeception\Module\AcceptanceHelper::Codeception\Module\{closure}() must be an instance of Facebook\WebDriver\RemoteWebDriver, instance of Facebook\WebDriver\Remote\RemoteWebDriver given`.

Thus, the problem was the typehint on the `$webdriver` arg not matching the behavior of the 1.0+ facebook/webdriver code.