### PR TITLE
Correction for non ascii encoding with mb_ function

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -80,7 +80,6 @@ install:
   - '[[ "$TRAVIS_PHP_VERSION" == "5.4" ]] || composer install -d frameworks-zend-expressive --no-dev  --prefer-dist'
 
 before_script:
-  - '[[ "$TRAVIS_PHP_VERSION" == "hhvm" ]] || echo "mbstring.internal_encoding = UTF-8" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini'
   - '[[ "$TRAVIS_PHP_VERSION" == "hhvm" ]] || [[ "$TRAVIS_PHP_VERSION" == "7.0" ]] || echo "extension = mongo.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini'
   # create config file for hhvm daemon
   - '[[ "$TRAVIS_PHP_VERSION" != "hhvm" ]] || echo "pid = /tmp/hhvm.pid" >>/tmp/hhvm.ini'

--- a/.travis.yml
+++ b/.travis.yml
@@ -80,6 +80,7 @@ install:
   - '[[ "$TRAVIS_PHP_VERSION" == "5.4" ]] || composer install -d frameworks-zend-expressive --no-dev  --prefer-dist'
 
 before_script:
+  - '[[ "$TRAVIS_PHP_VERSION" == "hhvm" ]] || echo "mbstring.internal_encoding = UTF-8" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini'
   - '[[ "$TRAVIS_PHP_VERSION" == "hhvm" ]] || [[ "$TRAVIS_PHP_VERSION" == "7.0" ]] || echo "extension = mongo.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini'
   # create config file for hhvm daemon
   - '[[ "$TRAVIS_PHP_VERSION" != "hhvm" ]] || echo "pid = /tmp/hhvm.pid" >>/tmp/hhvm.ini'

--- a/src/Codeception/Lib/Console/Message.php
+++ b/src/Codeception/Lib/Console/Message.php
@@ -31,7 +31,14 @@ class Message
 
     public function width($length, $char = ' ')
     {
-        $message_length = strlen(strip_tags($this->message));
+        $message = strip_tags($this->message);
+
+        if (function_exists('mb_strlen')) {
+            $message_length = mb_strlen($message);
+        } else {
+            $message_length = strlen($message);
+        }
+
         if ($message_length < $length) {
             $this->message .= str_repeat($char, $length - $message_length);
         }
@@ -40,7 +47,13 @@ class Message
 
     public function cut($length)
     {
-        $this->message = substr($this->message, 0, $length);
+        if (function_exists("mb_substr")) {
+            $this->message = mb_substr($this->message, 0, $length);
+        } else {
+            $this->message = substr($this->message, 0, $length);
+        }
+
+
         return $this;
     }
 

--- a/src/Codeception/Lib/Console/Message.php
+++ b/src/Codeception/Lib/Console/Message.php
@@ -31,13 +31,7 @@ class Message
 
     public function width($length, $char = ' ')
     {
-        $message = strip_tags($this->message);
-
-        if (function_exists('mb_strlen')) {
-            $message_length = mb_strlen($message);
-        } else {
-            $message_length = strlen($message);
-        }
+        $message_length = mb_strlen(strip_tags($this->message), 'utf-8');
 
         if ($message_length < $length) {
             $this->message .= str_repeat($char, $length - $message_length);
@@ -47,12 +41,7 @@ class Message
 
     public function cut($length)
     {
-        if (function_exists("mb_substr")) {
-            $this->message = mb_substr($this->message, 0, $length);
-        } else {
-            $this->message = substr($this->message, 0, $length);
-        }
-
+        $this->message = mb_substr($this->message, 0, $length, 'utf-8');
 
         return $this;
     }
@@ -121,10 +110,7 @@ class Message
 
     public function getLength()
     {
-        if (function_exists('mb_strlen')) {
-            return mb_strlen($this->message, 'utf-8');
-        }
-        return strlen($this->message);
+        return mb_strlen($this->message, 'utf-8');
     }
 
     public function __toString()

--- a/tests/unit/Codeception/Lib/Console/MessageTest.php
+++ b/tests/unit/Codeception/Lib/Console/MessageTest.php
@@ -10,27 +10,22 @@ class MessageTest extends \Codeception\TestCase\Test
     {
         $message = new Message('very long text');
         $this->assertEquals('very long ', $message->cut(10)->getMessage());
+
+        $message = new Message('очень длинный текст');
+        $this->assertEquals('очень длин', $message->cut(10)->getMessage());
     }
     
     //test message cutting
     public function testVeryLongTestNameVeryLongTestNameVeryLongTestNameVeryLongTestNameVeryLongTestNameVeryLongTestNameVeryLongTestName() {}
 
-    // skip if mb_substr not exists
-    public function testUTF8Message()
+    // test multibyte message width
+    public function testWidth()
     {
-        if (function_exists('mb_substr')) {
-            $message = new Message('очень длинный текст');
-            $this->assertEquals('очень длин', $message->cut(10)->getMessage());
-        }
-    }
+        $message = new Message('message example');
+        $this->assertEquals('message example               ', $message->width(30)->getMessage());
 
-    // skip if mb_strlen not exists
-    public function testUTF8Width()
-    {
-        if (function_exists('mb_strlen')) {
-            $message = new Message('пример текста');
-            $this->assertEquals('пример текста                 ', $message->width(30)->getMessage());
-        }
+        $message = new Message('пример текста');
+        $this->assertEquals('пример текста                 ', $message->width(30)->getMessage());
     }
 }
  

--- a/tests/unit/Codeception/Lib/Console/MessageTest.php
+++ b/tests/unit/Codeception/Lib/Console/MessageTest.php
@@ -29,10 +29,7 @@ class MessageTest extends \Codeception\TestCase\Test
     {
         if (function_exists('mb_strlen')) {
             $message = new Message('пример текста');
-            $this->assertEquals(
-                'пример текста                 ',
-                $message->width(30)->getMessage())
-            ;
+            $this->assertEquals('пример текста                 ', $message->width(30)->getMessage());
         }
     }
 }

--- a/tests/unit/Codeception/Lib/Console/MessageTest.php
+++ b/tests/unit/Codeception/Lib/Console/MessageTest.php
@@ -14,5 +14,26 @@ class MessageTest extends \Codeception\TestCase\Test
     
     //test message cutting
     public function testVeryLongTestNameVeryLongTestNameVeryLongTestNameVeryLongTestNameVeryLongTestNameVeryLongTestNameVeryLongTestName() {}
+
+    // skip if mb_substr not exists
+    public function testUTF8Message()
+    {
+        if (function_exists('mb_substr')) {
+            $message = new Message('очень длинный текст');
+            $this->assertEquals('очень длин', $message->cut(10)->getMessage());
+        }
+    }
+
+    // skip if mb_strlen not exists
+    public function testUTF8Width()
+    {
+        if (function_exists('mb_strlen')) {
+            $message = new Message('пример текста');
+            $this->assertEquals(
+                'пример текста                 ',
+                $message->width(30)->getMessage())
+            ;
+        }
+    }
 }
  


### PR DESCRIPTION
While using utf-8 text as messages in tests output is not correct in some cases

```php
// example
public function testBlaBla($I)
{
    $I->wantTo('бла бла');
}

public function testBlaBlaBla($I)
{
    $I->wantTo('бла бла бла');
}
```