### PR TITLE
Specify package requirements for module

### DIFF
--- a/src/Codeception/Lib/Interfaces/RequiresPackage.php
+++ b/src/Codeception/Lib/Interfaces/RequiresPackage.php
@@ -1,0 +1,11 @@
+<?php
+namespace Codeception\Lib\Interfaces;
+
+interface RequiresPackage
+{
+
+    /**
+     * Returns list of classes and corresponding packages required for this module
+     */
+    public function _requires();
+}

--- a/src/Codeception/Module.php
+++ b/src/Codeception/Module.php
@@ -1,6 +1,8 @@
 <?php
 namespace Codeception;
 
+use Codeception\Exception\ModuleException;
+use Codeception\Lib\Interfaces\RequiresPackage;
 use Codeception\Lib\ModuleContainer;
 use Codeception\Util\Shared\Asserts;
 
@@ -91,6 +93,18 @@ abstract class Module
                 "\nOptions: " . implode(', ', $this->requiredFields) . " are required\n" .
                 "Please, update the configuration and set all the required fields\n\n"
             );
+        }
+        if ($this instanceof RequiresPackage) {
+            $errorMessage = '';
+            foreach ($this->_requires() as $className => $package) {
+                if (class_exists($className)) {
+                    continue;
+                }
+                $errorMessage .= "Class $className can't be loaded, please add $package to composer.json\n";
+            }
+            if ($errorMessage) {
+                throw new ModuleException($this, $errorMessage);
+            }
         }
     }
 

--- a/src/Codeception/Module/AMQP.php
+++ b/src/Codeception/Module/AMQP.php
@@ -1,6 +1,7 @@
 <?php
 namespace Codeception\Module;
 
+use Codeception\Lib\Interfaces\RequiresPackage;
 use Codeception\Module as CodeceptionModule;
 use Codeception\Exception\ModuleException as ModuleException;
 use Codeception\TestInterface;
@@ -56,7 +57,7 @@ use PhpAmqpLib\Exception\AMQPProtocolChannelException;
  * @author tiger.seo@gmail.com
  * @author davert
  */
