### PR TITLE
Detect cmd/console width on Windows

### DIFF
--- a/src/Codeception/Subscriber/Console.php
+++ b/src/Codeception/Subscriber/Console.php
@@ -521,12 +521,12 @@ class Console implements EventSubscriberInterface
     {
         $this->width = 60;
         if (!$this->isWin()
-            && (php_sapi_name() == "cli")
+            && (php_sapi_name() === "cli")
             && (getenv('TERM'))
             && (getenv('TERM') != 'unknown')
         ) {
             $this->width = (int) (`command -v tput >> /dev/null 2>&1 && tput cols`) - 2;
-        } elseif ($this->isWin() && (php_sapi_name() == "cli")) {
+        } elseif ($this->isWin() && (php_sapi_name() === "cli")) {
             exec('mode con', $output);
             preg_match('/^ +.* +(\d+)$/', $output[4], $matches);
             if (!empty($matches[1])) {

--- a/src/Codeception/Subscriber/Console.php
+++ b/src/Codeception/Subscriber/Console.php
@@ -529,7 +529,7 @@ class Console implements EventSubscriberInterface
         } else if ($this->isWin() && (php_sapi_name() == "cli")) {
             exec('mode con', $output);
             preg_match('/^ +.* +(\d+)$/', $output[4], $matches);
-            $this->width = (int) $matches[1] - 2;
+            $this->width = (int) $matches[1];
         }
 
         return $this->width;

--- a/src/Codeception/Subscriber/Console.php
+++ b/src/Codeception/Subscriber/Console.php
@@ -527,7 +527,7 @@ class Console implements EventSubscriberInterface
         ) {
             $this->width = (int) (`command -v tput >> /dev/null 2>&1 && tput cols`) - 2;
         } else if ($this->isWin() && (php_sapi_name() == "cli")) {
-           $this->width = 200; 
+            $this->width = 200; 
         }
 
         return $this->width;

--- a/src/Codeception/Subscriber/Console.php
+++ b/src/Codeception/Subscriber/Console.php
@@ -526,6 +526,8 @@ class Console implements EventSubscriberInterface
             && (getenv('TERM') != 'unknown')
         ) {
             $this->width = (int) (`command -v tput >> /dev/null 2>&1 && tput cols`) - 2;
+        } else if ($this->isWin() && (php_sapi_name() == "cli")) {
+           $this->width = 200; 
         }
 
         return $this->width;

--- a/src/Codeception/Subscriber/Console.php
+++ b/src/Codeception/Subscriber/Console.php
@@ -529,7 +529,9 @@ class Console implements EventSubscriberInterface
         } elseif ($this->isWin() && (php_sapi_name() == "cli")) {
             exec('mode con', $output);
             preg_match('/^ +.* +(\d+)$/', $output[4], $matches);
-            $this->width = (int) $matches[1];
+            if (!empty($matches[1])) {
+                $this->width = (int) $matches[1];
+            }
         }
         return $this->width;
     }

--- a/src/Codeception/Subscriber/Console.php
+++ b/src/Codeception/Subscriber/Console.php
@@ -527,7 +527,7 @@ class Console implements EventSubscriberInterface
         ) {
             $this->width = (int) (`command -v tput >> /dev/null 2>&1 && tput cols`) - 2;
         } else if ($this->isWin() && (php_sapi_name() == "cli")) {
-            $this->width = 200; 
+            $this->width = 200;
         }
 
         return $this->width;

--- a/src/Codeception/Subscriber/Console.php
+++ b/src/Codeception/Subscriber/Console.php
@@ -526,12 +526,11 @@ class Console implements EventSubscriberInterface
             && (getenv('TERM') != 'unknown')
         ) {
             $this->width = (int) (`command -v tput >> /dev/null 2>&1 && tput cols`) - 2;
-        } else if ($this->isWin() && (php_sapi_name() == "cli")) {
+        } elseif ($this->isWin() && (php_sapi_name() == "cli")) {
             exec('mode con', $output);
             preg_match('/^ +.* +(\d+)$/', $output[4], $matches);
             $this->width = (int) $matches[1];
         }
-
         return $this->width;
     }
 

--- a/src/Codeception/Subscriber/Console.php
+++ b/src/Codeception/Subscriber/Console.php
@@ -527,7 +527,9 @@ class Console implements EventSubscriberInterface
         ) {
             $this->width = (int) (`command -v tput >> /dev/null 2>&1 && tput cols`) - 2;
         } else if ($this->isWin() && (php_sapi_name() == "cli")) {
-            $this->width = 200;
+            exec('mode con', $output);
+            preg_match('/^ +.* +(\d+)$/', $output[4], $matches);
+            $this->width = (int) $matches[1] - 2;
         }
 
         return $this->width;


### PR DESCRIPTION
Hello
I run codeception on Windows
I noticed that on Windows the debug may cause a print error when large method names are used in test suites.

In the code the default width used in method detectWidth is set to 60
As the terminal width is not detected on Windows, this width remains set to 60
This causes the maxLength of the message displayed in debug to be limited to 60 characters
As soon as your method name goes above a certain size the message length grows and may go over 60
And you may have an error occuring in the Step class in method getArgumentsAsString provoked by a division by zero on line 117

I dont know if there is a way to capture the cli width on Windows with PHP. I am not sure of that.
But giving a few more characters to the defaut width value on Windows allowed me to run all tests in debug mode without facing any printing errors