### PR TITLE
Improved message for connection failures in WebDriver

### DIFF
--- a/src/Codeception/Module/AngularJS.php
+++ b/src/Codeception/Module/AngularJS.php
@@ -2,6 +2,7 @@
 namespace Codeception\Module;
 
 use Codeception\Step;
+use Codeception\TestInterface;
 use Facebook\WebDriver\WebDriverBy;
 
 /**
@@ -83,9 +84,9 @@ EOF;
         parent::_setConfig(array_merge($this->defaultAngularConfig, $config));
     }
 
-    public function _initialize()
+    public function _before(TestInterface $test)
     {
-        parent::_initialize();
+        parent::_before($test);
         $this->webDriver->manage()->timeouts()->setScriptTimeout($this->config['script_timeout']);
     }
 

--- a/src/Codeception/Module/WebDriver.php
+++ b/src/Codeception/Module/WebDriver.php
@@ -294,7 +294,6 @@ class WebDriver extends CodeceptionModule implements
         $this->connectionTimeoutInMs = $this->config['connection_timeout'] * 1000;
         $this->requestTimeoutInMs = $this->config['request_timeout'] * 1000;
         $this->loadFirefoxProfile();
-        $this->_initializeSession();
     }
 
     public function _conflicts()
@@ -305,7 +304,7 @@ class WebDriver extends CodeceptionModule implements
     public function _before(TestInterface $test)
     {
         if (!isset($this->webDriver)) {
-            $this->_initialize();
+            $this->_initializeSession();
         }
         $test->getMetadata()->setCurrent([
             'browser' => $this->config['browser'],
@@ -1138,10 +1137,8 @@ class WebDriver extends CodeceptionModule implements
             $this->sessions[] = $this->_backupSession();
             $this->webDriver->manage()->timeouts()->implicitlyWait($this->config['wait']);
             $this->initialWindowSize();
-        } catch (\Exception $e) {
-            throw new ConnectionException(
-                $e->getMessage() . "\n \nPlease make sure that Selenium Server or PhantomJS is running."
-            );
+        } catch (WebDriverCurlException $e) {
+            throw new ConnectionException("Can't connect to Webdriver at {$this->wd_host}. Please make sure that Selenium Server or PhantomJS is running.");
         }
     }
 

--- a/src/Codeception/Test/Test.php
+++ b/src/Codeception/Test/Test.php
@@ -72,8 +72,9 @@ abstract class Test implements TestInterface, Interfaces\Descriptive
         
         try {
             $result->startTest($this);
-        } catch (\Exception $e) {
-            $status = self::STATUS_ERROR;
+        } catch (\Exception $er) {
+            // failure is created: not a user's test code error so we don't need detailed stacktrace
+            $this->testResult->addError($this, new \PHPUnit_Framework_AssertionFailedError($er->getMessage()), 0);
             $this->ignored = true;
         }
 


### PR DESCRIPTION
Some additional improvements to #3534 

* Changed how errors are added for in test.before listeners
* Fixed AngularJS + WebDriver compatibility
* Selenium connection failure message is single line now

![selection_155](https://cloud.githubusercontent.com/assets/220264/19293543/f2da5884-902d-11e6-981a-3d68c97a0185.png)