### PR TITLE
Empty coverage simple workaround

### DIFF
--- a/src/Codeception/Coverage/Subscriber/LocalServer.php
+++ b/src/Codeception/Coverage/Subscriber/LocalServer.php
@@ -103,15 +103,21 @@ class LocalServer extends SuiteSubscriber
         if (!$this->isEnabled()) {
             return;
         }
+        $coverageFile = Configuration::outputDir() . 'c3tmp/codecoverage.serialized';
 
-        if (!file_exists(Configuration::outputDir() . 'c3tmp/codecoverage.serialized')) {
+        $retries = 5;
+        while (!file_exists($coverageFile) && --$retries >= 0) {
+            usleep(0.5 * 1000000); // 0.5 sec
+        }
+
+        if (!file_exists($coverageFile)) {
             if (file_exists(Configuration::outputDir() . 'c3tmp/error.txt')) {
                 throw new \RuntimeException(file_get_contents(Configuration::outputDir() . 'c3tmp/error.txt'));
             }
             return;
         }
 
-        $contents = file_get_contents(Configuration::outputDir() . 'c3tmp/codecoverage.serialized');
+        $contents = file_get_contents($coverageFile);
         $coverage = @unserialize($contents);
         if ($coverage === false) {
             return;


### PR DESCRIPTION
Sometimes coverage is empty because c3 creates coverage file later, than afterSuite executed.
Related to #1719

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/codeception/codeception/2785)
<!-- Reviewable:end -->
