### PR TITLE
[WebDriver] Improved exception message thrown when click('name') does not match any element

### DIFF
--- a/src/Codeception/Module/WebDriver.php
+++ b/src/Codeception/Module/WebDriver.php
@@ -734,7 +734,11 @@ class WebDriver extends CodeceptionModule implements
         }
         $el = $this->findClickable($page, $link);
         if (!$el) {
-            $els = $this->match($page, $link);
+            try {
+                $els = $this->match($page, $link);
+            } catch (MalformedLocatorException $e) {
+                throw new ElementNotFound("name=$link", "'$link' is invalid CSS and XPath selector and Link or Button");
+            }
             $el = reset($els);
         }
         if (!$el) {

--- a/tests/data/app/view/info.php
+++ b/tests/data/app/view/info.php
@@ -28,6 +28,7 @@
 <p>Текст на русском</p>
 <a href="/">Ссылочка</a>
 <a href="/">Franšízy - pobočky</a>
+<a href="/cookies">Link 3</a>
 
 <a href="/login" class="sign">Sign in!</a>
 

--- a/tests/unit/Codeception/Module/TestsForWeb.php
+++ b/tests/unit/Codeception/Module/TestsForWeb.php
@@ -1490,6 +1490,24 @@ abstract class TestsForWeb extends \Codeception\TestCase\Test
         $this->module->seeCurrentUrlEquals('/');
     }
 
+    /**
+     * @issue https://github.com/Codeception/Codeception/issues/3528
+     */
+    public function testClickThrowsElementNotFoundExceptionWhenTextContainsNumber()
+    {
+        $this->setExpectedException('Codeception\Exception\ElementNotFound',
+            "'Link 2' is invalid CSS and XPath selector and Link or Button element with 'name=Link 2' was not found.");
+        $this->module->amOnPage('/info');
+        $this->module->click('Link 2');
+    }
+
+    public function testClickExistingLinkWithTextContainingNumber()
+    {
+        $this->module->amOnPage('/info');
+        $this->module->click('Link 3');
+        $this->module->seeCurrentUrlEquals('/cookies');
+    }
+
     public function testSelectOptionValueSelector()
     {
         $this->module->amOnPage('/form/select_selectors');


### PR DESCRIPTION
New message matches message thrown by InnerBrowser and looks like this:
```php
$I->click('Link 2');
```
> 'Link 2' is invalid CSS and XPath selector and Link or Button element with 'name=Link 2' was not found.

Fixes #3528