### PR TITLE
[Sqlite] Use _ROWID_ to remove inserted rows after test

### DIFF
--- a/src/Codeception/Lib/Driver/Sqlite.php
+++ b/src/Codeception/Lib/Driver/Sqlite.php
@@ -53,6 +53,10 @@ class Sqlite extends Db
     public function getPrimaryKey($tableName)
     {
         if (!isset($this->primaryKeys[$tableName])) {
+            if ($this->hasRowId($tableName)) {
+                return $this->primaryKeys[$tableName] = ['_ROWID_'];
+            }
+
             $primaryKey = [];
             $query = 'PRAGMA table_info(' . $this->getQuotedName($tableName) . ')';
             $stmt = $this->executeQuery($query, []);
@@ -68,5 +72,18 @@ class Sqlite extends Db
         }
 
         return $this->primaryKeys[$tableName];
+    }
+
+    /**
+     * @param $tableName
+     * @return bool
+     */
+    private function hasRowId($tableName)
+    {
+        $params = ['type' => 'table', 'name' => $tableName];
+        $select = $this->select('sql', 'sqlite_master', $params);
+        $result = $this->executeQuery($select, $params);
+        $sql = $result->fetchColumn(0);
+        return strpos($sql, ') WITHOUT ROWID') === false;
     }
 }

--- a/tests/data/dumps/sqlite-54.sql
+++ b/tests/data/dumps/sqlite-54.sql
@@ -11,14 +11,21 @@ INSERT INTO "permissions" VALUES(5,3,2,'member');
 INSERT INTO "permissions" VALUES(7,4,2,'admin');
 
 DROP TABLE IF EXISTS "users";
-CREATE TABLE "users" ("id" INTEGER PRIMARY KEY  AUTOINCREMENT  NOT NULL , "name" VARCHAR, "email" VARCHAR, "created_at" DATETIME DEFAULT CURRENT_TIMESTAMP);
-INSERT INTO "users" VALUES(1,'davert','davert@mail.ua','2012-02-01 21:17:04');
-INSERT INTO "users" VALUES(2,'nick','nick@mail.ua','2012-02-01 21:17:15');
-INSERT INTO "users" VALUES(3,'miles','miles@davis.com','2012-02-01 21:17:25');
-INSERT INTO "users" VALUES(4,'bird','charlie@parker.com','2012-02-01 21:17:39');
+CREATE TABLE "users" ("name" VARCHAR, "email" VARCHAR, "created_at" DATETIME DEFAULT CURRENT_TIMESTAMP);
+INSERT INTO "users" VALUES('davert','davert@mail.ua','2012-02-01 21:17:04');
+INSERT INTO "users" VALUES('nick','nick@mail.ua','2012-02-01 21:17:15');
+INSERT INTO "users" VALUES('miles','miles@davis.com','2012-02-01 21:17:25');
+INSERT INTO "users" VALUES('bird','charlie@parker.com','2012-02-01 21:17:39');
 
 DROP TABLE IF EXISTS "empty_table";
 CREATE TABLE "empty_table" ("id" INTEGER PRIMARY KEY  AUTOINCREMENT  NOT NULL , "field" VARCHAR);
