### PR TITLE
[REST] seeResponseIsJson must fail when response is empty

### DIFF
--- a/src/Codeception/Lib/Console/MessageFactory.php
+++ b/src/Codeception/Lib/Console/MessageFactory.php
@@ -45,17 +45,16 @@ class MessageFactory
 
     /**
      * @param ComparisonFailure $failure
-     * @return Message|null
+     * @return string
      */
     public function prepareComparisonFailureMessage(ComparisonFailure $failure)
     {
-        $message = $this->message($failure->getMessage());
         $diff = $this->diffFactory->createDiff($failure);
         if (!$diff) {
-            return $message;
+            return '';
         }
         $diff = $this->colorizer->colorize($diff);
 
-        return $message->append("\n<comment>- Expected</comment> | <info>+ Actual</info>\n")->append($diff);
+        return "\n<comment>- Expected</comment> | <info>+ Actual</info>\n$diff";
     }
 }

--- a/src/Codeception/Module/REST.php
+++ b/src/Codeception/Module/REST.php
@@ -604,7 +604,9 @@ EOF;
      */
     public function seeResponseIsJson()
     {
-        json_decode($this->connectionModule->_getResponseContent());
+        $responseContent = $this->connectionModule->_getResponseContent();
+        \PHPUnit_Framework_Assert::assertNotEquals('', $responseContent, 'response is empty');
+        json_decode($responseContent);
         $errorCode = json_last_error();
         $errorMessage = json_last_error_msg();
         \PHPUnit_Framework_Assert::assertEquals(
@@ -612,8 +614,8 @@ EOF;
             $errorCode,
             sprintf(
                 "Invalid json: %s. System message: %s.",
-                $this->connectionModule->_getResponseContent(),
-                json_last_error_msg()
+                $responseContent,
+                $errorMessage
             )
         );
     }

--- a/src/Codeception/Subscriber/Console.php
+++ b/src/Codeception/Subscriber/Console.php
@@ -374,7 +374,7 @@ class Console implements EventSubscriberInterface
         if ($e instanceof \PHPUnit_Framework_ExpectationFailedException) {
             $comparisonFailure = $e->getComparisonFailure();
             if ($comparisonFailure) {
-                $message = $this->messageFactory->prepareComparisonFailureMessage($comparisonFailure);
+                $message->append($this->messageFactory->prepareComparisonFailureMessage($comparisonFailure));
             }
         }
 

--- a/tests/unit/Codeception/Module/RestTest.php
+++ b/tests/unit/Codeception/Module/RestTest.php
@@ -323,6 +323,20 @@ class RestTest extends \PHPUnit_Framework_TestCase
         $this->module->dontSeeResponseMatchesJsonType(['id' => 'integer'], '$.users[0]');
     }
 
+    public function testSeeResponseIsJsonFailsWhenResponseIsEmpty()
+    {
+        $this->shouldFail();
+        $this->setStubResponse('');
+        $this->module->seeResponseIsJson();
+    }
+
+    public function testSeeResponseIsJsonFailsWhenResponseIsInvalidJson()
+    {
+        $this->shouldFail();
+        $this->setStubResponse('{');
+        $this->module->seeResponseIsJson();
+    }
+
 
     protected function shouldFail()
     {


### PR DESCRIPTION
This change makes behaviour of this method on PHP5 consistent with PHP7
Closes #3400