### PR TITLE
Unset HTTP Auth credentials on Guzzle 5

### DIFF
--- a/src/Codeception/Lib/Connector/Guzzle.php
+++ b/src/Codeception/Lib/Connector/Guzzle.php
@@ -81,6 +81,10 @@ class Guzzle extends Client
 
     public function setAuth($username, $password)
     {
+        if (!$username) {
+            unset($this->requestOptions['auth']);
+            return;
+        }
         $this->requestOptions['auth'] = [$username, $password];
     }
 


### PR DESCRIPTION
I copied this new functionality from Guzzle6.php to Guzzle.php

 #2896