### PR TITLE
fix 3392: normalize namespace in DI getter

### DIFF
--- a/src/Codeception/Lib/Di.php
+++ b/src/Codeception/Lib/Di.php
@@ -21,6 +21,8 @@ class Di
 
     public function get($className)
     {
+        // normalize namespace
+        $className = ltrim($className, '\\');
         return isset($this->container[$className]) ? $this->container[$className] : null;
     }
 


### PR DESCRIPTION
Fix #3392 
Caused by https://github.com/Codeception/Codeception/commit/27d9994262b9649c1c1173070413dad031ccd5f6 . Namespace normalizing was added into instantiate method, but missed in getter.