### PR TITLE
selectOption - select option from different selector

### DIFF
--- a/src/Codeception/Module/WebDriver.php
+++ b/src/Codeception/Module/WebDriver.php
@@ -1101,7 +1101,7 @@ class WebDriver extends CodeceptionModule implements
         // partially matching
         foreach ($option as $opt) {
             try {
-                $optElement = $el->findElement(WebDriverBy::xpath('//option [contains (., "' . $opt . '")]'));
+                $optElement = $el->findElement(WebDriverBy::xpath('.//option [contains (., "' . $opt . '")]'));
                 $matched = true;
                 if (!$optElement->isSelected()) {
                     $optElement->click();

--- a/tests/data/app/view/form/select_second.php
+++ b/tests/data/app/view/form/select_second.php
@@ -1,0 +1,14 @@
+<html>
+<body>
+<form action="/form/complex" method="POST">
+    <select id="select1">
+        <option value="select1_value1">Value1</option>
+        <option value="select1_value2">Value2</option>
+    </select>
+    <select id="select2">
+        <option value="select2_value1">Value1</option>
+    </select>
+    <input type="submit" value="Submit" />
+</form>
+</body>
+</html>

--- a/tests/web/WebDriverTest.php
+++ b/tests/web/WebDriverTest.php
@@ -70,6 +70,13 @@ class WebDriverTest extends TestsForBrowsers
         $this->assertEquals('adult', $form['age']);
     }
 
+    public function testSelectInvalidOptionForSecondSelectFails()
+    {
+        $this->shouldFail();
+        $this->module->amOnPage('/form/select_second');
+        $this->module->selectOption('#select2', 'Value2');
+    }
+
     public function testSeeInPopup()
     {
         $this->notForPhantomJS();


### PR DESCRIPTION
Hello,

Module :  WebDriver
Version : 2.2.1
Browser : Firefox

```html
<select id="select1">
<option value="select1_value1">Value1</option>
<option value="select1_value2">Value2</option>
</select>

<select id="select2">
<option value="select2_value1">Value1</option>
</select>
```

```php
$I->selectOption('#select2', 'Value2');
```

**Actual behaviour**
The value "Value2" in field "#select1" is selected

**Expected behaviour**
Failed to select the value "Value2" because it is not in "#select2" field.

**Fix**
I only replace xPath "//option" to ".//option". Like this the findElement will only search in the childs and not everywhere