### PR TITLE
Added support for PHPUnitBridge

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,11 +9,11 @@ matrix:
     - php: hhvm # because we haven't fixed all issues yet
   include:
     - php: 5.4 # lowest versions of all dependencies
-      env: SYMFONY=2.7.0 # latest version of 2.7.*
+      env: SYMFONY=2.7.0 SYMFONY_DEPRECATIONS_HELPER=weak # latest version of 2.7.*
     - php: 5.5
-      env: dependencies=lowest
+      env: dependencies=lowest SYMFONY_DEPRECATIONS_HELPER=weak
     - php: 5.6
-      env: SYMFONY=2.8.0 # latest version of 2.8.*
+      env: SYMFONY=2.8.0 SYMFONY_DEPRECATIONS_HELPER=weak # latest version of 2.8.*
 
 addons:
   postgresql: "9.2"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 #### 2.1.9
 
+* Added full support of phpunit-bridge features.
 * [Laravel] Fixed issue where non-existing services were called in _before and _after methods. See #3028.
 * [WebDriver] fixed using `saveSessionSnapshot` with codecoverage. Closes #2923
 * [ZF2] create new instance of Application for each request

--- a/composer.json
+++ b/composer.json
@@ -44,7 +44,8 @@
         "codeception/specify": "BDD-style code blocks",
         "codeception/verify": "BDD-style assertions",
         "monolog/monolog": "Log test steps",
-        "phpseclib/phpseclib": "Extension required to use the SFTP option in the FTP Module."
+        "phpseclib/phpseclib": "Extension required to use the SFTP option in the FTP Module.",
+        "symfony/phpunit-bridge": "For phpunit-bridge support"
     },
 
     "autoload":{

--- a/src/Codeception/PHPUnit/Runner.php
+++ b/src/Codeception/PHPUnit/Runner.php
@@ -55,6 +55,10 @@ class Runner extends \PHPUnit_TextUI_TestRunner
             $this->applyReporters($result, $arguments);
         }
 
+        if (class_exists('\Symfony\Bridge\PhpUnit\SymfonyTestsListener')) {
+            $arguments['listeners'] = isset($arguments['listeners']) ? $arguments['listeners'] : array();
+            $arguments['listeners'][] = new \Symfony\Bridge\PhpUnit\SymfonyTestsListener();
+        }
         $arguments['listeners'][] = $this->printer;
 
         // clean up listeners between suites

--- a/src/Codeception/Subscriber/ErrorHandler.php
+++ b/src/Codeception/Subscriber/ErrorHandler.php
@@ -18,6 +18,9 @@ class ErrorHandler implements EventSubscriberInterface
      */
     private static $stopped = false;
 
+    private $deprecationsInstalled = false;
+    private $oldHandler;
+
     /**
      * @var int stores bitmask for errors
      */
@@ -30,12 +33,19 @@ class ErrorHandler implements EventSubscriberInterface
             $this->errorLevel = $settings['error_level'];
         }
         error_reporting(eval("return {$this->errorLevel};"));
-        set_error_handler([$this, 'errorHandler']);
+        // We must register shutdown function before deprecation error handler to restore previous error handler
+        // and silence DeprecationErrorHandler yelling about 'THE ERROR HANDLER HAS CHANGED!'
         register_shutdown_function([$this, 'shutdownHandler']);
+        $this->registerDeprecationErrorHandler();
+        $this->oldHandler = set_error_handler([$this, 'errorHandler']);
     }
 
-    public function errorHandler($errno, $errstr, $errfile, $errline)
+    public function errorHandler($errno, $errstr, $errfile, $errline, $context)
     {
+        if (E_USER_DEPRECATED === $errno) {
+            $this->handleDeprecationError($errno, $errstr, $errfile, $errline, $context);
+        }
+
         if (!(error_reporting() & $errno)) {
             // This error code is not included in error_reporting
             return false;
@@ -50,6 +60,10 @@ class ErrorHandler implements EventSubscriberInterface
 
     public function shutdownHandler()
     {
+        if ($this->deprecationsInstalled) {
+            restore_error_handler();
+        }
+
         if (self::$stopped) {
             return;
         }
@@ -69,4 +83,30 @@ class ErrorHandler implements EventSubscriberInterface
         echo "\n\n\nFATAL ERROR. TESTS NOT FINISHED.\n";
         echo sprintf("%s \nin %s:%d\n", $error['message'], $error['file'], $error['line']);
     }
+
+    private function registerDeprecationErrorHandler()
+    {
+        if (class_exists('\Symfony\Bridge\PhpUnit\DeprecationErrorHandler')) {
+            // DeprecationErrorHandler only will be installed if array('PHPUnit_Util_ErrorHandler', 'handleError')
+            // is installed or no other error handlers are installed.
+            // So we will remove Symfony\Component\Debug\ErrorHandler if it's installed.
+            $old = set_error_handler('var_dump');
+            restore_error_handler();
+
+            if ($old && is_array($old) && count($old) > 0 && is_object($old[0]) && get_class($old[0]) === 'Symfony\Component\Debug\ErrorHandler') {
+                restore_error_handler();
+            }
+
+            $this->deprecationsInstalled = true;
+            \Symfony\Bridge\PhpUnit\DeprecationErrorHandler::register(getenv('SYMFONY_DEPRECATIONS_HELPER'));
+        }
+    }
+
+    private function handleDeprecationError($type, $message, $file, $line, $context)
+    {
+        if ($this->deprecationsInstalled && $this->oldHandler) {
+            call_user_func($this->oldHandler, $type, $message, $file, $line, $context);
+        }
+    }
+
 }


### PR DESCRIPTION
Build is failing because Symfony-demo has some deprecated code and it need to define SYMFONY_DEPRECATIONS_HELPER='weak' to print deprecations but don't fail.