### PR TITLE
Fix detection of refresh timeout for max interval.

### DIFF
--- a/src/Codeception/Lib/Connector/Guzzle6.php
+++ b/src/Codeception/Lib/Connector/Guzzle6.php
@@ -128,7 +128,7 @@ class Guzzle6 extends Client
             if (!$matchesMeta && isset($headers['Refresh'])) {
                 // match by header
                 preg_match(
-                    '~(\d*);?url=(.*)~',
+                    '~(\d*); ?url=(.*)~',
                     (string) reset($headers['Refresh']),
                     $matches
                 );


### PR DESCRIPTION
Refresh headers always have a semicolon, but a space following it is optional.