### PR TITLE
Don't fail test validation when exec function is disabled (#3345)

### DIFF
--- a/src/Codeception/Lib/Parser.php
+++ b/src/Codeception/Lib/Parser.php
@@ -131,7 +131,7 @@ class Parser
         if (empty($config['settings']['lint'])) { // lint disabled in config
             return;
         }
-        if(function_exists("exec")) {
+        if (function_exists("exec")) {
             exec("php -l ".escapeshellarg($file)." 2>&1", $output, $code);
         }
         if ($code !== 0) {

--- a/src/Codeception/Lib/Parser.php
+++ b/src/Codeception/Lib/Parser.php
@@ -131,7 +131,9 @@ class Parser
         if (empty($config['settings']['lint'])) { // lint disabled in config
             return;
         }
-        exec("php -l ".escapeshellarg($file)." 2>&1", $output, $code);
+        if(function_exists("exec")) {
+            exec("php -l ".escapeshellarg($file)." 2>&1", $output, $code);
+        }
         if ($code !== 0) {
             throw new TestParseException($file, implode("\n", $output));
         }


### PR DESCRIPTION
Fixes #3324
It is much more elegant solution than @exec. If you want warn user about that validation was not performed. You should do this on entry point, but not each time when this function is being executed.
