### PR TITLE
Fix incorrect example class name in Step docs

### DIFF
--- a/docs/06-ReusingTestCode.md
+++ b/docs/06-ReusingTestCode.md
@@ -177,7 +177,7 @@ As you see, this class is very simple. It extends `AcceptanceTester` class, thus
 <?php
 namespace Step\Acceptance;
 
-class Member extends \AcceptanceTester
+class Admin extends \AcceptanceTester
 {
     public function loginAsAdmin()
     {


### PR DESCRIPTION
It is `Admin` in the other related examples, but was `Member` in this one.

Feel free to slap me if I was supposed to open an issue to accompany the PR, even for a single-word docs typo. 😄 