### PR TITLE
Fixed typo in Laravel5.md

### DIFF
--- a/docs/modules/Laravel5.md
+++ b/docs/modules/Laravel5.md
@@ -160,7 +160,7 @@ Example of Usage
 $I->amLoggedAs(['username' => 'jane * `example.com',`  'password' => 'password']);
 
 // provide User object
-$I->amLoggesAs( new User );
+$I->amLoggedAs( new User );
 
 // can be verified with $I->seeAuthentication();
 ?>


### PR DESCRIPTION
There's a typo for the `amLoggedAs` function documentation:

```
$I->amLoggesAs( new User );
```

should be:

```
$I->amLoggedAs( new User );
```