### PR TITLE
[SOAP] Fix grabTextContentFrom() after the second request

### DIFF
--- a/src/Codeception/Module/SOAP.php
+++ b/src/Codeception/Module/SOAP.php
@@ -37,8 +37,8 @@ use Codeception\Util\XmlStructure;
  *
  * ## Public Properties
  *
- * * xmlRequest - last soap request (DOMDocument)
- * * xmlResponse - last soap response (DOMDocument)
+ * * xmlRequest - last SOAP request (DOMDocument)
+ * * xmlResponse - last SOAP response (DOMDocument)
  *
  */
 class SOAP extends CodeceptionModule implements DependsOnModule

--- a/src/Codeception/Module/SOAP.php
+++ b/src/Codeception/Module/SOAP.php
@@ -126,7 +126,9 @@ EOF;
     
     private function getXmlStructure()
     {
-        $this->xmlStructure = new XmlStructure($this->getXmlResponse());
+        if (!$this->xmlStructure) {
+            $this->xmlStructure = new XmlStructure($this->getXmlResponse());
+        }
         return $this->xmlStructure;
     }
     
@@ -219,6 +221,7 @@ EOF;
 
         $this->debugSection("Response", $response);
         $this->xmlResponse = SoapUtils::toXml($response);
+        $this->xmlStructure = null;
     }
 
     /**

--- a/src/Codeception/Module/SOAP.php
+++ b/src/Codeception/Module/SOAP.php
@@ -37,8 +37,8 @@ use Codeception\Util\XmlStructure;
  *
  * ## Public Properties
  *
- * * request - last soap request (DOMDocument)
- * * response - last soap response (DOMDocument)
+ * * xmlRequest - last soap request (DOMDocument)
+ * * xmlResponse - last soap response (DOMDocument)
  *
  */
 class SOAP extends CodeceptionModule implements DependsOnModule
@@ -315,7 +315,6 @@ EOF;
      * ``` php
      * <?php
      *
-     * $I->seeResponseContains("<user><query>CreateUser<name>Davert</davert></user>");
      * $I->seeSoapResponseContainsStructure("<query><name></name></query>");
      * ?>
      * ```

--- a/src/Codeception/Module/SOAP.php
+++ b/src/Codeception/Module/SOAP.php
@@ -177,8 +177,8 @@ EOF;
      * Example:
      *
      * ``` php
-     * $I->sendRequest('UpdateUser', '<user><id>1</id><name>notdavert</name></user>');
-     * $I->sendRequest('UpdateUser', \Codeception\Utils\Soap::request()->user
+     * $I->sendSoapRequest('UpdateUser', '<user><id>1</id><name>notdavert</name></user>');
+     * $I->sendSoapRequest('UpdateUser', \Codeception\Utils\Soap::request()->user
      *   ->id->val(1)->parent()
      *   ->name->val('notdavert');
      * ```

--- a/src/Codeception/Module/SOAP.php
+++ b/src/Codeception/Module/SOAP.php
@@ -126,9 +126,7 @@ EOF;
     
     private function getXmlStructure()
     {
-        if (!$this->xmlStructure) {
-            $this->xmlStructure = new XmlStructure($this->getXmlResponse());
-        }
+        $this->xmlStructure = new XmlStructure($this->getXmlResponse());
         return $this->xmlStructure;
     }
     


### PR DESCRIPTION
**Test :**
```php
$I->sendRequest('ShowUser', '<user><name>notdavert</name></user>');
$I->grabTextContentFrom("//*[local-name() = 'login']");
$I->sendRequest('ShowUser', '<user><name>eXorus</name></user>');
$I->grabTextContentFrom("//*[local-name() = 'login']");
```
**Actual Result :**
notdavert
notdavert

**Result Expected with my fix**
notdavert
eXorus

The fix consist to always rewrite xmlStructure from xmlResponse and not only when it's null because if you call a second times the xmlStructure will be the xmlStructure of the fist call.

Bug was introduced in 2.1.7