### PR TITLE
[FIX] pass the zend request the files

### DIFF
--- a/src/Codeception/Lib/Connector/ZF2.php
+++ b/src/Codeception/Lib/Connector/ZF2.php
@@ -76,6 +76,7 @@ class ZF2 extends Client
 
         $zendRequest->setQuery(new Parameters($query));
         $zendRequest->setPost(new Parameters($post));
+        $zendRequest->setFiles(new Parameters($request->getFiles()));
         $zendRequest->setContent($content);
         $zendRequest->setMethod($method);
         $zendRequest->setUri($uri);


### PR DESCRIPTION
While using codeception for testing a ZF2 project, we found out that files attached to a REST call were not received in Zend's action methods. After investigation, we could see that get and post parameters were attached to the Zend request object, but files were not. This fixes this issue.