### PR TITLE
Fix loading of parameters from `.env.*` files

### DIFF
--- a/src/Codeception/Configuration.php
+++ b/src/Codeception/Configuration.php
@@ -646,7 +646,7 @@ class Configuration
             }
 
             // .env and ini files
-            if (preg_match('~(\.ini|\.env)$~', $paramStorage)) {
+            if (preg_match('~(\.ini$|\.env(\.|$))~', $paramStorage)) {
                 $params = parse_ini_file($paramsFile);
                 static::$params = array_merge(self::$params, $params);
                 continue;


### PR DESCRIPTION
The documentation [states](http://codeception.com/docs/06-ModulesAndHelpers#Dynamic-Configuration-With-Params) that we can load params from files named `.env` or `.env.something` but the latter doesn't work because the regex only matches filenames ending with `.env` or `.ini`