### PR TITLE
expected type for $param set for pressKey webdriver action.

### DIFF
--- a/src/Codeception/Module/WebDriver.php
+++ b/src/Codeception/Module/WebDriver.php
@@ -2296,7 +2296,7 @@ class WebDriver extends CodeceptionModule implements
      * ```
      *
      * @param $element
-     * @param $char Can be char or array with modifier. You can provide several chars.
+     * @param $char string|array Can be char or array with modifier. You can provide several chars.
      * @throws \Codeception\Exception\ElementNotFound
      */
     public function pressKey($element, $char)


### PR DESCRIPTION
![screen shot 2016-09-08 at 5 08 53 pm](https://cloud.githubusercontent.com/assets/611784/18367068/4f33770c-75e7-11e6-8caf-b456583e85dc.png)

Minor, but my IDE complains that its expecting some random type `Can`, because a description was written on a doc, without a type. This adds the expected string or array.