### PR TITLE
Database test improvements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -53,6 +53,7 @@ install:
   - '[[ -z "$SYMFONY" ]] || composer require symfony/css-selector=~$SYMFONY --no-update --ignore-platform-reqs'
   - '[[ -z "$SYMFONY" ]] || composer require symfony/dom-crawler=~$SYMFONY --no-update --ignore-platform-reqs'
   - '[[ -z "$SYMFONY" ]] || composer require symfony/browser-kit=~$SYMFONY --no-update --ignore-platform-reqs'
+  - '[[ "$TRAVIS_PHP_VERSION" != "hhvm" ]] || composer remove mongodb/mongodb --no-update --dev'
   - composer_parameters="-n --prefer-dist" # this variable will be used in all composer install commands
   - '[[ "$dependencies" != "lowest" ]] || composer_parameters="$composer_parameters --prefer-lowest"'
   - composer update $composer_parameters

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,7 @@ services:
 sudo: false
 
 install:
-  - pecl install mongodb
+  - '[[ "$TRAVIS_PHP_VERSION" == "hhvm" ]] || pecl install mongodb'
   #- echo "extension = mongodb.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini
   # use hhvm-serve instead of builtin server
   - '[[ "$TRAVIS_PHP_VERSION" != "hhvm" ]] || mkdir -p /home/travis/go/{src,bin,pkg}'

--- a/src/Codeception/Lib/Driver/Sqlite.php
+++ b/src/Codeception/Lib/Driver/Sqlite.php
@@ -2,6 +2,7 @@
 namespace Codeception\Lib\Driver;
 
 use Codeception\Configuration;
+use Codeception\Exception\ModuleException;
 
 class Sqlite extends Db
 {
@@ -11,7 +12,12 @@ class Sqlite extends Db
 
     public function __construct($dsn, $user, $password)
     {
-        $this->filename = Configuration::projectDir() . substr($dsn, 7);
+        $filename = substr($dsn, 7);
+        if ($filename === ':memory:') {
+            throw new ModuleException(__CLASS__, ':memory: database is not supported');
+        }
+
+        $this->filename = Configuration::projectDir() . $filename;
         $this->dsn = 'sqlite:' . $this->filename;
         parent::__construct($this->dsn, $user, $password);
     }

--- a/tests/unit/Codeception/Lib/Driver/PostgresTest.php
+++ b/tests/unit/Codeception/Lib/Driver/PostgresTest.php
@@ -38,7 +38,7 @@ class PostgresTest extends \PHPUnit_Framework_TestCase
         try {
             $this->postgres = Db::create(self::$config['dsn'], self::$config['user'], self::$config['password']);
         } catch (\Exception $e) {
-            $this->markTestSkipped('Coudn\'t establish connection to database');
+            $this->markTestSkipped('Coudn\'t establish connection to database: ' . $e->getMessage());
         }
         $this->postgres->load(self::$sql);
     }

--- a/tests/unit/Codeception/Lib/Driver/SqliteTest.php
+++ b/tests/unit/Codeception/Lib/Driver/SqliteTest.php
@@ -92,4 +92,14 @@ class SqliteTest extends \PHPUnit_Framework_TestCase
         );
         self::$sqlite->getPrimaryColumn('composite_pk');
     }
+
+    public function testThrowsExceptionIfInMemoryDatabaseIsUsed()
+    {
+        $this->setExpectedException(
+            '\Codeception\Exception\ModuleException',
+            ':memory: database is not supported'
+        );
+
+        Db::create('sqlite::memory:', '', '');
+    }
 }

--- a/tests/unit/Codeception/Module/MongoDbTest.php
+++ b/tests/unit/Codeception/Module/MongoDbTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use Codeception\Module\MongoDb;
+use Codeception\Exception\ModuleException;
 
 class MongoDbTest extends \PHPUnit_Framework_TestCase
 {
@@ -36,7 +37,11 @@ class MongoDbTest extends \PHPUnit_Framework_TestCase
 
         $this->module = new MongoDb(make_container());
         $this->module->_setConfig($this->mongoConfig);
-        $this->module->_initialize();
+        try {
+            $this->module->_initialize();
+        } catch (ModuleException $e) {
+            $this->markTestSkipped($e->getMessage());
+        }
 
         $this->db = $mongo->selectDatabase('test');
         $this->userCollection = $this->db->users;


### PR DESCRIPTION
A bunch of small improvements:
[PostgresTest] Print the reason why connection failed
[MongoDbTest] mark test as skipped if connection failed
[TravisCI] Don't install mongodb extension on hhvm, because pecl is not available
[Sqlite] Throw exception if in-memory database is used #3319