### PR TITLE
Display only distinct deprecation messages

### DIFF
--- a/src/Codeception/Subscriber/Console.php
+++ b/src/Codeception/Subscriber/Console.php
@@ -322,8 +322,11 @@ class Console implements EventSubscriberInterface
     public function afterSuite(SuiteEvent $e)
     {
         $this->message()->width($this->width, '-')->writeln();
-        $deprecationMessages = Notification::all();
-        foreach (array_unique($deprecationMessages) as $message) {
+        $messages = Notification::all();
+        foreach (array_count_values($messages) as $message => $count) {
+            if ($count > 1) {
+                $message = $count . 'x ' . $message;
+            }
             $this->output->notification($message);
         }
     }

--- a/src/Codeception/Subscriber/Console.php
+++ b/src/Codeception/Subscriber/Console.php
@@ -323,7 +323,7 @@ class Console implements EventSubscriberInterface
     {
         $this->message()->width($this->width, '-')->writeln();
         $deprecationMessages = Notification::all();
-        foreach ($deprecationMessages as $message) {
+        foreach (array_unique($deprecationMessages) as $message) {
             $this->output->notification($message);
         }
     }


### PR DESCRIPTION
Related to #3424

Before:
```
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
DEPRECATION: Usage of Zend\ServiceManager\ServiceManager::getServiceLocator is deprecated since v3.0.0; please use the container passed to the factory instead /home/.../codeception-zf2-tests/vendor/zendframework/zend-servicemanager/src/ServiceManager.php:164
DEPRECATION: Usage of Zend\ServiceManager\ServiceManager::getServiceLocator is deprecated since v3.0.0; please use the container passed to the factory instead /home/.../codeception-zf2-tests/vendor/zendframework/zend-servicemanager/src/ServiceManager.php:164
DEPRECATION: Usage of Zend\ServiceManager\ServiceManager::getServiceLocator is deprecated since v3.0.0; please use the container passed to the factory instead /home/.../codeception-zf2-tests/vendor/zendframework/zend-servicemanager/src/ServiceManager.php:164


Time: 2.27 seconds, Memory: 20.00MB
```

After:
```
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
DEPRECATION: Usage of Zend\ServiceManager\ServiceManager::getServiceLocator is deprecated since v3.0.0; please use the container passed to the factory instead /home/.../codeception-zf2-tests/vendor/zendframework/zend-servicemanager/src/ServiceManager.php:164


Time: 2.54 seconds, Memory: 20.00MB
```