### PR TITLE
Add information about minimum supported version of Laravel 5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@
 * `codecept dry-run` command added to show scenario steps without executing them.
 * *Breaking* [Dbh] module removed
 * *Breaking* [Laravel4] module removed. See #2866
+* *Breaking* [Laravel5] Minimum supported Laravel version is 5.1. See [#3243](https://github.com/Codeception/Codeception/issues/3243#issuecomment-227078266)
 * *Breaking* [Laravel5] Removed `createModel` method, use `have` method instead. See #2866
 * *Breaking* [Laravel5] Removed `makeModel` method. See #2866
 * *Breaking* [Laravel5] Renamed `haveModel` method to `have`. See #2866

--- a/src/Codeception/Module/Laravel5.php
+++ b/src/Codeception/Module/Laravel5.php
@@ -19,6 +19,10 @@ use Illuminate\Database\Eloquent\Model as EloquentModel;
  * It should **not** be used for acceptance tests.
  * See the Acceptance tests section below for more details.
  *
+ * As of Codeception 2.2 this module only works for Laravel 5.1 and later releases.
+ * If you want to test a Laravel 5.0 application you have to use Codeception 2.1.
+ * You can also upgrade your Laravel application to 5.1, for more details check the Laravel Upgrade Guide at <https://laravel.com/docs/master/upgrade>.
+ *
  * ## Demo project
  * <https://github.com/janhenkgerritsen/codeception-laravel5-sample>
  *


### PR DESCRIPTION
Codeception 2.2 does not support Laravel 5.0, only Laravel 5.1 and later releases. For more details see #3243.