### PR TITLE
InnerBrowser::see matches UTF-8 text case-insensitively

### DIFF
--- a/src/Codeception/PHPUnit/Constraint/Page.php
+++ b/src/Codeception/PHPUnit/Constraint/Page.php
@@ -3,15 +3,43 @@ namespace Codeception\PHPUnit\Constraint;
 
 use Codeception\Lib\Console\Message;
 
-class Page extends \PHPUnit_Framework_Constraint_StringContains
+class Page extends \PHPUnit_Framework_Constraint
 {
     protected $uri;
 
     public function __construct($string, $uri = '')
     {
+        parent::__construct();
         $this->string = (string)$string;
         $this->uri = $uri;
-        $this->ignoreCase = true;
+    }
+
+    /**
+     * Evaluates the constraint for parameter $other. Returns true if the
+     * constraint is met, false otherwise.
+     *
+     * @param mixed $other Value or object to evaluate.
+     *
+     * @return bool
+     */
+    protected function matches($other)
+    {
+        return mb_stripos($other, $this->string, null, 'UTF-8') !== false;
+    }
+
+    /**
+     * Returns a string representation of the constraint.
+     *
+     * @return string
+     */
+    public function toString()
+    {
+        $string = mb_strtolower($this->string, 'UTF-8');
+
+        return sprintf(
+            'contains "%s"',
+            $string
+        );
     }
 
     protected function failureDescription($other)

--- a/tests/unit/Codeception/Module/TestsForWeb.php
+++ b/tests/unit/Codeception/Module/TestsForWeb.php
@@ -60,6 +60,15 @@ abstract class TestsForWeb extends \Codeception\TestCase\Test
         $this->module->dontSee('Welcome', 'h6');
     }
 
+    /**
+     * @Issue https://github.com/Codeception/Codeception/issues/3114
+     */
+    public function testSeeIsCaseInsensitiveForUnicodeText()
+    {
+        $this->module->amOnPage('/info');
+        $this->module->see('ссылочка');
+    }
+
     public function testSeeInSource()
     {
         $this->module->amOnPage('/');

--- a/tests/unit/Codeception/Module/TestsForWeb.php
+++ b/tests/unit/Codeception/Module/TestsForWeb.php
@@ -67,6 +67,14 @@ abstract class TestsForWeb extends \Codeception\TestCase\Test
     {
         $this->module->amOnPage('/info');
         $this->module->see('ссылочка');
+        $this->module->see('ссылочка', 'a');
+    }
+
+    public function testDontSeeIsCaseInsensitiveForUnicodeText()
+    {
+        $this->setExpectedException("PHPUnit_Framework_AssertionFailedError");
+        $this->module->amOnPage('/info');
+        $this->module->dontSee('ссылочка');
     }
 
     public function testSeeInSource()


### PR DESCRIPTION
Fixes #3114 