### PR TITLE
Fix checking "host" attribute in Yii2 Module / getInternalDomains()

### DIFF
--- a/src/Codeception/Module/Yii2.php
+++ b/src/Codeception/Module/Yii2.php
@@ -92,7 +92,7 @@ class Yii2 extends Framework implements ActiveRecord, PartedModule
         if ($this->transaction && $this->config['cleanup']) {
             $this->transaction->rollback();
         }
-        
+
         \yii\web\UploadedFile::reset();
 
         if (Yii::$app) {
@@ -272,7 +272,7 @@ class Yii2 extends Framework implements ActiveRecord, PartedModule
         if (Yii::$app->urlManager->enablePrettyUrl) {
             foreach (Yii::$app->urlManager->rules as $rule) {
                 /** @var \yii\web\UrlRule $rule */
-                if ($rule->host !== null) {
+                if (isset($rule->host)) {
                     $domains[] = $this->getDomainRegex($rule->host);
                 }
             }


### PR DESCRIPTION
Accessing $rule->host fails because \yii\rest\UrlRule not have "host" attribute.