### PR TITLE
Curl extension is required

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,6 +18,7 @@
         "php": ">=5.4.0 <8.0",
         "ext-json": "*",
         "ext-mbstring": "*",
+        "ext-curl": "*",
         "phpunit/phpunit": ">4.8.20 <5.4",
         "phpunit/php-code-coverage": ">=2.1.3",
         "facebook/webdriver": ">=1.0.1 <2.0",


### PR DESCRIPTION
I has always been required: https://github.com/Codeception/Codeception/blob/2.1.10/src/Codeception/Command/Run.php#L380
I just made it explicit in composer.json