### PR TITLE
[Yii1] Escape domain regex

### DIFF
--- a/src/Codeception/Module/Yii1.php
+++ b/src/Codeception/Module/Yii1.php
@@ -234,6 +234,7 @@ class Yii1 extends Framework implements PartedModule
         foreach ($parameters as $name => $value) {
             $template = str_replace("#$name#", $value, $template);
         }
+        $template = str_replace('/', '\\/', $template);
         return '/^' . $template . '$/u';
     }
 


### PR DESCRIPTION
When using Yii1 together with the REST module, the following situation occurs in `InnerBrowser.php:202` when using `http:yii-codeception.test` as url:
```php
preg_match('/^http\://yii\-codeception\.test$/u', 'yii-codeception.test')
```

The call to `preg_match` fails as it treats the slash behind the `http\:` as the end of the regex and sees the following slash as (invalid) regex option. This pull request fixes this. 