### PR TITLE
Save all screenshots and page sources + show their names in log message

### DIFF
--- a/src/Codeception/Command/Console.php
+++ b/src/Codeception/Command/Console.php
@@ -59,7 +59,11 @@ class Console extends Command
         $options['debug'] = true;
         $options['silent'] = true;
         $options['interactive'] = false;
-        $options['colors'] = true;
+        if (strtoupper(substr(PHP_OS, 0, 3)) === 'WIN') {
+            $options['colors'] = false;
+        } else {
+            $options['colors'] = true;
+        }
 
         Debug::setOutput(new Output($options));
 

--- a/src/Codeception/Module/WebDriver.php
+++ b/src/Codeception/Module/WebDriver.php
@@ -374,9 +374,18 @@ class WebDriver extends CodeceptionModule implements
         $this->debugWebDriverLogs();
         $filename = preg_replace('~\W~', '.', Descriptor::getTestSignature($test));
         $outputDir = codecept_output_dir();
-        $this->_saveScreenshot($outputDir . mb_strcut($filename, 0, 245, 'utf-8') . '.fail.png');
-        $this->_savePageSource($outputDir . mb_strcut($filename, 0, 244, 'utf-8') . '.fail.html');
-        $this->debug("Screenshot and page source were saved into '$outputDir' dir");
+        $filenamePng = mb_strcut($filename, 0, 245, 'utf-8') . '.fail.png';
+        $filenameHtml = mb_strcut($filename, 0, 244, 'utf-8') . '.fail.html';
+        for ($i = 1; $i < 1000; $i++) {
+            if ((! file_exists($outputDir . $filenamePng)) && (! file_exists($outputDir . $filenameHtml))) {
+                break;
+            }
+            $filenamePng = mb_strcut($filename . '.' . $i, 0, 245, 'utf-8') . '.fail.png';
+            $filenameHtml = mb_strcut($filename . '.' . $i, 0, 244, 'utf-8') . '.fail.html';
+        }
+        $this->_saveScreenshot($outputDir . $filenamePng);
+        $this->_savePageSource($outputDir . $filenameHtml);
+        $this->debug("Screenshot and page source were saved into '$outputDir' dir [$filenamePng, $filenameHtml]");
     }
 
     /**

--- a/src/Codeception/Module/WebDriver.php
+++ b/src/Codeception/Module/WebDriver.php
@@ -374,18 +374,9 @@ class WebDriver extends CodeceptionModule implements
         $this->debugWebDriverLogs();
         $filename = preg_replace('~\W~', '.', Descriptor::getTestSignature($test));
         $outputDir = codecept_output_dir();
-        $filenamePng = mb_strcut($filename, 0, 245, 'utf-8') . '.fail.png';
-        $filenameHtml = mb_strcut($filename, 0, 244, 'utf-8') . '.fail.html';
-        for ($i = 1; $i < 1000; $i++) {
-            if ((! file_exists($outputDir . $filenamePng)) && (! file_exists($outputDir . $filenameHtml))) {
-                break;
-            }
-            $filenamePng = mb_strcut($filename . '.' . $i, 0, 245, 'utf-8') . '.fail.png';
-            $filenameHtml = mb_strcut($filename . '.' . $i, 0, 244, 'utf-8') . '.fail.html';
-        }
-        $this->_saveScreenshot($outputDir . $filenamePng);
-        $this->_savePageSource($outputDir . $filenameHtml);
-        $this->debug("Screenshot and page source were saved into '$outputDir' dir [$filenamePng, $filenameHtml]");
+        $this->_saveScreenshot($outputDir . mb_strcut($filename, 0, 245, 'utf-8') . '.fail.png');
+        $this->_savePageSource($outputDir . mb_strcut($filename, 0, 244, 'utf-8') . '.fail.html');
+        $this->debug("Screenshot and page source were saved into '$outputDir' dir");
     }
 
     /**


### PR DESCRIPTION
When you run test with "can" asserts and some of them fails then you will have screenshot and page source only from last one.
Try this test:

```
<?php 
$I = new NoGuy($scenario);

$code = "document.body.innerHTML = '<div style=\"text-align: center; padding-top: 50px;\"><h1>TEST %d</h1></div>';";
$I->wantTo('Test creating multiple screenshots');
$I->amOnPage('/');

$I->executeJS(sprintf($code, 1));
usleep(500000);
$I->canSee('TEST 2');

$I->executeJS(sprintf($code, 2));
usleep(500000);
$I->canSee('TEST 3');

$I->executeJS(sprintf($code, 3));
usleep(500000);
$I->canSee('TEST 4');
```