### PR TITLE
bugfix issue 3481: fix pattern matching in run test by name

### DIFF
--- a/docs/02-GettingStarted.md
+++ b/docs/02-GettingStarted.md
@@ -223,13 +223,13 @@ Tests can be started with the `run` command.
 php codecept run
 ```
 
-With the first argument you can run tests from one suite.
+With the first argument you can run all tests from one suite.
 
 ```bash
 php codecept run acceptance
 ```
 
-To run exactly one test, add a second argument. Provide a local path to the test, from the suite directory.
+To limit tests run to a single class, add a second argument. Provide a local path to the test class, from the suite directory.
 
 ```bash
 php codecept run acceptance SigninCept.php
@@ -241,19 +241,23 @@ Alternatively you can provide the full path to test file:
 php codecept run tests/acceptance/SigninCept.php
 ```
 
-You can execute one test from a test class (for Cest or Test formats)
+You can further filter which tests are run by appending a regular expression to the class, separated by a colon (for Cest or Test formats):
 
 ```bash
-php codecept run tests/acceptance/SignInCest.php:anonymousLogin
+php codecept run tests/acceptance/SignInCest.php:^anonymousLogin$
 ```
 
-You can provide a directory path as well:
+You can provide a directory path as well. This will execute all tests from the backend dir:
 
 ```bash
 php codecept run tests/acceptance/backend
 ```
 
-This will execute all tests from the backend dir.
+Combined with regular expressions, you can filter tests in the same directory. This will execute all tests from the backend dir beginning with the word login:
+
+```bash
+php codecept run tests/acceptance/backend:^login
+```
 
 To execute a group of tests that are not stored in the same directory, you can organize them in [groups](http://codeception.com/docs/07-AdvancedUsage#Groups).
 

--- a/docs/02-GettingStarted.md
+++ b/docs/02-GettingStarted.md
@@ -241,7 +241,7 @@ Alternatively you can provide the full path to test file:
 php codecept run tests/acceptance/SigninCept.php
 ```
 
-You can further filter which tests are run by appending a regular expression to the class, separated by a colon (for Cest or Test formats):
+You can further filter which tests are run by appending a method name to the class, separated by a colon (for Cest or Test formats):
 
 ```bash
 php codecept run tests/acceptance/SignInCest.php:^anonymousLogin$
@@ -253,7 +253,7 @@ You can provide a directory path as well. This will execute all tests from the b
 php codecept run tests/acceptance/backend
 ```
 
-Combined with regular expressions, you can filter tests in the same directory. This will execute all tests from the backend dir beginning with the word login:
+Using regular expressions, you can even run many different test methods from the same directory or class. For example, this will execute all tests from the backend dir beginning with the word login:
 
 ```bash
 php codecept run tests/acceptance/backend:^login

--- a/src/Codeception/Command/Run.php
+++ b/src/Codeception/Command/Run.php
@@ -349,6 +349,12 @@ class Run extends Command
         $test_parts = explode(':', $path, 2);
         if (count($test_parts) > 1) {
             list($path, $filter) = $test_parts;
+            // use carat to signify start of string like in normal regex
+            // phpunit --filter matches against the fully qualified method name, so tests actually begin with :
+            $carat_pos = strpos($filter, '^');
+            if ($carat_pos !== false) {
+                $filter = substr_replace($filter, ':', $carat_pos, 1);
+            }
             return $filter;
         }
 

--- a/src/Codeception/Command/Run.php
+++ b/src/Codeception/Command/Run.php
@@ -346,7 +346,7 @@ class Run extends Command
 
     private function matchFilteredTestName(&$path)
     {
-        $test_parts = explode(':', $path);
+        $test_parts = explode(':', $path, 2);
         if (count($test_parts) > 1) {
             list($path, $filter) = $test_parts;
             return $filter;


### PR DESCRIPTION
Bugfix for #3481 

Changes are low risk in that the current majority case behavior remains the same; for test names of the format dir/ClassName:testName, nothing has changed. However, this change allows the use of additional ':' characters, which can be used to more accurately filter tests by name.

This change should also cover enhancement #2736