### PR TITLE
Search field by label without "for"

### DIFF
--- a/src/Codeception/Lib/InnerBrowser.php
+++ b/src/Codeception/Lib/InnerBrowser.php
@@ -817,11 +817,13 @@ class InnerBrowser extends Module implements Web, PageSourceSaver, ElementLocato
         }
 
         // by label
-        $label = $this->strictMatch(['xpath' => sprintf('.//label[text()[normalize-space()=%s]]', Crawler::xpathLiteral($field))]);
+        $label = $this->strictMatch(['xpath' => sprintf('.//label[descendant-or-self::node()[text()[normalize-space()=%s]]]', Crawler::xpathLiteral($field))]);
         if (count($label)) {
             $label = $label->first();
             if ($label->attr('for')) {
                 $input = $this->strictMatch(['id' => $label->attr('for')]);
+            } else {
+                $input = $this->strictMatch(['xpath' => sprintf('.//label[descendant-or-self::node()[text()[normalize-space()=%s]]]//input', Crawler::xpathLiteral($field))]);
             }
         }
 

--- a/tests/data/app/view/form/field.php
+++ b/tests/data/app/view/form/field.php
@@ -2,6 +2,12 @@
 <body>
 <form action="/form/complex" method="POST">
     <label for="name">Name</label>
+    <label>
+        <b>Other label</b>
+        <div>
+            <input name="othername">
+        </div>
+    </label>
     <input type="text" id="name" name="name" value="OLD_VALUE" />
     <input type="submit" value="Submit" />
 </form>

--- a/tests/unit/Codeception/Module/TestsForWeb.php
+++ b/tests/unit/Codeception/Module/TestsForWeb.php
@@ -363,6 +363,15 @@ abstract class TestsForWeb extends \Codeception\TestCase\Test
         $this->assertEquals('Nothing special', $form['name']);
     }
 
+    public function testTextFieldByLabelWithoutFor()
+    {
+        $this->module->amOnPage('/form/field');
+        $this->module->fillField('Other label', 'Nothing special');
+        $this->module->click('Submit');
+        $form = data::get('form');
+        $this->assertEquals('Nothing special', $form['othername']);
+    }
+
     public function testFileFieldByCss()
     {
         $this->module->amOnPage('/form/file');


### PR DESCRIPTION
Search input fields in constructions like
```
<label>
   <b>Some label</b>
   <input name="name">
</label>
```