### PR TITLE
Changed the way sqlite is managing the files

### DIFF
--- a/src/Codeception/Lib/Driver/Sqlite.php
+++ b/src/Codeception/Lib/Driver/Sqlite.php
@@ -11,9 +11,9 @@ class Sqlite extends Db
 
     public function __construct($dsn, $user, $password)
     {
-        parent::__construct($dsn, $user, $password);
-        $this->filename = Configuration::projectDir() . substr($this->dsn, 7);
+        $this->filename = Configuration::projectDir() . substr($dsn, 7);
         $this->dsn = 'sqlite:' . $this->filename;
+        parent::__construct($this->dsn, $user, $password);
     }
 
     public function cleanup()


### PR DESCRIPTION
I started to have some problems while using sqlite to run tests.

Originally Sqlite constructor did the following:
```php
        parent::__construct($dsn, $user, $password);
        $this->filename = Configuration::projectDir() . substr($this->dsn, 7);
        $this->dsn = 'sqlite:' . $this->filename;
```

The call to parent::__construct creates a connection using the dsn from the parameter, then the filename and dsn are modified prepending the projectDir.
This fails, caused a problem while running my tests because if the connection was successful, then the load failed because the path had been changed, and if I changed the path in the dsn to match the one in load, then the connection failed.
I think it is better to first prepend the projectDir and then call parent, so connection and load use the same path.

```php
        $this->filename = Configuration::projectDir() . substr($dsn, 7);
        $this->dsn = 'sqlite:' . $this->filename;
        parent::__construct($this->dsn, $user, $password);
```
Still, this won't work with absolute paths. But I am not sure if that was planned by design.