### PR TITLE
Fixed problems with default messages of asserts

### DIFF
--- a/src/Codeception/Module/Asserts.php
+++ b/src/Codeception/Module/Asserts.php
@@ -248,7 +248,7 @@ class Asserts extends CodeceptionModule
      * @param $actual
      * @param $description
      */
-    public function assertGreaterOrEquals($expected, $actual, $description  = '')
+    public function assertGreaterOrEquals($expected, $actual, $description = '')
     {
         $this->assertGreaterThanOrEqual($expected, $actual, $description);
     }
@@ -258,7 +258,7 @@ class Asserts extends CodeceptionModule
      * @param $actual
      * @param $description
      */
-    public function assertLessOrEquals($expected, $actual, $description  = '')
+    public function assertLessOrEquals($expected, $actual, $description = '')
     {
         $this->assertLessThanOrEqual($expected, $actual, $description);
     }
@@ -277,7 +277,7 @@ class Asserts extends CodeceptionModule
      * @param $actual
      * @param $description
      */
-    public function assertArrayHasKey($key, $actual, $description  = '')
+    public function assertArrayHasKey($key, $actual, $description = '')
     {
         parent::assertArrayHasKey($key, $actual, $description);
     }

--- a/src/Codeception/Module/Asserts.php
+++ b/src/Codeception/Module/Asserts.php
@@ -248,7 +248,7 @@ class Asserts extends CodeceptionModule
      * @param $actual
      * @param $description
      */
-    public function assertGreaterOrEquals($expected, $actual, $description = null)
+    public function assertGreaterOrEquals($expected, $actual, $description  = '')
     {
         $this->assertGreaterThanOrEqual($expected, $actual, $description);
     }
@@ -258,7 +258,7 @@ class Asserts extends CodeceptionModule
      * @param $actual
      * @param $description
      */
-    public function assertLessOrEquals($expected, $actual, $description = null)
+    public function assertLessOrEquals($expected, $actual, $description  = '')
     {
         $this->assertLessThanOrEqual($expected, $actual, $description);
     }
@@ -267,7 +267,7 @@ class Asserts extends CodeceptionModule
      * @param $actual
      * @param $description
      */
-    public function assertIsEmpty($actual, $description = null)
+    public function assertIsEmpty($actual, $description = '')
     {
         $this->assertEmpty($actual, $description);
     }
@@ -277,7 +277,7 @@ class Asserts extends CodeceptionModule
      * @param $actual
      * @param $description
      */
-    public function assertArrayHasKey($key, $actual, $description = null)
+    public function assertArrayHasKey($key, $actual, $description  = '')
     {
         parent::assertArrayHasKey($key, $actual, $description);
     }
@@ -287,7 +287,7 @@ class Asserts extends CodeceptionModule
      * @param $actual
      * @param $description
      */
-    public function assertArrayNotHasKey($key, $actual, $description = null)
+    public function assertArrayNotHasKey($key, $actual, $description = '')
     {
         parent::assertArrayNotHasKey($key, $actual, $description);
     }
@@ -297,7 +297,7 @@ class Asserts extends CodeceptionModule
      * @param $actual
      * @param $description
      */
-    public function assertInstanceOf($class, $actual, $description = null)
+    public function assertInstanceOf($class, $actual, $description = '')
     {
         parent::assertInstanceOf($class, $actual, $description);
     }
@@ -307,7 +307,7 @@ class Asserts extends CodeceptionModule
      * @param $actual
      * @param $description
      */
-    public function assertNotInstanceOf($class, $actual, $description = null)
+    public function assertNotInstanceOf($class, $actual, $description = '')
     {
         parent::assertNotInstanceOf($class, $actual, $description);
     }
@@ -317,7 +317,7 @@ class Asserts extends CodeceptionModule
      * @param $actual
      * @param $description
      */
-    public function assertInternalType($type, $actual, $description = null)
+    public function assertInternalType($type, $actual, $description = '')
     {
         parent::assertInternalType($type, $actual, $description);
     }

