### PR TITLE
Using valid example of expectException()

### DIFF
--- a/docs/05-UnitTests.md
+++ b/docs/05-UnitTests.md
@@ -336,7 +336,7 @@ To check your code for exception you can use `expectException` method from `Asse
 
 ```php
 <?php
-$t->expectException(new Exception, {
+$t->expectException(Exception::class, function() {
    throw new Exception; 
 });
 ```


### PR DESCRIPTION
Also, using `Exception::class` is generic enough for any sort of Exception implementation, and lighter than actually instantiating an exception just to get its class.