### PR TITLE
UTF-8 improvements

### DIFF
--- a/src/Codeception/Lib/Console/Message.php
+++ b/src/Codeception/Lib/Console/Message.php
@@ -113,6 +113,11 @@ class Message
         return mb_strwidth($includeTags ? $this->message : strip_tags($this->message), 'utf-8');
     }
 
+    public static function ucfirst($text)
+    {
+        return mb_strtoupper(mb_substr($text, 0, 1, 'utf-8'), 'utf-8') . mb_substr($text, 1, null, 'utf-8');
+    }
+
     public function __toString()
     {
         return $this->message;

--- a/src/Codeception/Scenario.php
+++ b/src/Codeception/Scenario.php
@@ -136,7 +136,7 @@ class Scenario
             }
         }
         $text = str_replace(['"\'', '\'"'], ["'", "'"], $text);
-        $text = "<h3>" . strtoupper('I want to ' . $this->getFeature()) . "</h3>" . $text;
+        $text = "<h3>" . mb_strtoupper('I want to ' . $this->getFeature(), 'utf-8') . "</h3>" . $text;
         return $text;
     }
 
@@ -144,7 +144,7 @@ class Scenario
     {
         $text = implode("\r\n", $this->getSteps());
         $text = str_replace(array('"\'', '\'"'), array("'", "'"), $text);
-        $text = strtoupper('I want to ' . $this->getFeature()) . str_repeat("\r\n", 2) . $text . str_repeat("\r\n", 2);
+        $text = mb_strtoupper('I want to ' . $this->getFeature(), 'utf-8') . "\r\n\r\n" . $text . "\r\n\r\n";
         return $text;
     }
 

--- a/src/Codeception/Subscriber/Console.php
+++ b/src/Codeception/Subscriber/Console.php
@@ -521,11 +521,7 @@ class Console implements EventSubscriberInterface
 
         if ($feature) {
             $this->message = $this
-                ->message(
-                    $inProgress
-                    ? $feature
-                    : mb_strtoupper(mb_substr($feature, 0, 1, 'utf-8'), 'utf-8') . mb_substr($feature, 1, null, 'utf-8')
-                )
+                ->message($inProgress ? $feature : Message::ucfirst($feature))
                 ->apply(function ($str) {
                     return str_replace('with data set', "|", $str);
                 })


### PR DESCRIPTION
* Created Message::ucfirst for utf-8 texts (it is used only once in 2.1 branch, but it will be used in more places in 2.2).
* Changes strtoupper to mb_strtoupper in Scenario::getText and Scenario::getHtml