### PR TITLE
FIX can failed in console:

### DIFF
--- a/src/Codeception/Scenario.php
+++ b/src/Codeception/Scenario.php
@@ -69,7 +69,12 @@ class Scenario
             $result = $step->run($this->metadata->getService('modules'));
         } catch (ConditionalAssertionFailed $f) {
             $result = $this->test->getTestResultObject();
-            $result->addFailure(clone($this->test), $f, $result->time());
+            if (is_null($result)) {
+                $this->metadata->getService('dispatcher')->dispatch(Events::STEP_AFTER, new StepEvent($this->test, $step));
+                throw $f;
+            } else {
+                $result->addFailure(clone($this->test), $f, $result->time());
+            }
         } catch (\Exception $e) {
             $this->metadata->getService('dispatcher')->dispatch(Events::STEP_AFTER, new StepEvent($this->test, $step));
             throw $e;


### PR DESCRIPTION
PHP Fatal error:  Call to a member function addFailure() on null in ...\Codeception\Scenario.php on line 72

Fatal error: Call to a member function addFailure() on null in ...\Codeception\Scenario.php on line 72

FATAL ERROR. TESTS NOT FINISHED.
Call to a member function addFailure() on null
in ...\Codeception\Scenario.php:72


Reproduce:
1. Run console: codecept console acceptance
2. Run in console: amOnPage('/');
3. Run in console: canSeeElement('#xxx');
... and the error should occurred.