### PR TITLE
Add another test case for <select> names with square brackets

### DIFF
--- a/tests/data/app/view/form/names-sq-brackets.php
+++ b/tests/data/app/view/form/names-sq-brackets.php
@@ -35,7 +35,7 @@
             <option value="4">Select 4</option>
             <option value="5">Select 5</option>
         </select>
-        <select name="product[stock_data][is_in_stock]">
+        <select id="inventory_stock_availability" name="product[stock_data][is_in_stock]" class="select">
             <option value="0">Out of Stock</option>
         </select>
     </form>

--- a/tests/data/app/view/form/names-sq-brackets.php
+++ b/tests/data/app/view/form/names-sq-brackets.php
@@ -35,9 +35,10 @@
             <option value="4">Select 4</option>
             <option value="5">Select 5</option>
         </select>
-        <select id="inventory_stock_availability" name="product[stock_data][is_in_stock]" class="select">
-            <option value="0">Out of Stock</option>
-        </select>
+        <select id="inventory_stock_availability" name="product[stock_data][is_in_stock]" class="select" >
+                                            <option value="1" >In Stock</option>
+                                            <option value="0" selected="selected">Out of Stock</option>
+                        </select>
     </form>
 </body>
 </html>

--- a/tests/data/app/view/form/names-sq-brackets.php
+++ b/tests/data/app/view/form/names-sq-brackets.php
@@ -35,6 +35,9 @@
             <option value="4">Select 4</option>
             <option value="5">Select 5</option>
         </select>
+        <select name="product[stock_data][is_in_stock]">
+            <option value="0">Out of Stock</option>
+        </select>
     </form>
 </body>
 </html>

--- a/tests/data/app/view/form/names-sq-brackets.php
+++ b/tests/data/app/view/form/names-sq-brackets.php
@@ -35,6 +35,7 @@
             <option value="4">Select 4</option>
             <option value="5">Select 5</option>
         </select>
+        <label for="inventory_stock_availability">Stock Availability</label>
         <select id="inventory_stock_availability" name="product[stock_data][is_in_stock]" class="select" >
                                             <option value="1" >In Stock</option>
                                             <option value="0" selected="selected">Out of Stock</option>

--- a/tests/unit/Codeception/Module/TestsForWeb.php
+++ b/tests/unit/Codeception/Module/TestsForWeb.php
@@ -1432,7 +1432,6 @@ abstract class TestsForWeb extends \Codeception\TestCase\Test
         $this->module->selectOption('//input[@name="input[radio][name][]"]', '1');
 
         $this->module->selectOption('//select[@name="select[name][]"]', '1');
-        $this->module->selectOption('//select[@name="select[name][]"]', '1');
         $this->module->selectOption('//select[@name="product[stock_data][is_in_stock]"]', '0');
     }
 

--- a/tests/unit/Codeception/Module/TestsForWeb.php
+++ b/tests/unit/Codeception/Module/TestsForWeb.php
@@ -1432,6 +1432,8 @@ abstract class TestsForWeb extends \Codeception\TestCase\Test
         $this->module->selectOption('//input[@name="input[radio][name][]"]', '1');
 
         $this->module->selectOption('//select[@name="select[name][]"]', '1');
+        $this->module->selectOption('//select[@name="select[name][]"]', '1');
+        $this->module->selectOption('//select[@name="product[stock_data][is_in_stock]"]', '0');
     }
 
     public function testFillFieldWithAmpersand()


### PR DESCRIPTION
I'm having an issue similar to this one: https://github.com/Codeception/Codeception/issues/2062

I'm getting `[InvalidArgumentException] Unreachable field "product"` exception in my tests, and the test cases added in https://github.com/Codeception/Codeception/pull/2077 don't seem to be covering my case.

I couldn't run the tests for this project locally to check if the issue is reproduced with this test, so I'm sending this pull request to see what CI will show.