### PR TITLE
Fix to #2872

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 #### 2.1.7
 
+* Global Bootstrap, Suite Bootstrap, Module Initialization happens before test loading. Fixes issues of autoloading TestCase classes introduced in 2.1.5, see #2872
 * Added option to skip PHP files validation in `codeception.yml` settings: lint: false
 * `Util\Locator` added `contains` method to easily locate any element containing a text.
 * [Laravel5] Added `guard` parameters to `seeAuthentication` and `dontSeeAuthentication` methods. By @janhenkgerritsen. See #2876

--- a/src/Codeception/Codecept.php
+++ b/src/Codeception/Codecept.php
@@ -198,8 +198,8 @@ class Codecept
     public function runSuite($settings, $suite, $test = null)
     {
         $suiteManager = new SuiteManager($this->dispatcher, $suite, $settings);
-        $suiteManager->loadTests($test);
         $suiteManager->initialize();
+        $suiteManager->loadTests($test);
         $suiteManager->run($this->runner, $this->result, $this->options);
         return $this->result;
     }

--- a/src/Codeception/Subscriber/Bootstrap.php
+++ b/src/Codeception/Subscriber/Bootstrap.php
@@ -11,7 +11,7 @@ class Bootstrap implements EventSubscriberInterface
     use Shared\StaticEvents;
 
     static $events = [
-        Events::SUITE_BEFORE => 'loadBootstrap',
+        Events::SUITE_INIT => 'loadBootstrap',
     ];
 
     public function loadBootstrap(SuiteEvent $e)

--- a/tests/cli/OrderCest.php
+++ b/tests/cli/OrderCest.php
@@ -43,7 +43,7 @@ class OrderCest
         $I->amInPath('tests/data/sandbox');
         $I->executeCommand('run order --no-exit --group simple');
         $I->seeFileFound('order.txt','tests/_output');
-        $I->seeFileContentsEqual("BIB({{{[ST][STFFT][STF][ST])}}}");
+        $I->seeFileContentsEqual("BIBP({{{[ST][STFFT][STF][ST])}}}");
     }
 
     public function checkCestOrder(CliGuy $I)
@@ -91,5 +91,13 @@ class OrderCest
         $I->executeCommand('run order BeforeAfterClassTest.php');
         $I->seeFileFound('order.txt', 'tests/_output');
         $I->seeInThisFile('BIB({[1][2])}');
+    }
+
+    public function checkBootstrapIsLoadedBeforeTests(CliGuy $I)
+    {
+        $I->amInPath('tests/data/sandbox');
+        $I->executeCommand('run order ParsedLoadedTest.php');
+        $I->seeFileFound('order.txt', 'tests/_output');
+        $I->seeInThisFile('BIBP(T)');
     }
 }

--- a/tests/data/claypit/tests/order/FailedCept.php
+++ b/tests/data/claypit/tests/order/FailedCept.php
@@ -1,5 +1,5 @@
 <?php
-$scenario->group('simple');
+// @group simple
 \Codeception\Module\OrderHelper::appendToFile('S');
 $I = new OrderGuy($scenario);
 $I->wantTo('write a marker and fail');

--- a/tests/data/claypit/tests/order/ParsedLoadedTest.php
+++ b/tests/data/claypit/tests/order/ParsedLoadedTest.php
@@ -1,0 +1,10 @@
+<?php
+\Codeception\Module\OrderHelper::appendToFile('P'); // parsed
+
+class ParsedLoadedTest  extends \PHPUnit_Framework_TestCase
+{
+    public function testSomething()
+    {
+        \Codeception\Module\OrderHelper::appendToFile('T');
+    }
+}


### PR DESCRIPTION
Changes the order in which tests are loaded. Load happens just after bootstrap and module initializations, so autoloadrs can work. 

This behavior was broken since 2.1.5