### PR TITLE
fix #3374 missing REQUEST_TIME server variables

### DIFF
--- a/src/Codeception/Lib/InnerBrowser.php
+++ b/src/Codeception/Lib/InnerBrowser.php
@@ -164,7 +164,8 @@ class InnerBrowser extends Module implements Web, PageSourceSaver, ElementLocato
                 $server[$header] = $val;
             }
         }
-
+        $server['REQUEST_TIME'] = time();
+        $server['REQUEST_TIME_FLOAT'] = microtime(true);
         if ($this instanceof Framework) {
             if (preg_match('#^(//|https?://(?!localhost))#', $uri)) {
                 $hostname = parse_url($uri, PHP_URL_HOST);


### PR DESCRIPTION
This PR fix #3374.

The Problem is described in the issue in detail. Basically the `REQUEST_TIME` and `REQUEST_TIME_FLOAT` headers are missing, when use the phalcon modul.

When run functional tests with coverage PHPUnit throws a exception `vendor/phpunit/php-code-coverage/src/Report/Text.php` line 132.