### PR TITLE
Added a grabNumRecords to Db module

### DIFF
--- a/src/Codeception/Module/Db.php
+++ b/src/Codeception/Module/Db.php
@@ -89,8 +89,9 @@ use Codeception\TestInterface;
  * ```
  * ## Query generation
  *
- * seeInDatabase, dontSeeInDatabase, seeNumRecords and grabFromDatabase methods accept arrays as criteria.
- * WHERE condition is generated using item key as a field name and item value as a field value.
+ * seeInDatabase, dontSeeInDatabase, seeNumRecords, grabFromDatabase and grabNumRecords methods
+ * accept arrays as criteria. WHERE condition is generated using item key as a field name and
+ * item value as a field value.
  *
  * Example:
  * ``` php
@@ -427,5 +428,18 @@ class Db extends CodeceptionModule implements DbInterface
     public function grabFromDatabase($table, $column, $criteria = [])
     {
         return $this->proceedSeeInDatabase($table, $column, $criteria);
+    }
+
+    /**
+     * Returns the number of rows in a database
+     *
+     * @param string $table    Table name
+     * @param array  $criteria Search criteria [Optional]
+     *
+     * @return int
+     */
+    public function grabNumRecords($table, array $criteria = [])
+    {
+        return $this->countInDatabase($table, $criteria);
     }
 }

--- a/tests/unit/Codeception/Module/DbTest.php
+++ b/tests/unit/Codeception/Module/DbTest.php
@@ -56,6 +56,16 @@ class DbTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('davert@mail.ua', $email);
     }
 
+    public function testGrabNumRecords()
+    {
+        $num = self::$module->grabNumRecords('users', ['name' => 'davert']);
+        $this->assertEquals($num, 1);
+        $num = self::$module->grabNumRecords('users', ['name' => 'davert', 'email' => 'xxx@yyy.zz']);
+        $this->assertEquals($num, 0);
+        $num = self::$module->grabNumRecords('users', ['name' => 'user1']);
+        $this->assertEquals($num, 0);
+    }
+
     public function testHaveAndSeeInDatabase()
     {
         self::$module->_before(\Codeception\Util\Stub::makeEmpty('\Codeception\TestInterface'));


### PR DESCRIPTION
You might want to compare how many records are in a table before and after some operations. The table might not be empty to begin with.

For example:
```
$count = $I->grabNumRecords( 'book' );
$I->click( 'Save' );
$I->see( 'Field is required' );
$I->seeNumRecords( 'book', $count );
```