### PR TITLE
Fix a minor typo with PHPDoc generation

### DIFF
--- a/src/Codeception/Lib/Interfaces/Web.php
+++ b/src/Codeception/Lib/Interfaces/Web.php
@@ -649,7 +649,7 @@ interface Web
      * $I->selectOption('Which OS do you use?', array('text' => 'Windows')); // Only search by text 'Windows'
      * $I->selectOption('Which OS do you use?', array('value' => 'windows')); // Only search by value 'windows'
      * ?>
-     + ```
+     * ```
      *
      * @param $select
      * @param $option

--- a/tests/data/claypit/tests/_support/_generated/OtherGuyActions.php
+++ b/tests/data/claypit/tests/_support/_generated/OtherGuyActions.php
@@ -1440,7 +1440,7 @@ trait OtherGuyActions
      * $I->selectOption('Which OS do you use?', array('text' => 'Windows')); // Only search by text 'Windows'
      * $I->selectOption('Which OS do you use?', array('value' => 'windows')); // Only search by value 'windows'
      * ?>
-     + ```
+     * ```
      *
      * @param $select
      * @param $option

--- a/tests/support/_generated/AngularGuyActions.php
+++ b/tests/support/_generated/AngularGuyActions.php
@@ -1406,7 +1406,7 @@ trait AngularGuyActions
      * $I->selectOption('Which OS do you use?', array('text' => 'Windows')); // Only search by text 'Windows'
      * $I->selectOption('Which OS do you use?', array('value' => 'windows')); // Only search by value 'windows'
      * ?>
-     + ```
+     * ```
      *
      * @param $select
      * @param $option

--- a/tests/support/_generated/WebGuyActions.php
+++ b/tests/support/_generated/WebGuyActions.php
@@ -1381,7 +1381,7 @@ trait WebGuyActions
      * $I->selectOption('Which OS do you use?', array('text' => 'Windows')); // Only search by text 'Windows'
      * $I->selectOption('Which OS do you use?', array('value' => 'windows')); // Only search by value 'windows'
      * ?>
-     + ```
+     * ```
      *
      * @param $select
      * @param $option


### PR DESCRIPTION
This fixes an incredibly small typo in a couple of the PHPDoc blocks which have a plus sign instead of an asterisk.