### PR TITLE
Making testing for phalcon 1.3.x usable

### DIFF
--- a/src/Codeception/Lib/Connector/Phalcon1.php
+++ b/src/Codeception/Lib/Connector/Phalcon1.php
@@ -16,7 +16,7 @@ use ReflectionProperty;
 use RuntimeException;
 use Closure;
 
-class Phalcon extends Client
+class Phalcon1 extends Client
 {
     use PhpSuperGlobalsConverter;
 
@@ -156,7 +156,7 @@ class Phalcon extends Client
     }
 }
 
-class PhalconMemorySession implements SessionInterface
+class Phalcon1MemorySession implements SessionInterface
 {
     /**
      * @var string
@@ -212,7 +212,7 @@ class PhalconMemorySession implements SessionInterface
      *
      * @param array $options
      */
-    public function setOptions(array $options)
+    public function setOptions($options)
     {
         if (isset($options['uniqueId'])) {
             $this->sessionId = $options['uniqueId'];

--- a/src/Codeception/Lib/Connector/Phalcon2.php
+++ b/src/Codeception/Lib/Connector/Phalcon2.php
@@ -1,0 +1,20 @@
+<?php
+namespace Codeception\Lib\Connector;
+
+class Phalcon2 extends Phalcon1
+{
+}
+
+class Phalcon2MemorySession extends Phalcon1MemorySession
+{
+    /**
+     * @inheritdoc
+     * Due to difference of version 1.3.x
+     *
+     * @param array $options
+     */
+    public function setOptions(array $options)
+    {
+        parent::setOptions($options);
+    }
+}

--- a/src/Codeception/Module/Phalcon1.php
+++ b/src/Codeception/Module/Phalcon1.php
@@ -13,13 +13,13 @@ use Codeception\Util\ReflectionHelper;
 use Phalcon\Mvc\Url;
 use Codeception\TestCase;
 use Codeception\Configuration;
-use Codeception\Lib\Connector\Phalcon as PhalconConnector;
+use Codeception\Lib\Connector\Phalcon1 as Phalcon1Connector;
+use Codeception\Lib\Connector\Phalcon1MemorySession;
 use Codeception\Lib\Framework;
 use Codeception\Lib\Interfaces\ActiveRecord;
 use Codeception\Lib\Interfaces\PartedModule;
 use Codeception\Exception\ModuleConfigException;
 use Exception;
-use Codeception\Lib\Connector\PhalconMemorySession;
 
 /**
  * This module provides integration with [Phalcon framework](http://www.phalconphp.com/) (1.x).
@@ -96,7 +96,7 @@ class Phalcon1 extends Framework implements ActiveRecord, PartedModule
 
     /**
      * Phalcon Connector
-     * @var PhalconConnector
+     * @var Phalcon1Connector
      */
     public $client;
 
@@ -121,8 +121,7 @@ class Phalcon1 extends Framework implements ActiveRecord, PartedModule
                 . 'return new \Phalcon\Mvc\Application($di);'
             );
         }
-
-        $this->client = new PhalconConnector();
+        $this->client = $this->createClient();
     }
 
     /**
@@ -149,7 +148,7 @@ class Phalcon1 extends Framework implements ActiveRecord, PartedModule
 
         if ($this->di->has('session')) {
             // Destroy existing sessions of previous tests
-            $this->di['session'] = new PhalconMemorySession();
+            $this->di['session'] = $this->createSession();
         }
 
         if ($this->di->has('cookies')) {
@@ -211,6 +210,22 @@ class Phalcon1 extends Framework implements ActiveRecord, PartedModule
     public function _parts()
     {
         return ['orm'];
+    }
+
+    /**
+     * @return Phalcon1Connector
+     */
+    public function createClient()
+    {
+        return new Phalcon1Connector();
+    }
+
+    /**
+     * @return Phalcon1MemorySession
+     */
+    public function createSession()
+    {
+        return new Phalcon1MemorySession();
     }
 
     /**

--- a/src/Codeception/Module/Phalcon2.php
+++ b/src/Codeception/Module/Phalcon2.php
@@ -2,7 +2,8 @@
 namespace Codeception\Module;
 
 use Phalcon\Di;
-use Phalcon\Mvc\Model as PhalconModel;
+use Codeception\Lib\Connector\Phalcon2 as Phalcon2Connector;
+use Codeception\Lib\Connector\Phalcon2MemorySession;
 use Codeception\TestCase;
 
 /**
@@ -62,4 +63,19 @@ use Codeception\TestCase;
  */
 class Phalcon2 extends Phalcon1
 {
+    /**
+     * @return Phalcon2Connector
+     */
+    public function createClient()
+    {
+        return new Phalcon2Connector();
+    }
+
+    /**
+     * @return Phalcon2MemorySession
+     */
+    public function createSession()
+    {
+        return new Phalcon2MemorySession();
+    }
 }


### PR DESCRIPTION
Due to differences of declaration for some function arguments in
different phalcon versions (1.3.x -> 2.x) was it unable to run tests on
version 1.3.x. The commit is an offer to make both (1.x and 2.x) version
usable for testing.