### PR TITLE
Group Files not working with @example

### DIFF
--- a/src/Codeception/Lib/GroupManager.php
+++ b/src/Codeception/Lib/GroupManager.php
@@ -105,6 +105,7 @@ class GroupManager
             $groups = array_merge($groups, \PHPUnit_Util_Test::getGroups(get_class($test), $test->getName(false)));
         }
         if ($test instanceof \PHPUnit_Framework_TestSuite_DataProvider) {
+
             if ($test->testAt(0) != false && $test->testAt(0) instanceof TestInterface) {
                 $groups = array_merge($groups, $test->testAt(0)->getMetadata()->getGroups());
                 $filename = Descriptor::getTestFileName($test->testAt(0));

--- a/src/Codeception/Lib/GroupManager.php
+++ b/src/Codeception/Lib/GroupManager.php
@@ -105,10 +105,10 @@ class GroupManager
             $groups = array_merge($groups, \PHPUnit_Util_Test::getGroups(get_class($test), $test->getName(false)));
         }
         if ($test instanceof \PHPUnit_Framework_TestSuite_DataProvider) {
-
-            if ($test->testAt(0) != false && $test->testAt(0) instanceof TestInterface) {
-                $groups = array_merge($groups, $test->testAt(0)->getMetadata()->getGroups());
-                $filename = Descriptor::getTestFileName($test->testAt(0));
+            $firstTest = $test->testAt(0);
+            if ($firstTest != false && $firstTest instanceof TestInterface) {
+                $groups = array_merge($groups, $firstTest->getMetadata()->getGroups());
+                $filename = Descriptor::getTestFileName($firstTest);
             }
         }
 

--- a/src/Codeception/Lib/GroupManager.php
+++ b/src/Codeception/Lib/GroupManager.php
@@ -105,7 +105,7 @@ class GroupManager
             $groups = array_merge($groups, \PHPUnit_Util_Test::getGroups(get_class($test), $test->getName(false)));
         }
         if ($test instanceof \PHPUnit_Framework_TestSuite_DataProvider) {
-            if(!empty($test->testAt(0)) && $test->testAt(0) instanceof TestInterface) {
+            if (!empty($test->testAt(0)) && $test->testAt(0) instanceof TestInterface) {
                 $groups = array_merge($groups, $test->testAt(0)->getMetadata()->getGroups());
                 $filename = Descriptor::getTestFileName($test->testAt(0));
             }

--- a/src/Codeception/Lib/GroupManager.php
+++ b/src/Codeception/Lib/GroupManager.php
@@ -104,6 +104,10 @@ class GroupManager
         if ($test instanceof \PHPUnit_Framework_TestCase) {
             $groups = array_merge($groups, \PHPUnit_Util_Test::getGroups(get_class($test), $test->getName(false)));
         }
+        if ($test instanceof \PHPUnit_Framework_TestSuite_DataProvider) {
+            $groups = array_merge($groups, $test->testAt(0)->getMetadata()->getGroups());
+            $filename = Descriptor::getTestFileName($test->testAt(0));
+        }
 
         foreach ($this->testsInGroups as $group => $tests) {
             foreach ($tests as $testPattern) {

--- a/src/Codeception/Lib/GroupManager.php
+++ b/src/Codeception/Lib/GroupManager.php
@@ -105,7 +105,6 @@ class GroupManager
             $groups = array_merge($groups, \PHPUnit_Util_Test::getGroups(get_class($test), $test->getName(false)));
         }
         if ($test instanceof \PHPUnit_Framework_TestSuite_DataProvider) {
-            
             if ($test->testAt(0) != false && $test->testAt(0) instanceof TestInterface) {
                 $groups = array_merge($groups, $test->testAt(0)->getMetadata()->getGroups());
                 $filename = Descriptor::getTestFileName($test->testAt(0));

--- a/src/Codeception/Lib/GroupManager.php
+++ b/src/Codeception/Lib/GroupManager.php
@@ -105,7 +105,8 @@ class GroupManager
             $groups = array_merge($groups, \PHPUnit_Util_Test::getGroups(get_class($test), $test->getName(false)));
         }
         if ($test instanceof \PHPUnit_Framework_TestSuite_DataProvider) {
-            if (!empty($test->testAt(0)) && $test->testAt(0) instanceof TestInterface) {
+            
+            if ($test->testAt(0) != false && $test->testAt(0) instanceof TestInterface) {
                 $groups = array_merge($groups, $test->testAt(0)->getMetadata()->getGroups());
                 $filename = Descriptor::getTestFileName($test->testAt(0));
             }

--- a/src/Codeception/Lib/GroupManager.php
+++ b/src/Codeception/Lib/GroupManager.php
@@ -105,8 +105,10 @@ class GroupManager
             $groups = array_merge($groups, \PHPUnit_Util_Test::getGroups(get_class($test), $test->getName(false)));
         }
         if ($test instanceof \PHPUnit_Framework_TestSuite_DataProvider) {
-            $groups = array_merge($groups, $test->testAt(0)->getMetadata()->getGroups());
-            $filename = Descriptor::getTestFileName($test->testAt(0));
+            if(!empty($test->testAt(0)) && $test->testAt(0) instanceof TestInterface) {
+                $groups = array_merge($groups, $test->testAt(0)->getMetadata()->getGroups());
+                $filename = Descriptor::getTestFileName($test->testAt(0));
+            }
         }
 
         foreach ($this->testsInGroups as $group => $tests) {

--- a/src/Codeception/SuiteManager.php
+++ b/src/Codeception/SuiteManager.php
@@ -125,8 +125,7 @@ class SuiteManager
 
         if ($test instanceof \PHPUnit_Framework_TestSuite_DataProvider) {
             $groupDetails = [];
-            foreach ($groups as $group)
-            {
+            foreach ($groups as $group) {
                 $groupDetails[$group] = $test->getGroupDetails()['default'];
             }
             $test->setGroupDetails($groupDetails);

--- a/src/Codeception/SuiteManager.php
+++ b/src/Codeception/SuiteManager.php
@@ -122,6 +122,16 @@ class SuiteManager
         }
 
         $groups = $this->groupManager->groupsForTest($test);
+        
+        if ($test instanceof \PHPUnit_Framework_TestSuite_DataProvider) {
+            $groupDetails = [];
+            foreach($groups as $group)
+            {
+                $groupDetails[$group] = $test->getGroupDetails()['default'];
+            }
+            $test->setGroupDetails($groupDetails);
+        }
+        
         $this->suite->addTest($test, $groups);
 
         if (!empty($groups) && $test instanceof TestInterface) {

--- a/src/Codeception/SuiteManager.php
+++ b/src/Codeception/SuiteManager.php
@@ -122,16 +122,16 @@ class SuiteManager
         }
 
         $groups = $this->groupManager->groupsForTest($test);
-        
+
         if ($test instanceof \PHPUnit_Framework_TestSuite_DataProvider) {
             $groupDetails = [];
-            foreach($groups as $group)
+            foreach ($groups as $group)
             {
                 $groupDetails[$group] = $test->getGroupDetails()['default'];
             }
             $test->setGroupDetails($groupDetails);
         }
-        
+
         $this->suite->addTest($test, $groups);
 
         if (!empty($groups) && $test instanceof TestInterface) {

--- a/src/Codeception/Test/Loader/Cest.php
+++ b/src/Codeception/Test/Loader/Cest.php
@@ -60,9 +60,7 @@ class Cest implements LoaderInterface
                         }
                         $test = new CestFormat($unit, $method, $file);
                         $test->getMetadata()->setCurrent(['example' => $example]);
-
-                        $groups = Annotation::forMethod($unit, $method)->fetchAll('group');
-                        $dataProvider->addTest($test, $groups);
+                        $dataProvider->addTest($test);
                     }
                     $this->tests[] = $dataProvider;
                     continue;


### PR DESCRIPTION
Fix #3278 

acceptance/welcomeCest.php :
```php
class welcomeCest
{
    public function testCase1(AcceptanceTester $I)
    {
        $I->amOnUrl('https://www.google.fr');
    }
    /**
    * @group grouptc2
    */
    public function testCase2(AcceptanceTester $I)
    {
        $I->amOnUrl('https://www.google.fr');
    }

    /**
    * @group grouptc3
    * @example (url="https://www.google.fr")
    * @example (url="https://www.bing.com")
    * @example (url="https://duckduckgo.com")
    */
    public function testCase3(AcceptanceTester $I, $scenario, \Codeception\Example $example)
    {
        $I->amOnUrl($example['url']);
    }
    /**
    * @example (url="https://www.google.fr")
    * @example (url="https://www.bing.com")
    * @example (url="https://duckduckgo.com")
    */
    public function testCase4(AcceptanceTester $I, $scenario, \Codeception\Example $example)
    {
        $I->amOnUrl($example['url']);
    }
}
```

acceptance.suite.yml:
```yml
groups:
    grouptc4: tests/_data/grouptc4
```
_data/grouptc4:
```
tests/acceptance/welcomeCest.php
```

**Result before the fix:**
run => tc1, tc2, tc3, tc4
run -g grouptc2 => tc2
run -g grouptc3 => tc3
run -g grouptc4 =>  tc1, tc2

**Result after the fix:**
run => tc1, tc2, tc3, tc4
run -g grouptc2 => tc2
run -g grouptc3 => tc3
run -g grouptc4 =>  tc1, tc2, tc3, tc4