### PR TITLE
Replaced strlen with mb_strlen in Codeception\Step

### DIFF
--- a/src/Codeception/Step.php
+++ b/src/Codeception/Step.php
@@ -100,14 +100,14 @@ abstract class Step
         foreach ($arguments as $key => $argument) {
             $stringifiedArgument = $this->stringifyArgument($argument);
             $arguments[$key] = $stringifiedArgument;
-            $totalLength += strlen($stringifiedArgument);
+            $totalLength += mb_strlen($stringifiedArgument, 'utf-8');
         }
 
         if ($totalLength > $maxLength) {
             //sort arguments from shortest to longest
             uasort($arguments, function($arg1, $arg2) {
-                $length1 = strlen($arg1);
-                $length2 = strlen($arg2);
+                $length1 = mb_strlen($arg1, 'utf-8');
+                $length2 = mb_strlen($arg2, 'utf-8');
                 if ($length1 === $length2) {
                     return 0;
                 }

--- a/tests/unit/Codeception/StepTest.php
+++ b/tests/unit/Codeception/StepTest.php
@@ -82,4 +82,11 @@ class StepTest extends \PHPUnit_Framework_TestCase
         $output = $step->toString(200);
         $this->assertEquals('see "UPPER CASE"', $output);
     }
+
+    public function testMultiByteTextLengthIsMeasuredCorrectly()
+    {
+        $step = $this->getStep(['see', ['ŽŽŽŽŽŽŽŽŽŽ', 'AAAAAAAAAAA']]);
+        $output = $step->toString(30);
+        $this->assertEquals('see "ŽŽŽŽŽŽŽŽŽŽ","AAAAAAAAAAA"', $output);
+    }
 }


### PR DESCRIPTION
Used mb_strlen for measuring total output length and sorting parameters by length in Codeception\Step.

But started by writing a failing test.