### PR TITLE
bugfix 3513: fix codception misspellings

### DIFF
--- a/src/Codeception/Lib/ModuleContainer.php
+++ b/src/Codeception/Lib/ModuleContainer.php
@@ -469,8 +469,8 @@ class ModuleContainer
     /**
      * Check if the modules passed as arguments to this method conflict with each other.
      *
-     * @param \Codception\Module $module
-     * @param \Codception\Module $otherModule
+     * @param \Codeception\Module $module
+     * @param \Codeception\Module $otherModule
      * @throws \Codeception\Exception\ModuleConflictException
      */
     private function validateConflict($module, $otherModule)

--- a/tests/unit/Codeception/ApplicationTest.php
+++ b/tests/unit/Codeception/ApplicationTest.php
@@ -1,8 +1,6 @@
 <?php
 
-namespace Codception;
-
-use Codeception\Application;
+namespace Codeception;
 
 class ApplicationTest extends \PHPUnit_Framework_TestCase
 {


### PR DESCRIPTION
Bugfix for #3513 -- misspellings in doc and namespace.

Neither was referenced anywhere else, so changes are non-breaking.

Asserted that unit test passed after changes via `codecept run tests/unit/Codeception/ApplicationTest.php`