### PR TITLE
Fix DataFactory::haveMultiple argument order

### DIFF
--- a/src/Codeception/Module/DataFactory.php
+++ b/src/Codeception/Module/DataFactory.php
@@ -242,6 +242,6 @@ EOF;
      */
     public function haveMultiple($name, $times, array $extraAttrs = [])
     {
-        return $this->factoryMuffin->seed($name, $times, $extraAttrs);
+        return $this->factoryMuffin->seed($times, $name, $extraAttrs);
     }
 }


### PR DESCRIPTION
Correct the order of the FactoryMuffin::seed call which is `$times, $name, ...` instead of `$name, $times, ...`.

1. [DataFactory::haveMultiple call](https://github.com/Codeception/Codeception/blob/master/src/Codeception/Module/DataFactory.php#L245)
2. [FactoryMuffin::seed function](https://github.com/thephpleague/factory-muffin/blob/master/src/FactoryMuffin.php#L82)