-class AMQP extends CodeceptionModule
+class AMQP extends CodeceptionModule implements RequiresPackage
 {
     protected $config = [
         'host'     => 'locahost',
@@ -78,6 +79,11 @@ class AMQP extends CodeceptionModule
     protected $channel;
 
     protected $requiredFields = ['host', 'username', 'password', 'vhost'];
+
+    public function _requires()
+    {
+        return ['PhpAmqpLib\Connection\AMQPStreamConnection' => '"php-amqplib/php-amqplib": "~2.4"'];
+    }
 
     public function _initialize()
     {

--- a/src/Codeception/Module/DataFactory.php
+++ b/src/Codeception/Module/DataFactory.php
@@ -5,6 +5,7 @@ use Codeception\Lib\Interfaces\DataMapper;
 use Codeception\Lib\Interfaces\DependsOnModule;
 use Codeception\Lib\Interfaces\ORM;
 use Codeception\Exception\ModuleException;
+use Codeception\Lib\Interfaces\RequiresPackage;
 use Codeception\TestInterface;
 use League\FactoryMuffin\FactoryMuffin;
 use League\FactoryMuffin\Stores\RepositoryStore;
@@ -120,7 +121,7 @@ gst * You should create this directory manually and create PHP files in it with 
  * 'user' => 'entity|User'
  * ```
  */
-class DataFactory extends \Codeception\Module implements DependsOnModule
+class DataFactory extends \Codeception\Module implements DependsOnModule, RequiresPackage
 {
     protected $dependencyMessage = <<<EOF
 ORM module (like Doctrine2) or Framework module with ActiveRecord support is required:
@@ -146,15 +147,16 @@ EOF;
 
     protected $config = ['factories' => null];
 
+    public function _requires()
+    {
+        return [
+            'League\FactoryMuffin\FactoryMuffin' => '"league/factory-muffin": "^3.0"',
+            'League\FactoryMuffin\Faker\Facade' => '"league/factory-muffin-faker": "^1.0"'
+        ];
+    }
+
     public function _beforeSuite($settings = [])
     {
-        if (!class_exists('League\FactoryMuffin\FactoryMuffin')) {
-            throw new ModuleException($this, 'FactoryMuffin not installed. Please add `"league/factory-muffin": "^3.0"` to composer.json');
-        }
-        if (!class_exists('League\FactoryMuffin\Faker\Facade')) {
-            throw new ModuleException($this, 'FactoryMuffin requires Faker integration. Please add `"league/factory-muffin-faker": "^1.0"` to composer.json');
-        }
-
         $store = null;
         if ($this->ormModule instanceof DataMapper) { // for Doctrine
             $store = new RepositoryStore($this->ormModule->_getEntityManager());

--- a/src/Codeception/Module/Facebook.php
+++ b/src/Codeception/Module/Facebook.php
@@ -5,6 +5,7 @@ use Codeception\Exception\ModuleException as ModuleException;
 use Codeception\Exception\ModuleConfigException as ModuleConfigException;
 use Codeception\Lib\Driver\Facebook as FacebookDriver;
 use Codeception\Lib\Interfaces\DependsOnModule;
+use Codeception\Lib\Interfaces\RequiresPackage;
 use Codeception\Module as BaseModule;
 
 /**
@@ -79,7 +80,7 @@ use Codeception\Module as BaseModule;
  * @since 1.6.3
  * @author tiger.seo@gmail.com
  */
-class Facebook extends BaseModule implements DependsOnModule
+class Facebook extends BaseModule implements DependsOnModule, RequiresPackage
 {
     protected $requiredFields = ['app_id', 'secret'];
 
@@ -112,6 +113,11 @@ modules
                 locale: uk_UA
                 permissions: [email, publish_stream]
 EOF;
+
+    public function _requires()
+    {
+        return ['Facebook\Facebook' => '"facebook/php-sdk-v4": "~5.0"'];
+    }
 
     public function _depends()
     {

--- a/src/Codeception/Module/MongoDb.php
+++ b/src/Codeception/Module/MongoDb.php
@@ -1,6 +1,7 @@
 <?php
 namespace Codeception\Module;
 
+use Codeception\Lib\Interfaces\RequiresPackage;
 use Codeception\Module as CodeceptionModule;
 use Codeception\Configuration as Configuration;
 use Codeception\Exception\ModuleConfigException;
@@ -29,7 +30,7 @@ use Codeception\TestInterface;
  *
  * * Maintainer: **judgedim**, **davert**
  * * Stability: **beta**
- * * Contact: codecept@davert.mail.ua
+ * * Contact: davert@codeception.com
  *
  * *Please review the code of non-stable modules and provide patches if you have issues.*
  *
@@ -43,7 +44,7 @@ use Codeception\TestInterface;
  * * cleanup: true - should the dump be reloaded after each test
  *
  */
-class MongoDb extends CodeceptionModule
+class MongoDb extends CodeceptionModule implements RequiresPackage
 {
     /**
      * @api
@@ -351,5 +352,13 @@ class MongoDb extends CodeceptionModule
         $collection = $this->driver->getDbh()->selectCollection($collection);
         $res = $collection->count($criteria);
         \PHPUnit_Framework_Assert::assertSame($expected, $res);
+    }
+
+    /**
+     * Returns list of classes and corresponding packages required for this module
+     */
+    public function _requires()
+    {
+        return ['MongoDB\Client' => '"mongodb/mongodb": "^1.0"'];
     }
 }

--- a/src/Codeception/Module/PhpBrowser.php
+++ b/src/Codeception/Module/PhpBrowser.php
@@ -7,6 +7,7 @@ use Codeception\Lib\Connector\Guzzle6;
 use Codeception\Lib\InnerBrowser;
 use Codeception\Lib\Interfaces\MultiSession;
 use Codeception\Lib\Interfaces\Remote;
+use Codeception\Lib\Interfaces\RequiresPackage;
 use Codeception\TestInterface;
 use Codeception\Util\Uri;
 use GuzzleHttp\Client as GuzzleClient;
@@ -23,7 +24,7 @@ use GuzzleHttp\Client as GuzzleClient;
  *
  * * Maintainer: **davert**
  * * Stability: **stable**
- * * Contact: davert.codecept@mailican.com
+ * * Contact: codeception@codeception.com
  * * Works with [Guzzle](http://guzzlephp.org/)
  *
  * *Please review the code of non-stable modules and provide patches if you have issues.*
@@ -77,7 +78,7 @@ use GuzzleHttp\Client as GuzzleClient;
  * * `client` - Symfony BrowserKit instance.
  *
  */
-class PhpBrowser extends InnerBrowser implements Remote, MultiSession
+class PhpBrowser extends InnerBrowser implements Remote, MultiSession, RequiresPackage
 {
 
     private $isGuzzlePsr7;
@@ -123,6 +124,11 @@ class PhpBrowser extends InnerBrowser implements Remote, MultiSession
      */
     public $guzzle;
 
+    public function _requires()
+    {
+        return ['GuzzleHttp\Client' => '"guzzlehttp/guzzle": ">=4.1.4 <7.0"'];
+    }
+
     public function _initialize()
     {
         $this->client = $this->guessGuzzleConnector();
@@ -131,12 +137,6 @@ class PhpBrowser extends InnerBrowser implements Remote, MultiSession
 
     protected function guessGuzzleConnector()
     {
-        if (!class_exists('GuzzleHttp\Client')) {
-            throw new ModuleException(
-                $this,
-                "Guzzle is not installed. Please install `guzzlehttp/guzzle` with composer"
-            );
-        }
         if (class_exists('GuzzleHttp\Url')) {
             $this->isGuzzlePsr7 = false;
             return new \Codeception\Lib\Connector\Guzzle();

--- a/src/Codeception/Module/Redis.php
+++ b/src/Codeception/Module/Redis.php
@@ -2,6 +2,7 @@
 
 namespace Codeception\Module;
 
+use Codeception\Lib\Interfaces\RequiresPackage;
 use Codeception\Module as CodeceptionModule;
 use Codeception\TestCase;
 use Codeception\Exception\ModuleException;
@@ -31,7 +32,7 @@ use Predis\Client as RedisDriver;
  *
  * @author Marc Verney <marc@marcverney.net>
  */
-class Redis extends CodeceptionModule
+class Redis extends CodeceptionModule implements RequiresPackage
 {
     /**
      * {@inheritdoc}
@@ -59,6 +60,11 @@ class Redis extends CodeceptionModule
      */
     public $driver;
 
+    public function _requires()
+    {
+        return ['Predis\Client' => '"predis/predis": "^1.0"'];
+    }
+
     /**
      * Instructions to run after configuration is loaded
      *
@@ -66,9 +72,6 @@ class Redis extends CodeceptionModule
      */
     public function _initialize()
     {
-        if (!class_exists('Predis\Client')) {
-            throw new ModuleException($this, 'This module requires Predis library to be installed. Please add "predis/predis": "^1.0" to composer.json');
-        }
         try {
             $this->driver = new RedisDriver([
                 'host'     => $this->config['host'],

--- a/src/Codeception/Module/WebDriver.php
+++ b/src/Codeception/Module/WebDriver.php
@@ -13,6 +13,7 @@ use Codeception\Lib\Interfaces\ElementLocator;
 use Codeception\Lib\Interfaces\MultiSession as MultiSessionInterface;
 use Codeception\Lib\Interfaces\PageSourceSaver;
 use Codeception\Lib\Interfaces\Remote as RemoteInterface;
+use Codeception\Lib\Interfaces\RequiresPackage;
 use Codeception\Lib\Interfaces\ScreenshotSaver;
 use Codeception\Lib\Interfaces\SessionSnapshot;
 use Codeception\Lib\Interfaces\Web as WebInterface;
@@ -239,7 +240,8 @@ class WebDriver extends CodeceptionModule implements
     ScreenshotSaver,
     PageSourceSaver,
     ElementLocator,
-    ConflictsWithModule
+    ConflictsWithModule,
+    RequiresPackage
 {
     protected $requiredFields = ['browser', 'url'];
     protected $config = [
@@ -275,6 +277,11 @@ class WebDriver extends CodeceptionModule implements
      * @var RemoteWebDriver
      */
     public $webDriver;
+
+    public function _requires()
+    {
+        return ['Facebook\WebDriver\Remote\RemoteWebDriver' => '"facebook/webdriver": "^1.0.1"'];
+    }
 
     public function _initialize()
     {

--- a/src/Codeception/Subscriber/Console.php
+++ b/src/Codeception/Subscriber/Console.php
@@ -610,11 +610,8 @@ class Console implements EventSubscriberInterface
     {
         $time = $event->getTime();
         if ($time) {
-            $seconds = (int) ($milliseconds = (int) ($time * 100)) / 100;
-            $time = ($seconds % 60) . '.' . $milliseconds;
-
             $this
-                ->message($time)
+                ->message(number_format(round($time, 2),2))
                 ->prepend('(')
                 ->append('s)')
                 ->style('info')

--- a/tests/unit/Codeception/ModuleTest.php
+++ b/tests/unit/Codeception/ModuleTest.php
@@ -1,0 +1,29 @@
+<?php
+
+use Codeception\Util\Stub;
+
+class ModuleTest extends \PHPUnit_Framework_TestCase
+{
+    public function testRequirements()
+    {
+        $module = Stub::make('ModuleStub');
+        try {
+            $module->_setConfig([]);
+        } catch (\Exception $e) {
+            $this->assertContains('"error"', $e->getMessage());
+            $this->assertContains('no\such\class', $e->getMessage());
+            $this->assertContains('composer', $e->getMessage());
+            $this->assertNotContains('installed', $e->getMessage());
+            return;
+        }
+        $this->fail('no exception thrown');
+    }
+}
+
+class ModuleStub extends \Codeception\Module implements \Codeception\Lib\Interfaces\RequiresPackage
+{
+    public function _requires()
+    {
+        return ['no\such\class' => '"error"', 'Codeception\Module' => '"installed"'];
+    }
+}


### PR DESCRIPTION
Each module implementing `RequiresPackage` can now specify its external dependencies by implementing `_requires` method. If required class can't be found and exception is thrown with proposal to add corresponding package to composer.json.

For instance, PHPBrowser module has its requirements specified
```php
    public function _requires()
    {
        return ['GuzzleHttp\Client' => '"guzzlehttp/guzzle": ">=4.1.4 <7.0"'];
    }
```
If `codeception/base` is installed you will get the the exception which suggests to install '"guzzlehttp/guzzle": ">=4.1.4 <7.0"'