### PR TITLE
bugfix issue 3481: perform exact match on test name

### DIFF
--- a/src/Codeception/Command/Run.php
+++ b/src/Codeception/Command/Run.php
@@ -349,7 +349,7 @@ class Run extends Command
         $test_parts = explode(':', $path);
         if (count($test_parts) > 1) {
             list($path, $filter) = $test_parts;
-            return $filter;
+            return ':' . $filter .'$';
         }
 
         return null;


### PR DESCRIPTION
Alternative pull request for issue #3481. Adds ':' and '$' to test name filter to perform an exact match as described in the documentation.