### PR TITLE
add gherkin docs

### DIFF
--- a/src/Codeception/Module/WebDriver.php
+++ b/src/Codeception/Module/WebDriver.php
@@ -544,6 +544,8 @@ class WebDriver extends CodeceptionModule implements
      * ?>
      * ```
      *
+     * @When I save a screenshot in :name
+     *
      * @param $name
      */
     public function makeScreenshot($name)


### PR DESCRIPTION
I would suggest to put gherkin docs into the modules. I have add an example to demonstrate it. If it would excepted i can do more work. this has two benefits

1. codeception comes with a lot of default gherkin steps like behat does
2. you don't need boilerplate code in your *Tester.php classes like
```
    /**
     * Saving a screenshot
     *
     * @When I save a screenshot in :filename
     */
    public function iSaveAScreenshotIn($filename)
    {
        $this->makeScreenshot($filename);
    }
```

I would also suggest to orientate on behat|mink|behatch to make the migration as simple as possible. 