### PR TITLE
Fix format with Double-Width Characters

### DIFF
--- a/src/Codeception/Lib/Console/Message.php
+++ b/src/Codeception/Lib/Console/Message.php
@@ -31,7 +31,7 @@ class Message
 
     public function width($length, $char = ' ')
     {
-        $message_length = mb_strlen(strip_tags($this->message), 'utf-8');
+        $message_length = mb_strwidth(strip_tags($this->message), 'utf-8');
 
         if ($message_length < $length) {
             $this->message .= str_repeat($char, $length - $message_length);

--- a/src/Codeception/Lib/Console/Message.php
+++ b/src/Codeception/Lib/Console/Message.php
@@ -31,7 +31,7 @@ class Message
 
     public function width($length, $char = ' ')
     {
-        $message_length = mb_strwidth(strip_tags($this->message), 'utf-8');
+        $message_length = $this->getLength();
 
         if ($message_length < $length) {
             $this->message .= str_repeat($char, $length - $message_length);
@@ -108,9 +108,9 @@ class Message
         return $this;
     }
 
-    public function getLength()
+    public function getLength($includeTags = false)
     {
-        return mb_strlen($this->message, 'utf-8');
+        return mb_strwidth($includeTags ? $this->message : strip_tags($this->message), 'utf-8');
     }
 
     public function __toString()

--- a/src/Codeception/Subscriber/Console.php
+++ b/src/Codeception/Subscriber/Console.php
@@ -593,7 +593,7 @@ class Console implements EventSubscriberInterface
         }
         if ($this->message) {
             $this->message('')
-                ->width($this->columns[0] - $this->message->apply('strip_tags')->getLength() - $conditionalLen)
+                ->width($this->columns[0] - $this->message->getLength() - $conditionalLen)
                 ->append($conditionalFails)
                 ->write();
         }


### PR DESCRIPTION
When the test case named with double-width characters, test result's format is broken.

![2016-05-26 19 13 23](https://cloud.githubusercontent.com/assets/1610650/15571870/62d60ce6-2378-11e6-8ab8-652d1778e922.png)

after this fix:

![2016-05-26 19 13 59](https://cloud.githubusercontent.com/assets/1610650/15571872/67944db0-2378-11e6-90e6-f0433f450cc2.png)
