### PR TITLE
Fix the count of tests printed in console when tests are filtered (2.1)

### DIFF
--- a/src/Codeception/PHPUnit/Runner.php
+++ b/src/Codeception/PHPUnit/Runner.php
@@ -41,30 +41,9 @@ class Runner extends \PHPUnit_TextUI_TestRunner
         return $this->printer;
     }
 
-    public function doEnhancedRun(
-        \PHPUnit_Framework_Test $suite,
-        \PHPUnit_Framework_TestResult $result,
-        array $arguments = []
-    ) {
-        unset($GLOBALS['app']); // hook for not to serialize globals
-
+    public function prepareSuite(\PHPUnit_Framework_Test $suite, array &$arguments)
+    {
         $this->handleConfiguration($arguments);
-        $result->convertErrorsToExceptions(false);
-
-        if (empty(self::$persistentListeners)) {
-            $this->applyReporters($result, $arguments);
-        }
-
-        if (class_exists('\Symfony\Bridge\PhpUnit\SymfonyTestsListener')) {
-            $arguments['listeners'] = isset($arguments['listeners']) ? $arguments['listeners'] : array();
-            $arguments['listeners'][] = new \Symfony\Bridge\PhpUnit\SymfonyTestsListener();
-        }
-        $arguments['listeners'][] = $this->printer;
-
-        // clean up listeners between suites
-        foreach ($arguments['listeners'] as $listener) {
-            $result->addListener($listener);
-        }
 
         $filterFactory = new \PHPUnit_Runner_Filter_Factory();
         if ($arguments['groups']) {
@@ -89,6 +68,31 @@ class Runner extends \PHPUnit_TextUI_TestRunner
         }
 
         $suite->injectFilter($filterFactory);
+    }
+
+    public function doEnhancedRun(
+        \PHPUnit_Framework_Test $suite,
+        \PHPUnit_Framework_TestResult $result,
+        array $arguments = []
+    ) {
+        unset($GLOBALS['app']); // hook for not to serialize globals
+
+        $result->convertErrorsToExceptions(false);
+
+        if (empty(self::$persistentListeners)) {
+            $this->applyReporters($result, $arguments);
+        }
+
+        if (class_exists('\Symfony\Bridge\PhpUnit\SymfonyTestsListener')) {
+            $arguments['listeners'] = isset($arguments['listeners']) ? $arguments['listeners'] : array();
+            $arguments['listeners'][] = new \Symfony\Bridge\PhpUnit\SymfonyTestsListener();
+        }
+        $arguments['listeners'][] = $this->printer;
+
+        // clean up listeners between suites
+        foreach ($arguments['listeners'] as $listener) {
+            $result->addListener($listener);
+        }
 
         $suite->run($result);
         unset($suite);

--- a/src/Codeception/Subscriber/Console.php
+++ b/src/Codeception/Subscriber/Console.php
@@ -97,7 +97,7 @@ class Console implements EventSubscriberInterface
         $this->buildResultsTable($e);
 
         $this->message("%s Tests (%d) ")
-            ->with(ucfirst($e->getSuite()->getName()), count($e->getSuite()->tests()))
+            ->with(ucfirst($e->getSuite()->getName()), $e->getSuite()->count())
             ->style('bold')
             ->width(array_sum($this->columns), '-')
             ->prepend("\n")

--- a/src/Codeception/SuiteManager.php
+++ b/src/Codeception/SuiteManager.php
@@ -149,6 +149,7 @@ class SuiteManager
 
     public function run(PHPUnit\Runner $runner, \PHPUnit_Framework_TestResult $result, $options)
     {
+        $runner->prepareSuite($this->suite, $options);
         $this->dispatcher->dispatch(Events::SUITE_BEFORE, new Event\SuiteEvent($this->suite, $result, $this->settings));
         $runner->doEnhancedRun($this->suite, $result, $options);
         $this->dispatcher->dispatch(Events::SUITE_AFTER, new Event\SuiteEvent($this->suite, $result, $this->settings));

--- a/tests/cli/RunCest.php
+++ b/tests/cli/RunCest.php
@@ -113,6 +113,7 @@ class RunCest
     public function runOneGroup(\CliGuy $I)
     {
         $I->executeCommand('run skipped -g notorun');
+        $I->seeInShellOutput('Skipped Tests (1)');
         $I->seeInShellOutput("IncompleteMeCept");
         $I->dontSeeInShellOutput("SkipMeCept");
     }
@@ -120,6 +121,7 @@ class RunCest
     public function skipRunOneGroup(\CliGuy $I)
     {
         $I->executeCommand('run skipped --skip-group notorun');
+        $I->seeInShellOutput('Skipped Tests (2)');
         $I->seeInShellOutput("SkipMeCept");
         $I->dontSeeInShellOutput("IncompleteMeCept");
     }
@@ -127,17 +129,19 @@ class RunCest
     public function skipGroupOfCest(\CliGuy $I)
     {
         $I->executeCommand('run dummy');
-        $I->seeInShellOutput('optimistic');
+        $I->seeInShellOutput('Optimistic');
+        $I->seeInShellOutput('Dummy Tests (5)');
         $I->executeCommand('run dummy --skip-group ok');
-        $I->seeInShellOutput('pessimistic');
-        $I->dontSeeInShellOutput('optimistic');
+        $I->seeInShellOutput('Pessimistic');
+        $I->seeInShellOutput('Dummy Tests (4)');
+        $I->dontSeeInShellOutput('Optimistic');
     }
 
     public function runTwoSuites(\CliGuy $I)
     {
         $I->executeCommand('run skipped,dummy --no-exit');
-        $I->seeInShellOutput("Skipped Tests");
-        $I->seeInShellOutput("Dummy Tests");
+        $I->seeInShellOutput("Skipped Tests (3)");
+        $I->seeInShellOutput("Dummy Tests (5)");
         $I->dontSeeInShellOutput("Remote Tests");
     }
 


### PR DESCRIPTION
I cherry-picked this change from master to 2.1
#3034 