### PR TITLE
Fixes mongorestore command syntax and adds --quiet option to config

### DIFF
--- a/src/Codeception/Lib/Driver/MongoDb.php
+++ b/src/Codeception/Lib/Driver/MongoDb.php
@@ -17,6 +17,7 @@ class MongoDb
     private $user;
     private $password;
     private $client;
+    private $quiet = '';
 
     public static function connect($dsn, $user, $password)
     {
@@ -168,9 +169,11 @@ class MongoDb
     {
         list($host, $port) = $this->getHostPort();
         $cmd = sprintf(
-            "mongorestore --host %s --port %s %s%s",
+            "mongorestore %s --host %s --port %s -d %s %s %s",
+            $this->quiet,
             $host,
             $port,
+            $this->dbName,
             $this->createUserPasswordCmdString(),
             escapeshellarg($dumpFile)
         );
@@ -193,10 +196,12 @@ class MongoDb
         }
         $dirName = trim(shell_exec($getDirCmd));
         $cmd = sprintf(
-            'tar -xzf %s && mongorestore --host %s --port %s%s %s && rm -r %s',
+            'tar -xzf %s && mongorestore %s --host %s --port %s -d %s %s %s && rm -r %s',
             escapeshellarg($dumpFile),
+            $this->quiet,
             $host,
             $port,
+            $this->dbName,
             $this->createUserPasswordCmdString(),
             $dirName,
             $dirName
@@ -246,5 +251,10 @@ class MongoDb
             return [$hostPort[0], self::DEFAULT_PORT];
         }
         throw new ModuleException($this, '$dsn MUST be like (mongodb://)<host>:<port>/<db name>');
+    }
+
+    public function setQuiet($quiet)
+    {
+        $this->quiet = $quiet ? '--quiet' : '';
     }
 }

--- a/src/Codeception/Module/MongoDb.php
+++ b/src/Codeception/Module/MongoDb.php
@@ -74,6 +74,7 @@ class MongoDb extends CodeceptionModule implements RequiresPackage
         'dump_type' => self::DUMP_TYPE_JS,
         'user'      => null,
         'password'  => null,
+        'quiet'     => false,
     ];
 
     protected $populated = false;
@@ -206,18 +207,22 @@ class MongoDb extends CodeceptionModule implements RequiresPackage
 
     protected function loadDump()
     {
+        $this->validateDump();
+
         if ($this->isDumpFileEmpty) {
             return;
         }
 
         try {
-            if ($this->config['dump_type'] === DUMP_TYPE_JS) {
+            if ($this->config['dump_type'] === self::DUMP_TYPE_JS) {
                 $this->driver->load($this->dumpFile);
             }
-            if ($this->config['dump_type'] === DUMP_TYPE_MONGODUMP) {
+            if ($this->config['dump_type'] === self::DUMP_TYPE_MONGODUMP) {
+                $this->driver->setQuiet($this->config['quiet']);
                 $this->driver->loadFromMongoDump($this->dumpFile);
             }
-            if ($this->config['dump_type'] === DUMP_TYPE_MONGODUMP_TAR_GZ) {
+            if ($this->config['dump_type'] === self::DUMP_TYPE_MONGODUMP_TAR_GZ) {
+                $this->driver->setQuiet($this->config['quiet']);
                 $this->driver->loadFromTarGzMongoDump($this->dumpFile);
             }
         } catch (\Exception $e) {


### PR DESCRIPTION
I was unable to load my tar.gz mongo dump and I found that there were some things missing from the files that would allow me to load my dumps. For example not using the `validateDump()` function even though it's there and the mongorestore syntax not including what database to restore to. 

While I was at it, I added the ability to `--quiet` the restore or else if you are using `cleanup` and `populate` options you will be getting the load message every time. 