### PR TITLE
Fix self-update command to update only to stable versions

### DIFF
--- a/tests/unit/Codeception/Command/BaseCommandRunner.php
+++ b/tests/unit/Codeception/Command/BaseCommandRunner.php
@@ -39,14 +39,15 @@ class BaseCommandRunner extends \PHPUnit_Framework_TestCase
         $this->output = $commandTester->getDisplay();
     }
 
-    protected function makeCommand($className, $saved = true)
+    protected function makeCommand($className, $saved = true, $extraMethods = [])
     {
         if (!$this->config) {
             $this->config = [];
         }
+
         $self = $this;
-        $this->command = Stub::construct(
-            $className, [$this->commandName], [
+
+        $mockedMethods = [
             'save'            => function ($file, $output) use ($self, $saved) {
                 if (!$saved) {
                     return false;
@@ -73,7 +74,13 @@ class BaseCommandRunner extends \PHPUnit_Framework_TestCase
             'getApplication'  => function () {
                 return new \Codeception\Util\Maybe;
             }
-        ]
+        ];
+        $mockedMethods = array_merge($mockedMethods, $extraMethods);
+
+        $this->command = Stub::construct(
+            $className,
+            [$this->commandName],
+            $mockedMethods
         );
     }
 

--- a/tests/unit/Codeception/Command/SelfUpdateTest.php
+++ b/tests/unit/Codeception/Command/SelfUpdateTest.php
@@ -1,0 +1,46 @@
+<?php
+require_once __DIR__ . DIRECTORY_SEPARATOR . 'BaseCommandRunner.php';
+
+class SelfUpdateTest extends BaseCommandRunner
+{
+    const COMMAND_CLASS = '\Codeception\Command\SelfUpdate';
+
+    public function testHasUpdate()
+    {
+        $this->setUpCommand('2.1.2', ['2.1.0-beta', '2.1.2', '2.1.3', '2.2.0-RC2']);
+        $this->execute();
+
+        $this->assertContains('Codeception version 2.1.2', $this->output);
+        $this->assertContains('A newer version is available: 2.1.3', $this->output);
+    }
+    
+    public function testAlreadyLatest()
+    {
+        $this->setUpCommand('2.1.8', ['2.1.0-beta', '2.1.7', '2.1.8', '2.2.0-RC2']);
+        $this->execute();
+
+        $this->assertContains('Codeception version 2.1.8', $this->output);
+        $this->assertContains('You are already using the latest version.', $this->output);
+    }
+
+    /**
+     * @param string $version
+     * @param array $tags
+     */
+    protected function setUpCommand($version, $tags)
+    {
+        $this->makeCommand(
+            self::COMMAND_CLASS,
+            false,
+            [
+                'getCurrentVersion' => function () use ($version) {
+                    return $version;
+                },
+                'getGithubTags' => function () use ($tags) {
+                    return $tags;
+                }
+            ]
+        );
+        $this->config = [];
+    }
+}


### PR DESCRIPTION
This PR fixes the issue when `self-update` updates `2.1.7` to `2.2.0-RC2` instead of `2.1.8`.