### PR TITLE
Fix setupbeforeclass bug issue 2934

### DIFF
--- a/src/Codeception/Subscriber/BeforeAfterTest.php
+++ b/src/Codeception/Subscriber/BeforeAfterTest.php
@@ -23,6 +23,11 @@ class BeforeAfterTest implements EventSubscriberInterface
     {
         foreach ($e->getSuite()->tests() as $test) {
             /** @var $test \PHPUnit_Framework_Test  * */
+            if ($test instanceof \PHPUnit_Framework_TestSuite_DataProvider) {
+                $potentialTestClass = strstr($test->getName(), '::', true);
+                $this->hooks[$potentialTestClass] = \PHPUnit_Util_Test::getHookMethods($potentialTestClass);
+            }
+
             $testClass = get_class($test);
             $this->hooks[$testClass] = \PHPUnit_Util_Test::getHookMethods($testClass);
         }

--- a/tests/cli/OrderCest.php
+++ b/tests/cli/OrderCest.php
@@ -43,7 +43,7 @@ class OrderCest
         $I->amInPath('tests/data/sandbox');
         $I->executeCommand('run order --no-exit --group simple');
         $I->seeFileFound('order.txt','tests/_output');
-        $I->seeFileContentsEqual("BIBP({{{[ST][STFFT][STF][ST])}}}");
+        $I->seeFileContentsEqual("BIBP({{{{[ST][STFFT][STF][ST])}}}}");
     }
 
     public function checkCestOrder(CliGuy $I)

--- a/tests/cli/OrderCest.php
+++ b/tests/cli/OrderCest.php
@@ -93,6 +93,14 @@ class OrderCest
         $I->seeInThisFile('BIB({[1][2])}');
     }
 
+    public function checkAfterBeforeClassInTestWithDataProvider(CliGuy $I)
+    {
+        $I->amInPath('tests/data/sandbox');
+        $I->executeCommand('run order BeforeAfterClassWithDataProviderTest.php');
+        $I->seeFileFound('order.txt', 'tests/_output');
+        $I->seeInThisFile('BIB({[A][B][C])}');
+    }
+
     public function checkBootstrapIsLoadedBeforeTests(CliGuy $I)
     {
         $I->amInPath('tests/data/sandbox');

--- a/tests/data/claypit/tests/order/BeforeAfterClassWithDataProviderTest.php
+++ b/tests/data/claypit/tests/order/BeforeAfterClassWithDataProviderTest.php
@@ -1,0 +1,39 @@
+<?php
+/**
+ * @group App
+ * @group New
+ */
+class BeforeAfterClassWithDataProviderTest extends \Codeception\TestCase\Test
+{
+	/**
+	 * @beforeClass
+	 */
+	public static function setUpSomeSharedFixtures()
+	{
+		\Codeception\Module\OrderHelper::appendToFile('{');
+	}
+
+	/**
+	 * @dataProvider getAbc
+	 *
+	 * @param string $letter
+	 */
+	public function testAbc($letter)
+	{
+		\Codeception\Module\OrderHelper::appendToFile($letter);
+	}
+
+	public static function getAbc()
+	{
+		return [['A'], ['B'], ['C']];
+	}
+
+	/**
+	 * @afterClass
+	 */
+	public static function tearDownSomeSharedFixtures()
+	{
+		\Codeception\Module\OrderHelper::appendToFile('}');
+	}
+
+}


### PR DESCRIPTION
Fix Issue #2934 (setUpBeforeClass not working with @dataProvider).

The method setUpBeforeClass, methods annotated with `@beforeClass`, and the _beforeSuite method did not get called if the test case only contained tests annotated with `@dataProvider`. 

This happened because such test cases were included in PHPUnit_Framework_TestSuite_DataProvider instances, which do not have hooks for setup or teardown 'before class'.

However, if a single test of the test case was not annotated, than the hooks would run, since at least one test did not get converted to PHPUnit_Framework_TestSuite_DataProvider.

I've provided a simple, though inelegant fix, and a test to guard against such bugs.

Kind regards,
Fabian