### PR TITLE
No more conflict between SOAP and REST

### DIFF
--- a/src/Codeception/Module/SOAP.php
+++ b/src/Codeception/Module/SOAP.php
@@ -389,13 +389,21 @@ EOF;
      *
      * @param $code
      */
-    public function seeResponseCodeIs($code)
+    public function seeSoapResponseCodeIs($code)
     {
         $this->assertEquals(
             $code,
             $this->client->getInternalResponse()->getStatus(),
             "soap response code matches expected"
         );
+    }
+
+    /**
+     * @deprecated use seeSoapResponseCodeIs instead
+     */
+    public function seeResponseCodeIs($code)
+    {
+        $this->seeSoapResponseCodeIs($code);
     }
 
     /**

--- a/src/Codeception/Module/SOAP.php
+++ b/src/Codeception/Module/SOAP.php
@@ -1,7 +1,6 @@
 <?php
 namespace Codeception\Module;
 
-use Codeception\Lib\Interfaces\ConflictsWithModule;
 use Codeception\Lib\Interfaces\DependsOnModule;
 use Codeception\Module as CodeceptionModule;
 use Codeception\TestInterface;
@@ -11,7 +10,6 @@ use Codeception\Lib\Framework;
 use Codeception\Lib\InnerBrowser;
 use Codeception\Util\Soap as SoapUtils;
 use Codeception\Util\XmlStructure;
-use Codeception\Lib\Interfaces\API;
 
 /**
  * Module for testing SOAP WSDL web services.
@@ -43,21 +41,17 @@ use Codeception\Lib\Interfaces\API;
  * * xmlRequest - last SOAP request (DOMDocument)
  * * xmlResponse - last SOAP response (DOMDocument)
  *
- * ## Conflicts
- *
- * Conflicts with REST module
- *
  */
-class SOAP extends CodeceptionModule implements DependsOnModule, API, ConflictsWithModule
+class SOAP extends CodeceptionModule implements DependsOnModule
 {
     protected $config = [
         'schema' => "",
         'schema_url' => 'http://schemas.xmlsoap.org/soap/envelope/',
         'framework_collect_buffer' => true
     ];
-    
+
     protected $requiredFields = ['endpoint'];
-    
+
     protected $dependencyMessage = <<<EOF
 Example using PhpBrowser as backend for SOAP module.
 --
@@ -114,11 +108,6 @@ EOF;
         return ['Codeception\Lib\InnerBrowser' => $this->dependencyMessage];
     }
 
-    public function _conflicts()
-    {
-        return 'Codeception\Lib\Interfaces\API';
-    }
-
     public function _inject(InnerBrowser $connectionModule)
     {
         $this->connectionModule = $connectionModule;
@@ -126,7 +115,7 @@ EOF;
             $this->isFunctional = true;
         }
     }
-    
+
     private function getClient()
     {
         if (!$this->client) {
@@ -142,7 +131,7 @@ EOF;
         }
         return $this->xmlResponse;
     }
-    
+
     private function getXmlStructure()
     {
         if (!$this->xmlStructure) {
@@ -150,7 +139,7 @@ EOF;
         }
         return $this->xmlStructure;
     }
-    
+
     /**
      * Prepare SOAP header.
      * Receives header name and parameters as array.

--- a/tests/unit/Codeception/Module/SoapTest.php
+++ b/tests/unit/Codeception/Module/SoapTest.php
@@ -29,12 +29,6 @@ class SoapTest extends \PHPUnit_Framework_TestCase
         $this->module->_before(Stub::makeEmpty('\Codeception\Test\Test'));
         $this->module->client = Stub::makeEmpty('\Codeception\Lib\Connector\Universal');
     }
-
-    public function testConflictsWithAPI()
-    {
-        $this->assertInstanceOf('Codeception\Lib\Interfaces\ConflictsWithModule', $this->module);
-        $this->assertEquals('Codeception\Lib\Interfaces\API', $this->module->_conflicts());
-    }
     
     public function testXmlIsBuilt()
     {


### PR DESCRIPTION
Fix #3512

**User of Codeception  <= v2.2.3**
No conflict between SOAP and REST
it will take seeResponseCodeIs of SOAP or seeResponseCodeIs of REST depends on the order of modules in yml

**User of Codeception v2.2.4**
Conflict between SOAP and REST
SOAP and REST can't be together so nobody are using both.

**User of Codeception > v2.2.4**
No conflict between SOAP and REST
it will take seeResponseCodeIs of SOAP or seeResponseCodeIs of REST depends on the order of modules in yml
seeSoapResponseCodeIs will always be the response of SOAP.

Tips : Put the REST module after the SOAP module to be sure to have:
seeResponseCodeIs => REST
seeSoapResponseCodeIs => SOAP

Related to  #3104 