### PR TITLE
Check the return value of application->handle()

### DIFF
--- a/src/Codeception/Lib/Connector/Phalcon.php
+++ b/src/Codeception/Lib/Connector/Phalcon.php
@@ -11,7 +11,6 @@ use Phalcon\Mvc\Application;
 use Phalcon\Mvc\Micro as MicroApplication;
 use Phalcon\Http\Request;
 use Phalcon\Http\RequestInterface;
-use Phalcon\Http\Response as PhResponse;
 use Phalcon\Http\ResponseInterface;
 use Phalcon\Session\AdapterInterface as SessionInterface;
 use ReflectionProperty;

--- a/src/Codeception/Lib/Connector/Phalcon.php
+++ b/src/Codeception/Lib/Connector/Phalcon.php
@@ -11,6 +11,8 @@ use Phalcon\Mvc\Application;
 use Phalcon\Mvc\Micro as MicroApplication;
 use Phalcon\Http\Request;
 use Phalcon\Http\RequestInterface;
+use Phalcon\Http\Response as PhResponse;
+use Phalcon\Http\ResponseInterface;
 use Phalcon\Session\AdapterInterface as SessionInterface;
 use ReflectionProperty;
 use RuntimeException;
@@ -113,6 +115,9 @@ class Phalcon extends Client
         $di['request'] = Stub::construct($phRequest, [], ['getRawBody' => $request->getContent()]);
 
         $response = $application->handle();
+        if (!$response instanceof ResponseInterface) {
+            $response = $application->response;
+        }
 
         $headers = $response->getHeaders();
         $status = (int) $headers->get('Status');


### PR DESCRIPTION
In the Phalcon Micro Application, when you use the middleware in `before`, and it will be return the boolean (true or false) to make the application process pass through or stop.

When I use `return false` to stop the application, the Lib of Phalcon will got the boolean in LINE 115,

```
// Here will got the boolean when middleware `before` return false.
$response = $application->handle();
```

And the Library will be broken. So I add the check and IF NOT `ResponseInterface`, get the response from `$application->response` will be ok.