### PR TITLE
Fix the count of tests printed in console when tests are filtered

### DIFF
--- a/src/Codeception/PHPUnit/Runner.php
+++ b/src/Codeception/PHPUnit/Runner.php
@@ -41,26 +41,9 @@ class Runner extends \PHPUnit_TextUI_TestRunner
         return $this->printer;
     }
 
-    public function doEnhancedRun(
-        \PHPUnit_Framework_Test $suite,
-        \PHPUnit_Framework_TestResult $result,
-        array $arguments = []
-    ) {
-        unset($GLOBALS['app']); // hook for not to serialize globals
-
+    public function prepareSuite(\PHPUnit_Framework_Test $suite, array &$arguments)
+    {
         $this->handleConfiguration($arguments);
-        $result->convertErrorsToExceptions(false);
-
-        if (empty(self::$persistentListeners)) {
-            $this->applyReporters($result, $arguments);
-        }
-
-        $arguments['listeners'][] = $this->printer;
-
-        // clean up listeners between suites
-        foreach ($arguments['listeners'] as $listener) {
-            $result->addListener($listener);
-        }
 
         $filterFactory = new \PHPUnit_Runner_Filter_Factory();
         if ($arguments['groups']) {
@@ -85,6 +68,27 @@ class Runner extends \PHPUnit_TextUI_TestRunner
         }
 
         $suite->injectFilter($filterFactory);
+    }
+
+    public function doEnhancedRun(
+        \PHPUnit_Framework_Test $suite,
+        \PHPUnit_Framework_TestResult $result,
+        array $arguments = []
+    ) {
+        unset($GLOBALS['app']); // hook for not to serialize globals
+
+        $result->convertErrorsToExceptions(false);
+
+        if (empty(self::$persistentListeners)) {
+            $this->applyReporters($result, $arguments);
+        }
+
+        $arguments['listeners'][] = $this->printer;
+
+        // clean up listeners between suites
+        foreach ($arguments['listeners'] as $listener) {
+            $result->addListener($listener);
+        }
 
         $suite->run($result);
         unset($suite);

--- a/src/Codeception/Subscriber/Console.php
+++ b/src/Codeception/Subscriber/Console.php
@@ -113,7 +113,7 @@ class Console implements EventSubscriberInterface
             $this->namespace = $settings['namespace'];
         }
         $this->message("%s Tests (%d) ")
-            ->with(ucfirst($e->getSuite()->getName()), count($e->getSuite()->tests()))
+            ->with(ucfirst($e->getSuite()->getName()), $e->getSuite()->count())
             ->style('bold')
             ->width($this->width, '-')
             ->prepend("\n")

--- a/src/Codeception/SuiteManager.php
+++ b/src/Codeception/SuiteManager.php
@@ -141,6 +141,7 @@ class SuiteManager
 
     public function run(PHPUnit\Runner $runner, \PHPUnit_Framework_TestResult $result, $options)
     {
+        $runner->prepareSuite($this->suite, $options);
         $this->dispatcher->dispatch(Events::SUITE_BEFORE, new Event\SuiteEvent($this->suite, $result, $this->settings));
         $runner->doEnhancedRun($this->suite, $result, $options);
         $this->dispatcher->dispatch(Events::SUITE_AFTER, new Event\SuiteEvent($this->suite, $result, $this->settings));

--- a/tests/cli/RunCest.php
+++ b/tests/cli/RunCest.php
@@ -113,6 +113,7 @@ class RunCest
     public function runOneGroup(\CliGuy $I)
     {
         $I->executeCommand('run skipped -g notorun');
+        $I->seeInShellOutput('Skipped Tests (1)');
         $I->seeInShellOutput("IncompleteMeCept");
         $I->dontSeeInShellOutput("SkipMeCept");
     }
@@ -120,6 +121,7 @@ class RunCest
     public function skipRunOneGroup(\CliGuy $I)
     {
         $I->executeCommand('run skipped --skip-group notorun');
+        $I->seeInShellOutput('Skipped Tests (2)');
         $I->seeInShellOutput("SkipMeCept");
         $I->dontSeeInShellOutput("IncompleteMeCept");
     }
@@ -128,16 +130,18 @@ class RunCest
     {
         $I->executeCommand('run dummy');
         $I->seeInShellOutput('Optimistic');
+        $I->seeInShellOutput('Dummy Tests (5)');
         $I->executeCommand('run dummy --skip-group ok');
         $I->seeInShellOutput('Pessimistic');
+        $I->seeInShellOutput('Dummy Tests (4)');
         $I->dontSeeInShellOutput('Optimistic');
     }
 
     public function runTwoSuites(\CliGuy $I)
     {
         $I->executeCommand('run skipped,dummy --no-exit');
-        $I->seeInShellOutput("Skipped Tests");
-        $I->seeInShellOutput("Dummy Tests");
+        $I->seeInShellOutput("Skipped Tests (3)");
+        $I->seeInShellOutput("Dummy Tests (5)");
         $I->dontSeeInShellOutput("Remote Tests");
     }
 


### PR DESCRIPTION
Fix for #3033 
I'm not sure this would be the best solution to the issue, maybe a refactor of the Loader would be better, but this seems more like something that can join easily into 2.2.