### PR TITLE
Fixes #3551 - Monolog implementation

### DIFF
--- a/ext/Logger.php
+++ b/ext/Logger.php
@@ -11,6 +11,7 @@ use Codeception\Extension;
 use Codeception\Test\Descriptor;
 use Monolog\Handler\RotatingFileHandler;
 use Codeception\Configuration as Config;
+use Psr\Log\LoggerInterface;
 
 /**
  * Log suites/tests/steps using Monolog library.
@@ -37,15 +38,15 @@ use Codeception\Configuration as Config;
 class Logger extends Extension
 {
     public static $events = [
-        Events::SUITE_BEFORE => 'beforeSuite',
-        Events::TEST_BEFORE => 'beforeTest',
-        Events::TEST_AFTER => 'afterTest',
-        Events::TEST_END => 'endTest',
-        Events::STEP_BEFORE => 'beforeStep',
-        Events::TEST_FAIL => 'testFail',
-        Events::TEST_ERROR => 'testError',
+        Events::SUITE_BEFORE    => 'beforeSuite',
+        Events::TEST_BEFORE     => 'beforeTest',
+        Events::TEST_AFTER      => 'afterTest',
+        Events::TEST_END        => 'endTest',
+        Events::STEP_BEFORE     => 'beforeStep',
+        Events::TEST_FAIL       => 'testFail',
+        Events::TEST_ERROR      => 'testError',
         Events::TEST_INCOMPLETE => 'testIncomplete',
-        Events::TEST_SKIPPED => 'testSkipped',
+        Events::TEST_SKIPPED    => 'testSkipped',
     ];
 
     protected $logHandler;

--- a/ext/Logger.php
+++ b/ext/Logger.php
@@ -150,48 +150,9 @@ class Logger extends Extension
         self::info((string)$e->getStep());
     }
 
-    public static function emergency($message, array $context = array())
+    public static function __callStatic($name, $arguments)
     {
-        self::getLogger()->emergency($message, $context);
-    }
-
-    public static function alert($message, array $context = array())
-    {
-        self::getLogger()->alert($message, $context);
-    }
-
-    public static function critical($message, array $context = array())
-    {
-        self::getLogger()->critical($message, $context);
-    }
-
-    public static function error($message, array $context = array())
-    {
-        self::getLogger()->error($message, $context);
-    }
-
-    public static function warning($message, array $context = array())
-    {
-        self::getLogger()->warning($message, $context);
-    }
-
-    public static function notice($message, array $context = array())
-    {
-        self::getLogger()->emergency($message, $context);
-    }
-
-    public static function info($message, array $context = array())
-    {
-        self::getLogger()->info($message, $context);
-    }
-
-    public static function debug($message, array $context = array())
-    {
-        self::getLogger()->debug($message, $context);
-    }
-
-    public static function log($level, $message, array $context = array())
-    {
-        self::getLogger()->log($level, $message, $context);
+        $logger = self::getLogger();
+        call_user_func_array(array($logger, $name), $arguments);
     }
 }


### PR DESCRIPTION
Hey,

I had a crack at https://github.com/Codeception/Codeception/issues/3551 - You can now use Monolog how you'd usually use it in any of your tests, plus they all log with the correct namespace. 
