### PR TITLE
#3128 Fixed stack overflow too comples regex

### DIFF
--- a/src/Codeception/Module/Db.php
+++ b/src/Codeception/Module/Db.php
@@ -149,7 +149,7 @@ class Db extends CodeceptionModule implements DbInterface
                 );
             }
             $sql = file_get_contents(Configuration::projectDir() . $this->config['dump']);
-            $sql = preg_replace('%/\*(?!!\d+)(?:(?!\*/).)*\*/%s', "", $sql);
+            $sql = preg_replace('%/\*(?!!\d+).*?\*/%s', '', $sql);
             if (!empty($sql)) {
                 $this->sql = explode("\n", $sql);
             }


### PR DESCRIPTION
Simple lazy/non-greedy match-all instead of complex non-capturing negative lookahead.

Still matches both single line and multiline comments. Just like it did before.
Matching single-line comments should not be required, but excluding them would make regex more complex.