### PR TITLE
Fix docblocks for have and haveMultiple methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+#### 2.2.6
+
+* [Laravel5][Lumen] Fixed issue that caused the `have` and `haveMultiple` methods not being available when using the ORM part of the modules. See #3587. By @janhenkgerritsen
+
 #### 2.2.5
 
 * Support for PhpUnit 5.x.

--- a/src/Codeception/Module/Laravel5.php
+++ b/src/Codeception/Module/Laravel5.php
@@ -1029,7 +1029,7 @@ class Laravel5 extends Framework implements ActiveRecord, PartedModule
         return (array) $query->first();
     }
 
-    /*
+    /**
      * Use Laravel's model factory to create a model.
      * Can only be used with Laravel 5.1 and later.
      *
@@ -1057,7 +1057,7 @@ class Laravel5 extends Framework implements ActiveRecord, PartedModule
         }
     }
 
-    /*
+    /**
      * Use Laravel's model factory to create multiple models.
      * Can only be used with Laravel 5.1 and later.
      *

--- a/src/Codeception/Module/Lumen.php
+++ b/src/Codeception/Module/Lumen.php
@@ -476,7 +476,7 @@ class Lumen extends Framework implements ActiveRecord, PartedModule
         return (array)$query->first();
     }
 
-    /*
+    /**
      * Use Lumen's model factory to create a model.
      * Can only be used with Lumen 5.1 and later.
      *
@@ -504,7 +504,7 @@ class Lumen extends Framework implements ActiveRecord, PartedModule
         }
     }
 
-    /*
+    /**
      * Use Laravel's model factory to create multiple models.
      * Can only be used with Lumen 5.1 and later.
      *


### PR DESCRIPTION
The docblocks for the `have` and `haveMultiple` methods of the Laravel5 and Lumen modules were not formatted correctly. Because of this the annotations could not be read, which led to these methods not being available when only using the ORM part of the modules.