### PR TITLE
Diff shows only changed lines

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,9 @@
         "symfony/browser-kit": ">=2.7 <4.0",
         "symfony/css-selector": ">=2.7 <4.0",
         "symfony/dom-crawler": ">=2.7 <4.0",
-        "behat/gherkin": "~4.4.0"
+        "behat/gherkin": "~4.4.0",
+        "sebastian/comparator": "~1.1",
+        "sebastian/diff": "^1.4"
 
     },
     "require-dev": {

--- a/src/Codeception/Lib/Console/MessageFactory.php
+++ b/src/Codeception/Lib/Console/MessageFactory.php
@@ -1,0 +1,69 @@
+<?php
+namespace Codeception\Lib\Console;
+
+use SebastianBergmann\Comparator\ComparisonFailure;
+use SebastianBergmann\Diff\Differ;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * MessageFactory
+ **/
+class MessageFactory
+{
+    /**
+     * @var OutputInterface
+     */
+    private $output;
+
+    /**
+     * MessageFactory constructor.
+     * @param Output $output
+     */
+    public function __construct(Output $output)
+    {
+        $this->output = $output;
+    }
+
+    /**
+     * @param string $text
+     * @return Message
+     */
+    public function message($text = '')
+    {
+        return new Message($text, $this->output);
+    }
+
+    /**
+     * @param ComparisonFailure $failure
+     * @return Message|null
+     */
+    public function prepareCompMessage(ComparisonFailure $failure)
+    {
+        $compMessage = $failure->getMessage();
+        $diff = $this->getDiff($failure->getExpectedAsString(), $failure->getActualAsString());
+
+        if (!$diff) {
+            return null;
+        }
+
+        return $this
+            ->message($compMessage)
+            ->append($diff);
+    }
+
+    /**
+     * @param string $expected
+     * @param string $actual
+     * @return string
+     */
+    private function getDiff($expected = '', $actual = '')
+    {
+        if (!$actual && !$expected) {
+            return '';
+        }
+
+        $differ = new Differ("- Expected | + Actual\n");
+
+        return $differ->diff($expected, $actual);
+    }
+}

--- a/src/Codeception/Lib/Console/MessageFactory.php
+++ b/src/Codeception/Lib/Console/MessageFactory.php
@@ -37,17 +37,15 @@ class MessageFactory
      * @param ComparisonFailure $failure
      * @return Message|null
      */
-    public function prepareCompMessage(ComparisonFailure $failure)
+    public function prepareComparisonFailureMessage(ComparisonFailure $failure)
     {
-        $compMessage = $failure->getMessage();
         $diff = $this->getDiff($failure->getExpectedAsString(), $failure->getActualAsString());
-
         if (!$diff) {
             return null;
         }
 
         return $this
-            ->message($compMessage)
+            ->message($failure->getMessage())
             ->append($diff);
     }
 

--- a/src/Codeception/Subscriber/Console.php
+++ b/src/Codeception/Subscriber/Console.php
@@ -375,9 +375,9 @@ class Console implements EventSubscriberInterface
         $message = $this->message($e->getMessage());
 
         if ($e instanceof \PHPUnit_Framework_ExpectationFailedException) {
-            if ($e->getComparisonFailure()) {
-                $comparisionFailure = $e->getComparisonFailure();
-                $message = $this->messageFactory->prepareCompMessage($comparisionFailure);
+            $comparisonFailure = $e->getComparisonFailure();
+            if ($comparisonFailure) {
+                $message = $this->messageFactory->prepareCompMessage($comparisonFailure);
             }
         }
 
@@ -386,7 +386,7 @@ class Console implements EventSubscriberInterface
             || $class === 'PHPUnit_Framework_AssertionFailedError';
 
         if (!$isFailure) {
-            $message->prepend("[$class] ")->block("error");
+            $message->prepend("[$class] ")->block('error');
         }
 
         if ($isFailure && $cause) {

--- a/src/Codeception/Subscriber/Console.php
+++ b/src/Codeception/Subscriber/Console.php
@@ -8,6 +8,7 @@ use Codeception\Event\SuiteEvent;
 use Codeception\Event\TestEvent;
 use Codeception\Events;
 use Codeception\Lib\Console\Message;
+use Codeception\Lib\Console\MessageFactory;
 use Codeception\Lib\Console\Output;
 use Codeception\Lib\Notification;
 use Codeception\Step;
@@ -23,20 +24,23 @@ class Console implements EventSubscriberInterface
 {
     use Shared\StaticEvents;
 
+    /**
+     * @var string[]
+     */
     public static $events = [
-        Events::SUITE_BEFORE    => 'beforeSuite',
-        Events::SUITE_AFTER     => 'afterSuite',
-        Events::TEST_START      => 'startTest',
-        Events::TEST_END        => 'endTest',
-        Events::STEP_BEFORE     => 'beforeStep',
-        Events::STEP_AFTER      => 'afterStep',
-        Events::TEST_SUCCESS    => 'testSuccess',
-        Events::TEST_FAIL       => 'testFail',
-        Events::TEST_ERROR      => 'testError',
-        Events::TEST_INCOMPLETE => 'testIncomplete',
-        Events::TEST_SKIPPED    => 'testSkipped',
-        Events::TEST_FAIL_PRINT => 'printFail',
-        Events::RESULT_PRINT_AFTER => 'afterResult'
+        Events::SUITE_BEFORE       => 'beforeSuite',
+        Events::SUITE_AFTER        => 'afterSuite',
+        Events::TEST_START         => 'startTest',
+        Events::TEST_END           => 'endTest',
+        Events::STEP_BEFORE        => 'beforeStep',
+        Events::STEP_AFTER         => 'afterStep',
+        Events::TEST_SUCCESS       => 'testSuccess',
+        Events::TEST_FAIL          => 'testFail',
+        Events::TEST_ERROR         => 'testError',
+        Events::TEST_INCOMPLETE    => 'testIncomplete',
+        Events::TEST_SKIPPED       => 'testSkipped',
+        Events::TEST_FAIL_PRINT    => 'printFail',
+        Events::RESULT_PRINT_AFTER => 'afterResult',
     ];
 
     /**
@@ -57,6 +61,10 @@ class Console implements EventSubscriberInterface
     protected $rawStackTrace = false;
     protected $traceLength = 5;
     protected $width;
+
+    /**
+     * @var OutputInterface
+     */
     protected $output;
     protected $fails = [];
     protected $reports = [];
@@ -74,13 +82,19 @@ class Console implements EventSubscriberInterface
         'json'      => null,
     ];
 
+    /**
+     * @var MessageFactory
+     */
+    protected $messageFactory;
+
     public function __construct($options)
     {
+        $this->output = new Output($options);
+        $this->messageFactory = new MessageFactory($this->output);
         $this->options = array_merge($this->options, $options);
         $this->debug = $this->options['debug'] || $this->options['verbosity'] >= OutputInterface::VERBOSITY_VERY_VERBOSE;
         $this->steps = $this->debug || $this->options['steps'];
         $this->rawStackTrace = ($this->options['verbosity'] === OutputInterface::VERBOSITY_DEBUG);
-        $this->output = new Output($options);
         if ($this->debug) {
             Debug::setOutput($this->output);
         }
@@ -198,6 +212,7 @@ class Console implements EventSubscriberInterface
         if ((strpos($path, '/') === 0) or (strpos($path, ':') === 1)) { // absolute path
             return $path;
         }
+
         return codecept_output_dir() . $path;
     }
 
@@ -205,6 +220,7 @@ class Console implements EventSubscriberInterface
     {
         if ($this->isDetailed($e->getTest())) {
             $this->message('PASSED')->center(' ')->style('ok')->append("\n")->writeln();
+
             return;
         }
         $this->writelnFinishedTest($e, $this->message($this->chars['success'])->style('ok'));
@@ -220,6 +236,7 @@ class Console implements EventSubscriberInterface
     {
         if ($this->isDetailed($e->getTest())) {
             $this->message('FAIL')->center(' ')->style('fail')->append("\n")->writeln();
+
             return;
         }
         $this->writelnFinishedTest($e, $this->message($this->chars['fail'])->style('fail'));
@@ -229,6 +246,7 @@ class Console implements EventSubscriberInterface
     {
         if ($this->isDetailed($e->getTest())) {
             $this->message('ERROR')->center(' ')->style('fail')->append("\n")->writeln();
+
             return;
         }
         $this->writelnFinishedTest($e, $this->message('E')->style('fail'));
@@ -239,6 +257,7 @@ class Console implements EventSubscriberInterface
         if ($this->isDetailed($e->getTest())) {
             $msg = $e->getFail()->getMessage();
             $this->message('SKIPPED')->append($msg ? ": $msg" : '')->center(' ')->style('pending')->writeln();
+
             return;
         }
         $this->writelnFinishedTest($e, $this->message('S')->style('pending'));
@@ -249,6 +268,7 @@ class Console implements EventSubscriberInterface
         if ($this->isDetailed($e->getTest())) {
             $msg = $e->getFail()->getMessage();
             $this->message('INCOMPLETE')->append($msg ? ": $msg" : '')->center(' ')->style('pending')->writeln();
+
             return;
         }
         $this->writelnFinishedTest($e, $this->message('I')->style('pending'));
@@ -259,6 +279,7 @@ class Console implements EventSubscriberInterface
         if ($test instanceof ScenarioDriven && $this->steps) {
             return true;
         }
+
         return false;
     }
 
@@ -324,6 +345,7 @@ class Console implements EventSubscriberInterface
 
         if ($failedTest instanceof ScenarioDriven) {
             $this->printScenarioFail($failedTest, $fail);
+
             return;
         }
 
@@ -337,6 +359,7 @@ class Console implements EventSubscriberInterface
             if ($e->getMessage()) {
                 $this->message($e->getMessage())->prepend("\n")->writeln();
             }
+
             return;
         }
 
@@ -353,12 +376,8 @@ class Console implements EventSubscriberInterface
 
         if ($e instanceof \PHPUnit_Framework_ExpectationFailedException) {
             if ($e->getComparisonFailure()) {
-                $comp = $e->getComparisonFailure();
-                if ($comp->getDiff()) {
-                    $message = $this->message($comp->getMessage())->append(" ( <comment>-Expected</comment> | <info>+Actual</info> ) \n");
-                    $message->append("- <comment>" . str_replace("\n", "\n- ", $comp->getExpectedAsString()))->append("</comment>\n");
-                    $message->append("+ <info>" . str_replace("\n", "\n+ ", $comp->getActualAsString()))->append("</info>\n");
-                }
+                $comparisionFailure = $e->getComparisonFailure();
+                $message = $this->messageFactory->prepareCompMessage($comparisionFailure);
             }
         }
 
@@ -385,7 +404,7 @@ class Console implements EventSubscriberInterface
         $failedStep = "";
         foreach ($failedTest->getScenario()->getSteps() as $step) {
             if ($step->hasFailed()) {
-                $failedStep = (string)$step;
+                $failedStep = (string) $step;
                 break;
             }
         }
@@ -394,10 +413,12 @@ class Console implements EventSubscriberInterface
         $this->printScenarioTrace($failedTest, $failToString);
         if ($this->output->getVerbosity() == OutputInterface::VERBOSITY_DEBUG) {
             $this->printExceptionTrace($fail);
+
             return;
         }
         if (!$fail instanceof \PHPUnit_Framework_AssertionFailedError) {
             $this->printExceptionTrace($fail);
+
             return;
         }
     }
@@ -412,6 +433,7 @@ class Console implements EventSubscriberInterface
 
         if ($this->rawStackTrace) {
             $this->message(\PHPUnit_Util_Filter::getFilteredStacktrace($e, true, false))->writeln();
+
             return;
         }
 
@@ -444,15 +466,6 @@ class Console implements EventSubscriberInterface
         if ($prev) {
             $this->printExceptionTrace($prev);
         }
-    }
-
-    /**
-     * @param string $text
-     * @return Message
-     */
-    protected function message($text = '')
-    {
-        return new Message($text, $this->output);
     }
 
     /**
@@ -530,8 +543,9 @@ class Console implements EventSubscriberInterface
             && (getenv('TERM'))
             && (getenv('TERM') != 'unknown')
         ) {
-            $this->width = (int)(`command -v tput >> /dev/null 2>&1 && tput cols`) - 2;
+            $this->width = (int) (`command -v tput >> /dev/null 2>&1 && tput cols`) - 2;
         }
+
         return $this->width;
     }
 
@@ -542,7 +556,7 @@ class Console implements EventSubscriberInterface
 
     /**
      * @param \PHPUnit_Framework_SelfDescribing $test
-     * @param bool $inProgress
+     * @param bool                              $inProgress
      */
     protected function writeCurrentTest(\PHPUnit_Framework_SelfDescribing $test, $inProgress = true)
     {
@@ -579,19 +593,35 @@ class Console implements EventSubscriberInterface
         }
         $conditionalFails = "<error>$conditionalFails</error> ";
         $this->message($conditionalFails)->write();
+        $this->writeTimeInformation($event);
+        $this->output->writeln('');
+    }
 
+    /**
+     * @param $string
+     * @return Message
+     */
+    private function message($string = '')
+    {
+        return $this->messageFactory->message($string);
+    }
+
+    /**
+     * @param TestEvent $event
+     */
+    protected function writeTimeInformation(TestEvent $event)
+    {
         $time = $event->getTime();
-
         if ($time) {
-            $seconds = (int)($milliseconds = (int)($time * 100)) / 100;
+            $seconds = (int) ($milliseconds = (int) ($time * 100)) / 100;
             $time = ($seconds % 60) . '.' . $milliseconds;
 
-            $this->message($time)
+            $this
+                ->message($time)
                 ->prepend('(')
                 ->append('s)')
                 ->style('info')
                 ->write();
         }
-        $this->output->writeln('');
     }
 }

