### PR TITLE
Update Symfony2 framework module and connector, fix client generation…

### DIFF
--- a/src/Codeception/Lib/Connector/Symfony2.php
+++ b/src/Codeception/Lib/Connector/Symfony2.php
@@ -3,11 +3,20 @@ namespace Codeception\Lib\Connector;
 
 class Symfony2 extends \Symfony\Component\HttpKernel\Client
 {
-    
     /**
      * @var boolean
      */
-    private static $hasPerformedRequest;
+    private $rebootable = true;
+
+    /**
+     * @var boolean
+     */
+    private $hasPerformedRequest = false;
+
+    /**
+     * @var \Symfony\Component\DependencyInjection\ContainerInterface
+     */
+    private $container = null;
 
     /**
      * @var array
@@ -15,51 +24,63 @@ class Symfony2 extends \Symfony\Component\HttpKernel\Client
     public $persistentServices = [];
 
     /**
-     * @param Request $request
+     * Constructor.
+     *
+     * @param \Symfony\Component\HttpKernel\Kernel  $kernel     A booted HttpKernel instance
+     * @param array                                 $services   An injected services
+     * @param boolean                               $rebootable
+     */
+    public function __construct(\Symfony\Component\HttpKernel\Kernel $kernel, array $services = [], $rebootable = true)
+    {
+        parent::__construct($kernel);
+        $this->followRedirects(true);
+        $this->rebootable = (boolean)$rebootable;
+        $this->persistentServices = $services;
+        $this->rebootKernel();
+    }
+
+    /**
+     * @param \Symfony\Component\HttpFoundation\Request $request
      */
     protected function doRequest($request)
     {
-        $services = [];
-        if (self::$hasPerformedRequest) {
-            $services = $this->persistServices();
-            $this->kernel = clone $this->kernel;
-        } else {
-            self::$hasPerformedRequest = true;
+        if ($this->rebootable) {
+            if ($this->hasPerformedRequest) {
+                $this->rebootKernel();
+            } else {
+                $this->hasPerformedRequest = true;
+            }
         }
-        $this->kernel->boot();
-
-        $container = $this->kernel->getContainer();
-        if ($this->kernel->getContainer()->has('profiler')) {
-            $container->get('profiler')->enable();
-        }
-
-        $this->injectPersistedServices($services);
-
         return parent::doRequest($request);
     }
 
     /**
-     * @return array
+     * Reboot kernel
+     *
+     * Services from the list of persistent services
+     * are updated from service container before kernel shutdown
+     * and injected into newly initialized container after kernel boot.
      */
-    protected function persistServices()
+    public function rebootKernel()
     {
-        $services = [];
-        foreach ($this->persistentServices as $serviceName) {
-            if (!$this->kernel->getContainer()->has($serviceName)) {
-                continue;
+        if ($this->container) {
+            foreach ($this->persistentServices as $serviceName => $service) {
+                if ($this->container->has($serviceName)) {
+                    $this->persistentServices[$serviceName] = $this->container->get($serviceName);
+                }
             }
-            $services[$serviceName] = $this->kernel->getContainer()->get($serviceName);
         }
-        return $services;
-    }
 
-    /**
-     * @param array $services
-     */
-    protected function injectPersistedServices($services)
-    {
-        foreach ($services as $serviceName => $service) {
-            $this->kernel->getContainer()->set($serviceName, $service);
+        $this->kernel->shutdown();
+        $this->kernel->boot();
+        $this->container = $this->kernel->getContainer();
+
+        if ($this->container->has('profiler')) {
+            $this->container->get('profiler')->enable();
+        }
+
+        foreach ($this->persistentServices as $serviceName => $service) {
+            $this->container->set($serviceName, $service);
         }
     }
 }

--- a/src/Codeception/Module/Symfony2.php
+++ b/src/Codeception/Module/Symfony2.php
@@ -9,6 +9,7 @@ use Codeception\Lib\Connector\Symfony2 as Symfony2Connector;
 use Codeception\Lib\Interfaces\DoctrineProvider;
 use Codeception\Lib\Interfaces\PartedModule;
 use Symfony\Component\Finder\Finder;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
  * This module uses Symfony2 Crawler and HttpKernel to emulate requests and test response.
@@ -30,8 +31,9 @@ use Symfony\Component\Finder\Finder;
  * * environment: 'local' - environment used for load kernel
  * * debug: true - turn on/off debug mode
  * * em_service: 'doctrine.orm.entity_manager' - use the stated EntityManager to pair with Doctrine Module.
- * * cache_router: 'false' - enable router caching between tests in order to [increase performance](http://lakion.com/blog/how-did-we-speed-up-sylius-behat-suite-with-blackfire) 
- * 
+ * * cache_router: 'false' - enable router caching between tests in order to [increase performance](http://lakion.com/blog/how-did-we-speed-up-sylius-behat-suite-with-blackfire)
+ * * rebootable_client: 'true' - reboot client's kernel before each request
+ *
  * ### Example (`functional.suite.yml`) - Symfony 2.x Directory Structure
  *
  * ```
@@ -48,7 +50,8 @@ use Symfony\Component\Finder\Finder;
  * * environment: 'local' - environment used for load kernel
  * * em_service: 'doctrine.orm.entity_manager' - use the stated EntityManager to pair with Doctrine Module.
  * * debug: true - turn on/off debug mode
- * * cache_router: 'false' - enable router caching between tests in order to [increase performance](http://lakion.com/blog/how-did-we-speed-up-sylius-behat-suite-with-blackfire) 
+ * * cache_router: 'false' - enable router caching between tests in order to [increase performance](http://lakion.com/blog/how-did-we-speed-up-sylius-behat-suite-with-blackfire)
+ * * rebootable_client: 'true' - reboot client's kernel before each request
  *
  * ### Example (`functional.suite.yml`) - Symfony 3 Directory Structure
  *
@@ -64,14 +67,13 @@ use Symfony\Component\Finder\Finder;
  *
  * * kernel - HttpKernel instance
  * * client - current Crawler instance
- * * container - dependency injection container instance
  *
  * ## Parts
- * 
- * * services - allows to use Symfony2 DIC only with WebDriver or PhpBrowser modules. 
- * 
+ *
+ * * services - allows to use Symfony2 DIC only with WebDriver or PhpBrowser modules.
+ *
  * Usage example:
- * 
+ *
  * ```yaml
  * class_name: AcceptanceTester
  * modules:
@@ -84,6 +86,9 @@ use Symfony\Component\Finder\Finder;
  *             url: http://your-url.com
  *             browser: phantomjs
  * ```
+ *
+ * @property-read ContainerInterface $container
+ *
  */
 class Symfony2 extends Framework implements DoctrineProvider, PartedModule
 {
@@ -93,9 +98,10 @@ class Symfony2 extends Framework implements DoctrineProvider, PartedModule
     public $kernel;
 
     /**
-     * @var \Symfony\Component\DependencyInjection\ContainerInterface
+     * @var ContainerInterface
+     * @deprecated Use _getContainer() instead
      */
-    public $container;
+    private $container;
 
     public $config = [
         'app_path' => 'app',
@@ -103,7 +109,8 @@ class Symfony2 extends Framework implements DoctrineProvider, PartedModule
         'environment' => 'test',
         'debug' => true,
         'cache_router' => false,
-        'em_service' => 'doctrine.orm.entity_manager'
+        'em_service' => 'doctrine.orm.entity_manager',
+        'rebootable_client' => true,
     ];
 
     /**
@@ -119,7 +126,37 @@ class Symfony2 extends Framework implements DoctrineProvider, PartedModule
      */
     protected $kernelClass;
 
-    public $permanentServices = [];
+    /**
+     * Services that should be persistent permanently for all tests
+     *
+     * @var array
+     */
+    protected $permanentServices = [];
+
+    /**
+     * Services that should be persistent during test execution between kernel reboots
+     *
+     * @var array
+     */
+    protected $persistentServices = [];
+
+    public function __get($property)
+    {
+        $result = null;
+        if (property_exists($this, $property)) {
+            switch ($property) {
+                case 'container':
+                    $result = $this->_getContainer();
+                    break;
+                default:
+                    $this->fail(sprintf('Property "%s" can not be accessed.', $property));
+                    break;
+            }
+        } else {
+            $this->fail(sprintf('Property "%s" does not exist.', $property));
+        }
+        return $result;
+    }
 
     public function _initialize()
     {
@@ -143,41 +180,66 @@ class Symfony2 extends Framework implements DoctrineProvider, PartedModule
             ini_set($xdebugMaxLevelKey, $maxNestingLevel);
         }
 
-        $this->bootKernel();
-        $this->container = $this->kernel->getContainer();
-    }
-
-    public function _before(\Codeception\TestCase $test)
-    {
-        $this->client = new Symfony2Connector($this->kernel);
-        $this->client->followRedirects(true);
-    }
-
-    public function _getEntityManager()
-    {
-        $this->bootKernel();
-        if (!$this->kernel->getContainer()->has($this->config['em_service'])) {
-            return null;
-        }
-        $this->client->persistentServices[] = $this->config['em_service'];
-        $this->client->persistentServices[] = 'doctrine.orm.default_entity_manager';
-        return $this->grabService($this->config['em_service']);
-    }
-
-    protected function bootKernel()
-    {
-        if ($this->kernel) {
-            return;
-        }
         $this->kernel = new $this->kernelClass($this->config['environment'], $this->config['debug']);
         $this->kernel->boot();
+
         if ($this->config['cache_router'] === true) {
-            if (isset($this->permanentServices['router'])) {
-                $this->kernel->getContainer()->set('router', $this->permanentServices['router']);
-            } else {
-                $this->permanentServices['router'] = $this->grabService('router');
+            $this->persistService('router', true);
+        }
+    }
+
+    /**
+     * Initialize new client instance before each test
+     */
+    public function _before(\Codeception\TestCase $test)
+    {
+        $this->persistentServices = array_merge($this->persistentServices, $this->permanentServices);
+        $this->client = new Symfony2Connector($this->kernel, $this->persistentServices, $this->config['rebootable_client']);
+    }
+
+    /**
+     * Update permanent services after each test
+     */
+    public function _after(\Codeception\TestCase $test)
+    {
+        foreach ($this->permanentServices as $serviceName => $service) {
+            $this->permanentServices[$serviceName] = $this->grabService($serviceName);
+        }
+        parent::_after($test);
+    }
+
+    /**
+     * Retrieve Entity Manager.
+     *
+     * EM service is retrieved once and then that instance returned on each call
+     */
+    public function _getEntityManager()
+    {
+        if ($this->kernel === null) {
+            $this->fail('Symfony2 platform module is not loaded');
+        }
+        if (!isset($this->permanentServices[$this->config['em_service']])) {
+            // try to persist configured EM
+            $this->persistService($this->config['em_service'], true);
+
+            if ($this->_getContainer()->has('doctrine')) {
+                $this->persistService('doctrine', true);
+            }
+            if ($this->_getContainer()->has('doctrine.orm.default_entity_manager')) {
+                $this->persistService('doctrine.orm.default_entity_manager', true);
             }
         }
+        return $this->permanentServices[$this->config['em_service']];
+    }
+
+    /**
+     * Return container.
+     *
+     * @return ContainerInterface
+     */
+    public function _getContainer()
+    {
+        return $this->kernel->getContainer();
     }
 
     /**
@@ -210,11 +272,48 @@ class Symfony2 extends Framework implements DoctrineProvider, PartedModule
     }
 
     /**
+     * Get service $serviceName and add it to the lists of persistent services.
+     * If $isPermanent then service becomes persistent between tests
+     *
+     * @param string  $serviceName
+     * @param boolean $isPermanent
+     */
+    public function persistService($serviceName, $isPermanent = false)
+    {
+        $service = $this->grabService($serviceName);
+        $this->persistentServices[$serviceName] = $service;
+        if ($isPermanent) {
+            $this->permanentServices[$serviceName] = $service;
+        }
+        if ($this->client) {
+            $this->client->persistentServices[$serviceName] = $service;
+        }
+    }
+
+    /**
+     * Remove service $serviceName from the lists of persistent services.
+     *
+     * @param string $serviceName
+     */
+    public function unpersistService($serviceName)
+    {
+        if (isset($this->persistentServices[$serviceName])) {
+            unset($this->persistentServices[$serviceName]);
+        }
+        if (isset($this->permanentServices[$serviceName])) {
+            unset($this->permanentServices[$serviceName]);
+        }
+        if ($this->client && isset($this->client->persistentServices[$serviceName])) {
+            unset($this->client->persistentServices[$serviceName]);
+        }
+    }
+
+    /**
      * Invalidate previously cached routes.
      */
     public function invalidateCachedRouter()
     {
-        $this->permanentServices['router'] = null;
+        $this->unpersistService('router');
     }
 
     /**
@@ -233,11 +332,9 @@ class Symfony2 extends Framework implements DoctrineProvider, PartedModule
     public function amOnRoute($routeName, array $params = [])
     {
         $router = $this->grabService('router');
-        $route = $router->getRouteCollection()->get($routeName);
-        if (!$route) {
+        if (!$router->getRouteCollection()->get($routeName)) {
             $this->fail(sprintf('Route with name "%s" does not exists.', $routeName));
         }
-
         $url = $router->generate($routeName, $params);
         $this->amOnPage($url);
     }
@@ -258,12 +355,11 @@ class Symfony2 extends Framework implements DoctrineProvider, PartedModule
     public function seeCurrentRouteIs($routeName, array $params = [])
     {
         $router = $this->grabService('router');
-        $route = $router->getRouteCollection()->get($routeName);
-        if (!$route) {
+        if (!$router->getRouteCollection()->get($routeName)) {
             $this->fail(sprintf('Route with name "%s" does not exists.', $routeName));
         }
-
-        $this->seeCurrentUrlEquals($router->generate($routeName, $params));
+        $url = $router->generate($routeName, $params);
+        $this->seeCurrentUrlEquals($url);
     }
 
     /**
@@ -281,18 +377,16 @@ class Symfony2 extends Framework implements DoctrineProvider, PartedModule
     public function seeInCurrentRoute($routeName)
     {
         $router = $this->grabService('router');
-
-        $route = $router->getRouteCollection()->get($routeName);
-        if (!$route) {
+        if (!$router->getRouteCollection()->get($routeName)) {
             $this->fail(sprintf('Route with name "%s" does not exists.', $routeName));
         }
-        
+
         try {
             $matchedRouteName = $router->match($this->grabFromCurrentUrl())['_route'];
         } catch (\Exception\ResourceNotFoundException $e) {
             $this->fail(sprintf('The "%s" url does not match with any route', $routeName));
         }
-        
+
         $this->assertEquals($matchedRouteName, $routeName);
     }
 
@@ -303,7 +397,7 @@ class Symfony2 extends Framework implements DoctrineProvider, PartedModule
      */
     public function seeEmailIsSent()
     {
-        $profile = $this->getProfiler();
+        $profile = $this->getProfile();
         if (!$profile) {
             $this->fail('Emails can\'t be tested without Profiler');
         }
@@ -350,16 +444,17 @@ class Symfony2 extends Framework implements DoctrineProvider, PartedModule
      */
     public function grabService($service)
     {
-        if (!$this->kernel->getContainer()->has($service)) {
+        $container = $this->_getContainer();
+        if (!$container->has($service)) {
             $this->fail("Service $service is not available in container");
         }
-        return $this->kernel->getContainer()->get($service);
+        return $container->get($service);
     }
 
     /**
      * @return \Symfony\Component\HttpKernel\Profiler\Profile
      */
-    protected function getProfiler()
+    protected function getProfile()
     {
         $profiler = $this->grabService('profiler');
         $response = $this->client->getResponse();
@@ -376,7 +471,7 @@ class Symfony2 extends Framework implements DoctrineProvider, PartedModule
     {
         parent::debugResponse($url);
 
-        if ($profile = $this->getProfiler()) {
+        if ($profile = $this->getProfile()) {
             if ($profile->hasCollector('security')) {
                 if ($profile->getCollector('security')->isAuthenticated()) {
                     $this->debugSection('User', $profile->getCollector('security')->getUser() . ' [' . implode(',', $profile->getCollector('security')->getRoles()) . ']');
@@ -405,8 +500,9 @@ class Symfony2 extends Framework implements DoctrineProvider, PartedModule
     {
         $internalDomains = [];
 
+        $routes = $this->grabService('router')->getRouteCollection();
         /* @var \Symfony\Component\Routing\Route $route */
-        foreach ($this->grabService('router')->getRouteCollection() as $route) {
+        foreach ($routes as $route) {
             if (!is_null($route->getHost())) {
                 $compiled = $route->compile();
                 if (!is_null($compiled->getHostRegex())) {
@@ -416,5 +512,30 @@ class Symfony2 extends Framework implements DoctrineProvider, PartedModule
         }
 
         return array_unique($internalDomains);
+    }
+
+    /**
+     * Reboot client's kernel.
+     * Can be used to manually reboot kernel when 'rebootable_client' => false
+     *
+     * ``` php
+     * <?php
+     * ...
+     * perform some requests
+     * ...
+     * $I->rebootClientKernel();
+     * ...
+     * perform other requests
+     * ...
+     *
+     * ?>
+     * ```
+     *
+     */
+    public function rebootClientKernel()
+    {
+        if ($this->client) {
+            $this->client->rebootKernel();
+        }
     }
 }


### PR DESCRIPTION
…, update Doctrine EM retrieval. Improve memory usage. Unify service retrieval.

This PR provides solution for https://github.com/Codeception/Codeception/issues/2938, https://github.com/Codeception/Codeception/issues/2954.

This PR proposes the following model of Symfony2 framework module and client:
- module's `$container` is a read-only property. It returns active client's service container during test execution or self service container between tests when accessed externally.
- the module has `$persistentServices` array which contains services to persist between requests (kernel reboots) in a test.
- the module has `$permanentServices` array which contains services to persist between tests.
- persistence status of any service can be changed at any moment during test execution (public methods `persistService(...)` / `unpersistService(...)`).
- the app kernel is booted during module initialization in order to make framework features available before client creation.
- a client is created before each test. It is created based on current kernel, currently retrieved persistent services and a configuration option marking client's kernel rebootable between requests or not. Client's kernel is rebooted in its constructor to ensure clean environment for test. 
- client's persistent services are being updated before kernel shutdown and injected into newly initialized service container after kernel boot during test execution.
- client's kernel can be rebooted using `$I->rebootClientKernel()` during test execution.
- permanent services are updated after test execution.
- cached router is permanent by default if used.
- doctrine's EM service is permanent by default.

Test results of Codeception's Symfony2 framework test app (https://github.com/Codeception/symfony-demo):
![symfony2_test_app](http://content.screencast.com/users/vyarmolenko/folders/Jing/media/c55f8aa9-4fd4-4696-8558-dbb75dc4e174/2016-04-07_1129.png)

Test results of modified version of https://github.com/AlexStansfield/codeception-test - an application used to reproduce https://github.com/Codeception/Codeception/issues/2025:
![issue2025_test_app](http://content.screencast.com/users/vyarmolenko/folders/Jing/media/1f668fca-0c93-4fcc-bcc0-318909857489/2016-04-06_1930.png)
Modifications to this test app include:
- creation of a copy of EntityCest.php - Entinty1Cest.php to check several cests in a suite, 
- making some methods of EntityCest.php to perform several `sendPOST(...)` requests to check correct work and measure performance of a solution.

Performing tests with modified version of Codeception on my Symfony2 app showed memory consumption was around 190 Mb's (previously tests failed due to insufficient memory with a 3GB's configuration) and execution time became around 19 minutes (and even lower - 11 minutes - with `config['cached_router'] = true`)

This PR also includes:
- change retrieval of Doctrine's Entity Manager to make it compatible with new client generation logic and the model of persistent services and to avoid/solve https://github.com/Codeception/Codeception/issues/2025, https://github.com/Codeception/Codeception/issues/2853  
- unification of service retrieval in existing public methods of Symfony2 module.