### PR TITLE
REST::seeResponseMatchesJsonType() doc block fix

### DIFF
--- a/src/Codeception/Module/REST.php
+++ b/src/Codeception/Module/REST.php
@@ -786,7 +786,7 @@ EOF;
      * ```php
      * <?php
      * // {'user_id': 1, 'name': 'davert', 'is_active': false}
-     * $I->seeResponseIsJsonType([
+     * $I->seeResponseMatchesJsonType([
      *      'user_id' => 'integer',
      *      'name' => 'string|null',
      *      'is_active' => 'boolean'
@@ -812,7 +812,7 @@ EOF;
      * ```php
      * <?php
      * // {'user_id': 1, 'name': 'davert', 'company': {'name': 'Codegyre'}}
-     * $I->seeResponseIsJsonType([
+     * $I->seeResponseMatchesJsonType([
      *      'user_id' => 'integer|string', // multiple types
      *      'company' => ['name' => 'string']
      * ]);
@@ -835,13 +835,13 @@ EOF;
      * ```php
      * <?php
      * // {'user_id': 1, 'email' => 'davert@codeception.com'}
-     * $I->seeResponseIsJsonType([
+     * $I->seeResponseMatchesJsonType([
      *      'user_id' => 'string:>0:<1000', // multiple filters can be used
      *      'email' => 'string:regex(~\@~)' // we just check that @ char is included
      * ]);
      *
      * // {'user_id': '1'}
-     * $I->seeResponseIsJsonType([
+     * $I->seeResponseMatchesJsonType([
      *      'user_id' => 'string:>0', // works with strings as well
      * }
      * ?>
@@ -853,6 +853,7 @@ EOF;
      * @part json
      * @version 2.1.3
      * @param array $jsonType
+     * @param string $jsonPath
      */
     public function seeResponseMatchesJsonType(array $jsonType, $jsonPath = null)
     {


### PR DESCRIPTION
REST::seeResponseMatchesJsonType() doc block fix accoarding to new method name and args.
Also need it in http://codeception.com/docs/modules/REST#seeResponseMatchesJsonType