### PR TITLE
Catch errors in _before for not to crash and continue test execution

### DIFF
--- a/src/Codeception/Test/Test.php
+++ b/src/Codeception/Test/Test.php
@@ -65,7 +65,16 @@ abstract class Test implements TestInterface, Interfaces\Descriptive
     final public function run(\PHPUnit_Framework_TestResult $result = null)
     {
         $this->testResult = $result;
-        $result->startTest($this);
+        $status = self::STATUS_PENDING;
+        $time = 0;
+        $e = null;
+
+        try {
+            $result->startTest($this);
+        } catch (\Exception $e) {
+            $status = self::STATUS_ERROR;
+            $this->ignored = true;
+        }
 
         foreach ($this->hooks as $hook) {
             if (method_exists($this, $hook.'Start')) {
@@ -73,9 +82,6 @@ abstract class Test implements TestInterface, Interfaces\Descriptive
             }
         }
 
-        $status = self::STATUS_PENDING;
-        $time = 0;
-        $e = null;
         if (!$this->ignored) {
             \PHP_Timer::start();
             try {


### PR DESCRIPTION
If exception is thrown in `test.before` tests will continue to be executed but test will be marked as error and skipped. 