### PR TITLE
[Module : SOAP] Implement onReconfigure()

### DIFF
--- a/src/Codeception/Module/SOAP.php
+++ b/src/Codeception/Module/SOAP.php
@@ -101,6 +101,13 @@ EOF;
         $this->xmlStructure = null;
     }
 
+    protected function onReconfigure()
+    {
+        $this->buildRequest();
+        $this->xmlResponse = null;
+        $this->xmlStructure = null;
+    }
+
     public function _depends()
     {
         return ['Codeception\Lib\InnerBrowser' => $this->dependencyMessage];


### PR DESCRIPTION
Hello,

This PR allow to send different request on different endpoint in the same test case.

Cest file :
```php
class testApiCest
{
    public function test(ApiTester $I)
    {
        $I->switchEndPoint("https://api1.company.com");
        $I->sendSoapRequest('UpdateUser', '<user><id>1</id><name>notdavert</name></user>');

        $I->switchEndPoint("https://api2.company.com");
        $I->sendSoapRequest('UpdateUser', '<user><id>1</id><name>notdavert</name></user>');
    }
}
```

Helper file :
```php
    public function switchEndPoint ($endpoint)
    {
        $this->getModule('SOAP')->_reconfigure(['endpoint' => $endpoint]);
    }
```

Actual result :
- First UpdateUser on API1
- Second UpdateUser on API1

Expected result :
- First UpdateUser on API1
- Second UpdateUser on API2

With this PR it's working like expected result.