### PR TITLE
Fix private property accessible

### DIFF
--- a/src/Codeception/Module/Yii1.php
+++ b/src/Codeception/Module/Yii1.php
@@ -247,7 +247,8 @@ class Yii1 extends Framework implements PartedModule
     {
         $domains = [$this->getDomainRegex(Yii::app()->request->getHostInfo())];
         if (Yii::app()->urlManager->urlFormat === 'path') {
-            $rules = ReflectionHelper::readPrivateProperty(Yii::app()->urlManager, '_rules');
+            $parent = Yii::app()->urlManager instanceof \CUrlManager ? '\CUrlManager' : null;
+            $rules = ReflectionHelper::readPrivateProperty(Yii::app()->urlManager, '_rules', $parent);
             foreach ($rules as $rule) {
                 if ($rule->hasHostInfo === true) {
                     $domains[] = $this->getDomainRegex($rule->template, $rule->params);


### PR DESCRIPTION
Yii1 configuration allows to change `urlManager` class to subclass of `CUrlManager`,
like this:

```php
# in configuration file
[
    'components' => [
        'urlManager' => ['class' => 'application.components.extendedUrlManager']
    ]
]
```

When `Yii::app()->urlManager` returns subclass of `CUrlManger`,
`ReflectionException` will raise in `ReflectionHelper::readPrivateProperty` without third argument.