### PR TITLE
Support different line endings in dump

### DIFF
--- a/src/Codeception/Module/Db.php
+++ b/src/Codeception/Module/Db.php
@@ -168,19 +168,7 @@ class Db extends CodeceptionModule implements DbInterface
     public function _initialize()
     {
         if ($this->config['dump'] && ($this->config['cleanup'] or ($this->config['populate']))) {
-            if (!file_exists(Configuration::projectDir() . $this->config['dump'])) {
-                throw new ModuleConfigException(
-                    __CLASS__,
-                    "\nFile with dump doesn't exist.\n"
-                    . "Please, check path for sql file: "
-                    . $this->config['dump']
-                );
-            }
-            $sql = file_get_contents(Configuration::projectDir() . $this->config['dump']);
-            $sql = preg_replace('%/\*(?!!\d+).*?\*/%s', '', $sql);
-            if (!empty($sql)) {
-                $this->sql = explode("\n", $sql);
-            }
+            $this->readSql();
         }
 
         $this->connect();
@@ -192,6 +180,23 @@ class Db extends CodeceptionModule implements DbInterface
             }
             $this->loadDump();
             $this->populated = true;
+        }
+    }
+
+    private function readSql()
+    {
+        if (!file_exists(Configuration::projectDir() . $this->config['dump'])) {
+            throw new ModuleConfigException(
+                __CLASS__,
+                "\nFile with dump doesn't exist.\n"
+                . "Please, check path for sql file: "
+                . $this->config['dump']
+            );
+        }
+        $sql = file_get_contents(Configuration::projectDir() . $this->config['dump']);
+        $sql = preg_replace('%/\*(?!!\d+).*?\*/%s', '', $sql);
+        if (!empty($sql)) {
+            $this->sql = explode("\n", $sql);
         }
     }
 

--- a/src/Codeception/Module/Db.php
+++ b/src/Codeception/Module/Db.php
@@ -200,7 +200,8 @@ class Db extends CodeceptionModule implements DbInterface
         $sql = preg_replace('%/\*(?!!\d+).*?\*/%s', '', $sql);
 
         if (!empty($sql)) {
-            $this->sql = explode("\n", $sql);
+            // split SQL dump into lines
+            $this->sql = preg_split('/\r\n|\n|\r/', $sql, -1, PREG_SPLIT_NO_EMPTY);
         }
     }
 

--- a/src/Codeception/Module/Db.php
+++ b/src/Codeception/Module/Db.php
@@ -193,8 +193,12 @@ class Db extends CodeceptionModule implements DbInterface
                 . $this->config['dump']
             );
         }
+
         $sql = file_get_contents(Configuration::projectDir() . $this->config['dump']);
+
+        // remove C-style comments (except MySQL directives)
         $sql = preg_replace('%/\*(?!!\d+).*?\*/%s', '', $sql);
+
         if (!empty($sql)) {
             $this->sql = explode("\n", $sql);
         }


### PR DESCRIPTION
This adds support for all common end-of-line sequences.
Effectively it fixes problems with COPY command in SQL dump on Windows.

Splitting only by LF caused problems on Windows when SQL dump contained Windows line endings.
For example, `PostgreSql` driver expects lines to not contain any of end-of-line characters here: https://github.com/Codeception/Codeception/blob/2.2/src/Codeception/Lib/Driver/PostgreSql.php#L90
If a line ends with CR+LF then the `$sql` argument contains a string ending with CR and therefore it does never call `pg_end_copy` and `pg_close`.