### PR TITLE
Typo in "dontSeeXmlResponseMatchesXpath"

### DIFF
--- a/src/Codeception/Module/REST.php
+++ b/src/Codeception/Module/REST.php
@@ -974,7 +974,7 @@ EOF;
     public function dontSeeXmlResponseMatchesXpath($xpath)
     {
         $structure = new XmlStructure($this->connectionModule->_getResponseContent());
-        $this->assertTrue($structure->matchesXpath($xpath), 'accidentally matched xpath');
+        $this->assertFalse($structure->matchesXpath($xpath), 'accidentally matched xpath');
     }
 
     /**


### PR DESCRIPTION
Assertion should be negative. Specified xpath shouldn't be in XML structure.