### PR TITLE
Remove Exception typehint

### DIFF
--- a/src/Codeception/PHPUnit/Overrides/Filter.php
+++ b/src/Codeception/PHPUnit/Overrides/Filter.php
@@ -10,7 +10,7 @@ class PHPUnit_Util_Filter
         'Codeception\TestCase\\',
     ];
 
-    public static function getFilteredStackTrace(Exception $e, $asString = true, $filter = true)
+    public static function getFilteredStackTrace($e, $asString = true, $filter = true)
     {
         $stackTrace = $asString ? '' : [];
 


### PR DESCRIPTION
Remove typehint to be consistent with PHPUnit.

PHPUnit’s [`PHPUnit_Framework_Constraint_Exception->failureDescription()`](https://github.com/sebastianbergmann/phpunit/blob/5.5.2/src/Framework/Constraint/Exception.php#L57) will pass on an object of type `Exception` or `Throwable` to `PHPUnit_Util_Filter`. Codeception is [currently](https://github.com/Codeception/Codeception/blob/2.2/src/Codeception/PHPUnit/Overrides/Filter.php#L13) only accepting objects of type `Exception`.

This will make the Codeception code fail with any `Throwable` you throw at it.

This was changed in PHPUnit 5.0.9, see sebastianbergmann/phpunit@4faa59897ba626bdc0c57c25207e7cbdf9678d9e