### PR TITLE
Fixed typo in Laravel5.php module

### DIFF
--- a/src/Codeception/Module/Laravel5.php
+++ b/src/Codeception/Module/Laravel5.php
@@ -616,7 +616,7 @@ class Laravel5 extends Framework implements ActiveRecord, PartedModule
      * $I->amLoggedAs(['username' => 'jane@example.com', 'password' => 'password']);
      *
      * // provide User object
-     * $I->amLoggesAs( new User );
+     * $I->amLoggedAs( new User );
      *
      * // can be verified with $I->seeAuthentication();
      * ?>


### PR DESCRIPTION
Previously #2706, fixed in the module itself as the .md file is automatically generated.

There's a typo for the `amLoggedAs` function documentation:

```
$I->amLoggesAs( new User );
```

should be:

```
$I->amLoggedAs( new User );
```