### PR TITLE
Unified api for setting/delitting headers

### DIFF
--- a/src/Codeception/Lib/InnerBrowser.php
+++ b/src/Codeception/Lib/InnerBrowser.php
@@ -47,6 +47,8 @@ class InnerBrowser extends Module implements Web, PageSourceSaver, ElementLocato
      */
     protected $forms = [];
 
+    public $headers = [];
+
     protected $defaultCookieParameters = ['expires' => null, 'path' => '/', 'domain' => '', 'secure' => false];
 
     protected $internalDomains = null;
@@ -64,6 +66,7 @@ class InnerBrowser extends Module implements Web, PageSourceSaver, ElementLocato
         $this->client = null;
         $this->crawler = null;
         $this->forms = [];
+        $this->headers = [];
     }
 
     public function _conflicts()
@@ -136,10 +139,26 @@ class InnerBrowser extends Module implements Web, PageSourceSaver, ElementLocato
 
     protected function clientRequest($method, $uri, array $parameters = array(), array $files = array(), array $server = array(), $content = null, $changeHistory = true)
     {
+        $this->debugSection("Request Headers", $this->headers);
+
+        foreach ($this->headers as $header => $val) { // moved from REST module
+
+            if (!$val) {
+                continue;
+            }
+
+            $header = str_replace('-', '_', strtoupper($header));
+            $server["HTTP_$header"] = $val;
+
+            // Issue #827 - symfony foundation requires 'CONTENT_TYPE' without HTTP_
+            if ($this instanceof Framework && $header === 'CONTENT_TYPE') {
+                $server[$header] = $val;
+            }
+        }
+
         if ($this instanceof Framework) {
             if (preg_match('#^(//|https?://(?!localhost))#', $uri)) {
                 $hostname = parse_url($uri, PHP_URL_HOST);
-
                 if (!$this->isInternalDomain($hostname)) {
                     throw new ExternalUrlException(get_class($this) . " can't open external URL: " . $uri);
                 }
@@ -154,13 +173,13 @@ class InnerBrowser extends Module implements Web, PageSourceSaver, ElementLocato
             $result = $this->client->request($method, $uri, $parameters, $files, $server, $content, $changeHistory);
             $this->debugResponse($uri);
             return $result;
-        } else {
-            $maxRedirects = ReflectionHelper::readPrivateProperty($this->client, 'maxRedirects', 'Symfony\Component\BrowserKit\Client');
-            $this->client->followRedirects(false);
-            $result = $this->client->request($method, $uri, $parameters, $files, $server, $content, $changeHistory);
-            $this->debugResponse($uri);
-            return $this->redirectIfNecessary($result, $maxRedirects, 0);
         }
+
+        $maxRedirects = ReflectionHelper::readPrivateProperty($this->client, 'maxRedirects', 'Symfony\Component\BrowserKit\Client');
+        $this->client->followRedirects(false);
+        $result = $this->client->request($method, $uri, $parameters, $files, $server, $content, $changeHistory);
+        $this->debugResponse($uri);
+        return $this->redirectIfNecessary($result, $maxRedirects, 0);
     }
 
     protected function isInternalDomain($domain)
@@ -239,6 +258,49 @@ class InnerBrowser extends Module implements Web, PageSourceSaver, ElementLocato
     {
         $this->client->setServerParameter('PHP_AUTH_USER', $username);
         $this->client->setServerParameter('PHP_AUTH_PW', $password);
+    }
+
+    /**
+     * Sets the HTTP header to the passed value - which is used on
+     * subsequent HTTP requests through PhpBrowser.
+     *
+     * Example:
+     * ```php
+     * <?php
+     * $I->setHeader('X-Requested-With', 'Codeception');
+     * $I->amOnPage('test-headers.php');
+     * ?>
+     * ```
+     *
+     * @param string $name the name of the request header
+     * @param string $value the value to set it to for subsequent
+     *        requests
+     */
+    public function haveHttpHeader($name, $value)
+    {
+        $this->headers[$name] = $value;
+    }
+
+    /**
+     * Deletes the header with the passed name.  Subsequent requests
+     * will not have the deleted header in its request.
+     *
+     * Example:
+     * ```php
+     * <?php
+     * $I->haveHttpHeader('X-Requested-With', 'Codeception');
+     * $I->amOnPage('test-headers.php');
+     * // ...
+     * $I->deleteHeader('X-Requested-With');
+     * $I->amOnPage('some-other-page.php');
+     * ?>
+     * ```
+     *
+     * @param string $name the name of the header to delete.
+     */
+    public function deleteHeader($name)
+    {
+        unset($this->headers[$name]);
     }
 
 
@@ -320,20 +382,22 @@ class InnerBrowser extends Module implements Web, PageSourceSaver, ElementLocato
     {
         if (!$selector) {
             $this->assertPageContains($text);
-        } else {
-            $nodes = $this->match($selector);
-            $this->assertDomContains($nodes, $this->stringifySelector($selector), $text);
+            return;
         }
+
+        $nodes = $this->match($selector);
+        $this->assertDomContains($nodes, $this->stringifySelector($selector), $text);
     }
 
     public function dontSee($text, $selector = null)
     {
         if (!$selector) {
             $this->assertPageNotContains($text);
-        } else {
-            $nodes = $this->match($selector);
-            $this->assertDomNotContains($nodes, $this->stringifySelector($selector), $text);
+            return;
         }
+
+        $nodes = $this->match($selector);
+        $this->assertDomNotContains($nodes, $this->stringifySelector($selector), $text);
     }
 
     public function seeInSource($raw)

--- a/src/Codeception/Module/PhpBrowser.php
+++ b/src/Codeception/Module/PhpBrowser.php
@@ -150,46 +150,14 @@ class PhpBrowser extends InnerBrowser implements Remote, MultiSession
     }
 
     /**
-     * Sets the HTTP header to the passed value - which is used on
-     * subsequent HTTP requests through PhpBrowser.
+     * Alias to `haveHttpHeader`
      *
-     * Example:
-     * ```php
-     * <?php
-     * $I->setHeader('X-Requested-With', 'Codeception');
-     * $I->amOnPage('test-headers.php');
-     * ?>
-     * ```
-     *
-     * @param string $name the name of the request header
-     * @param string $value the value to set it to for subsequent
-     *        requests
+     * @param $name
+     * @param $value
      */
     public function setHeader($name, $value)
     {
-        $this->client->setHeader($name, $value);
-    }
-
-    /**
-     * Deletes the header with the passed name.  Subsequent requests
-     * will not have the deleted header in its request.
-     *
-     * Example:
-     * ```php
-     * <?php
-     * $I->setHeader('X-Requested-With', 'Codeception');
-     * $I->amOnPage('test-headers.php');
-     * // ...
-     * $I->deleteHeader('X-Requested-With');
-     * $I->amOnPage('some-other-page.php');
-     * ?>
-     * ```
-     * 
-     * @param string $name the name of the header to delete.
-     */
-    public function deleteHeader($name)
-    {
-        $this->client->deleteHeader($name);
+        $this->haveHttpHeader($name, $value);
     }
 
     public function amHttpAuthenticated($username, $password)

