### PR TITLE
Added missing support for LIKE condition to SqlSrv driver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+#### 2.1.10
+
+* [Db] Added missing support for LIKE condition to SqlSrv driver
+
 #### 2.1.9
 
 * PHPUnit 5.4 compatibility for creating mocks using `Codeception\Util\Stub` by @davertmik. See #3093 and #3080

--- a/src/Codeception/Lib/Driver/SqlSrv.php
+++ b/src/Codeception/Lib/Driver/SqlSrv.php
@@ -56,7 +56,12 @@ class SqlSrv extends Db
 
         $params = [];
         foreach ($criteria as $k => $v) {
-            $params[] = $this->getQuotedName($k) . " = ? ";
+            if (strpos(strtolower($k), ' like') > 0) {
+                $k = str_replace(' like', '', strtolower($k));
+                $params[] = $this->getQuotedName($k) . " LIKE ? ";
+            } else {
+                $params[] = $this->getQuotedName($k) . " = ? ";
+            }
         }
 
         return 'WHERE ' . implode('AND ', $params);

--- a/src/Codeception/Module/ZF1.php
+++ b/src/Codeception/Module/ZF1.php
@@ -40,9 +40,6 @@ use Zend_Controller_Router_Route_Chain;
  *
  * ## Cleaning up
  *
- * For Doctrine1 and Doctrine2 all queries are put inside rollback transaction.
- * If you are using one of this ORMs connect their modules to speed up testing.
- *
  * Unfortunately Zend_Db doesn't support nested transactions,
  * thus, for cleaning your database you should either use standard Db module or
  * [implement nested transactions yourself](http://blog.ekini.net/2010/03/05/zend-framework-how-to-use-nested-transactions-with-zend_db-and-mysql/).


### PR DESCRIPTION
SqlSrv didn't have it because it overrides generateWhereClause method.

Also I deleted misleading comment from ZF1 module.

I made these changes after reviewing  #3142
