### PR TITLE
Add some specification in grabFromDatabase to return all values

### DIFF
--- a/src/Codeception/Module/Db.php
+++ b/src/Codeception/Module/Db.php
@@ -363,18 +363,22 @@ class Db extends CodeceptionModule implements DbInterface
         return (int) $this->proceedSeeInDatabase($table, 'count(*)', $criteria);
     }
 
-    protected function proceedSeeInDatabase($table, $column, $criteria)
+    protected function proceedSeeInDatabase($table, $column, $criteria, $allValues = false)
     {
         $query = $this->driver->select($column, $table, $criteria);
         $this->debugSection('Query', $query, json_encode($criteria));
 
         $sth = $this->driver->executeQuery($query, array_values($criteria));
 
-        return $sth->fetchColumn();
+        return $allValues?
+            array_column($sth->fetchAll(), $column)
+            :
+            $sth->fetchColumn();
+
     }
 
-    public function grabFromDatabase($table, $column, $criteria = [])
+    public function grabFromDatabase($table, $column, $criteria = [], $allValues = false)
     {
-        return $this->proceedSeeInDatabase($table, $column, $criteria);
+        return $this->proceedSeeInDatabase($table, $column, $criteria, $allValues);
     }
 }

--- a/src/Codeception/Module/Dbh.php
+++ b/src/Codeception/Module/Dbh.php
@@ -105,7 +105,7 @@ class Dbh extends CodeceptionModule implements DbInterface
         \PHPUnit_Framework_Assert::assertLessThan(1, $res);
     }
 
-    protected function proceedSeeInDatabase($table, $column, $criteria)
+    protected function proceedSeeInDatabase($table, $column, $criteria, $allValues = false)
     {
         $params = [];
         foreach ($criteria as $k => $v) {
@@ -119,11 +119,14 @@ class Dbh extends CodeceptionModule implements DbInterface
 
         $sth = self::$dbh->prepare($query);
         $sth->execute(array_values($criteria));
-        return $sth->fetchColumn();
+        return $allValues?
+            array_column($sth->fetchAll(), $column)
+            :
+            $sth->fetchColumn();
     }
 
-    public function grabFromDatabase($table, $column, $criteria = [])
+    public function grabFromDatabase($table, $column, $criteria = [], $allValues = false)
     {
-        return $this->proceedSeeInDatabase($table, $column, $criteria);
+        return $this->proceedSeeInDatabase($table, $column, $criteria, $allValues);
     }
 }


### PR DESCRIPTION
Sometimes i miss the option to get all the values that follow some criteria in grabFromDatabase. Most of the time if a table has a HasAndBelongsToMany(n:m) relation i want to check if All the values is there, so returning only the first one will not resolve my problem.