+
+CREATE TABLE "composite_pk" (
+  "group_id" INTEGER NOT NULL,
+  "id" INTEGER NOT NULL,
+  "status" VARCHAR NOT NULL,
+  PRIMARY KEY ("group_id", "id")
+);
 
 CREATE TABLE "no_pk" (
   "status" VARCHAR NOT NULL

--- a/tests/data/dumps/sqlite-54.sql
+++ b/tests/data/dumps/sqlite-54.sql
@@ -20,13 +20,6 @@ INSERT INTO "users" VALUES('bird','charlie@parker.com','2012-02-01 21:17:39');
 DROP TABLE IF EXISTS "empty_table";
 CREATE TABLE "empty_table" ("id" INTEGER PRIMARY KEY  AUTOINCREMENT  NOT NULL , "field" VARCHAR);
 
-CREATE TABLE "composite_pk" (
-  "group_id" INTEGER NOT NULL,
-  "id" INTEGER NOT NULL,
-  "status" VARCHAR NOT NULL,
-  PRIMARY KEY ("group_id", "id")
-);
-
 CREATE TABLE "no_pk" (
   "status" VARCHAR NOT NULL
 );

--- a/tests/data/dumps/sqlite-54.sql
+++ b/tests/data/dumps/sqlite-54.sql
@@ -1,0 +1,25 @@
+DROP TABLE IF EXISTS "groups";
+CREATE TABLE "groups" ("id" INTEGER PRIMARY KEY  AUTOINCREMENT  NOT NULL , "name" VARCHAR, "enabled" BOOLEAN, "created_at" DATETIME DEFAULT CURRENT_TIMESTAMP);
+INSERT INTO "groups" VALUES(1,'coders',1,'2012-02-01 21:17:50');
+INSERT INTO "groups" VALUES(2,'jazzman',0,'2012-02-01 21:18:40');
+
+DROP TABLE IF EXISTS "permissions";
+CREATE TABLE "permissions" ("id" INTEGER PRIMARY KEY  AUTOINCREMENT  NOT NULL , "user_id" INTEGER, "group_id" INTEGER, "role" VARCHAR);
+INSERT INTO "permissions" VALUES(1,1,1,'member');
+INSERT INTO "permissions" VALUES(2,2,1,'member');
+INSERT INTO "permissions" VALUES(5,3,2,'member');
+INSERT INTO "permissions" VALUES(7,4,2,'admin');
+
+DROP TABLE IF EXISTS "users";
+CREATE TABLE "users" ("id" INTEGER PRIMARY KEY  AUTOINCREMENT  NOT NULL , "name" VARCHAR, "email" VARCHAR, "created_at" DATETIME DEFAULT CURRENT_TIMESTAMP);
+INSERT INTO "users" VALUES(1,'davert','davert@mail.ua','2012-02-01 21:17:04');
+INSERT INTO "users" VALUES(2,'nick','nick@mail.ua','2012-02-01 21:17:15');
+INSERT INTO "users" VALUES(3,'miles','miles@davis.com','2012-02-01 21:17:25');
+INSERT INTO "users" VALUES(4,'bird','charlie@parker.com','2012-02-01 21:17:39');
+
+DROP TABLE IF EXISTS "empty_table";
+CREATE TABLE "empty_table" ("id" INTEGER PRIMARY KEY  AUTOINCREMENT  NOT NULL , "field" VARCHAR);
+
+CREATE TABLE "no_pk" (
+  "status" VARCHAR NOT NULL
+);

--- a/tests/data/dumps/sqlite.sql
+++ b/tests/data/dumps/sqlite.sql
@@ -11,11 +11,11 @@ INSERT INTO "permissions" VALUES(5,3,2,'member');
 INSERT INTO "permissions" VALUES(7,4,2,'admin');
 
 DROP TABLE IF EXISTS "users";
-CREATE TABLE "users" ("id" INTEGER PRIMARY KEY  AUTOINCREMENT  NOT NULL , "name" VARCHAR, "email" VARCHAR, "created_at" DATETIME DEFAULT CURRENT_TIMESTAMP);
-INSERT INTO "users" VALUES(1,'davert','davert@mail.ua','2012-02-01 21:17:04');
-INSERT INTO "users" VALUES(2,'nick','nick@mail.ua','2012-02-01 21:17:15');
-INSERT INTO "users" VALUES(3,'miles','miles@davis.com','2012-02-01 21:17:25');
-INSERT INTO "users" VALUES(4,'bird','charlie@parker.com','2012-02-01 21:17:39');
+CREATE TABLE "users" ("name" VARCHAR, "email" VARCHAR, "created_at" DATETIME DEFAULT CURRENT_TIMESTAMP);
+INSERT INTO "users" VALUES('davert','davert@mail.ua','2012-02-01 21:17:04');
+INSERT INTO "users" VALUES('nick','nick@mail.ua','2012-02-01 21:17:15');
+INSERT INTO "users" VALUES('miles','miles@davis.com','2012-02-01 21:17:25');
+INSERT INTO "users" VALUES('bird','charlie@parker.com','2012-02-01 21:17:39');
 
 DROP TABLE IF EXISTS "empty_table";
 CREATE TABLE "empty_table" ("id" INTEGER PRIMARY KEY  AUTOINCREMENT  NOT NULL , "field" VARCHAR);

--- a/tests/data/dumps/sqlite.sql
+++ b/tests/data/dumps/sqlite.sql
@@ -25,16 +25,16 @@ CREATE TABLE "composite_pk" (
   "id" INTEGER NOT NULL,
   "status" VARCHAR NOT NULL,
   PRIMARY KEY ("group_id", "id")
-);
+) WITHOUT ROWID;
 
 CREATE TABLE "no_pk" (
   "status" VARCHAR NOT NULL
 );
 
 CREATE TABLE "order" (
-  "id" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+  "id" INTEGER NOT NULL PRIMARY KEY,
   "name" VARCHAR NOT NULL,
   "status" VARCHAR NOT NULL
-);
+) WITHOUT ROWID;
 
 insert  into "order"("id","name","status") values (1,'main', 'open');

