### PR TITLE
New method grabService.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+* [Symfony] Deprecated `grabServiceFromContainer` use `grabService` instead. For consistency with other frameworks.
+
 #### 2.1.7
 
 * **PHPUnit 5.x support**


### PR DESCRIPTION
Created for consistency with other frameworks.
Old method `grabServiceFromContainer` has been deprecated and should be removed on future releases.