--- a/tests/unit/Codeception/Module/PhpBrowserRestTest.php
+++ b/tests/unit/Codeception/Module/PhpBrowserRestTest.php
@@ -51,7 +51,6 @@ class PhpBrowserRestTest extends \PHPUnit_Framework_TestCase
     {
         $this->module->sendGET('http://127.0.0.1:8010/rest/user/');
         $this->module->seeResponseCodeIs(200);
-        $this->assertEquals('http://127.0.0.1:8010/rest/user/', $this->module->client->getHistory()->current()->getUri());
     }
 
     public function testPost()

--- a/tests/unit/Codeception/Module/RestTest.php
+++ b/tests/unit/Codeception/Module/RestTest.php
@@ -45,13 +45,12 @@ class RestTest extends \PHPUnit_Framework_TestCase
     {
         $this->module->haveHttpHeader('Origin','http://www.example.com');
         $this->module->sendGET('/rest/user/');
-        $this->assertEquals(
-            'http://www.example.com',
-            $this->module->client->getServerParameter('HTTP_ORIGIN')
-        );
-
+        $server = $this->module->client->getInternalRequest()->getServer();
+        $this->assertArrayHasKey('HTTP_ORIGIN', $server);
         $this->module->_before(Stub::makeEmpty('\Codeception\Test\Test'));
-        $this->assertNull($this->module->client->getServerParameter('HTTP_ORIGIN', null));
+        $this->module->sendGET('/rest/user/');
+        $server = $this->module->client->getInternalRequest()->getServer();
+        $this->assertArrayNotHasKey('HTTP_ORIGIN', $server);
     }
 
     public function testGet()


### PR DESCRIPTION
Requests from REST module are sent through `_reqest` method of InnerBrowser.
Headers managing also moved from REST to InnerBrowser.

Now InnerBrowser and REST can set and unset headers equally:

* haveHttpHeader - to set (was not available in framework modules)
* deleteHeader - to unset it (was not available in REST + framework modules)