### PR TITLE
Fix support for nested arrays in the file array

### DIFF
--- a/src/Codeception/Lib/Connector/Laravel5.php
+++ b/src/Codeception/Lib/Connector/Laravel5.php
@@ -137,9 +137,19 @@ class Laravel5 extends Client
             return $files;
         }
 
+        return $this->convertToTestFiles($files);
+    }
+
+    private function convertToTestFiles(array $files)
+    {
         $filtered = [];
-        foreach ($files as $key => $file) {
-            $filtered[$key] = UploadedFile::createFromBase($file, true);
+
+        foreach ($files as $key => $value) {
+            if (is_array($value)) {
+                $filtered[$key] = $this->convertToTestFiles($value);
+            } else {
+                $filtered[$key] = UploadedFile::createFromBase($value, true);
+            }
         }
 
         return $filtered;


### PR DESCRIPTION
With the latest patch to this file, I accidentally removed support the files array being able to contain nested arrays of files. This fixes that blooper.