### PR TITLE
Improved steps output in 2.1 branch

### DIFF
--- a/src/Codeception/Step.php
+++ b/src/Codeception/Step.php
@@ -98,11 +98,12 @@ abstract class Step
 
     protected function getArgumentsAsString(array $arguments)
     {
+        $argumentsAsJson = [];
         foreach ($arguments as $key => $argument) {
-            $arguments[$key] = (is_string($argument)) ? trim($argument,"''") : $this->parseArgumentAsString($argument);
+            $argumentsAsJson []= stripcslashes(json_encode($this->parseArgumentAsString($argument), JSON_UNESCAPED_UNICODE));
         }
 
-        return stripcslashes(trim(json_encode($arguments, JSON_UNESCAPED_UNICODE), '[]'));
+        return implode(',', $argumentsAsJson);
     }
 
     protected function parseArgumentAsString($argument)
@@ -114,18 +115,35 @@ abstract class Step
             if (get_class($argument) == 'Facebook\WebDriver\WebDriverBy') {
                 return Locator::humanReadableString($argument);
             }
+            return $this->getClassName($argument);
         }
-        if ($argument instanceof \Closure) {
-            return 'lambda function';
-        }
-        if (is_callable($argument)) {
-            return 'callable function';
-        }
-        if (!is_object($argument)) {
+
+        if (is_array($argument)) {
+            foreach ($argument as $key => $value) {
+                if (is_object($value)) {
+                    $argument[$key] = $this->getClassName($value);
+                }
+            }
             return $argument;
         }
 
-        return (isset($argument->__mocked)) ? $this->formatClassName($argument->__mocked) : $this->formatClassName(get_class($argument));
+        if (is_resource($argument)) {
+            return (string)$argument;
+        }
+
+        return $argument;
+    }
+
+
+    protected function getClassName($argument)
+    {
+        if ($argument instanceof \Closure) {
+            return 'Closure';
+        } elseif ((isset($argument->__mocked))) {
+            return $this->formatClassName($argument->__mocked);
+        } else {
+            return $this->formatClassName(get_class($argument));
+        }
     }
 
     protected function formatClassName($classname)

--- a/tests/unit/Codeception/StepTest.php
+++ b/tests/unit/Codeception/StepTest.php
@@ -17,13 +17,16 @@ class StepTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('"' . Locator::humanReadableString($by) . '"', $step->getArguments(true));
 
         $step = $this->getStep([null, [['just', 'array']]]);
-        $this->assertEquals('"just","array"', $step->getArguments(true));
+        $this->assertEquals('["just","array"]', $step->getArguments(true));
 
         $step = $this->getStep([null, [function(){}]]);
-        $this->assertEquals('"lambda function"', $step->getArguments(true));
+        $this->assertEquals('"Closure"', $step->getArguments(true));
 
         $step = $this->getStep([null, [[$this, 'testGetArguments']]]);
-        $this->assertEquals('"callable function"', $step->getArguments(true));
+        $this->assertEquals('["StepTest","testGetArguments"]', $step->getArguments(true));
+
+        $step = $this->getStep([null, [['PDO', 'getAvailableDrivers']]]);
+        $this->assertEquals('["PDO","getAvailableDrivers"]', $step->getArguments(true));
     }
 
     public function testGetHtml()


### PR DESCRIPTION
Backporting some changes made in https://github.com/Codeception/Codeception/pull/2777 to 2.1

Don't trim external [ if the first or the argument is array;
Display "Closure" instead of "lambda function"
Eliminated "callable function" - a full content of array (or any other callable) is displayed, 
Objects in array are replaced with class name.


