### PR TITLE
Examples

### DIFF
--- a/src/Codeception/Example.php
+++ b/src/Codeception/Example.php
@@ -1,0 +1,77 @@
+<?php
+namespace Codeception;
+
+class Example implements \ArrayAccess
+{
+    protected $data;
+
+    public function __construct($data)
+    {
+        $this->data = $data;
+    }
+
+    /**
+     * Whether a offset exists
+     * @link http://php.net/manual/en/arrayaccess.offsetexists.php
+     * @param mixed $offset <p>
+     * An offset to check for.
+     * </p>
+     * @return boolean true on success or false on failure.
+     * </p>
+     * <p>
+     * The return value will be casted to boolean if non-boolean was returned.
+     * @since 5.0.0
+     */
+    public function offsetExists($offset)
+    {
+        return isset($this->data[$offset]);
+    }
+
+    /**
+     * Offset to retrieve
+     * @link http://php.net/manual/en/arrayaccess.offsetget.php
+     * @param mixed $offset <p>
+     * The offset to retrieve.
+     * </p>
+     * @return mixed Can return all value types.
+     * @since 5.0.0
+     */
+    public function offsetGet($offset)
+    {
+        if (!$this->offsetExists($offset)) {
+            throw new \PHPUnit_Framework_AssertionFailedError("Example $offset doesn't exist");
+        };
+        return $this->data[$offset];
+    }
+
+    /**
+     * Offset to set
+     * @link http://php.net/manual/en/arrayaccess.offsetset.php
+     * @param mixed $offset <p>
+     * The offset to assign the value to.
+     * </p>
+     * @param mixed $value <p>
+     * The value to set.
+     * </p>
+     * @return void
+     * @since 5.0.0
+     */
+    public function offsetSet($offset, $value)
+    {
+        $this->data[$offset] = $value;
+    }
+
+    /**
+     * Offset to unset
+     * @link http://php.net/manual/en/arrayaccess.offsetunset.php
+     * @param mixed $offset <p>
+     * The offset to unset.
+     * </p>
+     * @return void
+     * @since 5.0.0
+     */
+    public function offsetUnset($offset)
+    {
+        unset($this->data[$offset]);
+    }
+}

--- a/src/Codeception/SuiteManager.php
+++ b/src/Codeception/SuiteManager.php
@@ -111,9 +111,6 @@ class SuiteManager
                 $this->configureTest($t);
             }
         }
-        if ($test instanceof ScenarioDriven) {
-            $test->preload();
-        }
         if ($test instanceof TestInterface) {
             $this->checkEnvironmentExists($test);
             if (!$this->isExecutedInCurrentEnvironment($test)) {
@@ -227,5 +224,8 @@ class SuiteManager
             'env' => $this->env,
             'modules' => $this->moduleContainer->all()
         ]);
+        if ($t instanceof ScenarioDriven) {
+            $t->preload();
+        }
     }
 }

--- a/src/Codeception/Test/Gherkin.php
+++ b/src/Codeception/Test/Gherkin.php
@@ -2,7 +2,7 @@
 namespace Codeception\Test;
 
 use Behat\Gherkin\Node\FeatureNode;
-use Behat\Gherkin\Node\ScenarioNode;
+use Behat\Gherkin\Node\ScenarioInterface;
 use Behat\Gherkin\Node\StepNode;
 use Behat\Gherkin\Node\TableNode;
 use Codeception\Lib\Di;
@@ -30,7 +30,7 @@ class Gherkin extends Test implements ScenarioDriven
      */
     protected $scenario;
 
-    public function __construct(FeatureNode $featureNode, ScenarioNode $scenarioNode, $steps = [])
+    public function __construct(FeatureNode $featureNode, ScenarioInterface $scenarioNode, $steps = [])
     {
         $this->featureNode = $featureNode;
         $this->scenarioNode = $scenarioNode;

--- a/src/Codeception/Test/Loader/Cest.php
+++ b/src/Codeception/Test/Loader/Cest.php
@@ -1,6 +1,7 @@
 <?php
 namespace Codeception\Test\Loader;
 
+use Codeception\Lib\ExampleSuite;
 use Codeception\Lib\Parser;
 use Codeception\Test\Cest as CestFormat;
 use Codeception\Util\Annotation;
@@ -31,25 +32,33 @@ class Cest implements LoaderInterface
             if (!(new \ReflectionClass($testClass))->isInstantiable()) {
                 continue;
             }
-
             $unit = new $testClass;
 
             $methods = get_class_methods($testClass);
             foreach ($methods as $method) {
-                $test = $this->createTestForMethod($unit, $method, $file);
-                if ($test) {
-                    $this->tests[] = $test;
+                if (strpos($method, '_') === 0) {
+                    continue;
                 }
+
+                $examples = Annotation::forMethod($unit, $method)->fetchAll('example');
+                if (count($examples)) {
+                    $examples = array_map(
+                        function ($v) {
+                            return Annotation::arrayValue($v);
+                        }, $examples
+                    );
+                    $dataProvider = new \PHPUnit_Framework_TestSuite_DataProvider();
+                    foreach ($examples as $example) {
+                        $test = new CestFormat($unit, $method, $file);
+                        $test->getMetadata()->setCurrent(['example' => $example]);
+                        $dataProvider->addTest($test);
+                    }
+                    $this->tests[] = $dataProvider;
+                    continue;
+                }
+                $this->tests[] = new CestFormat($unit, $method, $file);
             }
         }
     }
 
