### PR TITLE
Fix non-init config value

### DIFF
--- a/src/Codeception/Lib/Parser.php
+++ b/src/Codeception/Lib/Parser.php
@@ -128,7 +128,7 @@ class Parser
     public static function validate($file)
     {
         $config = Configuration::config();
-        if (!$config['settings']['lint']) { // lint disabled in config
+        if (empty($config['settings']['lint'])) { // lint disabled in config
             return;
         }
         exec("php -l ".escapeshellarg($file)." 2>&1", $output, $code);


### PR DESCRIPTION
When $config['settings']['lint'] is not initialized codeception throws PHP Notice, fixed it.