### PR TITLE
Update WebDriver Doc - Wrong Regex

### DIFF
--- a/docs/modules/WebDriver.md
+++ b/docs/modules/WebDriver.md
@@ -761,7 +761,7 @@ If no parameters are provided, the full URI is returned.
 
 ``` php
 <?php
-$user_id = $I->grabFromCurrentUrl('~/user/(\d+)/~');
+$user_id = $I->grabFromCurrentUrl('~^/user/(\d+)/~');
 $uri = $I->grabFromCurrentUrl();
 ?>
 ```

--- a/docs/modules/WebDriver.md
+++ b/docs/modules/WebDriver.md
@@ -761,7 +761,7 @@ If no parameters are provided, the full URI is returned.
 
 ``` php
 <?php
-$user_id = $I->grabFromCurrentUrl('~$/user/(\d+)/~');
+$user_id = $I->grabFromCurrentUrl('~/user/(\d+)/~');
 $uri = $I->grabFromCurrentUrl();
 ?>
 ```


### PR DESCRIPTION
Hello,

According to the documentation 

```php
$I->amOnUrl('http://localhost/user/42/');
$link = $I->grabFromCurrentUrl();
$user_id = $I->grabFromCurrentUrl('~$/user/(\d+)/~');
```

Result will be:
link = /user/42/
user_id = 42

That's not true, result will be:
 Step  Grab from current url "~$/user/(\d+)/~"
 Fail  Couldn't match ~$/user/(\d+)/~ in /user/42/

So I fixed the doc with a new regex '~/user/(\d+)/~'
