### PR TITLE
Allow to get groups from scenario

### DIFF
--- a/src/Codeception/Scenario.php
+++ b/src/Codeception/Scenario.php
@@ -51,6 +51,11 @@ class Scenario
         return $this->metadata->getFeature();
     }
 
+    public function getGroups()
+    {
+        return $this->metadata->getGroups();
+    }
+
     public function current($key)
     {
         return $this->metadata->getCurrent($key);


### PR DESCRIPTION
Hi!
We use groups also to indicate that a test should, for instance, not being executed on firefox. So we do a:
`* @group non_firefox`

It would be great to have a getter for groups in the Scenario class.
Having that, we can do things like:

`        $groups = $scenario->getGroups();
`
`       if (in_array('non_firefox', $groups) and $scenario->current('browser') == 'firefox') {
            $scenario->skip();
        }`

Thanks for this great tool!
Lars