### PR TITLE
Corrected call_user_func arguments in Yii2

### DIFF
--- a/src/Codeception/Module/Yii2.php
+++ b/src/Codeception/Module/Yii2.php
@@ -167,7 +167,7 @@ class Yii2 extends Framework implements ActiveRecord, PartedModule
 
         // load fixtures before db transaction
         if (method_exists($test, self::TEST_FIXTURES_METHOD)) {
-            $this->haveFixtures(call_user_func($test, self::TEST_FIXTURES_METHOD));
+            $this->haveFixtures(call_user_func([$test, self::TEST_FIXTURES_METHOD]));
         }
 
         if ($this->config['cleanup'] && $this->app->has('db')) {


### PR DESCRIPTION
This code
``` php
// inside Cest file or Codeception\TestCase\Unit
public function _fixtures()
{
    return ['posts' => PostsFixture::className()]
}
```
threw exception: "call_user_func() expects parameter 1 to be a valid callback, no array or string given"

and I fixed it up