-    protected function createTestForMethod($cestInstance, $methodName, $file)
-    {
-        if (strpos($methodName, '_') === 0) {
-            return null;
-        }
-
-        return new CestFormat($cestInstance, $methodName, $file);
-    }
 }

--- a/src/Codeception/Util/Annotation.php
+++ b/src/Codeception/Util/Annotation.php
@@ -7,7 +7,7 @@ namespace Codeception\Util;
 class Annotation
 {
     protected static $reflectedClasses = [];
-    protected static $regex = '/@%s(?:[ \t]+(.*?))?[ \t]*\r?$/m';
+    protected static $regex = '/@%s(?:[ \t]*(.*?))?[ \t]*\r?$/m';
     protected static $lastReflected = null;
 
     /**
@@ -120,5 +120,35 @@ class Annotation
     public function raw()
     {
         return $this->currentReflectedItem->getDocComment();
+    }
+
+    /**
+     * Returns an associative array value of annotation
+     * Either JSON or Doctrine-annotation style allowed
+     * Returns null if not a valid array data
+     *
+     * @param $annotation
+     * @return array|mixed|string
+     */
+    public static function arrayValue($annotation)
+    {
+        $annotation = trim($annotation);
+        $openingBrace = substr($annotation, 0, 1);
+
+        // json-style data format
+        if (in_array($openingBrace, ['{', '['])) {
+            return json_decode($annotation, true);
+        }
+
+        // doctrine-style data format
+        if ($openingBrace === '(') {
+            preg_match_all('~(\w+)\s*?=\s*?"(.*?)"\s*?[,)]~', $annotation, $matches, PREG_SET_ORDER);
+            $data = [];
+            foreach ($matches as $item) {
+                $data[$item[1]] = $item[2];
+            }
+            return $data;
+        }
+        return null;
     }
 }

--- a/tests/cli/RunCest.php
+++ b/tests/cli/RunCest.php
@@ -337,5 +337,47 @@ EOF
         $I->seeInShellOutput('Step definition for `I have only idea of what\'s going on here` not found in contexts');
     }
 
+    public function runGherkinScenarioOutline(CliGuy $I)
+    {
+        $I->executeCommand('run scenario FileExamples.feature -v');
+        $I->seeInShellOutput('OK (3 tests');
+    }
+
+
+    /**
+     * @param CliGuy $I
+     * @after checkExampleFiles
+     */
+    public function runTestWithAnnotationExamples(CliGuy $I)
+    {
+        $I->executeCommand('run scenario ExamplesCest:filesExistsAnnotation --steps');
+    }
+
+    /**
+     * @param CliGuy $I
+     * @after checkExampleFiles
+     */
+    public function runTestWithJsonExamples(CliGuy $I)
+    {
+        $I->executeCommand('run scenario ExamplesCest:filesExistsByJson --steps');
+    }
+
+    /**
+     * @param CliGuy $I
+     * @after checkExampleFiles
+     */
+    public function runTestWithArrayExamples(CliGuy $I)
+    {
+        $I->executeCommand('run scenario ExamplesCest:filesExistsByArray --steps');
+    }
+
+    protected function checkExampleFiles(CliGuy $I)
+    {
+        $I->seeInShellOutput('OK (3 tests');
+        $I->seeInShellOutput('I see file found "scenario.suite.yml"');
+        $I->seeInShellOutput('I see file found "dummy.suite.yml"');
+        $I->seeInShellOutput('I see file found "unit.suite.yml"');
+    }
+
 
 }

