### PR TITLE
Limit step output length to 1 line

### DIFF
--- a/src/Codeception/Lib/Console/Message.php
+++ b/src/Codeception/Lib/Console/Message.php
@@ -31,7 +31,7 @@ class Message
 
     public function width($length, $char = ' ')
     {
-        $message_length = strlen(strip_tags($this->message));
+        $message_length = mb_strlen(strip_tags($this->message));
         if ($message_length < $length) {
             $this->message .= str_repeat($char, $length - $message_length);
         }
@@ -40,7 +40,7 @@ class Message
 
     public function cut($length)
     {
-        $this->message = substr($this->message, 0, $length);
+        $this->message = mb_substr($this->message, 0, $length);
         return $this;
     }
 
@@ -108,10 +108,7 @@ class Message
 
     public function getLength()
     {
-        if (function_exists('mb_strlen')) {
-            return mb_strlen($this->message);
-        }
-        return strlen($this->message);
+        return mb_strlen($this->message);
     }
 
     public function __toString()

--- a/src/Codeception/Step/Comment.php
+++ b/src/Codeception/Step/Comment.php
@@ -11,6 +11,11 @@ class Comment extends CodeceptionStep
         return $this->getAction();
     }
 
+    public function toString($maxLength)
+    {
+        return $this->getAction();
+    }
+
     public function getHumanizedAction()
     {
         return $this->getAction();
@@ -21,7 +26,7 @@ class Comment extends CodeceptionStep
         return '<strong>' . $this->getAction() . '</strong>';
     }
 
-    public function getPhpCode()
+    public function getPhpCode($maxLength)
     {
         return '// ' . $this->getAction();
     }

--- a/src/Codeception/Step/Meta.php
+++ b/src/Codeception/Step/Meta.php
@@ -21,14 +21,17 @@ class Meta extends CodeceptionStep
         $this->prefix = $actor;
     }
 
-    protected function getArgumentsAsString(array $arguments)
+    public function getArgumentsAsString($maxLength = 200)
     {
+        $argumentBackup = $this->arguments;
         $lastArgAsString = '';
-        $lastArg = end($arguments);
+        $lastArg = end($this->arguments);
         if (is_string($lastArg) && strpos($lastArg, "\n")  !== false) {
             $lastArgAsString = "\r\n   " . str_replace("\n", "\n   ", $lastArg);
-            array_pop($arguments);
+            array_pop($this->arguments);
         }
-        return parent::getArgumentsAsString($arguments) . $lastArgAsString;
+        $result = parent::getArgumentsAsString($maxLength) . $lastArgAsString;
+        $this->arguments = $argumentBackup;
+        return $result;
     }
 }

--- a/src/Codeception/Subscriber/Console.php
+++ b/src/Codeception/Subscriber/Console.php
@@ -260,10 +260,11 @@ class Console implements EventSubscriberInterface
             $msg->append('  ');
         }
         $msg->append($step->getPrefix());
+        $prefixLength = $msg->getLength();
         if (!$this->metaStep) {
             $msg->style('bold');
         }
-        $maxLength = $this->width - $msg->getLength();
+        $maxLength = $this->width - $prefixLength;
         $msg->append($step->toString($maxLength));
         if ($this->metaStep) {
             $msg->style('info');

--- a/tests/cli/RunCest.php
+++ b/tests/cli/RunCest.php
@@ -278,7 +278,7 @@ EOF
             $scenario->skip("Xdebug not loaded");
         }
 
-        $file = "codeception".DIRECTORY_SEPARATOR."c3";
+        $file = "codeception\\".DIRECTORY_SEPARATOR."c3";
         $I->executeCommand('run scenario SubStepsCept --steps');
         $I->seeInShellOutput(<<<EOF
 Scenario --


### PR DESCRIPTION
Example of effect:
Command: `php codecept run tests/cli/RunCest.php:Failed --steps`
Output:
```
Cli Tests (28) ----------------------------------------------------------------------
Run test with failed scenario RunCest.php
Scenario --
 I am in path "tests\/data\/sandbox"
 I execute command "run scenario FailedCept --steps --no-exit"
 I see in shell output "Fail when file is not found at FailedCept.php\nScenario -..."
 I expect to see scenario trace
 I see in shell output "Scenario Steps:\n\n 2. $I->seeFileFound(\"games.zip\") at..."
 PASSED 

-------------------------------------------------------------------------------------

```