### PR TITLE
Laravel5 fix issue with error handler for Laravel 5.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 #### 2.2.4
 
+# [Laravel5] Fixed an issue with error handling for Laravel 5.3. See #3420. By @bonsi.
 * [Laravel5] Fixed an issue with uploaded files. See #3417. By @torkiljohnsen.
 
 #### 2.2.3

--- a/src/Codeception/Lib/Connector/Laravel5.php
+++ b/src/Codeception/Lib/Connector/Laravel5.php
@@ -131,6 +131,12 @@ class Laravel5 extends Client
     {
         $files = parent::filterFiles($files);
 
+        if (! class_exists('Illuminate\Http\UploadedFile')) {
+            // The \Illuminate\Http\UploadedFile class was introduced in Laravel 5.2.15,
+            // so don't change the $files array if it does not exist.
+            return $files;
+        }
+
         $filtered = [];
         foreach ($files as $key => $file) {
             $filtered[$key] = UploadedFile::createFromBase($file, true);

--- a/src/Codeception/Lib/Connector/Laravel5/ExceptionHandlerDecorator.php
+++ b/src/Codeception/Lib/Connector/Laravel5/ExceptionHandlerDecorator.php
@@ -2,13 +2,14 @@
 namespace Codeception\Lib\Connector\Laravel5;
 
 use Exception;
+use Illuminate\Contracts\Debug\ExceptionHandler as ExceptionHandlerContract;
 
 /**
  * Class ExceptionHandlerDecorator
  *
  * @package Codeception\Lib\Connector\Laravel5
  */
-class ExceptionHandlerDecorator
+class ExceptionHandlerDecorator implements ExceptionHandlerContract
 {
     /**
      * @var ExceptionHandlerContract
@@ -39,6 +40,17 @@ class ExceptionHandlerDecorator
     }
 
     /**
+     * Report or log an exception.
+     *
+     * @param  \Exception $e
+     * @return void
+     */
+    public function report(Exception $e)
+    {
+        $this->laravelExceptionHandler->report($e);
+    }
+
+    /**
      * @param $request
      * @param Exception $e
      * @return \Symfony\Component\HttpFoundation\Response
@@ -58,6 +70,18 @@ class ExceptionHandlerDecorator
         }
 
         return $response;
+    }
+
+    /**
+     * Render an exception to the console.
+     *
+     * @param  \Symfony\Component\Console\Output\OutputInterface $output
+     * @param  \Exception $e
+     * @return void
+     */
+    public function renderForConsole($output, Exception $e)
+    {
+        $this->laravelExceptionHandler->renderForConsole($output, $e);
     }
 
     /**


### PR DESCRIPTION
Issue reported by @bonsi in #3420. He also provided this fix in #3421, but I created this PR because I wanted to change the order of the methods in the `ExceptionHandlerDecorator` class.