### PR TITLE
fix deps compatibility with Symfony3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,13 +22,13 @@
         "facebook/webdriver": ">=1.0.1",
         "guzzlehttp/guzzle": ">=4.1.4 <7.0",
         "guzzlehttp/psr7": "~1.0",
-        "symfony/finder": ">=2.4|<3.1",
-        "symfony/console": ">=2.4|<3.1",
-        "symfony/event-dispatcher": ">=2.4|<3.1",
-        "symfony/yaml": ">=2.4|<3.1",
-        "symfony/browser-kit": ">=2.4|<3.1",
-        "symfony/css-selector": ">=2.4|<3.1",
-        "symfony/dom-crawler": ">=2.4|<3.1"
+        "symfony/finder": ">=2.4,<3.1",
+        "symfony/console": ">=2.4,<3.1",
+        "symfony/event-dispatcher": ">=2.4,<3.1",
+        "symfony/yaml": ">=2.4,<3.1",
+        "symfony/browser-kit": ">=2.4,<3.1",
+        "symfony/css-selector": ">=2.4,<3.1",
+        "symfony/dom-crawler": ">=2.4,<3.1"
     },
     "require-dev": {
         "monolog/monolog": "~1.8",


### PR DESCRIPTION
In changelog I see Symfony3 support declared. It's not true, actually.
Probably, bug in composer.json.

app@core12-app:/application$ composer require --dev "codeception/codeception:2.1.5"
./composer.json has been updated
Loading composer repositories with package information
Updating dependencies (including require-dev)
Your requirements could not be resolved to an installable set of packages.

Problem 1
- Conclusion: remove symfony/symfony v3.0.1
- Conclusion: don't install symfony/symfony v3.0.1
- don't install symfony/symfony v3.0.1|remove symfony/css-selector v2.8.2
- don't install symfony/css-selector v2.8.2|don't install symfony/symfony v3.0.1
- don't install symfony/css-selector v2.8.2|don't install symfony/symfony v3.0.1
- Installation request for symfony/symfony == 3.0.1.0 -> satisfiable by symfony/symfony[v3.0.1].
- Installation request for symfony/css-selector == 2.8.2.0 -> satisfiable by symfony/css-selector[v2.8.2].