--- a/src/Codeception/Subscriber/Console.php
+++ b/src/Codeception/Subscriber/Console.php
@@ -89,12 +89,9 @@ class Console implements EventSubscriberInterface
 
     public function __construct($options)
     {
+        $this->prepareOptions($options);
         $this->output = new Output($options);
         $this->messageFactory = new MessageFactory($this->output);
-        $this->options = array_merge($this->options, $options);
-        $this->debug = $this->options['debug'] || $this->options['verbosity'] >= OutputInterface::VERBOSITY_VERY_VERBOSE;
-        $this->steps = $this->debug || $this->options['steps'];
-        $this->rawStackTrace = ($this->options['verbosity'] === OutputInterface::VERBOSITY_DEBUG);
         if ($this->debug) {
             Debug::setOutput($this->output);
         }
@@ -623,5 +620,16 @@ class Console implements EventSubscriberInterface
                 ->style('info')
                 ->write();
         }
+    }
+
+    /**
+     * @param $options
+     */
+    private function prepareOptions($options)
+    {
+        $this->options = array_merge($this->options, $options);
+        $this->debug = $this->options['debug'] || $this->options['verbosity'] >= OutputInterface::VERBOSITY_VERY_VERBOSE;
+        $this->steps = $this->debug || $this->options['steps'];
+        $this->rawStackTrace = ($this->options['verbosity'] === OutputInterface::VERBOSITY_DEBUG);
     }
 }