--- a/src/Codeception/Util/Shared/Asserts.php
+++ b/src/Codeception/Util/Shared/Asserts.php
@@ -262,7 +262,7 @@ trait Asserts
      * @param        $constraint
      * @param string $message
      */
-    protected function assertThat($haystack, $constraint, $message)
+    protected function assertThat($haystack, $constraint, $message = '')
     {
         \PHPUnit_Framework_Assert::assertThat($haystack, $constraint, $message);
     }
@@ -274,7 +274,7 @@ trait Asserts
      * @param        $constraint
      * @param string $message
      */
-    protected function assertThatItsNot($haystack, $constraint, $message)
+    protected function assertThatItsNot($haystack, $constraint, $message = '')
     {
         $constraint = new \PHPUnit_Framework_Constraint_Not($constraint);
         \PHPUnit_Framework_Assert::assertThat($haystack, $constraint, $message);
@@ -309,7 +309,7 @@ trait Asserts
      * @param $actual
      * @param $description
      */
-    protected function assertGreaterOrEquals($expected, $actual, $description)
+    protected function assertGreaterOrEquals($expected, $actual, $description = '')
     {
         \PHPUnit_Framework_Assert::assertGreaterThanOrEqual($expected, $actual, $description);
     }
@@ -319,7 +319,7 @@ trait Asserts
      * @param $actual
      * @param $description
      */
-    protected function assertLessOrEquals($expected, $actual, $description)
+    protected function assertLessOrEquals($expected, $actual, $description = '')
     {
         \PHPUnit_Framework_Assert::assertLessThanOrEqual($expected, $actual, $description);
     }
@@ -328,7 +328,7 @@ trait Asserts
      * @param $actual
      * @param $description
      */
-    protected function assertIsEmpty($actual, $description)
+    protected function assertIsEmpty($actual, $description = '')
     {
         \PHPUnit_Framework_Assert::assertEmpty($actual, $description);
     }
@@ -338,7 +338,7 @@ trait Asserts
      * @param $actual
      * @param $description
      */
-    protected function assertArrayHasKey($key, $actual, $description)
+    protected function assertArrayHasKey($key, $actual, $description = '')
     {
         \PHPUnit_Framework_Assert::assertArrayHasKey($key, $actual, $description);
     }
@@ -348,7 +348,7 @@ trait Asserts
      * @param $actual
      * @param $description
      */
-    protected function assertArrayNotHasKey($key, $actual, $description)
+    protected function assertArrayNotHasKey($key, $actual, $description = '')
     {
         \PHPUnit_Framework_Assert::assertArrayNotHasKey($key, $actual, $description);
     }
@@ -358,7 +358,7 @@ trait Asserts
      * @param $actual
      * @param $description
      */
-    protected function assertInstanceOf($class, $actual, $description)
+    protected function assertInstanceOf($class, $actual, $description = '')
     {
         \PHPUnit_Framework_Assert::assertInstanceOf($class, $actual, $description);
     }
@@ -368,7 +368,7 @@ trait Asserts
      * @param $actual
      * @param $description
      */
-    protected function assertNotInstanceOf($class, $actual, $description)
+    protected function assertNotInstanceOf($class, $actual, $description = '')
     {
         \PHPUnit_Framework_Assert::assertNotInstanceOf($class, $actual, $description);
     }
@@ -378,7 +378,7 @@ trait Asserts
      * @param $actual
      * @param $description
      */
-    protected function assertInternalType($type, $actual, $description)
+    protected function assertInternalType($type, $actual, $description = '')
     {
         \PHPUnit_Framework_Assert::assertInternalType($type, $actual, $description);
     }


### PR DESCRIPTION
I created a helper and extended \Codeception\Module\REST. When using

`$I->assertInternalType`

I recognized that the default message in Util/Shared/Asserts.php was missing. I found the same problem in some Asserts in Util/Asserts.php

This pull request adds this default messages and also corrects some default values for the messages which were set to null. I you look into PhpUnit itself the default message is ALWAYS an empty string.