### PR TITLE
Generate separate phar file for PHP 5.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -56,5 +56,8 @@
         "branch-alias": {
         }
     },
-    "bin":["codecept"]
+    "bin":["codecept"],
+    "config": {
+        "platform": {}
+    }
 }


### PR DESCRIPTION
PHP5.4 phar will be bundled with Guzzle 5.3 and Symfony 2.8
The main phar file will be bundled with the latest version of Guzzle 6 and Symfony 3.

Solves #2124