### PR TITLE
Fix indentation in Scenario

### DIFF
--- a/docs/071-BDD.md
+++ b/docs/071-BDD.md
@@ -52,12 +52,12 @@ Feature: checkout process
   As a customer
   I want to be able to buy several products 
 
-Scenario:
-  Given I have product with 600 $ price in my cart 
-  And I have product with 1000 $ price
-  When I go to checkout process 
-  Then I should see that total number of products is 2
-  And my order amount is 1600 $
+  Scenario:
+    Given I have product with 600 $ price in my cart 
+    And I have product with 1000 $ price
+    When I go to checkout process 
+    Then I should see that total number of products is 2
+    And my order amount is 1600 $
 ```
 
 Cucucmber, Behat, and sure, **Codeception** can execute this scenario step by step as an automated test. 


### PR DESCRIPTION
scenarios are described inside Features. The original doc was missing the right indentation