### PR TITLE
better Example::offsetExists() behavior

### DIFF
--- a/src/Codeception/Example.php
+++ b/src/Codeception/Example.php
@@ -26,7 +26,7 @@ class Example implements \ArrayAccess, \Countable, \IteratorAggregate
      */
     public function offsetExists($offset)
     {
-        return isset($this->data[$offset]);
+        return array_key_exists($offset, $this->data);
     }
 
     /**


### PR DESCRIPTION
Differentiate between missing keys and those with NULL values.