--- a/src/Codeception/Subscriber/Console.php
+++ b/src/Codeception/Subscriber/Console.php
@@ -377,7 +377,7 @@ class Console implements EventSubscriberInterface
         if ($e instanceof \PHPUnit_Framework_ExpectationFailedException) {
             $comparisonFailure = $e->getComparisonFailure();
             if ($comparisonFailure) {
-                $message = $this->messageFactory->prepareCompMessage($comparisonFailure);
+                $message = $this->messageFactory->prepareComparisonFailureMessage($comparisonFailure);
             }
         }
 

--- a/tests/unit/Codeception/Lib/Console/MessageFactoryTest.php
+++ b/tests/unit/Codeception/Lib/Console/MessageFactoryTest.php
@@ -27,7 +27,7 @@ class MessageFactoryTest extends \Codeception\Test\Unit
     {
         $expectedDiff = $this->getExpectedDiff();
         $failure = $this->createFailure();
-        $message = $this->messageFactory->prepareCompMessage($failure);
+        $message = $this->messageFactory->prepareComparisonFailureMessage($failure);
 
         $this->assertEquals($expectedDiff, (string) $message, 'The diff should be generated.');
     }

--- a/tests/unit/Codeception/Lib/Console/MessageFactoryTest.php
+++ b/tests/unit/Codeception/Lib/Console/MessageFactoryTest.php
@@ -1,0 +1,84 @@
+<?php
+namespace Codeception\Lib\Console;
+
+use Codeception\Util\Stub;
+use SebastianBergmann\Comparator\ComparisonFailure;
+
+/**
+ * MessageFactoryTest
+ **/
+class MessageFactoryTest extends \Codeception\Test\Unit
+{
+    /**
+     * @var MessageFactory
+     */
+    protected $messageFactory;
+
+    protected function setUp()
+    {
+        /**
+         * @var Output $stub
+         */
+        $stub = Stub::make(Output::class);
+        $this->messageFactory = new MessageFactory($stub);
+    }
+
+
+    public function testItCreatesMessageForComparisonFail()
+    {
+        $expectedDiff = $this->getExpectedDiff();
+        $fail = $this->failure();
+        $message = $this->messageFactory->prepareCompMessage($fail);
+
+        $this->assertEquals($expectedDiff, (string) $message, 'The diff should be generated.');
+    }
+
+    /**
+     * @return ComparisonFailure
+     */
+    protected function failure()
+    {
+        $leExpectedXml = <<<XML
+<note>
+    <to>Tove</to>
+    <from>Jani</from>
+    <heading>Reminder</heading>
+    <body>Don't forget me this weekend!</body>
+</note>
+XML;
+
+        $leActualXml = <<<XML
+<note>
+    <to>Tove</to>
+    <from>Jani</from>
+    <heading>Reminder
+    </heading>
+    <body>Don't forget me this weekend!</body>
+</note>
+XML;
+
+        return new ComparisonFailure($leExpectedXml, $leActualXml, $leExpectedXml, $leActualXml);
+    }
+
+    /**
+     * @return string
+     */
+    protected function getExpectedDiff()
+    {
+        $expectedDiff = <<<TXT
+- Expected | + Actual
+@@ @@
+ <note>
+     <to>Tove</to>
+     <from>Jani</from>
+-    <heading>Reminder</heading>
++    <heading>Reminder
++    </heading>
+     <body>Don't forget me this weekend!</body>
+ </note>
+TXT;
+
+        return $expectedDiff . "\n";
+    }
+
+}

