### PR TITLE
[DOC] Fix custom step class name (member => admin)

### DIFF
--- a/docs/06-ReusingTestCode.md
+++ b/docs/06-ReusingTestCode.md
@@ -177,7 +177,7 @@ As you see, this class is very simple. It extends `AcceptanceTester` class, thus
 <?php
 namespace Step\Acceptance;
 
-class Member extends \AcceptanceTester
+class Admin extends \AcceptanceTester
 {
     public function loginAsAdmin()
     {


### PR DESCRIPTION
In all other places this example is using "Admin" class, so "Member" should be changed.