### PR TITLE
Fix for "File name too long" error in failed tests

### DIFF
--- a/src/Codeception/Lib/InnerBrowser.php
+++ b/src/Codeception/Lib/InnerBrowser.php
@@ -58,7 +58,9 @@ class InnerBrowser extends Module implements Web, PageSourceSaver, ElementLocato
         if (!$this->client || !$this->client->getInternalResponse()) {
             return;
         }
-        $this->_savePageSource(codecept_output_dir().str_replace(['::', '\\', '/'], ['.', '.', '.'], Descriptor::getTestSignature($test)) . '.fail.html');
+        $filename = str_replace(['::', '\\', '/'], '.', Descriptor::getTestSignature($test));
+        $filename = mb_strcut($filename, 0, 244) . '.fail.html';
+        $this->_savePageSource(codecept_output_dir() . $filename);
     }
 
     public function _after(TestInterface $test)

--- a/src/Codeception/Lib/InnerBrowser.php
+++ b/src/Codeception/Lib/InnerBrowser.php
@@ -58,11 +58,8 @@ class InnerBrowser extends Module implements Web, PageSourceSaver, ElementLocato
         if (!$this->client || !$this->client->getInternalResponse()) {
             return;
         }
-        $filename = preg_replace('~\W~', '.', Descriptor::getTestSignature($test)) . '.fail.html';
-        $this->_savePageSource(codecept_output_dir() . $filename);
-        
-        $filename = str_replace(['::', '\\', '/'], '.', Descriptor::getTestSignature($test));
-        $filename = mb_strcut($filename, 0, 244) . '.fail.html';
+        $filename = preg_replace('~\W~', '.', Descriptor::getTestSignature($test));
+        $filename = mb_strcut($filename, 0, 244, 'utf-8') . '.fail.html';
         $this->_savePageSource(codecept_output_dir() . $filename);
     }
 

--- a/src/Codeception/Module/WebDriver.php
+++ b/src/Codeception/Module/WebDriver.php
@@ -365,10 +365,10 @@ class WebDriver extends CodeceptionModule implements
     public function _failed(TestInterface $test, $fail)
     {
         $this->debugWebDriverLogs();
-        $filename = preg_replace('~\W~', '.', Descriptor::getTestSignature($test)) . '.fail';
+        $filename = preg_replace('~\W~', '.', Descriptor::getTestSignature($test));
         $outputDir = codecept_output_dir();
-        $this->_saveScreenshot($outputDir . $filename . '.png');
-        $this->_savePageSource($outputDir . $filename . '.html');
+        $this->_saveScreenshot($outputDir . mb_strcut($filename, 0, 245, 'utf-8') . '.fail.png');
+        $this->_savePageSource($outputDir . mb_strcut($filename, 0, 244, 'utf-8') . '.fail.html');
         $this->debug("Screenshot and page source were saved into '$outputDir' dir");
     }
 


### PR DESCRIPTION
Fix for "File name too long" error in failed gherkin tests with too long description