### PR TITLE
Updated module Queue to work with pheanstalk library ~3.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,7 @@
         "facebook/php-sdk-v4": "~4.0.22",
         "videlalvaro/php-amqplib": "~2.4",
         "codeception/specify": "~0.3",
-        "pda/pheanstalk": "~2.0",
+        "pda/pheanstalk": "~3.0",
         "flow/jsonpath": "~0.2",
         "league/factory-muffin": "^3.0",
         "league/factory-muffin-faker": "^1.0"

--- a/docs/modules/Queue.md
+++ b/docs/modules/Queue.md
@@ -15,7 +15,7 @@ Supported and tested queue types are:
 
 The following dependencies are needed for the listed queue servers:
 
-* Beanstalkd: pda/pheanstalk ~2.0
+* Beanstalkd: pda/pheanstalk ~3.0
 * Amazon SQS: aws/aws-sdk-php
 * IronMQ: iron-io/iron_mq
 

--- a/src/Codeception/Lib/Driver/Beanstalk.php
+++ b/src/Codeception/Lib/Driver/Beanstalk.php
@@ -2,18 +2,20 @@
 namespace Codeception\Lib\Driver;
 
 use Codeception\Lib\Interfaces\Queue;
+use Pheanstalk\Pheanstalk;
+use Pheanstalk\Exception\ConnectionException;
 
 class Beanstalk implements Queue
 {
 
     /**
-     * @var \Pheanstalk_Pheanstalk
+     * @var Pheanstalk
      */
     protected $queue;
 
     public function openConnection($config)
     {
-        $this->queue = new \Pheanstalk_Pheanstalk($config['host'], $config['port'], $config['timeout']);
+        $this->queue = new Pheanstalk($config['host'], $config['port'], $config['timeout']);
     }
 
     /**
@@ -38,7 +40,7 @@ class Beanstalk implements Queue
     {
         try {
             return $this->queue->statsTube($queue)['total-jobs'];
-        } catch (\Pheanstalk_Exception_ServerException $ex) {
+        } catch (ConnectionException $ex) {
             \PHPUnit_Framework_Assert::fail("queue [$queue] not found");
         }
     }
@@ -71,7 +73,7 @@ class Beanstalk implements Queue
     {
         try {
             return $this->queue->statsTube($queue)['current-jobs-ready'];
-        } catch (\Pheanstalk_Exception_ServerException $e) {
+        } catch (ConnectionException $e) {
             \PHPUnit_Framework_Assert::fail("queue [$queue] not found");
         }
     }

--- a/src/Codeception/Module/Queue.php
+++ b/src/Codeception/Module/Queue.php
@@ -23,7 +23,7 @@ use Codeception\Lib\Driver\Iron;
  *
  * The following dependencies are needed for the listed queue servers:
  *
- * * Beanstalkd: pda/pheanstalk ~2.0
+ * * Beanstalkd: pda/pheanstalk ~3.0
  * * Amazon SQS: aws/aws-sdk-php
  * * IronMQ: iron-io/iron_mq
  *

--- a/tests/unit/Codeception/Module/Beanstalkd_Test.php
+++ b/tests/unit/Codeception/Module/Beanstalkd_Test.php
@@ -1,6 +1,7 @@
 <?php
 
 use Codeception\Util\Stub;
+use Pheanstalk\Exception\ConnectionException;
 
 class Beanstalkd_Test extends \PHPUnit_Framework_TestCase
 {
@@ -21,7 +22,7 @@ class Beanstalkd_Test extends \PHPUnit_Framework_TestCase
             $this->module->_before(Stub::makeEmpty('\Codeception\TestCase'));
         try {
             $this->module->clearQueue('default');
-        } catch (\Pheanstalk_Exception_ConnectionException $e) {
+        } catch (ConnectionException $e) {
             $this->markTestSkipped("Beanstalk is not running");
         }
     }


### PR DESCRIPTION
Updated module Queue to work with pheanstalk library ~3.0; Codeception module Queue (adapter for Beanstalk)