### PR TITLE
Fix for issue #3612

### DIFF
--- a/src/Codeception/Module/Yii2.php
+++ b/src/Codeception/Module/Yii2.php
@@ -166,12 +166,26 @@ class Yii2 extends Framework implements ActiveRecord, PartedModule
         $this->app = $this->client->getApplication();
 
         // load fixtures before db transaction
-        if (method_exists($test, self::TEST_FIXTURES_METHOD)) {
-            $this->haveFixtures(call_user_func([$test, self::TEST_FIXTURES_METHOD]));
+        if ($test instanceof \Codeception\Test\Cest) {
+            $this->loadFixtures($test->getTestClass());
+        } else {
+            $this->loadFixtures($test);
         }
 
         if ($this->config['cleanup'] && $this->app->has('db')) {
             $this->transaction = $this->app->db->beginTransaction();
+        }
+    }
+
+    /**
+     * load fixtures before db transaction
+     *
+     * @param mixed $test instance of test class
+     */
+    private function loadFixtures($test)
+    {
+        if (method_exists($test, self::TEST_FIXTURES_METHOD)) {
+            $this->haveFixtures(call_user_func([$test, self::TEST_FIXTURES_METHOD]));
         }
     }
 


### PR DESCRIPTION
Now in Codeception Yii2 Module Documentation at http://codeception.com/docs/modules/Yii2 on Fixture section now placed code example:
```php
<?php
// inside Cest file or Codeception\TestCase\Unit
public function _fixtures()
{
    return ['posts' => PostsFixture::className()]
}
```
For Cest file it does not work before this commit

Fixes #3612