### PR TITLE
Escape file paths before validate

### DIFF
--- a/src/Codeception/Lib/Parser.php
+++ b/src/Codeception/Lib/Parser.php
@@ -126,6 +126,7 @@ class Parser
 
     public static function validate($file)
     {
+        $file = str_replace(' ', '\ ', $file);
         exec("php -l ".escapeshellarg($file)." 2>&1", $output, $code);
         if ($code !== 0) {
             throw new TestParseException($file, implode("\n", $output));


### PR DESCRIPTION
Related #2760.

This PR escape the file path before run the exec command, adding support for file paths containing spaces.