### PR TITLE
Update ZF2 module

### DIFF
--- a/src/Codeception/Lib/Connector/ZF2.php
+++ b/src/Codeception/Lib/Connector/ZF2.php
@@ -54,9 +54,7 @@ class ZF2 extends Client
     {
         $this->createApplication();
         $zendRequest = $this->application->getRequest();
-        $zendResponse = $this->application->getResponse();
 
-        $zendResponse->setStatusCode(200);
         $uri = new HttpUri($request->getUri());
         $queryString = $uri->getQuery();
         $method = strtoupper($request->getMethod());
@@ -89,6 +87,11 @@ class ZF2 extends Client
         
         $zendRequest->setHeaders($this->extractHeaders($request));
         $this->application->run();
+
+        // get the response *after* the application has run, because other ZF 
+        //     libraries like API Agility may *replace* the application's response
+        //
+        $zendResponse = $this->application->getResponse();
 
         $this->zendRequest = $zendRequest;
 

--- a/src/Codeception/Lib/Connector/ZF2.php
+++ b/src/Codeception/Lib/Connector/ZF2.php
@@ -88,7 +88,7 @@ class ZF2 extends Client
         $zendRequest->setHeaders($this->extractHeaders($request));
         $this->application->run();
 
-        // get the response *after* the application has run, because other ZF 
+        // get the response *after* the application has run, because other ZF
         //     libraries like API Agility may *replace* the application's response
         //
         $zendResponse = $this->application->getResponse();


### PR DESCRIPTION
Update the `doRequest()` method in the ZF2 module's connector to grab the application's response _after_ the application has run. 

Before this fix, the `doRequest()` method grabbed the response _before_ the application was run. This resulted in an empty response when other ZF libraries like Api Agility replaced the application's response object with their own.

Fixes issue #2936.