### PR TITLE
Fix issue with REST module resetting server parameters

### DIFF
--- a/src/Codeception/Module/REST.php
+++ b/src/Codeception/Module/REST.php
@@ -108,9 +108,6 @@ EOF;
         $this->params = [];
         $this->response = "";
         $this->connectionModule->headers = [];
-        if ($this->client) {
-            $this->client->setServerParameters([]);
-        }
     }
 
     public function _conflicts()


### PR DESCRIPTION
If the REST module is used with the Laravel5 module and the REST module is configured after the Laravel5 module in the suite configuration file, this method will overwrite the server variables set by the Laravel5 module, in this case HTTP_HOST.

My guess is that this method call should have been removed when the `DependsOnModule` functionality for the REST module was implemented, however, I am not really familiar with the REST module, so please review this change before merging.

The issue fixed with this PR is the root cause for the problem in #3263.