### PR TITLE
Laravel5 add functionality to disable model events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 #### 2.2.3
 
+* [Laravel5] Added `disableModelEvents()` method and `disable_model_events` configuration option. Fixes #2897.
 * [REST] Allow objects in files array #3298
 * [ZendExpressive] allow instances of UploadedFile in files array
 

--- a/src/Codeception/Lib/Connector/Laravel5.php
+++ b/src/Codeception/Lib/Connector/Laravel5.php
@@ -2,6 +2,7 @@
 namespace Codeception\Lib\Connector;
 
 use Codeception\Lib\Connector\Laravel5\ExceptionHandlerDecorator;
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Foundation\Application;
 use Illuminate\Http\Request;
 use Symfony\Component\HttpFoundation\Request as SymfonyRequest;
@@ -46,6 +47,11 @@ class Laravel5 extends Client
     private $eventsDisabled;
 
     /**
+     * @var bool
+     */
+    private $modelEventsDisabled;
+
+    /**
      * @var array
      */
     private $bindings = [];
@@ -77,6 +83,7 @@ class Laravel5 extends Client
         $this->exceptionHandlingDisabled = $this->module->config['disable_exception_handling'];
         $this->middlewareDisabled = $this->module->config['disable_middleware'];
         $this->eventsDisabled = $this->module->config['disable_events'];
+        $this->modelEventsDisabled = $this->module->config['disable_model_events'];
 
         $this->initialize();
 
@@ -165,6 +172,10 @@ class Laravel5 extends Client
 
         if ($this->module->config['disable_events'] || $this->eventsDisabled) {
             $this->mockEventDispatcher();
+        }
+
+        if ($this->module->config['disable_model_events'] || $this->modelEventsDisabled) {
+            Model::unsetEventDispatcher();
         }
 
         $this->applyBindings();
@@ -315,6 +326,15 @@ class Laravel5 extends Client
     {
         $this->eventsDisabled = true;
         $this->mockEventDispatcher();
+    }
+
+    /**
+     * Disable model events.
+     */
+    public function disableModelEvents()
+    {
+        $this->modelEventsDisabled = true;
+        Model::unsetEventDispatcher();
     }
 
     /*

--- a/src/Codeception/Module/Laravel5.php
+++ b/src/Codeception/Module/Laravel5.php
@@ -47,7 +47,8 @@ use Illuminate\Database\Eloquent\Model as EloquentModel;
  * * packages: `string`, default `workbench` - Root path of application packages (if any).
  * * disable_exception_handling: `boolean`, default `true` - disable Laravel exception handling
  * * disable_middleware: `boolean`, default `false` - disable all middleware.
- * * disable_events: `boolean`, default `false` - disable all events.
+ * * disable_events: `boolean`, default `false` - disable events (does not disable model events).
+ * * disable_model_events: `boolean`, default `false` - disable model events.
  * * url: `string`, default `` - The application URL.
  *
  * ## API
@@ -105,6 +106,7 @@ class Laravel5 extends Framework implements ActiveRecord, PartedModule
                 'disable_exception_handling' => true,
                 'disable_middleware' => false,
                 'disable_events' => false,
+                'disable_model_events' => false,
             ],
             (array)$config
         );
@@ -279,6 +281,8 @@ class Laravel5 extends Framework implements ActiveRecord, PartedModule
 
     /**
      * Disable events for the next requests.
+     * This method does not disable model events.
+     * To disable model events you have to use the disableModelEvents() method.
      *
      * ``` php
      * <?php
@@ -289,6 +293,20 @@ class Laravel5 extends Framework implements ActiveRecord, PartedModule
     public function disableEvents()
     {
         $this->client->disableEvents();
+    }
+
+    /**
+     * Disable model events for the next requests.
+     *
+     * ``` php
+     * <?php
+     * $I->disableModelEvents();
+     * ?>
+     * ```
+     */
+    public function disableModelEvents()
+    {
+        $this->client->disableModelEvents();
     }
 
     /**


### PR DESCRIPTION
The `disableEvents()` method and the `disable_events` configuration option of the Laravel 5 module did not disable model events, for more details see #2897.