### PR TITLE
fix Bug in FTP Module

### DIFF
--- a/src/Codeception/Module/FTP.php
+++ b/src/Codeception/Module/FTP.php
@@ -135,7 +135,7 @@ class FTP extends Filesystem
     /**
      * Close the FTP connection & Clear up
      */
-    public function _after()
+    public function _after(TestCase $test)
     {
         $this->_closeConnection();
 
@@ -570,6 +570,7 @@ class FTP extends Filesystem
         }
         if (!$this->isSFTP()) {
             ftp_close($this->ftp);
+            $this->ftp = null;
         }
     }
 
@@ -733,7 +734,7 @@ class FTP extends Filesystem
      *
      * @param $filename
      */
-    private function delete($filename, $isDir = flase)
+    private function delete($filename, $isDir = false)
     {
         if ($this->isSFTP()) {
             $deleted = @$this->ftp->delete($filename, $isDir);


### PR DESCRIPTION
1. Add the argument of _after ()
2. $this->ftp to NULL, after ftp_close.  
If you do not do this, then _closeConnection() for ftp_close is re-executed when is called.
3. Fixed a typo flase to false
