### PR TITLE
Added JUnit report to Gherkin

### DIFF
--- a/src/Codeception/Test/Gherkin.php
+++ b/src/Codeception/Test/Gherkin.php
@@ -10,9 +10,10 @@ use Codeception\Lib\Di;
 use Codeception\Scenario;
 use Codeception\Step\Comment;
 use Codeception\Step\Meta;
+use Codeception\Test\Interfaces\Reported;
 use Codeception\Test\Interfaces\ScenarioDriven;
 
-class Gherkin extends Test implements ScenarioDriven
+class Gherkin extends Test implements ScenarioDriven, Reported
 {
     protected $steps = [];
 
@@ -189,5 +190,19 @@ class Gherkin extends Test implements ScenarioDriven
     public function getFeatureNode()
     {
         return $this->featureNode;
+    }
+
+    /**
+     * Field values for XML/JSON/TAP reports
+     *
+     * @return array
+     */
+    public function getReportFields()
+    {
+        return [
+            'file'    => $this->getFileName(),
+            'name'    => $this->toString(),
+            'feature' => $this->getFeature()
+        ];
     }
 }


### PR DESCRIPTION
Replaces #3270

Report looks like this

```xml
    <testcase file="/home/davert/Codeception/tests/data/claypit/tests/scenario/File.feature" name="Run gherkin: Check file exists" feature="Check file exists" assertions="4" time="0.009753"/>
    <testcase file="/home/davert/Codeception/tests/data/claypit/tests/scenario/FileExamples.feature" name="Suite configs: Check file exists | ., unit.suite.yml" feature="Check file exists | ., unit.suite.yml" assertions="1" time="0.005046"/>
    <testcase file="/home/davert/Codeception/tests/data/claypit/tests/scenario/FileExamples.feature" name="Suite configs: Check file exists | ., scenario.suite.yml" feature="Check file exists | ., scenario.suite.yml" assertions="1" time="0.005625"/>
    <testcase file="/home/davert/Codeception/tests/data/claypit/tests/scenario/FileExamples.feature" name="Suite configs: Check file exists | ., dummy.suite.yml" feature="Check file exists | ., dummy.suite.yml" assertions="1" time="0.003997"/>

```