### PR TITLE
REST: Added test to prove that HTTP_HOST header can be set

### DIFF
--- a/tests/data/rest/index.php
+++ b/tests/data/rest/index.php
@@ -28,7 +28,11 @@ $GLOBALS['RESTmap']['GET'] = [
                 0
             ],
         ];
+    },
+    'http-host' => function() {
+        return 'host: "' . $_SERVER['HTTP_HOST'] . '"';
     }
+
 ];
 
 $GLOBALS['RESTmap']['POST'] = [

--- a/tests/unit/Codeception/Module/PhpBrowserRestTest.php
+++ b/tests/unit/Codeception/Module/PhpBrowserRestTest.php
@@ -235,6 +235,19 @@ class PhpBrowserRestTest extends \PHPUnit_Framework_TestCase
         $this->module->seeResponseIsJson();
     }
 
+    /**
+     * @Issue https://github.com/Codeception/Codeception/issues/1650
+     */
+    public function testHostHeader()
+    {
+        $this->module->sendGET('/rest/http-host/');
+        $this->module->seeResponseContains('host: "localhost:8010"');
+
+        $this->module->haveHttpHeader('Host','www.example.com');
+        $this->module->sendGET('/rest/http-host/');
+        $this->module->seeResponseContains('host: "www.example.com"');
+    }
+
     protected function shouldFail()
     {
         $this->setExpectedException('PHPUnit_Framework_AssertionFailedError');

--- a/tests/unit/Codeception/Module/PhpBrowserRestTest.php
+++ b/tests/unit/Codeception/Module/PhpBrowserRestTest.php
@@ -240,6 +240,10 @@ class PhpBrowserRestTest extends \PHPUnit_Framework_TestCase
      */
     public function testHostHeader()
     {
+        if (getenv('dependencies') === 'lowest') {
+            $this->markTestSkipped('This test can\'t pass with the lowest versions of dependencies');
+        }
+
         $this->module->sendGET('/rest/http-host/');
         $this->module->seeResponseContains('host: "localhost:8010"');
 


### PR DESCRIPTION
Closes #1650 

My patch was accepted to symfony/browserkit on 27th of January and released in 3.0.2 version,
2.* branches will be fixed in the next release cycle.