### PR TITLE
REST::getRunningClient() made 'protected'

### DIFF
--- a/src/Codeception/Module/REST.php
+++ b/src/Codeception/Module/REST.php
@@ -138,7 +138,7 @@ EOF;
         }
     }
 
-    private function getRunningClient()
+    protected function getRunningClient()
     {
         if ($this->client->getInternalRequest() === null) {
             throw new ModuleException($this, "Response is empty. Use `\$I->sendXXX()` methods to send HTTP request");


### PR DESCRIPTION
Visibility of REST::getRunningClient() changed to 'protected' to allow its using in module extends.
For example:
```php
    public function grabHttpHeaders()
    {
        return $this->getRunningClient()->getInternalResponse()->getHeaders();
    }
```
instead of:
`return $this->client->getInternalResponse()->getHeaders();`