### PR TITLE
Fix for codecept autoloader search paths

### DIFF
--- a/codecept
+++ b/codecept
@@ -4,7 +4,15 @@
  * Codeception CLI
  */
 
-require_once dirname(__FILE__).'/autoload.php';
+if (
+    $autoloader = realpath(__DIR__ . '/autoload.php')
+    or $autoloader = realpath(dirname(__DIR__) . '/codeception/codeception/autoload.php')
+) {
+    require_once $autoloader;
+} else {
+    echo "Autoloader was not found";
+    exit(255);
+}
 
 use Symfony\Component\Console\Application;
 


### PR DESCRIPTION
I've tried to call codeception executable from the vendor/bin folder. But there was an error related to the search path of the autoload.php file. This fix should help codecept to find autoloader even if in the bin directory of another project