### PR TITLE
Diff shows only changed lines

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,9 @@
         "symfony/browser-kit": ">=2.7 <4.0",
         "symfony/css-selector": ">=2.7 <4.0",
         "symfony/dom-crawler": ">=2.7 <4.0",
-        "behat/gherkin": "~4.4.0"
+        "behat/gherkin": "~4.4.0",
+        "sebastian/comparator": "~1.1",
+        "sebastian/diff": "^1.4"
 
     },
     "require-dev": {

--- a/src/Codeception/Lib/Console/Colorizer.php
+++ b/src/Codeception/Lib/Console/Colorizer.php
@@ -8,6 +8,7 @@ class Colorizer
 {
     /**
      * @param string $string
+     * @return string
      */
     public function colorize($string = '')
     {

--- a/src/Codeception/Lib/Console/Colorizer.php
+++ b/src/Codeception/Lib/Console/Colorizer.php
@@ -25,7 +25,7 @@ class Colorizer
                 case '+':
                     $line = "<info>$line</info>";
                     break;
-                case '-';
+                case '-':
                     $line = "<comment>$line</comment>";
                     break;
             }

--- a/src/Codeception/Lib/Console/Colorizer.php
+++ b/src/Codeception/Lib/Console/Colorizer.php
@@ -1,0 +1,38 @@
+<?php
+namespace Codeception\Lib\Console;
+
+/**
+ * Colorizer
+ **/
+class Colorizer
+{
+    /**
+     * @param string $string
+     */
+    public function colorize($string = '')
+    {
+        $fp = fopen("php://memory", 'r+');
+        fwrite($fp, $string);
+        rewind($fp);
+
+        $colorizedMessage = '';
+        while ($line = fgets($fp)) {
+
+            $char = $line[0];
+            $line = trim($line);
+
+            switch ($char) {
+                case '+':
+                    $line = "<info>$line</info>";
+                    break;
+                case '-';
+                    $line = "<comment>$line</comment>";
+                    break;
+            }
+
+            $colorizedMessage .= $line . "\n";
+        }
+
+        return trim($colorizedMessage);
+    }
+}

--- a/src/Codeception/Lib/Console/Colorizer.php
+++ b/src/Codeception/Lib/Console/Colorizer.php
@@ -11,13 +11,12 @@ class Colorizer
      */
     public function colorize($string = '')
     {
-        $fp = fopen("php://memory", 'r+');
+        $fp = fopen('php://memory', 'r+');
         fwrite($fp, $string);
         rewind($fp);
 
         $colorizedMessage = '';
         while ($line = fgets($fp)) {
-
             $char = $line[0];
             $line = trim($line);
 

--- a/src/Codeception/Lib/Console/DiffFactory.php
+++ b/src/Codeception/Lib/Console/DiffFactory.php
@@ -1,0 +1,41 @@
+<?php
+namespace Codeception\Lib\Console;
+
+use SebastianBergmann\Comparator\ComparisonFailure;
+use SebastianBergmann\Diff\Differ;
+
+/**
+ * DiffFactory
+ **/
+class DiffFactory
+{
+    /**
+     * @param ComparisonFailure $failure
+     * @return string|null
+     */
+    public function createDiff(ComparisonFailure $failure)
+    {
+        $diff = $this->getDiff($failure->getExpectedAsString(), $failure->getActualAsString());
+        if (!$diff) {
+            return null;
+        }
+
+        return $diff;
+    }
+
+    /**
+     * @param string $expected
+     * @param string $actual
+     * @return string
+     */
+    private function getDiff($expected = '', $actual = '')
+    {
+        if (!$actual && !$expected) {
+            return '';
+        }
+
+        $differ = new Differ('');
+
+        return $differ->diff($expected, $actual);
+    }
+}

--- a/src/Codeception/Lib/Console/MessageFactory.php
+++ b/src/Codeception/Lib/Console/MessageFactory.php
@@ -2,7 +2,6 @@
 namespace Codeception\Lib\Console;
 
 use SebastianBergmann\Comparator\ComparisonFailure;
-use SebastianBergmann\Diff\Differ;
 use Symfony\Component\Console\Output\OutputInterface;
 
 /**
@@ -10,6 +9,10 @@ use Symfony\Component\Console\Output\OutputInterface;
  **/
 class MessageFactory
 {
+    /**
+     * @var DiffFactory
+     */
+    protected $diffFactory;
     /**
      * @var OutputInterface
      */
@@ -22,6 +25,8 @@ class MessageFactory
     public function __construct(Output $output)
     {
         $this->output = $output;
+        $this->diffFactory = new DiffFactory();
+        $this->colorizer = new Colorizer();
     }
 
     /**
@@ -39,29 +44,10 @@ class MessageFactory
      */
     public function prepareComparisonFailureMessage(ComparisonFailure $failure)
     {
-        $diff = $this->getDiff($failure->getExpectedAsString(), $failure->getActualAsString());
-        if (!$diff) {
-            return null;
-        }
+        $diff = $this->diffFactory->createDiff($failure);
+        $diff = $this->colorizer->colorize($diff);
 
-        return $this
-            ->message($failure->getMessage())
-            ->append($diff);
-    }
-
-    /**
-     * @param string $expected
-     * @param string $actual
-     * @return string
-     */
-    private function getDiff($expected = '', $actual = '')
-    {
-        if (!$actual && !$expected) {
-            return '';
-        }
-
-        $differ = new Differ("- Expected | + Actual\n");
-
-        return $differ->diff($expected, $actual);
+        return $this->message($diff)
+            ->prepend("<comment>- Expected</comment> | <info>+ Actual</info>\n");
     }
 }

--- a/src/Codeception/Lib/Console/MessageFactory.php
+++ b/src/Codeception/Lib/Console/MessageFactory.php
@@ -1,0 +1,67 @@
+<?php
+namespace Codeception\Lib\Console;
+
+use SebastianBergmann\Comparator\ComparisonFailure;
+use SebastianBergmann\Diff\Differ;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * MessageFactory
+ **/
+class MessageFactory
+{
+    /**
+     * @var OutputInterface
+     */
+    private $output;
+
+    /**
+     * MessageFactory constructor.
+     * @param Output $output
+     */
+    public function __construct(Output $output)
+    {
+        $this->output = $output;
+    }
+
+    /**
+     * @param string $text
+     * @return Message
+     */
+    public function message($text = '')
+    {
+        return new Message($text, $this->output);
+    }
+
+    /**
+     * @param ComparisonFailure $failure
+     * @return Message|null
+     */
+    public function prepareComparisonFailureMessage(ComparisonFailure $failure)
+    {
+        $diff = $this->getDiff($failure->getExpectedAsString(), $failure->getActualAsString());
+        if (!$diff) {
+            return null;
+        }
+
+        return $this
+            ->message($failure->getMessage())
+            ->append($diff);
+    }
+
+    /**
+     * @param string $expected
+     * @param string $actual
+     * @return string
+     */
+    private function getDiff($expected = '', $actual = '')
+    {
+        if (!$actual && !$expected) {
+            return '';
+        }
+
+        $differ = new Differ("- Expected | + Actual\n");
+
+        return $differ->diff($expected, $actual);
+    }
+}

--- a/tests/unit/Codeception/Lib/Console/ColorizerTest.php
+++ b/tests/unit/Codeception/Lib/Console/ColorizerTest.php
@@ -1,0 +1,48 @@
+<?php
+namespace Codeception\Lib\Console;
+
+use Codeception\Test\Unit;
+
+/**
+ * ColorizerTest
+ **/
+class ColorizerTest extends Unit
+{
+    /**
+     * @var Colorizer
+     */
+    protected $colorizer;
+
+    /**
+     *
+     */
+    protected function setUp()
+    {
+        parent::setUp();
+        $this->colorizer = new Colorizer();
+    }
+
+    public function testItAddFormatToDiffMessage()
+    {
+        $toColorizeInput = <<<PLAIN
+foo
+bar
++ actual line
+- expected line
+bar
+PLAIN;
+
+        $expectedColorized = <<<COLORED
+foo
+bar
+<info>+ actual line</info>
+<comment>- expected line</comment>
+bar
+COLORED;
+
+        $actual = $this->colorizer->colorize($toColorizeInput);
+
+
+        $this->assertEquals($expectedColorized,$actual, 'it should add the format tags');
+    }
+}

--- a/tests/unit/Codeception/Lib/Console/DiffFactoryTest.php
+++ b/tests/unit/Codeception/Lib/Console/DiffFactoryTest.php
@@ -5,29 +5,25 @@ use Codeception\Util\Stub;
 use SebastianBergmann\Comparator\ComparisonFailure;
 
 /**
- * MessageFactoryTest
+ * DiffFactoryTest
  **/
-class MessageFactoryTest extends \Codeception\Test\Unit
+class DiffFactoryTest extends \Codeception\Test\Unit
 {
     /**
-     * @var MessageFactory
+     * @var DiffFactory
      */
-    protected $messageFactory;
+    protected $diffFactory;
 
     protected function setUp()
     {
-        /**
-         * @var Output $stub
-         */
-        $stub = Stub::make('\Codeception\Lib\Console\Output');
-        $this->messageFactory = new MessageFactory($stub);
+        $this->diffFactory = new DiffFactory();
     }
 
     public function testItCreatesMessageForComparisonFailure()
     {
         $expectedDiff = $this->getExpectedDiff();
         $failure = $this->createFailure();
-        $message = $this->messageFactory->prepareComparisonFailureMessage($failure);
+        $message = $this->diffFactory->createDiff($failure);
 
         $this->assertEquals($expectedDiff, (string) $message, 'The diff should be generated.');
     }
@@ -65,7 +61,6 @@ XML;
     protected function getExpectedDiff()
     {
         $expectedDiff = <<<TXT
-- Expected | + Actual
 @@ @@
  <note>
      <to>Tove</to>

--- a/tests/unit/Codeception/Lib/Console/MessageFactoryTest.php
+++ b/tests/unit/Codeception/Lib/Console/MessageFactoryTest.php
@@ -1,0 +1,82 @@
+<?php
+namespace Codeception\Lib\Console;
+
+use Codeception\Util\Stub;
+use SebastianBergmann\Comparator\ComparisonFailure;
+
+/**
+ * MessageFactoryTest
+ **/
+class MessageFactoryTest extends \Codeception\Test\Unit
+{
+    /**
+     * @var MessageFactory
+     */
+    protected $messageFactory;
+
+    protected function setUp()
+    {
+        /**
+         * @var Output $stub
+         */
+        $stub = Stub::make('\Codeception\Lib\Console\Output');
+        $this->messageFactory = new MessageFactory($stub);
+    }
+
+    public function testItCreatesMessageForComparisonFailure()
+    {
+        $expectedDiff = $this->getExpectedDiff();
+        $failure = $this->createFailure();
+        $message = $this->messageFactory->prepareComparisonFailureMessage($failure);
+
+        $this->assertEquals($expectedDiff, (string) $message, 'The diff should be generated.');
+    }
+
+    /**
+     * @return ComparisonFailure
+     */
+    protected function createFailure()
+    {
+        $expectedXml = <<<XML
+<note>
+    <to>Tove</to>
+    <from>Jani</from>
+    <heading>Reminder</heading>
+    <body>Don't forget me this weekend!</body>
+</note>
+XML;
+
+        $actualXml = <<<XML
+<note>
+    <to>Tove</to>
+    <from>Jani</from>
+    <heading>Reminder
+    </heading>
+    <body>Don't forget me this weekend!</body>
+</note>
+XML;
+
+        return new ComparisonFailure($expectedXml, $actualXml, $expectedXml, $actualXml);
+    }
+
+    /**
+     * @return string
+     */
+    protected function getExpectedDiff()
+    {
+        $expectedDiff = <<<TXT
+- Expected | + Actual
+@@ @@
+ <note>
+     <to>Tove</to>
+     <from>Jani</from>
+-    <heading>Reminder</heading>
++    <heading>Reminder
++    </heading>
+     <body>Don't forget me this weekend!</body>
+ </note>
+TXT;
+
+        return $expectedDiff . "\n";
+    }
+}


### PR DESCRIPTION
Fixes #3230

The diff used to show both complete strings instead of only the changed lines,
I've added a unit test for the case and refactored a bit inside the Console.php

Todo: Add color output as this got lost during the diff changes.

