### PR TITLE
Laravel5 add methods to register service container bindings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 #### 2.2.2
 
 * Improved Examples to be Traversable; Fixed console output for complex data structures.
+* [Laravel5] Added `haveBinding`, `haveSingleton`, `haveContextualBinding` and `haveInstance` methods. By @janhenkgerritsen. See #2904.
 
 #### 2.2.1
 

--- a/src/Codeception/Lib/Connector/Laravel5.php
+++ b/src/Codeception/Lib/Connector/Laravel5.php
@@ -46,6 +46,21 @@ class Laravel5 extends Client
     private $eventsDisabled;
 
     /**
+     * @var array
+     */
+    private $bindings = [];
+
+    /**
+     * @var array
+     */
+    private $contextualBindings = [];
+
+    /**
+     * @var array
+     */
+    private $instances = [];
+
+    /**
      * @var object
      */
     private $oldDb;
@@ -152,6 +167,10 @@ class Laravel5 extends Client
             $this->mockEventDispatcher();
         }
 
+        $this->applyBindings();
+        $this->applyContextualBindings();
+        $this->applyInstances();
+
         $this->module->setApplication($this->app);
     }
 
@@ -214,6 +233,40 @@ class Laravel5 extends Client
         return $segments[0];
     }
 
+    /**
+     * Apply the registered Laravel service container bindings.
+     */
+    private function applyBindings()
+    {
+        foreach ($this->bindings as $abstract => $binding) {
+            list($concrete, $shared) = $binding;
+
+            $this->app->bind($abstract, $concrete, $shared);
+        }
+    }
+
+    /**
+     * Apply the registered Laravel service container contextual bindings.
+     */
+    private function applyContextualBindings()
+    {
+        foreach ($this->contextualBindings as $concrete => $bindings) {
+            foreach ($bindings as $abstract => $implementation) {
+                $this->app->addContextualBinding($concrete, $abstract, $implementation);
+            }
+        }
+    }
+
+    /**
+     * Apply the registered Laravel service container instance bindings.
+     */
+    private function applyInstances()
+    {
+        foreach ($this->instances as $abstract => $instance) {
+            $this->app->instance($abstract, $instance);
+        }
+    }
+
     //======================================================================
     // Public methods called by module
     //======================================================================
@@ -271,5 +324,47 @@ class Laravel5 extends Client
     {
         $this->middlewareDisabled = true;
         $this->app->instance('middleware.disable', true);
+    }
+
+    /**
+     * Register a Laravel service container binding that should be applied
+     * after initializing the Laravel Application object.
+     *
+     * @param $abstract
+     * @param $concrete
+     * @param bool $shared
+     */
+    public function haveBinding($abstract, $concrete, $shared = false)
+    {
+        $this->bindings[$abstract] = [$concrete, $shared];
+    }
+
+    /**
+     * Register a Laravel service container contextual binding that should be applied
+     * after initializing the Laravel Application object.
+     *
+     * @param $concrete
+     * @param $abstract
+     * @param $implementation
+     */
+    public function haveContextualBinding($concrete, $abstract, $implementation)
+    {
+        if (! isset($this->contextualBindings[$concrete])) {
+            $this->contextualBindings[$concrete] = [];
+        }
+
+        $this->contextualBindings[$concrete][$abstract] = $implementation;
+    }
+
+    /**
+     * Register a Laravel service container instance binding that should be applied
+     * after initializing the Laravel Application object.
+     *
+     * @param $abstract
+     * @param $instance
+     */
+    public function haveInstance($abstract, $instance)
+    {
+        $this->instances[$abstract] = $instance;
     }
 }

--- a/src/Codeception/Module/Laravel5.php
+++ b/src/Codeception/Module/Laravel5.php
@@ -726,8 +726,8 @@ class Laravel5 extends Framework implements ActiveRecord, PartedModule
     }
 
     /**
-     * Return an instance of a class from the IoC Container.
-     * (http://laravel.com/docs/ioc)
+     * Return an instance of a class from the Laravel service container.
+     * (https://laravel.com/docs/master/container)
      *
      * ``` php
      * <?php
@@ -750,6 +750,84 @@ class Laravel5 extends Framework implements ActiveRecord, PartedModule
     public function grabService($class)
     {
         return $this->app[$class];
+    }
+
+    /**
+     * Add a binding to the Laravel service container.
+     * (https://laravel.com/docs/master/container)
+     *
+     * ``` php
+     * <?php
+     * $I->haveBinding('My\Interface', 'My\Implementation');
+     * ?>
+     * ```
+     *
+     * @param $abstract
+     * @param $concrete
+     */
+    public function haveBinding($abstract, $concrete)
+    {
+        $this->client->haveBinding($abstract, $concrete);
+    }
+
+    /**
+     * Add a singleton binding to the Laravel service container.
+     * (https://laravel.com/docs/master/container)
+     *
+     * ``` php
+     * <?php
+     * $I->haveSingleton('My\Interface', 'My\Singleton');
+     * ?>
+     * ```
+     *
+     * @param $abstract
+     * @param $concrete
+     */
+    public function haveSingleton($abstract, $concrete)
+    {
+        $this->client->haveBinding($abstract, $concrete, true);
+    }
+
+    /**
+     * Add a contextual binding to the Laravel service container.
+     * (https://laravel.com/docs/master/container)
+     *
+     * ``` php
+     * <?php
+     * $I->haveContextualBinding('My\Class', '$variable', 'value');
+     *
+     * // This is similar to the following in your Laravel application
+     * $app->when('My\Class')
+     *     ->needs('$variable')
+     *     ->give('value');
+     * ?>
+     * ```
+     *
+     * @param $concrete
+     * @param $abstract
+     * @param $implementation
+     */
+    public function haveContextualBinding($concrete, $abstract, $implementation)
+    {
+        $this->client->haveContextualBinding($concrete, $abstract, $implementation);
+    }
+
+    /**
+     * Add an instance binding to the Laravel service container.
+     * (https://laravel.com/docs/master/container)
+     *
+     * ``` php
+     * <?php
+     * $I->haveInstance('My\Class', new My\Class());
+     * ?>
+     * ```
+     *
+     * @param $abstract
+     * @param $instance
+     */
+    public function haveInstance($abstract, $instance)
+    {
+        $this->client->haveInstance($abstract, $instance);
     }
 
     /**


### PR DESCRIPTION
This PR adds methods to the Laravel 5 module that enables users to register bindings to the Laravel service container, for more background see #2904.

The following methods are added to the Laravel 5 module:

```
public function haveBinding($abstract, $concrete);
public function haveSingleton($abstract, $concrete);
public function haveContextualBinding($concrete, $abstract, $implementation);
public function haveInstance($abstract, $instance);
```

I also created tests for this functionality in the Laravel 5 sample application. I will push these tests after merging this PR, because these tests will break the Codeception build if I push them without merging the new functionality.