### PR TITLE
Mongofill support

### DIFF
--- a/src/Codeception/Lib/Driver/MongoDb.php
+++ b/src/Codeception/Lib/Driver/MongoDb.php
@@ -95,7 +95,7 @@ class MongoDb
      */
     public function __construct($dsn, $user, $password)
     {
-        $this->legacy = class_exists('\\MongoClient');
+        $this->legacy = class_exists('\\MongoClient') && strpos(\MongoClient::VERSION, 'mongofill') === false;
 
         /* defining DB name */
         $this->dbName = substr($dsn, strrpos($dsn, '/') + 1);


### PR DESCRIPTION
If someone are using MongoDb with PHP7 or HHVM, he forced to use mongofill package(https://github.com/mongofill/mongofill). Mongofill has class MongoClient in the root namespace but it does't means that it's using legacy `mongo` driver instead of current `mongodb`. In order to make it work with Codeception MongoDB module I changed the way you check if user uses legacy driver by adding additional condition. So if there is `\MongoClient` class and there is no `mongofill` substring in its version -> use legacy mode. Normal mode otherwise.
Before fixing that cleaning of the database didn't work and I've got errors on duplicate keys every test which were using db.