### PR TITLE
REST::execute() small fix in argument defaults

### DIFF
--- a/src/Codeception/Module/REST.php
+++ b/src/Codeception/Module/REST.php
@@ -440,7 +440,7 @@ EOF;
         $this->execute('UNLINK', $url);
     }
 
-    protected function execute($method = 'GET', $url, $parameters = [], $files = [])
+    protected function execute($method, $url, $parameters = [], $files = [])
     {
         $this->debugSection("Request headers", $this->headers);
 


### PR DESCRIPTION
Add default value for $url in Module\REST::execute() accoarding to 
"Note that when using default arguments, any defaults should be on the right side of any non-default arguments; otherwise, things will not work as expected." 
http://php.net/manual/en/functions.arguments.php#functions.arguments.default