### PR TITLE
[SOAP] improve error of grabTextContentFrom when xpath not found

### DIFF
--- a/src/Codeception/Util/XmlStructure.php
+++ b/src/Codeception/Util/XmlStructure.php
@@ -45,7 +45,7 @@ class XmlStructure
         } catch (ParseException $e) {
         }
         $els = $xpath->query($cssOrXPath);
-        if ($els) {
+        if ($els->length) {
             return $els->item(0);
         }
         throw new ElementNotFound($cssOrXPath);


### PR DESCRIPTION
Hello,

$this->grabTextContentFrom("//*[local-name() = 'login']");

If [login] doesn't exist in the SOAP response you will have:
```
There was 1 error:
---------
1) soapCest: test
 Test  tests/api/soapCest.php:test
                                                                      
  [PHPUnit_Framework_Exception] Trying to get property of non-object
```
We don't know the name of property not found ... that's bad.

After the fix you will have:
```
There was 1 failure:
---------
1) soapCest: test
 Test  tests/api/soapCest.php:test
 Step  Grab Text Content From
 Fail   element with '//*[local-name() = 'login']' was not found.
```
It's better I think.

The fix was just because query return always a DOMNodeList but empty.
http://php.net/manual/en/domxpath.query.php
