### PR TITLE
fixes #3520 nested transactions in yii2 module

### DIFF
--- a/src/Codeception/Module/Yii2.php
+++ b/src/Codeception/Module/Yii2.php
@@ -10,6 +10,7 @@ use Codeception\Lib\Interfaces\ActiveRecord;
 use Codeception\Lib\Interfaces\PartedModule;
 use Codeception\Lib\Notification;
 use Codeception\TestInterface;
+use Codeception\Test\Unit as UnitTest;
 use Yii;
 use yii\db\ActiveRecordInterface;
 
@@ -142,7 +143,7 @@ class Yii2 extends Framework implements ActiveRecord, PartedModule
         $this->app = $this->client->getApplication();
 
         // load fixtures before db transaction
-        if (method_exists($test, 'fixtures') && ($fixtures = $test->fixtures()) !== false) {
+        if ($test instanceof UnitTest && method_exists($test, 'fixtures') && ($fixtures = $test->fixtures()) !== false) {
             $this->haveFixtures($fixtures);
         }
 

--- a/src/Codeception/Module/Yii2.php
+++ b/src/Codeception/Module/Yii2.php
@@ -141,6 +141,11 @@ class Yii2 extends Framework implements ActiveRecord, PartedModule
         $this->client->configFile = Configuration::projectDir() . $this->config['configFile'];
         $this->app = $this->client->getApplication();
 
+        // load fixtures before db transaction
+        if (method_exists($test, 'fixtures') && ($fixtures = $test->fixtures()) !== false) {
+            $this->haveFixtures($fixtures);
+        }
+
         if ($this->config['cleanup'] && $this->app->has('db')) {
             $this->transaction = $this->app->db->beginTransaction();
         }


### PR DESCRIPTION
I think it solves a problem discussed in #3520

MySQL does not supports ALTER TABLE within transactions. But the ActiveFixture model clears all data in table including a sequence before test.

If use cleanup option each unit test with nested transactions throws PDOException.