### PR TITLE
Fix deprecation notices

### DIFF
--- a/src/Codeception/Subscriber/ErrorHandler.php
+++ b/src/Codeception/Subscriber/ErrorHandler.php
@@ -43,14 +43,14 @@ class ErrorHandler implements EventSubscriberInterface
 
     public function errorHandler($errno, $errstr, $errfile, $errline, $context)
     {
-        if (!(error_reporting() & $errno)) {
-            // This error code is not included in error_reporting
-            return false;
-        }
-
         if (E_USER_DEPRECATED === $errno) {
             $this->handleDeprecationError($errno, $errstr, $errfile, $errline, $context);
             return;
+        }
+
+        if (!(error_reporting() & $errno)) {
+            // This error code is not included in error_reporting
+            return false;
         }
 
         if (strpos($errstr, 'Cannot modify header information') !== false) {

--- a/src/Codeception/Subscriber/ErrorHandler.php
+++ b/src/Codeception/Subscriber/ErrorHandler.php
@@ -115,8 +115,8 @@ class ErrorHandler implements EventSubscriberInterface
             call_user_func($this->oldHandler, $type, $message, $file, $line, $context);
             return;
         }
-        
-        // if the error is included in the configured error reporting 
+
+        // if the error is included in the configured error reporting
         if (error_reporting() & $type) {
             Notification::deprecate("$message", "$file:$line");
         }

--- a/src/Codeception/Subscriber/ErrorHandler.php
+++ b/src/Codeception/Subscriber/ErrorHandler.php
@@ -115,6 +115,10 @@ class ErrorHandler implements EventSubscriberInterface
             call_user_func($this->oldHandler, $type, $message, $file, $line, $context);
             return;
         }
-        Notification::deprecate("$message", "$file:$line");
+        
+        // if the error is included in the configured error reporting 
+        if (error_reporting() & $type) {
+            Notification::deprecate("$message", "$file:$line");
+        }
     }
 }

--- a/src/Codeception/Subscriber/ErrorHandler.php
+++ b/src/Codeception/Subscriber/ErrorHandler.php
@@ -43,14 +43,14 @@ class ErrorHandler implements EventSubscriberInterface
 
     public function errorHandler($errno, $errstr, $errfile, $errline, $context)
     {
-        if (E_USER_DEPRECATED === $errno) {
-            $this->handleDeprecationError($errno, $errstr, $errfile, $errline, $context);
-            return;
-        }
-
         if (!(error_reporting() & $errno)) {
             // This error code is not included in error_reporting
             return false;
+        }
+
+        if (E_USER_DEPRECATED === $errno) {
+            $this->handleDeprecationError($errno, $errstr, $errfile, $errline, $context);
+            return;
         }
 
         if (strpos($errstr, 'Cannot modify header information') !== false) {


### PR DESCRIPTION
Before, if the Symfony Deprecations Helper was not installed, Codeception would display each deprecation notice even if deprecation errors were ignored in Codeception's configuration.

Now, it should respect the configuration settings.

Fixes #3424.