### PR TITLE
HTML report to include screenshots of failures from WebDriver

### DIFF
--- a/src/Codeception/Lib/InnerBrowser.php
+++ b/src/Codeception/Lib/InnerBrowser.php
@@ -61,7 +61,8 @@ class InnerBrowser extends Module implements Web, PageSourceSaver, ElementLocato
         }
         $filename = preg_replace('~\W~', '.', Descriptor::getTestSignature($test));
         $filename = mb_strcut($filename, 0, 244, 'utf-8') . '.fail.html';
-        $this->_savePageSource(codecept_output_dir() . $filename);
+        $this->_savePageSource($report = codecept_output_dir() . $filename);
+        $test->getMetadata()->addReport('html', $report);
     }
 
     public function _after(TestInterface $test)

--- a/src/Codeception/Module/WebDriver.php
+++ b/src/Codeception/Module/WebDriver.php
@@ -374,8 +374,10 @@ class WebDriver extends CodeceptionModule implements
         $this->debugWebDriverLogs();
         $filename = preg_replace('~\W~', '.', Descriptor::getTestSignature($test));
         $outputDir = codecept_output_dir();
-        $this->_saveScreenshot($outputDir . mb_strcut($filename, 0, 245, 'utf-8') . '.fail.png');
-        $this->_savePageSource($outputDir . mb_strcut($filename, 0, 244, 'utf-8') . '.fail.html');
+        $this->_saveScreenshot($report = $outputDir . mb_strcut($filename, 0, 245, 'utf-8') . '.fail.png');
+        $test->getMetadata()->addReport('png', $report);
+        $this->_savePageSource($report = $outputDir . mb_strcut($filename, 0, 244, 'utf-8') . '.fail.html');
+        $test->getMetadata()->addReport('html', $report);
         $this->debug("Screenshot and page source were saved into '$outputDir' dir");
     }
 

--- a/src/Codeception/PHPUnit/ResultPrinter/HTML.php
+++ b/src/Codeception/PHPUnit/ResultPrinter/HTML.php
@@ -6,6 +6,7 @@ use Codeception\Step;
 use Codeception\Step\Meta;
 use Codeception\Test\Descriptor;
 use Codeception\Test\Interfaces\ScenarioDriven;
+use Codeception\TestInterface;
 
 class HTML extends CodeceptionResultPrinter
 {
@@ -132,16 +133,27 @@ class HTML extends CodeceptionResultPrinter
             $failure = $failTemplate->render();
         }
 
+        $png = '';
+        if ($test instanceof TestInterface) {
+            $reports = $test->getMetadata()->getReports();
+            if (isset($reports['png'])) {
+                $png = "<tr><td class='error screenshot'><img src='{$reports['png']}' alt='failure screenshot'></td></tr>";
+            }
+        }
+
         $toggle = $stepsBuffer ? '<span class="toggle">+</span>' : '';
+
+        $testString = preg_replace('~^([\s\w\\\]+):\s~', '<span class="quiet">$1 &raquo;</span> ', ucfirst(Descriptor::getTestAsString($test)));
 
         $scenarioTemplate->setVar(
             [
                 'id'             => ++$this->id,
-                'name'           => ucfirst(Descriptor::getTestAsString($test)),
+                'name'           => $testString,
                 'scenarioStatus' => $scenarioStatus,
                 'steps'          => $stepsBuffer,
                 'toggle'         => $toggle,
                 'failure'        => $failure,
+                'png'            => $png,
                 'time'           => round($time, 2)
             ]
         );

--- a/src/Codeception/PHPUnit/ResultPrinter/HTML.php
+++ b/src/Codeception/PHPUnit/ResultPrinter/HTML.php
@@ -134,11 +134,16 @@ class HTML extends CodeceptionResultPrinter
         }
 
         $png = '';
+        $html = '';
         if ($test instanceof TestInterface) {
             $reports = $test->getMetadata()->getReports();
             if (isset($reports['png'])) {
-                $png = "<tr><td class='error screenshot'><img src='{$reports['png']}' alt='failure screenshot'></td></tr>";
+                $png = "<tr><td class='error'><div class='screenshot'><img src='file://{$reports['png']}' alt='failure screenshot'></div></td></tr>";
             }
+            if (isset($reports['html'])) {
+                $html = "<tr><td class='error'>See <a href='file://{$reports['html']}' target='_blank'>HTML snapshot</a> of a failed page</td></tr>";
+            }
+
         }
 
         $toggle = $stepsBuffer ? '<span class="toggle">+</span>' : '';
@@ -154,6 +159,7 @@ class HTML extends CodeceptionResultPrinter
                 'toggle'         => $toggle,
                 'failure'        => $failure,
                 'png'            => $png,
+                'html'            => $html,
                 'time'           => round($time, 2)
             ]
         );

