### PR TITLE
Bugfix with duplicate instances in the container

### DIFF
--- a/src/Codeception/Lib/Di.php
+++ b/src/Codeception/Lib/Di.php
@@ -42,6 +42,9 @@ class Di
         $constructorArgs = null,
         $injectMethodName = self::DEFAULT_INJECT_METHOD_NAME
     ) {
+        // normalize namespace
+        $className = ltrim($className, '\\');
+        
         // get class from container
         if (isset($this->container[$className])) {
             if ($this->container[$className] instanceof $className) {


### PR DESCRIPTION
In some cases duplicates were present in the container, for example "Codeception\Modules\Symfony2" and "\Codeception\Modules\Symfony2"