### PR TITLE
Using Doctrine2 module with ZF2 as partly loaded results into an error

### DIFF
--- a/src/Codeception/Module/ZF2.php
+++ b/src/Codeception/Module/ZF2.php
@@ -135,6 +135,11 @@ class ZF2 extends Framework implements DoctrineProvider, PartedModule
 
     public function _getEntityManager()
     {
+        if (!$this->client) {
+            $this->client = new ZF2Connector();
+            $this->client->setApplicationConfig($this->applicationConfig);
+        }
+
         return $this->grabServiceFromContainer('Doctrine\ORM\EntityManager');
     }
 


### PR DESCRIPTION
Configuration:

```
class_name: AcceptanceTester
modules:
    enabled: [PhpBrowserHelper, \Helper\Acceptance, Asserts, Doctrine2, DbHelper, RestHelper]
    config:
        PhpBrowserHelper:
            url: 'http://localhost/'
        Doctrine2:
            depends: ZF2
```

Error:
```
Call to a member function grabServiceFromContainer() on a non-object in 
/var/www/localhost/vendor/codeception/codeception/src/Codeception/Module/ZF2.php:157
```