--- a/tests/unit/Codeception/Lib/Driver/SqliteTest.php
+++ b/tests/unit/Codeception/Lib/Driver/SqliteTest.php
@@ -82,7 +82,7 @@ class SqliteTest extends \PHPUnit_Framework_TestCase
     public function testGetSingleColumnPrimaryKeyWhenTableHasNoRowId()
     {
         if (version_compare(PHP_VERSION, '5.5.0', '<')) {
-            $this->markTestSkipped('Does not support WITHOUT ROWID on travis');
+            $this->markTestSkipped('Sqlite does not support WITHOUT ROWID on travis');
         }
         $this->assertEquals(['id'], self::$sqlite->getPrimaryKey('order'));
     }
@@ -90,7 +90,7 @@ class SqliteTest extends \PHPUnit_Framework_TestCase
     public function testGetCompositePrimaryKeyWhenTableHasNoRowId()
     {
         if (version_compare(PHP_VERSION, '5.5.0', '<')) {
-            $this->markTestSkipped('Does not support WITHOUT ROWID on travis');
+            $this->markTestSkipped('Sqlite does not support WITHOUT ROWID on travis');
         }
         $this->assertEquals(['group_id', 'id'], self::$sqlite->getPrimaryKey('composite_pk'));
     }
@@ -98,13 +98,16 @@ class SqliteTest extends \PHPUnit_Framework_TestCase
     public function testGetPrimaryColumnOfTableUsingReservedWordAsTableNameWhenTableHasNoRowId()
     {
         if (version_compare(PHP_VERSION, '5.5.0', '<')) {
-            $this->markTestSkipped('Does not support WITHOUT ROWID on travis');
+            $this->markTestSkipped('Sqlite does not support WITHOUT ROWID on travis');
         }
         $this->assertEquals('id', self::$sqlite->getPrimaryColumn('order'));
     }
 
     public function testGetPrimaryColumnThrowsExceptionIfTableHasCompositePrimaryKey()
     {
+        if (version_compare(PHP_VERSION, '5.5.0', '<')) {
+            $this->markTestSkipped('Sqlite does not support WITHOUT ROWID on travis');
+        }
         $this->setExpectedException(
             '\Exception',
             'getPrimaryColumn method does not support composite primary keys, use getPrimaryKey instead'

--- a/tests/unit/Codeception/Lib/Driver/SqliteTest.php
+++ b/tests/unit/Codeception/Lib/Driver/SqliteTest.php
@@ -64,22 +64,27 @@ class SqliteTest extends \PHPUnit_Framework_TestCase
         $this->assertNotEmpty($res->fetchAll());
     }
 
-    public function testGetSingleColumnPrimaryKey()
+    public function testGetPrimaryKeyReturnsRowIdIfTableHasIt()
+    {
+        $this->assertEquals(['_ROWID_'], self::$sqlite->getPrimaryKey('groups'));
+    }
+
+    public function testGetPrimaryKeyReturnsRowIdIfTableHasNoPrimaryKey()
+    {
+        $this->assertEquals(['_ROWID_'], self::$sqlite->getPrimaryKey('no_pk'));
+    }
+
+    public function testGetSingleColumnPrimaryKeyWhenTableHasNoRowId()
     {
         $this->assertEquals(['id'], self::$sqlite->getPrimaryKey('order'));
     }
 
-    public function testGetCompositePrimaryKey()
+    public function testGetCompositePrimaryKeyWhenTableHasNoRowId()
     {
         $this->assertEquals(['group_id', 'id'], self::$sqlite->getPrimaryKey('composite_pk'));
     }
 
-    public function testGetEmptyArrayIfTableHasNoPrimaryKey()
-    {
-        $this->assertEquals([], self::$sqlite->getPrimaryKey('no_pk'));
-    }
-
-    public function testGetPrimaryColumnOfTableUsingReservedWordAsTableName()
+    public function testGetPrimaryColumnOfTableUsingReservedWordAsTableNameWhenTableHasNoRowId()
     {
         $this->assertEquals('id', self::$sqlite->getPrimaryColumn('order'));
     }

--- a/tests/unit/Codeception/Lib/Driver/SqliteTest.php
+++ b/tests/unit/Codeception/Lib/Driver/SqliteTest.php
@@ -15,7 +15,13 @@ class SqliteTest extends \PHPUnit_Framework_TestCase
     
     public static function setUpBeforeClass()
     {
-        $sql = file_get_contents(\Codeception\Configuration::dataDir() . '/dumps/sqlite.sql');
+        if (version_compare(PHP_VERSION, '5.5.0', '<')) {
+            $dumpFile = '/dumps/sqlite-54.sql';
+        } else {
+            $dumpFile = '/dumps/sqlite.sql';
+        }
+
+        $sql = file_get_contents(\Codeception\Configuration::dataDir() . $dumpFile);
         $sql = preg_replace('%/\*(?:(?!\*/).)*\*/%s', "", $sql);
         self::$sql = explode("\n", $sql);
         try {
@@ -39,7 +45,6 @@ class SqliteTest extends \PHPUnit_Framework_TestCase
             self::$sqlite->cleanup();
         }
     }
-    
     
     public function testCleanupDatabase()
     {
@@ -76,16 +81,25 @@ class SqliteTest extends \PHPUnit_Framework_TestCase
 
     public function testGetSingleColumnPrimaryKeyWhenTableHasNoRowId()
     {
+        if (version_compare(PHP_VERSION, '5.5.0', '<')) {
+            $this->markTestSkipped('Does not support WITHOUT ROWID on travis');
+        }
         $this->assertEquals(['id'], self::$sqlite->getPrimaryKey('order'));
     }
 
     public function testGetCompositePrimaryKeyWhenTableHasNoRowId()
     {
+        if (version_compare(PHP_VERSION, '5.5.0', '<')) {
+            $this->markTestSkipped('Does not support WITHOUT ROWID on travis');
+        }
         $this->assertEquals(['group_id', 'id'], self::$sqlite->getPrimaryKey('composite_pk'));
     }
 
     public function testGetPrimaryColumnOfTableUsingReservedWordAsTableNameWhenTableHasNoRowId()
     {
+        if (version_compare(PHP_VERSION, '5.5.0', '<')) {
+            $this->markTestSkipped('Does not support WITHOUT ROWID on travis');
+        }
         $this->assertEquals('id', self::$sqlite->getPrimaryColumn('order'));
     }
 

--- a/tests/unit/Codeception/Module/DbTest.php
+++ b/tests/unit/Codeception/Module/DbTest.php
@@ -22,7 +22,12 @@ class DbTest extends \PHPUnit_Framework_TestCase
 
         $sqlite = self::$module->driver;
         $sqlite->cleanup();
-        $sql = file_get_contents(\Codeception\Configuration::dataDir() . '/dumps/sqlite.sql');
+        if (version_compare(PHP_VERSION, '5.5.0', '<')) {
+            $dumpFile = '/dumps/sqlite-54.sql';
+        } else {
+            $dumpFile = '/dumps/sqlite.sql';
+        }
+        $sql = file_get_contents(\Codeception\Configuration::dataDir() . $dumpFile);
         $sql = preg_replace('%/\*(?:(?!\*/).)*\*/%s', "", $sql);
         $sql = explode("\n", $sql);
         $sqlite->load($sql);
@@ -80,6 +85,9 @@ class DbTest extends \PHPUnit_Framework_TestCase
 
     public function testHaveInDatabaseWithCompositePrimaryKey()
     {
+        if (version_compare(PHP_VERSION, '5.5.0', '<')) {
+            $this->markTestSkipped('Does not support WITHOUT ROWID on travis');
+        }
         self::$module->_before(\Codeception\Util\Stub::makeEmpty('\Codeception\TestInterface'));
         $insertQuery = 'INSERT INTO composite_pk (group_id, id, status) VALUES(?, ?, ?)';
         //this test checks that module does not delete columns by partial primary key


### PR DESCRIPTION
Fixes #3680 

`removeInserted` didn't work for sqlite, because I didn't know that lastInsertId returns ROWID if sqlite table has it (default behaviour).
