### PR TITLE
Fixing Assertation message from null to expected value

### DIFF
--- a/src/Codeception/Module/REST.php
+++ b/src/Codeception/Module/REST.php
@@ -172,8 +172,9 @@ EOF;
     {
         if ($value !== null) {
             $this->assertEquals(
-                $this->getRunningClient()->getInternalResponse()->getHeader($name),
-                $value
+                $value,
+                $this->getRunningClient()->getInternalResponse()->getHeader($name)
+
             );
             return;
         }
@@ -193,8 +194,8 @@ EOF;
     {
         if ($value !== null) {
             $this->assertNotEquals(
-                $this->getRunningClient()->getInternalResponse()->getHeader($name),
-                $value
+                $value,
+                $this->getRunningClient()->getInternalResponse()->getHeader($name)
             );
             return;
         }

--- a/src/Codeception/Module/REST.php
+++ b/src/Codeception/Module/REST.php
@@ -174,7 +174,6 @@ EOF;
             $this->assertEquals(
                 $value,
                 $this->getRunningClient()->getInternalResponse()->getHeader($name)
-
             );
             return;
         }


### PR DESCRIPTION
Fix.
if in you use :
```
$I->seeHttpHeader('X-CustomHeader', "X009");
```
In report you will see : 
```
 Fail  Failed asserting that X009 matches expected null.
```
But should be :
```
 Fail  Failed asserting that null matches expected X009.
```
