### PR TITLE
Undefined variable  change to the correct  in MongoDb Module

### DIFF
--- a/src/Codeception/Module/MongoDb.php
+++ b/src/Codeception/Module/MongoDb.php
@@ -140,7 +140,7 @@ class MongoDb extends CodeceptionModule implements RequiresPackage
                 $this->isDumpFileEmpty = true;
                 $dumpDir = dir($this->dumpFile);
                 while (false !== ($entry = $dumpDir->read())) {
-                    if ($entity !== '..' && $entity !== '.') {
+                    if ($entry !== '..' && $entry !== '.') {
                         $this->isDumpFileEmpty = false;
                         break;
                     }


### PR DESCRIPTION
There were an issue with MongoDb Module. Variable `$enitiy` were undefined. I suppose that author meant `$entry` and just made a typo there. It doesn't affect anything except data import using `mongotype` dump type.