--- a/tests/unit/Codeception/Lib/Console/MessageFactoryTest.php
+++ b/tests/unit/Codeception/Lib/Console/MessageFactoryTest.php
@@ -23,12 +23,11 @@ class MessageFactoryTest extends \Codeception\Test\Unit
         $this->messageFactory = new MessageFactory($stub);
     }
 
-
-    public function testItCreatesMessageForComparisonFail()
+    public function testItCreatesMessageForComparisonFailure()
     {
         $expectedDiff = $this->getExpectedDiff();
-        $fail = $this->failure();
-        $message = $this->messageFactory->prepareCompMessage($fail);
+        $failure = $this->createFailure();
+        $message = $this->messageFactory->prepareCompMessage($failure);
 
         $this->assertEquals($expectedDiff, (string) $message, 'The diff should be generated.');
     }
@@ -36,9 +35,9 @@ class MessageFactoryTest extends \Codeception\Test\Unit
     /**
      * @return ComparisonFailure
      */
-    protected function failure()
+    protected function createFailure()
     {
-        $leExpectedXml = <<<XML
+        $expectedXml = <<<XML
 <note>
     <to>Tove</to>
     <from>Jani</from>
@@ -47,7 +46,7 @@ class MessageFactoryTest extends \Codeception\Test\Unit
 </note>
 XML;
 
-        $leActualXml = <<<XML
+        $actualXml = <<<XML
 <note>
     <to>Tove</to>
     <from>Jani</from>
@@ -57,7 +56,7 @@ XML;
 </note>
 XML;
 
-        return new ComparisonFailure($leExpectedXml, $leActualXml, $leExpectedXml, $leActualXml);
+        return new ComparisonFailure($expectedXml, $actualXml, $expectedXml, $actualXml);
     }
 
     /**
@@ -80,5 +79,4 @@ TXT;
 
         return $expectedDiff . "\n";
     }
-
 }

--- a/tests/unit/Codeception/Lib/Console/MessageFactoryTest.php
+++ b/tests/unit/Codeception/Lib/Console/MessageFactoryTest.php
@@ -19,7 +19,7 @@ class MessageFactoryTest extends \Codeception\Test\Unit
         /**
          * @var Output $stub
          */
-        $stub = Stub::make(Output::class);
+        $stub = Stub::make('\Codeception\Lib\Console\Output');
         $this->messageFactory = new MessageFactory($stub);
     }
 


### PR DESCRIPTION
The diff used to show both complete strings instead of only the changed lines,
I've added a unit test for the case and refactored a bit inside the Console.php

Todo: Add color output as this got lost during the diff changes.

fixes issue 3230