### PR TITLE
Fix replace comment in load dump file for mysql

### DIFF
--- a/src/Codeception/Module/Db.php
+++ b/src/Codeception/Module/Db.php
@@ -73,21 +73,21 @@ use Codeception\TestCase;
  *              reconnect: true
  *
  * ### SQL data dump
- * 
+ *
  *  * Comments are permitted.
  *  * The `dump.sql` may contain multiline statements.
  *  * The delimiter, a semi-colon in this case, must be on the same line as the last statement:
- *  
+ *
  * ```sql
  * -- Add a few contacts to the table.
  * REPLACE INTO `Contacts` (`created`, `modified`, `status`, `contact`, `first`, `last`) VALUES
  * (NOW(), NOW(), 1, 'Bob Ross', 'Bob', 'Ross'),
  * (NOW(), NOW(), 1, 'Fred Flintstone', 'Fred', 'Flintstone');
- * 
+ *
  * -- Remove existing orders for testing.
  * DELETE FROM `Order`;
  * ```
- * 
+ *
  * ## Public Properties
  * * dbh - contains the PDO connection
  * * driver - contains the Connection Driver
@@ -149,7 +149,8 @@ class Db extends CodeceptionModule implements DbInterface
                 );
             }
             $sql = file_get_contents(Configuration::projectDir() . $this->config['dump']);
-            $sql = preg_replace('%/\*(?!!\d+)(?:(?!\*/).)*\*/%s', "", $sql);
+            $sql = preg_replace('%/\*(!*\d+) SET NAMES utf8 (?:(?!\*/).)*\*/;?%s', "SET NAMES utf8;", $sql);
+            $sql = preg_replace('%/\*(!*\d+)(?:(?!\*/).)*\*/;?%s', "", $sql);
             if (!empty($sql)) {
                 $this->sql = explode("\n", $sql);
             }


### PR DESCRIPTION
comment look like this dump from Sequel Pro:

    /*!40101 SET @OLD_COLLATION_CONNECTION=@@COLLATION_CONNECTION */;

and don't replace this:

    ('/admin/*',2,NULL,NULL,NULL,1442237501,1442237501),

but set names shoud be keep.
replace

    /*!40101 SET NAMES utf8 */;

to

    SET NAMES utf8;