### PR TITLE
Remove backticks from documentation

### DIFF
--- a/docs/modules/WebDriver.md
+++ b/docs/modules/WebDriver.md
@@ -711,7 +711,7 @@ Fills a text field or textarea with the given string.
 
 ``` php
 <?php
-$I->fillField("//input[ * `type='text']",`  "Hello World!");
+$I->fillField("//input[ * type='text']",  "Hello World!");
 $I->fillField(['name' => 'email'], 'jon * `mail.com');` 
 ?>
 ```


### PR DESCRIPTION
There's random backticks in a block in the documentation, so I've removed them!