### PR TITLE
Remove methods from Laravel5 module _after hook

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -67,8 +67,8 @@ install:
   - '[[ "$TRAVIS_PHP_VERSION" == "hhvm" ]] || git clone -q --depth=1 https://github.com/Codeception/phalcon-demo.git frameworks-phalcon'
   - '[[ "$TRAVIS_PHP_VERSION" == "hhvm" ]] || composer update -d frameworks-phalcon $composer_parameters'
   # Laravel 5
-  - '[[ "$TRAVIS_PHP_VERSION" == "5.4" ]] || git clone -q -b codeception-2.2 https://github.com/janhenkgerritsen/codeception-laravel5-sample.git frameworks-l5'
-  - '[[ "$TRAVIS_PHP_VERSION" == "5.4" ]] || composer update -d frameworks-l5 $composer_parameters'
+  - '[[ "$TRAVIS_PHP_VERSION" == "5.4" ]] || [[ "$TRAVIS_PHP_VERSION" == "5.5" ]] || git clone -q -b codeception-2.2 https://github.com/janhenkgerritsen/codeception-laravel5-sample.git frameworks-l5'
+  - '[[ "$TRAVIS_PHP_VERSION" == "5.4" ]] || [[ "$TRAVIS_PHP_VERSION" == "5.5" ]] || composer update -d frameworks-l5 $composer_parameters'
   # Lumen
   - '[[ "$TRAVIS_PHP_VERSION" == "5.4" ]] || git clone -q -b codeception-2.2 https://github.com/janhenkgerritsen/codeception-lumen-sample.git frameworks-lumen'
   - '[[ "$TRAVIS_PHP_VERSION" == "5.4" ]] || composer update -d frameworks-lumen $composer_parameters'
@@ -111,8 +111,8 @@ before_script:
   - mysql -e 'CREATE DATABASE phalcon_demo CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;'
   - '[[ "$TRAVIS_PHP_VERSION" == "hhvm" ]] || cat frameworks-phalcon/schemas/phalcon_demo.sql | mysql phalcon_demo'
   # Laravel 5
-  - '[[ "$TRAVIS_PHP_VERSION" == "5.4" ]] || touch frameworks-l5/storage/testing.sqlite'
-  - '[[ "$TRAVIS_PHP_VERSION" == "5.4" ]] || php frameworks-l5/artisan migrate --database=sqlite_testing --force'
+  - '[[ "$TRAVIS_PHP_VERSION" == "5.4" ]] || [[ "$TRAVIS_PHP_VERSION" == "5.5" ]] || touch frameworks-l5/storage/testing.sqlite'
+  - '[[ "$TRAVIS_PHP_VERSION" == "5.4" ]] || [[ "$TRAVIS_PHP_VERSION" == "5.5" ]] || php frameworks-l5/artisan migrate --database=sqlite_testing --force'
   # Lumen
   - '[[ "$TRAVIS_PHP_VERSION" == "5.4" ]] || cp frameworks-lumen/.env.testing frameworks-lumen/.env'
   - '[[ "$TRAVIS_PHP_VERSION" == "5.4" ]] || touch frameworks-lumen/storage/testing.sqlite'
@@ -127,7 +127,7 @@ before_script:
   - php codecept build -c frameworks-yii-basic
   - '[[ "$TRAVIS_PHP_VERSION" == "hhvm" ]] || php codecept build -c frameworks-phalcon'
   - '[[ -z "$SYMFONY" ]] || php codecept build -c frameworks-symfony/src/AppBundle'
-  - '[[ "$TRAVIS_PHP_VERSION" == "5.4" ]] || php codecept build -c frameworks-l5'
+  - '[[ "$TRAVIS_PHP_VERSION" == "5.4" ]] || [[ "$TRAVIS_PHP_VERSION" == "5.5" ]] || php codecept build -c frameworks-l5'
   - '[[ "$TRAVIS_PHP_VERSION" == "5.4" ]] || php codecept build -c frameworks-lumen'
   - php codecept build -c frameworks-zf1
   - php codecept build -c frameworks-zf2
@@ -141,7 +141,7 @@ script:
   # disable xdebug before running framework tests
   - '[[ "$TRAVIS_PHP_VERSION" != "hhvm" ]] || echo "xdebug.enable = Off" >> /etc/hhvm/php.ini'
   - php codecept run functional -c frameworks-yii-basic # Yii2 tests
-  - '[[ "$TRAVIS_PHP_VERSION" == "5.4" ]] || php codecept run -c frameworks-l5' # Laravel5 Tests
+  - '[[ "$TRAVIS_PHP_VERSION" == "5.4" ]] || [[ "$TRAVIS_PHP_VERSION" == "5.5" ]] || php codecept run -c frameworks-l5' # Laravel5 Tests
   - '[[ "$TRAVIS_PHP_VERSION" == "5.4" ]] || php codecept run -c frameworks-lumen' # Lumen Tests
   - '[[ "$TRAVIS_PHP_VERSION" == "hhvm" ]] || php codecept run functional -c frameworks-phalcon' # Phalcon Tests
   - '[[ -z "$SYMFONY" ]] || php codecept run functional -c frameworks-symfony/src/AppBundle '# Symfony Tests

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 #### 2.2.5
+* [Laravel5] Removed calls to Auth::logout(), Session::flush() and Cache::flush() from after hook. See #3493. By @janhenkgerritsen
 * [Memcache] Updated `Memcache::seeInMemcached` to check if the key exists alone or with the desired value. By @sergeyklay
 * [Memcache] Added `Memcache::haveInMemcached`. By @sergeyklay
 * [Memcache] Fixed `Memcache::dontSeeInMemcached`. By @sergeyklay

--- a/src/Codeception/Lib/Connector/Laravel5.php
+++ b/src/Codeception/Lib/Connector/Laravel5.php
@@ -140,6 +140,10 @@ class Laravel5 extends Client
         return $this->convertToTestFiles($files);
     }
 
+    /**
+     * @param array $files
+     * @return array
+     */
     private function convertToTestFiles(array $files)
     {
         $filtered = [];

--- a/src/Codeception/Module/Laravel5.php
+++ b/src/Codeception/Module/Laravel5.php
@@ -170,18 +170,6 @@ class Laravel5 extends Framework implements ActiveRecord, PartedModule
             $this->app['db']->rollback();
         }
 
-        if (isset($this->app['auth'])) {
-            $this->app['auth']->logout();
-        }
-
-        if (isset($this->app['session'])) {
-            $this->app['session']->flush();
-        }
-
-        if (isset($this->app['cache'])) {
-            $this->app['cache']->flush();
-        }
-
         // disconnect from DB to prevent "Too many connections" issue
         if (isset($this->app['db'])) {
             $this->app['db']->disconnect();


### PR DESCRIPTION
This should fix #3483.

My first attempt to fix this issue was to test if a method `logout` existed on the guard object, but this does not work because the method will sometimes be called via magic methods.

After that I decided to just remove the call altogether, because I could not think of a good reason why the calls were there in the first place. Probably some leftover code from an earlier version of the module. I also deleted two other method calls for the same reasons.