### PR TITLE
Escape tags in debug output

### DIFF
--- a/src/Codeception/Lib/Console/Colorizer.php
+++ b/src/Codeception/Lib/Console/Colorizer.php
@@ -1,9 +1,8 @@
 <?php
 namespace Codeception\Lib\Console;
 
-/**
- * Colorizer
- **/
+use Symfony\Component\Console\Formatter\OutputFormatter;
+
 class Colorizer
 {
     /**
@@ -19,7 +18,7 @@ class Colorizer
         $colorizedMessage = '';
         while ($line = fgets($fp)) {
             $char = $line[0];
-            $line = trim($line);
+            $line = OutputFormatter::escape(trim($line));
 
             switch ($char) {
                 case '+':

--- a/src/Codeception/Lib/Console/Output.php
+++ b/src/Codeception/Lib/Console/Output.php
@@ -68,6 +68,8 @@ class Output extends ConsoleOutput
         $message = print_r($message, true);
         $message = str_replace("\n", "\n  ", $message);
         $message = $this->clean($message);
+        $message = OutputFormatter::escape($message);
+
         if ($this->waitForDebugOutput) {
             $this->writeln('');
             $this->waitForDebugOutput = false;

--- a/src/Codeception/Subscriber/Console.php
+++ b/src/Codeception/Subscriber/Console.php
@@ -391,7 +391,7 @@ class Console implements EventSubscriberInterface
         }
 
         if ($isFailure && $cause) {
-            $cause = ucfirst($cause);
+            $cause = OutputFormatter::escape(ucfirst($cause));
             $message->prepend("<error> Step </error> $cause\n<error> Fail </error> ");
         }
 

--- a/src/Codeception/Subscriber/Console.php
+++ b/src/Codeception/Subscriber/Console.php
@@ -18,6 +18,7 @@ use Codeception\Test\Descriptor;
 use Codeception\Test\Interfaces\ScenarioDriven;
 use Codeception\Util\Debug;
 use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Formatter\OutputFormatter;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
 class Console implements EventSubscriberInterface
@@ -312,7 +313,7 @@ class Console implements EventSubscriberInterface
             $msg->style('bold');
         }
         $maxLength = $this->width - $prefixLength;
-        $msg->append($step->toString($maxLength));
+        $msg->append(OutputFormatter::escape($step->toString($maxLength)));
         if ($this->metaStep) {
             $msg->style('info');
         }
@@ -357,7 +358,7 @@ class Console implements EventSubscriberInterface
     {
         if ($e instanceof \PHPUnit_Framework_SkippedTestError or $e instanceof \PHPUnit_Framework_IncompleteTestError) {
             if ($e->getMessage()) {
-                $this->message($e->getMessage())->prepend("\n")->writeln();
+                $this->message(OutputFormatter::escape($e->getMessage()))->prepend("\n")->writeln();
             }
 
             return;
@@ -372,7 +373,7 @@ class Console implements EventSubscriberInterface
         }
 
         $this->output->writeln('');
-        $message = $this->message($e->getMessage());
+        $message = $this->message(OutputFormatter::escape($e->getMessage()));
 
         if ($e instanceof \PHPUnit_Framework_ExpectationFailedException) {
             $comparisonFailure = $e->getComparisonFailure();
@@ -432,7 +433,7 @@ class Console implements EventSubscriberInterface
         }
 
         if ($this->rawStackTrace) {
-            $this->message(\PHPUnit_Util_Filter::getFilteredStacktrace($e, true, false))->writeln();
+            $this->message(OutputFormatter::escape(\PHPUnit_Util_Filter::getFilteredStacktrace($e, true, false)))->writeln();
 
             return;
         }
@@ -515,7 +516,7 @@ class Console implements EventSubscriberInterface
                 ->prepend(' ')
                 ->width(strlen($length))
                 ->append(". ");
-            $message->append($step->getPhpCode($this->width - $message->getLength()));
+            $message->append(OutputFormatter::escape($step->getPhpCode($this->width - $message->getLength())));
 
             if ($step->hasFailed()) {
                 $message->style('bold');

--- a/src/Codeception/Subscriber/Console.php
+++ b/src/Codeception/Subscriber/Console.php
@@ -469,25 +469,6 @@ class Console implements EventSubscriberInterface
         }
     }
 
-    /**
-     * Sample Message: create user in CreateUserCept.php is not ready for release
-     *
-     * @param $feature
-     * @param $fileName
-     * @param $failToString
-     */
-    public function printSkippedTest($feature, $fileName, $failToString)
-    {
-        $message = $this->message();
-        if ($feature) {
-            $message->append($feature)->style('focus')->append(' in ');
-        }
-        $message->append($fileName);
-        if ($failToString) {
-            $message->append(": $failToString");
-        }
-        $message->write(OutputInterface::VERBOSITY_VERBOSE);
-    }
 
     /**
      * @param $failedTest


### PR DESCRIPTION
I found `Symfony\Component\Console\Formatter\OutputFormatter::escape` and added it to all relevant places that I could find:
* codecept_debug
* diff output
* assertion messages and stack traces
* step parameters

Fixes #3495 