### PR TITLE
Add support for different selectors in WebDriver::submitForm

### DIFF
--- a/src/Codeception/Module/WebDriver.php
+++ b/src/Codeception/Module/WebDriver.php
@@ -1742,6 +1742,24 @@ class WebDriver extends CodeceptionModule implements
      *     ]
      * ]);
      * ```
+     *
+     * The `$button` parameter can be either a string, an array or an instance
+     * of Facebook\WebDriver\WebDriverBy. When it is a string, the
+     * button will be found by its "name" attribute. If $button is an
+     * array then it will be treated as a strict selector and a WebDriverBy
+     * will be used verbatim.
+     *
+     * For example, given the following HTML:
+     *
+     * ``` html
+     * <input type="submit" name="submitButton" value="Submit" />
+     * ```
+     *
+     * `$button` could be any one of the following:
+     *   - 'submitButton'
+     *   - ['name' => 'submitButton']
+     *   - WebDriverBy::name('submitButton')
+     *
      * @param $selector
      * @param $params
      * @param $button
@@ -1806,7 +1824,16 @@ class WebDriver extends CodeceptionModule implements
 
         $submitted = false;
         if (!empty($button)) {
-            $els = $form->findElements(WebDriverBy::name($button));
+            if (is_array($button)) {
+                $buttonSelector = $this->getStrictLocator($button);
+            } elseif ($button instanceof WebDriverBy) {
+                $buttonSelector = $button;
+            } else {
+                $buttonSelector = WebDriverBy::name($button);
+            }
+
+            $els = $form->findElements($buttonSelector);
+
             if (!empty($els)) {
                 $el = reset($els);
                 $el->click();

--- a/tests/data/app/view/form/strict_selectors.php
+++ b/tests/data/app/view/form/strict_selectors.php
@@ -1,0 +1,39 @@
+<html>
+<body>
+<form action="/form/complex" method="POST">
+
+    <input type="hidden" name="action" value="kill_all" />
+    <fieldset disabled="disabled">
+        <input type="text" id="disabled_fieldset" name="disabled_fieldset" value="disabled_fieldset" />
+    </fieldset>
+    <input  type="text" id="disabled_field" name="disabled_field" value="disabled_field" disabled="disabled" />
+    <label for="description">Description</label>
+    <textarea name="description" id="description" cols="30" rows="10"></textarea>
+
+    <label for="name">Name</label>
+    <input type="text" id="name" name="name" value="" />
+
+    <label for="age">Select your age</label>
+    <select name="age" id="age">
+        <option value="child">below 13</option>
+        <option value="teenage">13-21</option>
+        <option value="adult">21-60</option>
+        <option value="oldfag">60-100</option>
+        <option value="dead">100-210</option>
+    </select>
+
+    <select name="no_salutation" id="salutation" disabled="disabled" id="age">
+        <option value="mr" selected="selected">Mr</option>
+        <option value="ms">Mrs</option>
+    </select>
+
+
+    <input type="password" name="password" >
+    <label for="checkin">I Agree</label>
+    <input type="checkbox" id="checkin" name="terms" value="agree" checked="checked" />
+    <input type="submit" value="Submit" id="submit_button" name="submit_button_name" class="button" />
+
+    <?php print_r($_SERVER); ?>
+</form>
+</body>
+</html>

--- a/tests/web/WebDriverTest.php
+++ b/tests/web/WebDriverTest.php
@@ -134,6 +134,74 @@ class WebDriverTest extends TestsForBrowsers
         $this->assertEquals('child', $form['age']);
     }
 
+    /**
+     * @dataProvider strictSelectorProvider
+     */
+    public function testSubmitFormWithButtonAsStrictSelector(array $selector)
+    {
+        $this->module->amOnPage('/form/strict_selectors');
+        $this->module->submitForm('form', [
+                'name' => 'Davert',
+                'age' => 'child',
+                'terms' => 'agree',
+                'description' => 'My Bio'
+        ], $selector);
+
+        $form = data::get('form');
+
+        $this->assertEquals('Davert', $form['name']);
+        $this->assertEquals('kill_all', $form['action']);
+        $this->assertEquals('My Bio', $form['description']);
+        $this->assertEquals('agree', $form['terms']);
+        $this->assertEquals('child', $form['age']);
+    }
+
+    public function strictSelectorProvider()
+    {
+        return [
+            'by id' => [['id' => 'submit_button']],
+            'by name' => [['name' => 'submit_button_name']],
+            'by css' => [['css' => 'form #submit_button']],
+            'by xpath' => [['xpath' => '//*[@id="submit_button"]']],
+            'by link' => [['link' => 'Submit']],
+            'by class' => [['class' => 'button']],
+        ];
+    }
+
+    /**
+     * @dataProvider webDriverByProvider
+     */
+    public function testSubmitFormWithButtonAsWebDriverBy(WebDriverBy $selector)
+    {
+        $this->module->amOnPage('/form/strict_selectors');
+        $this->module->submitForm('form', [
+                'name' => 'Davert',
+                'age' => 'child',
+                'terms' => 'agree',
+                'description' => 'My Bio'
+        ], $selector);
+
+        $form = data::get('form');
+
+        $this->assertEquals('Davert', $form['name']);
+        $this->assertEquals('kill_all', $form['action']);
+        $this->assertEquals('My Bio', $form['description']);
+        $this->assertEquals('agree', $form['terms']);
+        $this->assertEquals('child', $form['age']);
+    }
+
+    public function webDriverByProvider()
+    {
+        return [
+            'by id' => [WebDriverBy::id('submit_button')],
+            'by name' => [WebDriverBy::name('submit_button_name')],
+            'by css selector' => [WebDriverBy::cssSelector('form #submit_button')],
+            'by xpath' => [WebDriverBy::xpath('//*[@id="submit_button"]')],
+            'by link text' => [WebDriverBy::linkText('Submit')],
+            'by class name' => [WebDriverBy::className('button')],
+        ];
+    }
+
     public function testRadioButtonByValue()
     {
         $this->module->amOnPage('/form/radio');


### PR DESCRIPTION
Hi

We've been updating some acceptance tests to use the `submitForm` method, but have hit an issue where some of our buttons don't have a `name` attribute so `submitForm` can't find them. We've been getting around this by adding names to the buttons that were missing them, but it would be nice to be able to find the button through different means so that we don't have to change our code just to write a test.

This PR adds support for strict selectors (e.g. `['id' => 'foo']`) and instances of `WebDriverBy` to be passed to `WebDriver::submitForm` as the `$button` parameter, so that the buttons can be found by more methods than just `name`.

For example, with the following HTML:

``` html
<input type="submit" id="submit" name="submitButton" value="Submit" />
```

`$button` could be any one of the following:
  - `'submitButton'`
  - `['id' => 'submit']`
  - `WebDriverBy::cssSelector('input[name="submitButton"]')`

Or any other valid strict locator or `WebDriverBy`.

The existing behaviour should be unchanged so this won't cause any backwards incompatibility issues.