### PR TITLE
Fix in the Logger extension.

### DIFF
--- a/ext/Logger.php
+++ b/ext/Logger.php
@@ -79,7 +79,7 @@ class Logger extends Extension
 
     public function beforeTest(TestEvent $e)
     {
-        $this->logger = new \Monolog\Logger($e->getTest()->getFileName());
+        $this->logger = new \Monolog\Logger($e->getTest()->getMetadata()->getFilename());
         $this->logger->pushHandler($this->logHandler);
         $this->logger->info('------------------------------------');
         $this->logger->info("STARTED: " . ucfirst($e->getTest()->getName(false)));


### PR DESCRIPTION
Using the logger ext in the version 2.2  codeception fails with the following error:

`PHP Fatal error:  Call to undefined method path/to/an/specific/class::getFileName() in /vendor/codeception/codeception/ext/Logger.php on line 82`

Checking the code it seems to since the 2.2 version the `Codeception\TestCase` was replaced with `Codeception\TestInterface` and  some methods were moved to the MetaData Class. 

So the Logger extension fails when it tries to use the `getFileName` method because it is still looking in the Test class instead of the Metadata class. 

In this PR I just fixed that.

