### PR TITLE
[REST] Display better diff output in seeResponseContainsJson

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,9 @@
 
 * [Laravel5] Added `disableModelEvents()` method and `disable_model_events` configuration option. Fixes #2897.
 * [REST] Allow objects in files array #3298
+* [ZF2] Added addServiceToContainer method
 * [ZendExpressive] allow instances of UploadedFile in files array
+* [ZF2] Added addServiceToContainer method
 
 #### 2.2.2
 

--- a/src/Codeception/Module/REST.php
+++ b/src/Codeception/Module/REST.php
@@ -4,6 +4,7 @@ namespace Codeception\Module;
 use Codeception\Exception\ModuleException;
 use Codeception\Lib\Interfaces\ConflictsWithModule;
 use Codeception\Module as CodeceptionModule;
+use Codeception\PHPUnit\Constraint\JsonContains;
 use Codeception\TestInterface;
 use Codeception\Lib\Interfaces\API;
 use Codeception\Lib\Framework;
@@ -667,13 +668,8 @@ EOF;
      */
     public function seeResponseContainsJson($json = [])
     {
-        $jsonResponseArray = new JsonArray($this->connectionModule->_getResponseContent());
-        \PHPUnit_Framework_Assert::assertTrue(
-            $jsonResponseArray->containsArray($json),
-            "Response JSON does not contain the provided JSON\n"
-            . "- <info>" . var_export($json, true) . "</info>\n"
-            . "+ " . var_export($jsonResponseArray->toArray(), true)
-        );
+    	\PHPUnit_Framework_Assert::assertThat($this->connectionModule->_getResponseContent(),
+            new JsonContains($json));
     }
 
     /**

--- a/src/Codeception/PHPUnit/Constraint/JsonContains.php
+++ b/src/Codeception/PHPUnit/Constraint/JsonContains.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace Codeception\PHPUnit\Constraint;
+
+use SebastianBergmann\Comparator\ComparisonFailure;
+use SebastianBergmann\Comparator\ArrayComparator;
+use SebastianBergmann\Comparator\Factory;
+use Codeception\Util\JsonArray;
+
+class JsonContains extends \PHPUnit_Framework_Constraint
+{
+    /**
+     * @var
+     */
+    protected $expected;
+
+    public function __construct(array $expected)
+    {
+        parent::__construct();
+        $this->expected = $expected;
+    }
+
+    /**
+     * Evaluates the constraint for parameter $other. Returns true if the
+     * constraint is met, false otherwise.
+     *
+     * @param mixed $other Value or object to evaluate.
+     *
+     * @return bool
+     */
+    protected function matches($other)
+    {
+        $jsonResponseArray = new JsonArray($other);
+
+        if ($jsonResponseArray->containsArray($this->expected)) {
+            return true;
+        }
+
+        $comparator = new ArrayComparator();
+        $comparator->setFactory(new Factory);
+        try {
+            //$comparator->assertEquals(var_export($this->expected, true), var_export($jsonResponseArray->toArray(), true));
+            $comparator->assertEquals($this->expected, $jsonResponseArray->toArray());
+        } catch (ComparisonFailure $failure) {
+            throw new \PHPUnit_Framework_ExpectationFailedException(
+                "Response JSON does not contain the provided JSON\n",
+                $failure);
+        }
+    }
+
+    /**
+     * Returns a string representation of the constraint.
+     *
+     * @return string
+     */
+    public function toString()
+    {
+        //unused
+        return '';
+    }
+
+    protected function failureDescription($other)
+    {
+        //unused
+        return '';
+    }
+}


### PR DESCRIPTION
I tested this change by removing size field from response.

Before:

```
1) PostMethodFileUploadCept: Upload file
 Test  tests/functional/REST/PostMethodFileUploadCept.php
 Step  See response contains json {"files":{"dump":{"name":"dump.sql","size":57}}}
 Fail  Response JSON does not contain the provided JSON
- array (
  'files' =>
  array (
    'dump' =>
    array (
      'name' => 'dump.sql',
      'size' => 57,
    ),
  ),
)
+ array (
  'requestMethod' => 'POST',
  'requestUri' => '/rest',
  'queryParams' =>
  array (
  ),
  'formParams' =>
  array (
  ),
  'rawBody' => '',
  'headers' =>
  array (
    'User-Agent' =>
    array (
      0 => 'Symfony2 BrowserKit',
    ),
    'Host' =>
    array (
      0 => 'localhost',
    ),
  ),
  'X-Auth-Token' => NULL,
  'files' =>
  array (
    'dump' =>
    array (
      'name' => 'dump.sql',
      'tmp_name' => '/home/gintas/workspace/codeception-zend-expressive-tests/tests/_data/dump.sql',
      'type' => 'text/plain',
      'error' => 0,
    ),
  ),
)
Failed asserting that false is true.
```

After:
```
1) PostMethodFileUploadCept: Upload file
 Test  tests/functional/REST/PostMethodFileUploadCept.php
 Step  See response contains json {"files":{"dump":{"name":"dump.sql","size":57}}}
 Fail  Failed asserting that two arrays are equal.
- Expected | + Actual
@@ @@
Array (
'files' => Array (
'dump' => Array (
'name' => 'dump.sql'
-            'size' => 57
+            'tmp_name' => '/home/gintas/workspace/codece...mp.sql'
+            'type' => 'text/plain'
+            'error' => 0
)
)
+    'requestMethod' => 'POST'
+    'requestUri' => '/rest'
+    'queryParams' => Array ()
+    'formParams' => Array ()
+    'rawBody' => ''
+    'headers' => Array (...)
+    'X-Auth-Token' => null
)
```