### PR TITLE
Seeder improvement in Laravel5 Module (#3552)

### DIFF
--- a/src/Codeception/Module/Laravel5.php
+++ b/src/Codeception/Module/Laravel5.php
@@ -110,7 +110,9 @@ class Laravel5 extends Framework implements ActiveRecord, PartedModule
             [
                 'cleanup' => true,
                 'run_database_migrations' => false,
+                'run_database_seeder' => false,
                 'database_migrations_path' => '',
+                'database_seeder_class' => ['DatabaseSeeder'],
                 'environment_file' => '.env',
                 'bootstrap' => 'bootstrap' . DIRECTORY_SEPARATOR . 'app.php',
                 'root' => '',
@@ -162,6 +164,13 @@ class Laravel5 extends Framework implements ActiveRecord, PartedModule
         if ($this->config['run_database_migrations']) {
             // Must be called before database transactions are started
             $this->callArtisan('migrate', ['--path' => $this->config['database_migrations_path']]);
+        }
+
+        if ($this->config['run_database_seeder']) {
+            // Must be called before database transactions are started
+            foreach ($this->config['database_seeder_class'] as $seeder_class) {
+                $this->callArtisan('db:seed', ['--class' => $seeder_class]);
+            }
         }
 
         if (isset($this->app['db']) && $this->config['cleanup']) {

--- a/src/Codeception/Module/Laravel5.php
+++ b/src/Codeception/Module/Laravel5.php
@@ -112,7 +112,7 @@ class Laravel5 extends Framework implements ActiveRecord, PartedModule
                 'run_database_migrations' => false,
                 'run_database_seeder' => false,
                 'database_migrations_path' => '',
-                'database_seeder_class' => ['DatabaseSeeder'],
+                'database_seeder_class' => 'DatabaseSeeder',
                 'environment_file' => '.env',
                 'bootstrap' => 'bootstrap' . DIRECTORY_SEPARATOR . 'app.php',
                 'root' => '',
@@ -168,9 +168,7 @@ class Laravel5 extends Framework implements ActiveRecord, PartedModule
 
         if ($this->config['run_database_seeder']) {
             // Must be called before database transactions are started
-            foreach ($this->config['database_seeder_class'] as $seeder_class) {
-                $this->callArtisan('db:seed', ['--class' => $seeder_class]);
-            }
+            $this->callArtisan('db:seed', ['--class' => $this->config['database_seeder_class']]);
         }
 
         if (isset($this->app['db']) && $this->config['cleanup']) {


### PR DESCRIPTION
Hello again,
I've made a more simple way for seeding the database.
So now you can set these parameters in the config file :
```yml
class_name: FunctionalTester
modules:
    enabled:
        - Laravel5:
            run_database_migrations: true      # not required to run seeding
            run_database_seeder: true          # required to use this feature
            database_seeder_class:             # not required ( must be an array )
            - UserTableSeeder
            - AnotherTableSeeder
```
If you didn't specify any seeder, the default `DatabaseSeeder` will be used.
Seeders are runned in the order of the array.

@janhenkgerritsen what do you think ? 
