### PR TITLE
Use Laravel UploadedFile class for requests

### DIFF
--- a/src/Codeception/Lib/Connector/Laravel5.php
+++ b/src/Codeception/Lib/Connector/Laravel5.php
@@ -120,6 +120,27 @@ class Laravel5 extends Client
     }
 
     /**
+     * Override filterFiles
+     *
+     * We need to create an array of \Illuminate\Http\UploadedFile, rather than
+     * \Symfony\Component\HttpFoundation\File\UploadedFile.
+     *
+     * @param array $files
+     * @return array
+     */
+    protected function filterFiles(array $files)
+    {
+        $files = parent::filterFiles($files);
+
+        $filtered = [];
+        foreach ($files as $key => $file) {
+            $filtered[$key] = UploadedFile::createFromBase($file, true);
+        }
+
+        return $filtered;
+    }
+
+    /**
      * Initialize the Laravel framework.
      *
      * @param SymfonyRequest $request


### PR DESCRIPTION
Using Symfony’s `UploadedFile` class has the effect that when Laravel’s `Request` class does `convertUploadedFiles()`, all files are converted to Laravel’s `UploadedFile` class, but with the `$test` set to false.

This, in turn, makes it difficult to use the class in a test, because the class then must pass the `is_uploaded_file()` test in `UploadedFile::isValid()`.

This is just a proposal, I have no tests to go with the code, as this repo is missing some basic requirements for this class to even be instantiable, like Laravel's Eloquent and Symfony's HttpFoundation component. Please have a look @janhenkgerritsen.