--- a/tests/data/claypit/tests/_support/ScenarioGuy.php
+++ b/tests/data/claypit/tests/_support/ScenarioGuy.php
@@ -44,6 +44,14 @@ class ScenarioGuy extends \Codeception\Actor
     }
 
     /**
+     * @Given I am inside :dir
+     */
+    public function openDir($path)
+    {
+        $this->amInPath($path);
+    }
+
+    /**
      * @Then there is a file :name
      */
     public function matchFile($name)

--- a/tests/data/claypit/tests/scenario/ExamplesCest.php
+++ b/tests/data/claypit/tests/scenario/ExamplesCest.php
@@ -1,0 +1,40 @@
+<?php
+use Codeception\Example;
+
+class ExamplesCest
+{
+    /**
+     * @example(path=".", file="scenario.suite.yml")
+     * @example(path=".", file="dummy.suite.yml")
+     * @example(path=".", file="unit.suite.yml")
+     */
+    public function filesExistsAnnotation(ScenarioGuy $I, Example $example)
+    {
+        $I->amInPath($example['path']);
+        $I->seeFileFound($example['file']);
+    }
+
+
+    /**
+     * @example { "path":".", "file":"scenario.suite.yml" }
+     * @example { "path":".", "file":"dummy.suite.yml" }
+     * @example { "path":".", "file":"unit.suite.yml" }
+     */
+    public function filesExistsByJson(ScenarioGuy $I, Example $example)
+    {
+        $I->amInPath($example['path']);
+        $I->seeFileFound($example['file']);
+    }
+
+    /**
+     * @example [".", "scenario.suite.yml"]
+     * @example [".", "dummy.suite.yml"]
+     * @example [".", "unit.suite.yml"]
+     */
+    public function filesExistsByArray(ScenarioGuy $I, Example $example)
+    {
+        $I->amInPath($example[0]);
+        $I->seeFileFound($example[1]);
+    }
+
+}

--- a/tests/data/claypit/tests/scenario/FileExamples.feature
+++ b/tests/data/claypit/tests/scenario/FileExamples.feature
@@ -1,0 +1,15 @@
+Feature: Suite configs
+  In order to run tests
+  As a user
+  I need to have suite config files
+
+  Scenario Outline: Check file exists
+    Given I have terminal opened
+    When I am inside "<directory>"
+    Then there is a file "<filename>"
+
+    Examples:
+      | directory | filename            |
+      | .         | unit.suite.yml      |
+      | .         | scenario.suite.yml  |
+      | .         | dummy.suite.yml     |

--- a/tests/unit/Codeception/Util/AnnotationTest.php
+++ b/tests/unit/Codeception/Util/AnnotationTest.php
@@ -39,5 +39,16 @@ class AnnotationTest extends PHPUnit_Framework_TestCase {
         );
     }
 
+    public function testValueToSupportJson()
+    {
+        $values = Annotation::arrayValue('{ "code": "200", "user": "davert", "email": "davert@gmail.com" }');
+        $this->assertEquals(['code' => '200', 'user' => 'davert', 'email' => 'davert@gmail.com'], $values);
+    }
+
+    public function testValueToSupportAnnotationStyle()
+    {
+        $values = Annotation::arrayValue('( code="200", user="davert", email = "davert@gmail.com")');
+        $this->assertEquals(['code' => '200', 'user' => 'davert', 'email' => 'davert@gmail.com'], $values);
+    }
 
 }


### PR DESCRIPTION
Implementation of Examples in Cest format and [Scenario Outlines](https://github.com/cucumber/cucumber/wiki/Scenario-Outlines) for Gherkin. 
Examples are DataProviders alternative for scenario driven tests. 

Examples can be passed as doctrine-style annotations, json-object or json-array.

```php
    /**
     * @example(path=".", file="scenario.suite.yml")
     * @example(path=".", file="dummy.suite.yml")
     * @example(path=".", file="unit.suite.yml")
     */
    public function filesExistsAnnotation(ScenarioGuy $I, Example $example)
    {
        $I->amInPath($example['path']);
        $I->seeFileFound($example['file']);
    }


    /**
     * @example { "path":".", "file":"scenario.suite.yml" }
     * @example { "path":".", "file":"dummy.suite.yml" }
     * @example { "path":".", "file":"unit.suite.yml" }
     */
    public function filesExistsByJson(ScenarioGuy $I, Example $example)
    {
        $I->amInPath($example['path']);
        $I->seeFileFound($example['file']);
    }

    /**
     * @example [".", "scenario.suite.yml"]
     * @example [".", "dummy.suite.yml"]
     * @example [".", "unit.suite.yml"]
     */
    public function filesExistsByArray(ScenarioGuy $I, Example $example)
    {
        $I->amInPath($example[0]);
        $I->seeFileFound($example[1]);
    }
```

See included file. 