### PR TITLE
Add optional parameter test to command gherkin:snippets

### DIFF
--- a/src/Codeception/Command/GherkinSnippets.php
+++ b/src/Codeception/Command/GherkinSnippets.php
@@ -18,6 +18,7 @@ class GherkinSnippets extends Command
         $this->setDefinition(
             [
                 new InputArgument('suite', InputArgument::REQUIRED, 'suite to scan for feature files'),
+                new InputArgument('test', InputArgument::OPTIONAL, 'test to be scanned'),
                 new InputOption('config', 'c', InputOption::VALUE_OPTIONAL, 'Use custom path for config'),
             ]
         );
@@ -33,9 +34,10 @@ class GherkinSnippets extends Command
     {
         $this->addStyles($output);
         $suite = $input->getArgument('suite');
+        $test = $input->getArgument('test');
         $config = $this->getSuiteConfig($suite, $input->getOption('config'));
 
-        $generator = new SnippetsGenerator($config);
+        $generator = new SnippetsGenerator($config, $test);
         $snippets = $generator->getSnippets();
 
         if (empty($snippets)) {

--- a/src/Codeception/Lib/Generator/GherkinSnippets.php
+++ b/src/Codeception/Lib/Generator/GherkinSnippets.php
@@ -26,9 +26,9 @@ EOF;
     {
         $loader = new Gherkin($settings);
         if (empty($test) || is_null($test)) {
-          $pattern = $loader->getPattern();
+            $pattern = $loader->getPattern();
         } else {
-          $pattern = $test;
+            $pattern = $test;
         }
 
         $finder = Finder::create()

--- a/src/Codeception/Lib/Generator/GherkinSnippets.php
+++ b/src/Codeception/Lib/Generator/GherkinSnippets.php
@@ -16,22 +16,27 @@ class GherkinSnippets
      {
         throw new \Codeception\Exception\Incomplete("Step `{{text}}` is not defined");
      }
-     
+
 EOF;
 
     protected $snippets = [];
     protected $processed = [];
 
-    public function __construct($settings)
+    public function __construct($settings, $test = null)
     {
         $loader = new Gherkin($settings);
+        if (empty($test) || is_null($test)) {
+          $pattern = $loader->getPattern();
+        } else {
+          $pattern = $test;
+        }
 
         $finder = Finder::create()
             ->files()
             ->sortByName()
             ->in($settings['path'])
             ->followLinks()
-            ->name($loader->getPattern());
+            ->name($pattern);
 
         foreach ($finder as $file) {
             $pathname = str_replace("//", "/", $file->getPathname());

--- a/tests/cli/GherkinCest.php
+++ b/tests/cli/GherkinCest.php
@@ -24,4 +24,11 @@ class GherkinCest
         $I->seeInShellOutput('@Given I have only idea of what\'s going on here');
         $I->seeInShellOutput('public function iHaveOnlyIdeaOfWhatsGoingOnHere');
     }
+
+    public function snippetsScenario(CliGuy $I)
+    {
+        $I->executeCommand('gherkin:snippets scenario FileExamples.feature');
+        $I->dontSeeInShellOutput('@Given I have only idea of what\'s going on here');
+        $I->dontSeeInShellOutput('public function iHaveOnlyIdeaOfWhatsGoingOnHere');
+    }    
 }


### PR DESCRIPTION
Implementation of #3119 for creating gherkin snippets for a specific feature. The new command line is similar to the syntax of `run`:
```
codecept gherkin:snippets suite [test]
```
Example:
```
codecept gherkin:snippets acceptance admin.feature
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/codeception/codeception/3212)
<!-- Reviewable:end -->
