### PR TITLE
[SOAP] Add flexibility with the config SOAPAction

### DIFF
--- a/src/Codeception/Module/SOAP.php
+++ b/src/Codeception/Module/SOAP.php
@@ -36,6 +36,7 @@ use Codeception\Lib\Interfaces\API;
  * ## Configuration
  *
  * * endpoint *required* - soap wsdl endpoint
+ * * SOAPAction - replace header SOAPAction (Set to '' to SOAP 1.2)
  *
  * ## Public Properties
  *

--- a/src/Codeception/Module/SOAP.php
+++ b/src/Codeception/Module/SOAP.php
@@ -36,7 +36,7 @@ use Codeception\Lib\Interfaces\API;
  * ## Configuration
  *
  * * endpoint *required* - soap wsdl endpoint
- * * SOAPAction - replace header SOAPAction (Set to '' to SOAP 1.2)
+ * * SOAPAction - replace SOAPAction HTTP header (Set to '' to SOAP 1.2)
  *
  * ## Public Properties
  *

--- a/src/Codeception/Module/SOAP.php
+++ b/src/Codeception/Module/SOAP.php
@@ -479,7 +479,7 @@ EOF;
             [
                 'HTTP_Content-Type' => 'text/xml; charset=UTF-8',
                 'HTTP_Content-Length' => strlen($body),
-                'HTTP_SOAPAction' => $action
+                'HTTP_SOAPAction' => isset($this->config['SOAPAction']) ? $this->config['SOAPAction'] : $action
             ],
             $body
         );


### PR DESCRIPTION
Hello,

I'm having trouble with Tomcat API (CXF Framework) that doesn't accept SOAPAction in HTTP Header because SOAPAction is deprecated from SOAP 1.2.
It will also fix #2201 maybe

So actual user will continue without config SOAPAction and the SOAPAction header will be send with the action value
Other people like me that want to do SOAP 1.2 will put '' in SOAPAction config.
