### PR TITLE
Don't fail test validation when exec function is disabled

### DIFF
--- a/src/Codeception/Lib/Parser.php
+++ b/src/Codeception/Lib/Parser.php
@@ -126,7 +126,11 @@ class Parser
         if (empty($config['settings']['lint'])) { // lint disabled in config
             return;
         }
-        exec("php -l ".escapeshellarg($file)." 2>&1", $output, $code);
+        @exec("php -l " . escapeshellarg($file) . " 2>&1", $output, $code);
+        if (!isset($code)) {
+            //probably exec function is disabled #3324
+            return;
+        }
         if ($code !== 0) {
             throw new TestParseException($file, implode("\n", $output));
         }


### PR DESCRIPTION
Fixes #3324 

I haven't tested this change - I made it using GitHub editor.