### PR TITLE
Friends - MultiSession : Replace close() by quit() in WebDriver and quit all sessions after test

### DIFF
--- a/src/Codeception/Lib/Actor/Shared/Friend.php
+++ b/src/Codeception/Lib/Actor/Shared/Friend.php
@@ -23,15 +23,8 @@ trait Friend
         if (!isset($this->friends[$name])) {
             $actor = $actorClass === null ? $this : new $actorClass($this->getScenario());
             $this->friends[$name] = new LibFriend($name, $actor, $this->getScenario()->current('modules'));
+            $this->getScenario()->friends[$name] = $this->friends[$name];
         }
         return $this->friends[$name];
-    }
-
-    public function leaveFriends()
-    {
-        foreach ($this->friends as $friend) {
-            $friend->leave();
-        }
-        $this->friends = [];
     }
 }

--- a/src/Codeception/Lib/Actor/Shared/Friend.php
+++ b/src/Codeception/Lib/Actor/Shared/Friend.php
@@ -26,4 +26,12 @@ trait Friend
         }
         return $this->friends[$name];
     }
+
+    public function leaveFriends()
+    {
+        foreach ($this->friends as $friend) {
+            $friend->leave();
+        }
+        $this->friends = [];
+    }
 }

--- a/src/Codeception/Lib/Friend.php
+++ b/src/Codeception/Lib/Friend.php
@@ -76,4 +76,3 @@ class Friend
         }
     }
 }
- 

--- a/src/Codeception/Lib/Friend.php
+++ b/src/Codeception/Lib/Friend.php
@@ -76,4 +76,3 @@ class Friend
         }
     }
 }
-

--- a/src/Codeception/Lib/Friend.php
+++ b/src/Codeception/Lib/Friend.php
@@ -76,3 +76,4 @@ class Friend
         }
     }
 }
+

--- a/src/Codeception/Lib/Friend.php
+++ b/src/Codeception/Lib/Friend.php
@@ -67,7 +67,7 @@ class Friend
         $this->actor->expectTo($prediction);
     }
 
-    public function __destruct()
+    public function leave()
     {
         foreach ($this->multiSessionModules as $module) {
             if (isset($this->data[$module->_getName()])) {

--- a/src/Codeception/Module/WebDriver.php
+++ b/src/Codeception/Module/WebDriver.php
@@ -325,11 +325,7 @@ class WebDriver extends CodeceptionModule implements
     public function _after(TestCase $test)
     {
         if ($this->config['restart'] && isset($this->webDriver)) {
-            
-            foreach($this->webDriver->getAllSessions() as $session) {
-                 $sessionToClose = $this->webDriver->createBySessionID($session['id']);
-                 $this->_closeSession($sessionToClose);
-            }
+            $this->webDriver->quit();
             // RemoteWebDriver consists of four parts, executor, mouse, keyboard and touch, quit only set executor to null,
             // but RemoteWebDriver doesn't provide public access to check on executor
             // so we need to unset $this->webDriver here to shut it down completely

--- a/src/Codeception/Module/WebDriver.php
+++ b/src/Codeception/Module/WebDriver.php
@@ -325,7 +325,11 @@ class WebDriver extends CodeceptionModule implements
     public function _after(TestCase $test)
     {
         if ($this->config['restart'] && isset($this->webDriver)) {
-            $this->webDriver->quit();
+            
+            foreach($this->webDriver->getAllSessions() as $session) {
+                 $sessionToClose = $this->webDriver->createBySessionID($session['id']);
+                 $this->_closeSession($sessionToClose);
+            }
             // RemoteWebDriver consists of four parts, executor, mouse, keyboard and touch, quit only set executor to null,
             // but RemoteWebDriver doesn't provide public access to check on executor
             // so we need to unset $this->webDriver here to shut it down completely

--- a/src/Codeception/Module/WebDriver.php
+++ b/src/Codeception/Module/WebDriver.php
@@ -1072,7 +1072,7 @@ class WebDriver extends CodeceptionModule implements
 
     public function _closeSession($webdriver)
     {
-        $webdriver->close();
+        $webdriver->quit();
     }
 
     /*

--- a/src/Codeception/Scenario.php
+++ b/src/Codeception/Scenario.php
@@ -25,6 +25,7 @@ class Scenario
     protected $env = [];
 
     protected $currents = [];
+    public $friends = [];
 
     /**
      * Constructor.

--- a/src/Codeception/TestCase/Cest.php
+++ b/src/Codeception/TestCase/Cest.php
@@ -134,7 +134,6 @@ class Cest extends CodeceptionTestCase implements
             throw new \Exception("Method {$this->testMethod} can't be found in tested class");
         }
         $this->invoke($this->testMethod, [$I, $this->scenario]);
-        $I->leaveFriends();
     }
 
     public function getTestClass()

--- a/src/Codeception/TestCase/Cest.php
+++ b/src/Codeception/TestCase/Cest.php
@@ -134,6 +134,7 @@ class Cest extends CodeceptionTestCase implements
             throw new \Exception("Method {$this->testMethod} can't be found in tested class");
         }
         $this->invoke($this->testMethod, [$I, $this->scenario]);
+        $I->leaveFriends();
     }
 
     public function getTestClass()


### PR DESCRIPTION
Hello,

I'm using Selenium Grid with Codeception Friends and Codeception doesn't kill correctly the browser so I'm stuck with a lot of node used for nothing :


```
public function testFriend1(AcceptanceTester $I)
{
   $I->amOnUrl('http://localhost/toto-nofriend');

   $toto = $I->haveFriend('toto', $I);
   $toto->does(function($I) {
      $I->amOnUrl('http://localhost/toto-friend');
   });
}
```


with Selenium Hub (2.53) and 2 Firefox nodes
"http://localhost/toto-nofriend" will be on node1
"http://localhost/toto-friend" will be on node2

**At the end of the test with close()**
node1 will be free slot
node2 will be always used (with state deleted but still used)

**At the end of the test with quit()**
node1 will be free slot
node2 will be free slot


