### PR TITLE
Optional parameter test for command gherkin:snippets

### DIFF
--- a/src/Codeception/Command/GherkinSnippets.php
+++ b/src/Codeception/Command/GherkinSnippets.php
@@ -18,6 +18,7 @@ class GherkinSnippets extends Command
         $this->setDefinition(
             [
                 new InputArgument('suite', InputArgument::REQUIRED, 'suite to scan for feature files'),
+                new InputArgument('test', InputArgument::OPTIONAL, 'test to be scanned'),
                 new InputOption('config', 'c', InputOption::VALUE_OPTIONAL, 'Use custom path for config'),
             ]
         );
@@ -33,9 +34,10 @@ class GherkinSnippets extends Command
     {
         $this->addStyles($output);
         $suite = $input->getArgument('suite');
+        $test = $input->getArgument('test');
         $config = $this->getSuiteConfig($suite, $input->getOption('config'));
 
-        $generator = new SnippetsGenerator($config);
+        $generator = new SnippetsGenerator($config, $test);
         $snippets = $generator->getSnippets();
 
         if (empty($snippets)) {

--- a/src/Codeception/Command/GherkinSnippets.php
+++ b/src/Codeception/Command/GherkinSnippets.php
@@ -39,10 +39,15 @@ class GherkinSnippets extends Command
 
         $generator = new SnippetsGenerator($config, $test);
         $snippets = $generator->getSnippets();
+        $features = $generator->getFeatures();
 
         if (empty($snippets)) {
             $output->writeln("<notice> All Gherkin steps are defined. Exiting... </notice>");
             return;
+        }
+        $output->writeln("<comment> Snippets found in: </comment>");
+        foreach ($features as $feature) {
+            $output->writeln("<info>  - {$feature} </info>");
         }
         $output->writeln("<comment> Generated Snippets: </comment>");
         $output->writeln("<info> ----------------------------------------- </info>");

--- a/src/Codeception/Lib/Generator/GherkinSnippets.php
+++ b/src/Codeception/Lib/Generator/GherkinSnippets.php
@@ -30,7 +30,7 @@ EOF;
         $loader = new Gherkin($settings);
         $pattern = $loader->getPattern();
         $path = $settings['path'];
-        if (empty($test) === false) {
+        if (!empty($test)) {
             if (preg_match($pattern, $test) == true) {
                 $pattern = $test;
             } else {
@@ -72,7 +72,7 @@ EOF;
                 if (!$matched) {
                     $this->addSnippet($step);
                     $file = str_ireplace($settings['path'], '', $test->getFeatureNode()->getFile());
-                    if( in_array($file, $this->features) === false ) {
+                    if (!in_array($file, $this->features)) {
                         $this->features[] = $file;
                     }
                 }

--- a/src/Codeception/Lib/Generator/GherkinSnippets.php
+++ b/src/Codeception/Lib/Generator/GherkinSnippets.php
@@ -16,22 +16,27 @@ class GherkinSnippets
      {
         throw new \Codeception\Exception\Incomplete("Step `{{text}}` is not defined");
      }
-     
+
 EOF;
 
     protected $snippets = [];
     protected $processed = [];
 
-    public function __construct($settings)
+    public function __construct($settings, $test = null)
     {
         $loader = new Gherkin($settings);
+        if (empty($test) || is_null($test)) {
+            $pattern = $loader->getPattern();
+        } else {
+            $pattern = $test;
+        }
 
         $finder = Finder::create()
             ->files()
             ->sortByName()
             ->in($settings['path'])
             ->followLinks()
-            ->name($loader->getPattern());
+            ->name($pattern);
 
         foreach ($finder as $file) {
             $pathname = str_replace("//", "/", $file->getPathname());

--- a/tests/cli/GherkinCest.php
+++ b/tests/cli/GherkinCest.php
@@ -25,10 +25,19 @@ class GherkinCest
         $I->seeInShellOutput('public function iHaveOnlyIdeaOfWhatsGoingOnHere');
     }
 
-    public function snippetsScenario(CliGuy $I)
+    public function snippetsScenarioFile(CliGuy $I)
     {
         $I->executeCommand('gherkin:snippets scenario FileExamples.feature');
         $I->dontSeeInShellOutput('@Given I have only idea of what\'s going on here');
         $I->dontSeeInShellOutput('public function iHaveOnlyIdeaOfWhatsGoingOnHere');
-    }    
+    }
+
+    public function snippetsScenarioFolder(CliGuy $I)
+    {
+        $I->executeCommand('gherkin:snippets scenario subfolder');
+        $I->seeInShellOutput('Given I have a feature in a subfolder');
+        $I->seeInShellOutput('public function iHaveAFeatureInASubfolder');
+        $I->dontSeeInShellOutput('@Given I have only idea of what\'s going on here');
+        $I->dontSeeInShellOutput('public function iHaveOnlyIdeaOfWhatsGoingOnHere');
+    }
 }

--- a/tests/cli/GherkinCest.php
+++ b/tests/cli/GherkinCest.php
@@ -24,4 +24,11 @@ class GherkinCest
         $I->seeInShellOutput('@Given I have only idea of what\'s going on here');
         $I->seeInShellOutput('public function iHaveOnlyIdeaOfWhatsGoingOnHere');
     }
+
+    public function snippetsScenario(CliGuy $I)
+    {
+        $I->executeCommand('gherkin:snippets scenario FileExamples.feature');
+        $I->dontSeeInShellOutput('@Given I have only idea of what\'s going on here');
+        $I->dontSeeInShellOutput('public function iHaveOnlyIdeaOfWhatsGoingOnHere');
+    }    
 }

--- a/tests/data/claypit/tests/scenario/subfolder/SubFile.feature
+++ b/tests/data/claypit/tests/scenario/subfolder/SubFile.feature
@@ -1,0 +1,7 @@
+Feature: Run gherkin
+  In order to test a feature
+  As a user
+  I need to be able to have subfolders
+
+  Scenario: Describe a feature in subfolder
+    Given I have a feature in a subfolder


### PR DESCRIPTION
Implementation of #3119 for creating gherkin snippets for a specific feature. The new command line is similar to the syntax of `run`:
```
codecept gherkin:snippets suite [test]
```
Example:
```
codecept gherkin:snippets acceptance admin.feature
```

As discussed in #3216, the parameter can also be a folder. It will then generate snippets for the .features contained within the folder (the root folder is the test suite folder)
Example:
```
codecept gherkin:snippets acceptance admin
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/codeception/codeception/3280)
<!-- Reviewable:end -->
