### PR TITLE
Fix junit xml report for gherkin tests

### DIFF
--- a/src/Codeception/PHPUnit/Log/JUnit.php
+++ b/src/Codeception/PHPUnit/Log/JUnit.php
@@ -2,6 +2,7 @@
 namespace Codeception\PHPUnit\Log;
 
 use Codeception\Configuration;
+use Codeception\Test\Gherkin;
 use Codeception\Test\Interfaces\Reported;
 use Codeception\Test\Test;
 
@@ -38,6 +39,14 @@ class JUnit extends \PHPUnit_Util_Log_JUnit
                 $numAssertions
             );
         }
+
+        if ($test instanceof Gherkin) {
+            $this->currentTestCase->setAttribute(
+                'name',
+                $test->getName() . ':' . $test->getMetadata()->getFeature()
+            );
+        }
+
         parent::endTest($test, $time);
     }
 }


### PR DESCRIPTION
Current report.xml looks like
```
<testsuites>
  <testsuite name="symfony">
    <testcase name="Banners"/>
    <testcase name="Banners"/>
    <testcase name="Banners"/>
  </testsuite>
<testsuites>
```
Teamcity sees this as one test. Imho the best option would be
```
<testsuites>
  <testsuite name="Banners">
    <testcase name="Show banner"/>
    <testcase name="Click on banner"/>
    <testcase name="Other"/>
  </testsuite>
<testsuites>
```
But this requires a very large change, so did this format
```
<testsuites>
  <testsuite name="symfony">
    <testcase name="Banners:Show banner"/>
    <testcase name="Banners:Click on banner"/>
    <testcase name="Banners:Other"/>
  </testsuite>
<testsuites>
```