--- a/src/Codeception/PHPUnit/ResultPrinter/template/scenario.html.dist
+++ b/src/Codeception/PHPUnit/ResultPrinter/template/scenario.html.dist
@@ -11,8 +11,10 @@
 
 {steps}
          {failure}
-
+         {png}
      </table>
+
+
     </td>
    </tr>
 

--- a/src/Codeception/PHPUnit/ResultPrinter/template/scenario.html.dist
+++ b/src/Codeception/PHPUnit/ResultPrinter/template/scenario.html.dist
@@ -12,6 +12,7 @@
 {steps}
          {failure}
          {png}
+         {html}
      </table>
 
 

--- a/src/Codeception/PHPUnit/ResultPrinter/template/scenarios.html.dist
+++ b/src/Codeception/PHPUnit/ResultPrinter/template/scenarios.html.dist
@@ -20,21 +20,22 @@
 		 .scenarioStepsTable .stepName { padding: 5px; }
 
 		 .scenarioStepsTable td {
-		 border: 1px solid #ccc;
-		 font-family: 'Varela Round', arial;
-		 -webkit-border-radius: 5px;
-		 -moz-border-radius: 5px;
-		 border-radius: 5px;
-		 background: rgb(255,255,255); /* Old browsers */
-		 background: -moz-linear-gradient(top, rgba(255,255,255,1) 0%, rgba(229,229,229,1) 100%); /* FF3.6+ */
-		 background: -webkit-gradient(linear, left top, left bottom, color-stop(0%,rgba(255,255,255,1)), color-stop(100%,rgba(229,229,229,1))); /* Chrome,Safari4+ */
-		 background: -webkit-linear-gradient(top, rgba(255,255,255,1) 0%,rgba(229,229,229,1) 100%); /* Chrome10+,Safari5.1+ */
-		 background: -o-linear-gradient(top, rgba(255,255,255,1) 0%,rgba(229,229,229,1) 100%); /* Opera11.10+ */
-		 background: -ms-linear-gradient(top, rgba(255,255,255,1) 0%,rgba(229,229,229,1) 100%); /* IE10+ */
-		 filter: progid:DXImageTransform.Microsoft.gradient( startColorstr='#ffffff', endColorstr='#e5e5e5',GradientType=0 ); /* IE6-9 */
-		 background: linear-gradient(top, rgba(255,255,255,1) 0%,rgba(229,229,229,1) 100%); /* W3C */
-
+            background: #fff;
 		 }
+
+         .quiet {
+             color: #333;
+             font-size: 0.8em;
+         }
+
+         .screenshot {
+             max-height: 400px;
+             overflow-y: scroll;
+             display: block;
+         }
+         .screenshot img {
+             zoom: 0.5;
+         }
 
          @media (max-width: 1200px) {
            #toolbar-filter {

--- a/src/Codeception/PHPUnit/ResultPrinter/template/scenarios.html.dist
+++ b/src/Codeception/PHPUnit/ResultPrinter/template/scenarios.html.dist
@@ -71,6 +71,10 @@
              border-radius: 0px;
          }
 
+         .scenarioStepsTable .error a {
+             color: #eef;
+         }
+
          .scenarioStepsTable.substeps td {
              background: #bdc3c7;
          }

--- a/src/Codeception/PHPUnit/ResultPrinter/template/step.html.dist
+++ b/src/Codeception/PHPUnit/ResultPrinter/template/step.html.dist
@@ -1,4 +1,4 @@
       <tr>
-       <td class="stepName {error}">{action}</td>
+       <td class="stepName {error}">&nbsp;&nbsp; {action}</td>
       </tr>
 

--- a/src/Codeception/PHPUnit/ResultPrinter/template/step.html.dist
+++ b/src/Codeception/PHPUnit/ResultPrinter/template/step.html.dist
@@ -1,4 +1,4 @@
       <tr>
-       <td class="stepName {error}">&nbsp;&nbsp; {action}</td>
+       <td class="stepName {error}">&nbsp;&nbsp;&nbsp;&nbsp;{action}</td>
       </tr>
 

--- a/src/Codeception/Test/Metadata.php
+++ b/src/Codeception/Test/Metadata.php
@@ -17,6 +17,7 @@ class Metadata
 
     protected $current = [];
     protected $services = [];
+    protected $reports = [];
 
     /**
      * @return mixed
@@ -190,5 +191,22 @@ class Metadata
     public function setServices($services)
     {
         $this->services = $services;
+    }
+
+    /**
+     * @return array
+     */
+    public function getReports()
+    {
+        return $this->reports;
+    }
+
+    /**
+     * @param $type
+     * @param $report
+     */
+    public function addReport($type, $report)
+    {
+        $this->reports[$type] = $report;
     }
 }


### PR DESCRIPTION
* added `reports` section to MetaData in tests
* WebDriver to store html and png reports to metadata
* improved styling of HTML report

![selection_154](https://cloud.githubusercontent.com/assets/220264/19292875/0854170a-9028-11e6-8e47-bb91568bff10.png)
