### PR TITLE
added Docker image layer badge

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -6,7 +6,7 @@
 [![Gitter](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/Codeception/Codeception?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 [![PHP 7 ready](http://php7ready.timesplinter.ch/Codeception/Codeception/badge.svg)](https://travis-ci.org/Codeception/Codeception)
 [![Scrutinizer Code Quality](https://scrutinizer-ci.com/g/Codeception/Codeception/badges/quality-score.png?b=2.2)](https://scrutinizer-ci.com/g/Codeception/Codeception/?branch=2.2)
-
+[![](https://images.microbadger.com/badges/image/codeception/codeception.svg)](https://microbadger.com/images/codeception/codeception "Get your own image badge on microbadger.com")
 
 **Modern PHP Testing for everyone** 
 


### PR DESCRIPTION
I got this via Mail...

> We saw your image on Docker Hub at codeception/codeception, and we thought you might like this badge for your Docker Hub page showing the image contents. 
>
> The badge that shows the number of layers and download size of your Docker image, and links to our site where you can see the contents of each layer. You can find out more about this - and why it's helpful - in this article. 
>
> If you’d like to use our badge here’s the markdown - you can simply paste this into the full description for codeception/codeception on Docker Hub.

Additional Link: https://medium.com/microscaling-systems/be-docker-image-conscious-deef8008fdce#.d5jh51wfw

Just close this PR, if you're not interested...