### PR TITLE
Avoid the last version of code coverage

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "ext-json": "*",
         "ext-mbstring": "*",
         "phpunit/phpunit": ">4.8.20 <6.0",
-        "phpunit/php-code-coverage": ">=2.1.3",
+        "phpunit/php-code-coverage": ">=2.1.3 <4.0",
         "facebook/webdriver": ">=1.0.1 <2.0",
         "guzzlehttp/guzzle": ">=4.1.4 <7.0",
         "guzzlehttp/psr7": "~1.0",


### PR DESCRIPTION
The last version of php-code-coverage introduce the use of namepsace and broke the code coverage generation in codecept

https://github.com/sebastianbergmann/php-code-coverage/blob/4.0.0/src/CodeCoverage.php#L25


