### PR TITLE
Fix encoding problems in PHP prior to 5.6 related to #120 and #2810

### DIFF
--- a/src/Codeception/Actor.php
+++ b/src/Codeception/Actor.php
@@ -36,7 +36,7 @@ abstract class Actor
 
     public function wantTo($text)
     {
-        $this->scenario->setFeature(mb_strtolower($text));
+        $this->scenario->setFeature(mb_strtolower($text, 'utf-8'));
     }
 
     public function __call($method, $arguments)

--- a/src/Codeception/Lib/Console/Message.php
+++ b/src/Codeception/Lib/Console/Message.php
@@ -109,7 +109,7 @@ class Message
     public function getLength()
     {
         if (function_exists('mb_strlen')) {
-            return mb_strlen($this->message);
+            return mb_strlen($this->message, 'utf-8');
         }
         return strlen($this->message);
     }


### PR DESCRIPTION
Fix utf-8 encoding issue in PHP < 5.6 (mb_* functions default charset)

## Before
![problem](https://cloud.githubusercontent.com/assets/3164102/13215080/43dfcc2e-d953-11e5-993d-07f33b081a8c.png)

## After
![fix](https://cloud.githubusercontent.com/assets/3164102/13215083/476fb818-d953-11e5-90d2-ff1da2bd6242.png)
