### PR TITLE
Fix #3225

### DIFF
--- a/src/Codeception/PHPUnit/ResultPrinter/HTML.php
+++ b/src/Codeception/PHPUnit/ResultPrinter/HTML.php
@@ -123,14 +123,16 @@ class HTML extends CodeceptionResultPrinter
             $this->templatePath . 'scenario.html'
         );
 
-        $failure = '';
+        $failures = '';
         $name = Descriptor::getTestSignature($test);
         if (isset($this->failures[$name])) {
             $failTemplate = new \Text_Template(
                 $this->templatePath . 'fail.html'
             );
-            $failTemplate->setVar(['fail' => nl2br($this->failures[$name])]);
-            $failure = $failTemplate->render();
+            foreach ($this->failures[$name] as $failure) {
+                $failTemplate->setVar(['fail' => nl2br($failure)]);
+                $failures .= $failTemplate->render() . PHP_EOL;
+            }
         }
 
         $png = '';
@@ -157,7 +159,7 @@ class HTML extends CodeceptionResultPrinter
                 'scenarioStatus' => $scenarioStatus,
                 'steps'          => $stepsBuffer,
                 'toggle'         => $toggle,
-                'failure'        => $failure,
+                'failure'        => $failures,
                 'png'            => $png,
                 'html'            => $html,
                 'time'           => round($time, 2)
@@ -232,7 +234,7 @@ class HTML extends CodeceptionResultPrinter
      */
     public function addError(\PHPUnit_Framework_Test $test, \Exception $e, $time)
     {
-        $this->failures[Descriptor::getTestSignature($test)] = $this->cleanMessage($e);
+        $this->failures[Descriptor::getTestSignature($test)][] = $this->cleanMessage($e);
         parent::addError($test, $e, $time);
     }
 
@@ -245,7 +247,7 @@ class HTML extends CodeceptionResultPrinter
      */
     public function addFailure(\PHPUnit_Framework_Test $test, \PHPUnit_Framework_AssertionFailedError $e, $time)
     {
-        $this->failures[Descriptor::getTestSignature($test)] = $this->cleanMessage($e);
+        $this->failures[Descriptor::getTestSignature($test)][] = $this->cleanMessage($e);
         parent::addFailure($test, $e, $time);
     }
 


### PR DESCRIPTION
Fix #3225

**Html part** - only one error/fail was saved, added nested array to fix it.

**Console part** - only the first failed step used always. 
1. Renamed `$this->fails` to `$this->conditionalFails`, as it really contains only `ConditionalAssertion` steps.
2. Added `$this->failedStep`.
3. Changed fails' handling in `printScenarioFail()`.
4. In `writelnFinishedTest()` renamed `$conditionalFails` to `$conditionalFailsMessage` to separate it from `$this->conditionalFails`.
5. Also removed excess second argument from `printScenarioTrace()` call. 

**Fixed html**: [report.html.zip](https://github.com/Codeception/Codeception/files/573155/report.html.zip)


**Fixed console output**:
```
Codeception PHP Testing Framework v2.2.6
Powered by PHPUnit 4.8.27 by Sebastian Bergmann and contributors.

Api Tests (1) ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
CanCept: Perform actions and see result
Signature: CanCept
Test: tests/api/temp/CanCept.php
Scenario --
 I am on page "/"
 I can see element "//nothere"
 FAIL 

 I can see element "//nothereeither"
 FAIL 

 I can see element "//doesntexist"
 FAIL 

 PASSED 

--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------


Time: 1.05 seconds, Memory: 22.00MB

There were 3 failures:

---------
1) CanCept: Perform actions and see result
 Test  tests/api/temp/CanCept.php
 Step  Can see element "//nothere"
 Fail  Element located either by name, CSS or XPath element with '//nothere' was not found.

Scenario Steps:

 4. $I->canSeeElement("//doesntexist") at tests/api/temp/CanCept.php:9
 3. $I->canSeeElement("//nothereeither") at tests/api/temp/CanCept.php:8
 2. $I->canSeeElement("//nothere") at tests/api/temp/CanCept.php:7
 1. $I->amOnPage("/") at tests/api/temp/CanCept.php:5


---------
2) CanCept: Perform actions and see result
 Test  tests/api/temp/CanCept.php
 Step  Can see element "//nothereeither"
 Fail  Element located either by name, CSS or XPath element with '//nothereeither' was not found.

Scenario Steps:

 4. $I->canSeeElement("//doesntexist") at tests/api/temp/CanCept.php:9
 3. $I->canSeeElement("//nothereeither") at tests/api/temp/CanCept.php:8
 2. $I->canSeeElement("//nothere") at tests/api/temp/CanCept.php:7
 1. $I->amOnPage("/") at tests/api/temp/CanCept.php:5


---------
3) CanCept: Perform actions and see result
 Test  tests/api/temp/CanCept.php
 Step  Can see element "//doesntexist"
 Fail  Element located either by name, CSS or XPath element with '//doesntexist' was not found.

Scenario Steps:

 4. $I->canSeeElement("//doesntexist") at tests/api/temp/CanCept.php:9
 3. $I->canSeeElement("//nothereeither") at tests/api/temp/CanCept.php:8
 2. $I->canSeeElement("//nothere") at tests/api/temp/CanCept.php:7
 1. $I->amOnPage("/") at tests/api/temp/CanCept.php:5


FAILURES!
Tests: 1, Assertions: 3, Failures: 3.
- HTML report generated in file:///Users/mitrichius/projects/codeception-issue/tests/_output/report.html
```