### PR TITLE
Update GroupManager.php use exact match only

### DIFF
--- a/src/Codeception/Lib/GroupManager.php
+++ b/src/Codeception/Lib/GroupManager.php
@@ -117,13 +117,13 @@ class GroupManager
                 if ($filename == $testPattern) {
                     $groups[] = $group;
                 }
-                if (strpos($filename . ':' . $test->getName(false), $testPattern) === 0) {
+                if (($filename . ':' . $test->getName(false)) === $testPattern) {
                     $groups[] = $group;
                 }
                 if ($test instanceof \PHPUnit_Framework_TestSuite_DataProvider) {
                     $firstTest = $test->testAt(0);
                     if ($firstTest != false && $firstTest instanceof TestInterface) {
-                        if (strpos($filename . ':' . $firstTest->getName(false), $testPattern) === 0) {
+                        if (($filename . ':' . $test->getName(false)) === $testPattern) {
                             $groups[] = $group;
                         }
                     }


### PR DESCRIPTION
#### What are you trying to achieve?

Rerun single failed test inside Cest file.

#### What do you get instead?

```
bin/codecept run -g failed
```

### Details

* Codeception version: 2.2.6
* PHP Version: 7.0.12
* Operating System: Linux, Ubuntu 16.04
* Installation type: Composer

We want to execute one specific test method in Cest only, but with original implementation this was not possible.

This change changes group test matches to exact match. We can look into ways how to use regular expression. Proposed change introduces BC break.

Example:

testCest:A
testCest:A2
testCest:A3

If I had failed test and create group that should be run with content of:
testCest:A

then all `testCest:A`, `testCest:A2`, `testCest:A3` will be executed.

With proposed change only `testCest:A` will be executed



Other possible implementation could use regular expressions. We could then write something like this to match only exact test case
`^testCest:A$`
or
`^testCest:A`