### PR TITLE
Reproduced and fixed issue #2841

### DIFF
--- a/src/Codeception/Util/Uri.php
+++ b/src/Codeception/Util/Uri.php
@@ -42,16 +42,17 @@ class Uri
                 }
             }
             $base = $base->withPath($path);
-        }
-        if (isset($parts['scheme'])) {
-            $base = $base->withScheme($parts['scheme']);
+            $base = $base->withQuery('');
+            $base = $base->withFragment('');
         }
         if (isset($parts['query'])) {
             $base = $base->withQuery($parts['query']);
+            $base = $base->withFragment('');
         }
         if (isset($parts['fragment'])) {
             $base = $base->withFragment($parts['fragment']);
         }
+
         return (string) $base;
 
     }

--- a/src/Codeception/Util/Uri.php
+++ b/src/Codeception/Util/Uri.php
@@ -29,6 +29,12 @@ class Uri
             return $uri;
         }
 
+        if (isset($parts['host'])) {
+            $base = $base->withHost($parts['host']);
+            $base = $base->withPath('');
+            $base = $base->withQuery('');
+            $base = $base->withFragment('');
+        }
         if (isset($parts['path'])) {
             $path = $parts['path'];
             if ($base->getPath() && (strpos($path, '/') !== 0) && !empty($path)) {

--- a/tests/data/app/controllers.php
+++ b/tests/data/app/controllers.php
@@ -164,9 +164,12 @@ class form {
     }
 
     function POST() {
+        data::set('query', $_GET);
         data::set('form', $_POST);
         data::set('files', $_FILES);
-        if (isset($_SERVER['HTTP_X_REQUESTED_WITH'])) data::set('ajax','post');
+        if (isset($_SERVER['HTTP_X_REQUESTED_WITH'])) {
+            data::set('ajax','post');
+        }
 
         $notice = 'Thank you!';
         include __DIR__.'/view/index.php';

--- a/tests/data/app/view/form/bug2841.php
+++ b/tests/data/app/view/form/bug2841.php
@@ -1,0 +1,10 @@
+<!doctype html>
+<html>
+    <head><title>hi</title></head>
+    <body>
+    <form name="form" action="/form/bug2841" method="post" enctype="multipart/form-data">
+        <input name="in" type="text" id="texty">
+        <button type="submit" name="submit-registration" id="submit-registration" class="submit-registration">CLICKY</button>
+    </form>
+    </body>
+</html>

--- a/tests/unit/Codeception/Module/PhpBrowserTest.php
+++ b/tests/unit/Codeception/Module/PhpBrowserTest.php
@@ -523,4 +523,15 @@ class PhpBrowserTest extends TestsForBrowsers
             "'Sign In!' is invalid CSS and XPath selector and Link or Button element with 'name=Sign In!' was not found");
         $this->module->click('Sign In!');
     }
+
+    /**
+     * @issue https://github.com/Codeception/Codeception/issues/2841
+     */
+    public function testSubmitFormDoesNotKeepGetParameters()
+    {
+        $this->module->amOnPage('/form/bug2841?stuff=other');
+        $this->module->fillField('#texty', 'thingshjere');
+        $this->module->click('#submit-registration');
+        $this->assertEmpty(data::get('query'), 'Query string is not empty');
+    }
 }

--- a/tests/unit/Codeception/Util/UriTest.php
+++ b/tests/unit/Codeception/Util/UriTest.php
@@ -33,6 +33,8 @@ class UriTest extends \Codeception\TestCase\Test
     public function testMergingScheme()
     {
         $this->assertEquals('https://google.com/account/', Uri::mergeUrls('http://google.com/', 'https://google.com/account/'));
+        $this->assertEquals('https://facebook.com/', Uri::mergeUrls('https://google.com/test/', '//facebook.com/'));
+        $this->assertEquals('https://facebook.com/#anchor2', Uri::mergeUrls('https://google.com/?param=1#anchor', '//facebook.com/#anchor2'));
     }
 
     /**

--- a/tests/unit/Codeception/Util/UriTest.php
+++ b/tests/unit/Codeception/Util/UriTest.php
@@ -36,6 +36,17 @@ class UriTest extends \Codeception\TestCase\Test
     }
 
     /**
+     * @Issue https://github.com/Codeception/Codeception/pull/2841
+     */
+    public function testMergingPath()
+    {
+        $this->assertEquals('/form/?param=1#anchor', Uri::mergeUrls('/form/?param=1', '#anchor'));
+        $this->assertEquals('/form/?param=1#anchor2', Uri::mergeUrls('/form/?param=1#anchor1', '#anchor2'));
+        $this->assertEquals('/form/?param=2', Uri::mergeUrls('/form/?param=1#anchor', '?param=2'));
+        $this->assertEquals('/page/', Uri::mergeUrls('/form/?param=1#anchor', '/page/'));
+    }
+
+    /**
      * @Issue https://github.com/Codeception/Codeception/pull/2499
      */
     public function testAppendAnchor()


### PR DESCRIPTION
Fixes #2841 

Don't keep query string if new URI sets a path.
Don't keep anchor if new URI sets a path or a query string.