### PR TITLE
htmlentities on html report generation

### DIFF
--- a/src/Codeception/PHPUnit/ResultPrinter/HTML.php
+++ b/src/Codeception/PHPUnit/ResultPrinter/HTML.php
@@ -114,7 +114,7 @@ class HTML extends CodeceptionResultPrinter
             $failTemplate = new \Text_Template(
                 $this->templatePath . 'fail.html'
             );
-            $failTemplate->setVar(['fail' => nl2br($this->failures[$name])]);
+            $failTemplate->setVar(['fail' => nl2br(htmlentities($this->failures[$name]))]);
             $failure = $failTemplate->render();
         }
 


### PR DESCRIPTION
When creating HTML report, if failure snippet contains html entities, the report HTML gets broken.
Added htmlentities to encode them when passing failures to the template. 