### PR TITLE
[doc] PhpBrowser doesn't support session

### DIFF
--- a/docs/06-ReusingTestCode.md
+++ b/docs/06-ReusingTestCode.md
@@ -131,7 +131,7 @@ Let's improve code of our `login` method by making it executed only once for the
 
 ```
 
-Please note that session restoration only works for `WebDriver` and `PhpBrowser` modules (modules implementing `Codeception\Lib\Interfaces\SessionSnapshot`) 
+Please note that session restoration only works for `WebDriver` module (modules implementing `Codeception\Lib\Interfaces\SessionSnapshot`) 
 
 ## StepObjects
 


### PR DESCRIPTION
cloned from https://github.com/Codeception/codeception.github.com/pull/108

doc here is incorrect:
http://codeception.com/docs/06-ReusingTestCode#Session-Snapshot

at least for current stable version (2.2.2)

    [RuntimeException] Call to undefined method AcceptanceTester::loadSessionSnapshot


confirmed by [StackOverFlow post](http://stackoverflow.com/q/33273378/2314626)
