### PR TITLE
Classes Reference

### DIFF
--- a/docs/modules/AngularJS.md
+++ b/docs/modules/AngularJS.md
@@ -775,7 +775,7 @@ $I->pressKey('#name', array('ctrl', 'a'), \Facebook\WebDriver\WebDriverKeys::DEL
 ```
 
  * `param` $element
- * `param` $char Can be char or array with modifier. You can provide several chars.
+ * `param` $char string|array Can be char or array with modifier. You can provide several chars.
  * `throws`  \Codeception\Exception\ElementNotFound
 
 
@@ -1341,6 +1341,24 @@ $I->submitForm('#my-form', [
     ]
 ]);
 ```
+
+The `$button` parameter can be either a string, an array or an instance
+of Facebook\WebDriver\WebDriverBy. When it is a string, the
+button will be found by its "name" attribute. If $button is an
+array then it will be treated as a strict selector and a WebDriverBy
+will be used verbatim.
+
+For example, given the following HTML:
+
+``` html
+<input type="submit" name="submitButton" value="Submit" />
+```
+
+`$button` could be any one of the following:
+  - 'submitButton'
+  - ['name' => 'submitButton']
+  - WebDriverBy::name('submitButton')
+
  * `param` $selector
  * `param` $params
  * `param` $button

--- a/docs/modules/Apc.md
+++ b/docs/modules/Apc.md
@@ -1,0 +1,116 @@
+# Apc
+
+
+This module interacts with the [Alternative PHP Cache (APC)](http://php.net/manual/en/intro.apcu.php)
+using either _APCu_ or _APC_ extension.
+
+Performs a cleanup by flushing all values after each test run.
+
+## Status
+
+* Maintainer: **Serghei Iakovlev**
+* Stability: **stable**
+* Contact: serghei@phalconphp.com
+
+### Example (`unit.suite.yml`)
+
+```yaml
+   modules:
+       - Apc
+```
+
+Be sure you don't use the production server to connect.
+
+
+
+## Actions
+
+### dontSeeInApc
+ 
+Checks item in APC(u) doesn't exist or is the same as expected.
+
+Examples:
+
+``` php
+<?php
+// With only one argument, only checks the key does not exist
+$I->dontSeeInApc('users_count');
+
+// Checks a 'users_count' exists does not exist or its value is not the one provided
+$I->dontSeeInApc('users_count', 200);
+?>
+```
+
+ * `param string|string[]` $key
+ * `param mixed` $value
+
+
+### flushApc
+ 
+Clears the APC(u) cache
+
+
+### grabValueFromApc
+ 
+Grabs value from APC(u) by key.
+
+Example:
+
+``` php
+<?php
+$users_count = $I->grabValueFromApc('users_count');
+?>
+```
+
+ * `param string|string[]` $key
+
+
+### haveInApc
+ 
+Stores an item `$value` with `$key` on the APC(u).
+
+Examples:
+
+```php
+<?php
+// Array
+$I->haveInApc('users', ['name' => 'miles', 'email' => 'miles * `davis.com']);` 
+
+// Object
+$I->haveInApc('user', UserRepository::findFirst());
+
+// Key as array of 'key => value'
+$entries = [];
+$entries['key1'] = 'value1';
+$entries['key2'] = 'value2';
+$entries['key3'] = ['value3a','value3b'];
+$entries['key4'] = 4;
+$I->haveInApc($entries, null);
+?>
+```
+
+ * `param string|array` $key
+ * `param mixed` $value
+ * `param int` $expiration
+
+
+### seeInApc
+ 
+Checks item in APC(u) exists and the same as expected.
+
+Examples:
+
+``` php
+<?php
+// With only one argument, only checks the key exists
+$I->seeInApc('users_count');
+
+// Checks a 'users_count' exists and has the value 200
+$I->seeInApc('users_count', 200);
+?>
+```
+
+ * `param string|string[]` $key
+ * `param mixed` $value
+
+<p>&nbsp;</p><div class="alert alert-warning">Module reference is taken from the source code. <a href="https://github.com/Codeception/Codeception/tree/2.2/src/Codeception/Module/Apc.php">Help us to improve documentation. Edit module reference</a></div>

--- a/docs/modules/Db.md
+++ b/docs/modules/Db.md
@@ -47,7 +47,7 @@ if you run into problems loading dumps and cleaning databases.
 * password *required* - password
 * dump - path to database dump
 * populate: true - whether the the dump should be loaded before the test suite is started
-* cleanup: true - whether the dump should be reloaded after each test
+* cleanup: true - whether the dump should be reloaded before each test
 * reconnect: false - whether the module should reconnect to the database before each test
 
 ## Example

--- a/docs/modules/Laravel5.md
+++ b/docs/modules/Laravel5.md
@@ -8,7 +8,8 @@ See the Acceptance tests section below for more details.
 
 As of Codeception 2.2 this module only works for Laravel 5.1 and later releases.
 If you want to test a Laravel 5.0 application you have to use Codeception 2.1.
-You can also upgrade your Laravel application to 5.1, for more details check the Laravel Upgrade Guide at <https://laravel.com/docs/master/upgrade>.
+You can also upgrade your Laravel application to 5.1, for more details check the Laravel Upgrade Guide
+at <https://laravel.com/docs/master/upgrade>.
 
 ## Demo project
 <https://github.com/janhenkgerritsen/codeception-laravel5-sample>
@@ -27,33 +28,43 @@ You can also upgrade your Laravel application to 5.1, for more details check the
 
 ## Config
 
-* cleanup: `boolean`, default `true` - all db queries will be run in transaction, which will be rolled back at the end of test.
-* run_database_migrations: `boolean`, default `false` - enable to run database migrations before each test.
-* environment_file: `string`, default `.env` - The .env file to load for the tests.
-* bootstrap: `string`, default `bootstrap/app.php` - Relative path to app.php config file.
-* root: `string`, default `` - Root path of our application.
-* packages: `string`, default `workbench` - Root path of application packages (if any).
-* disable_exception_handling: `boolean`, default `true` - disable Laravel exception handling
+* cleanup: `boolean`, default `true` - all database queries will be run in a transaction,
+  which will be rolled back at the end of each test.
+* run_database_migrations: `boolean`, default `false` - run database migrations before each test.
+* database_migrations_path: `string`, default `` - path to the database migrations, relative to the root of the application.
+* run_database_seeder: `boolean`, default `false` - run database seeder before each test.
+* database_seeder_class: `string`, default `` - database seeder class name.
+* environment_file: `string`, default `.env` - the environment file to load for the tests.
+* bootstrap: `string`, default `bootstrap/app.php` - relative path to app.php config file.
+* root: `string`, default `` - root path of the application.
+* packages: `string`, default `workbench` - root path of application packages (if any).
+* disable_exception_handling: `boolean`, default `true` - disable Laravel exception handling.
 * disable_middleware: `boolean`, default `false` - disable all middleware.
 * disable_events: `boolean`, default `false` - disable events (does not disable model events).
 * disable_model_events: `boolean`, default `false` - disable model events.
-* url: `string`, default `` - The application URL.
+* url: `string`, default `` - the application URL.
 
 ## API
 
-* app - `Illuminate\Foundation\Application` instance
-* client - `\Symfony\Component\BrowserKit\Client` instance
+* app - `Illuminate\Foundation\Application`
+* config - `array`
 
 ## Parts
 
-* ORM - include only haveRecord/grabRecord/seeRecord/dontSeeRecord actions
+* ORM - only include the database methods of this module:
+    * have
+    * haveMultiple
+    * haveRecord
+    * grabRecord
+    * seeRecord
+    * dontSeeRecord
 
 ## Acceptance tests
 
 You should not use this module for acceptance tests.
 If you want to use Laravel functionality with your acceptance tests,
 for example to do test setup, you can initialize the Laravel functionality
-by adding the following lines of code to your suite `_bootstrap.php` file:
+by adding the following lines of code to the `_bootstrap.php` file of your test suite:
 
     require 'bootstrap/autoload.php';
     $app = require 'bootstrap/app.php';
@@ -862,7 +873,23 @@ $value = $I->grabTextFrom('~<input value=(.*?)]~sgi'); // match with a regex
 
 
 ### have
-__not documented__
+ 
+Use Laravel's model factory to create a model.
+Can only be used with Laravel 5.1 and later.
+
+``` php
+<?php
+$I->have('App\User');
+$I->have('App\User', ['name' => 'John Doe']);
+$I->have('App\User', [], 'admin');
+?>
+```
+
+ * `see`  http://laravel.com/docs/5.1/testing#model-factories
+ * `param string` $model
+ * `param array` $attributes
+ * `param string` $name
+ * `[Part]` orm
 
 
 ### haveBinding
@@ -935,7 +962,24 @@ $I->haveInstance('My\Class', new My\Class());
 
 
 ### haveMultiple
-__not documented__
+ 
+Use Laravel's model factory to create multiple models.
+Can only be used with Laravel 5.1 and later.
+
+``` php
+<?php
+$I->haveMultiple('App\User', 10);
+$I->haveMultiple('App\User', 10, ['name' => 'John Doe']);
+$I->haveMultiple('App\User', 10, [], 'admin');
+?>
+```
+
+ * `see`  http://laravel.com/docs/5.1/testing#model-factories
+ * `param string` $model
+ * `param int` $times
+ * `param array` $attributes
+ * `param string` $name
+ * `[Part]` orm
 
 
 ### haveRecord

--- a/docs/modules/Lumen.md
+++ b/docs/modules/Lumen.md
@@ -16,16 +16,27 @@ Please try it and leave your feedback.
 
 ## Config
 
-* cleanup: `boolean`, default `true` - all db queries will be run in transaction, which will be rolled back at the end of test.
-* bootstrap: `string`, default `bootstrap/app.php` - Relative path to app.php config file.
-* root: `string`, default `` - Root path of our application.
-* packages: `string`, default `workbench` - Root path of application packages (if any).
+* cleanup: `boolean`, default `true` - all database queries will be run in a transaction,
+  which will be rolled back at the end of each test.
+* bootstrap: `string`, default `bootstrap/app.php` - relative path to app.php config file.
+* root: `string`, default `` - root path of the application.
+* packages: `string`, default `workbench` - root path of application packages (if any).
+* url: `string`, default `http://localhost` - the application URL
 
 ## API
 
-* app - `Illuminate\Foundation\Application` instance
-* client - `BrowserKit` client
+* app - `\Laravel\Lumen\Application`
+* config - `array`
 
+## Parts
+
+* ORM - only include the database methods of this module:
+    * have
+    * haveMultiple
+    * haveRecord
+    * grabRecord
+    * seeRecord
+    * dontSeeRecord
 
 
 ## Actions
@@ -157,11 +168,10 @@ Authenticates user for HTTP_AUTH
 
 ### amLoggedAs
  
-Set the currently logged in user for the application.
-Takes either an object that implements the User interface or
-an array of credentials.
+Set the authenticated user for the next request.
+This will not persist between multiple requests.
 
- * `param`  \Illuminate\Contracts\Auth\User|array $user
+ * `param`  \Illuminate\Contracts\Auth\Authenticatable
  * `param`  string|null $driver The authentication driver for Lumen <= 5.1.*, guard name for Lumen >= 5.2
  * `return` void
 
@@ -307,7 +317,7 @@ For checking the raw source code, use `seeInSource()`.
 
 ### dontSeeAuthentication
  
-Check that user is not authenticated
+Check that user is not authenticated.
 
 
 ### dontSeeCheckboxIsChecked
@@ -698,6 +708,26 @@ $value = $I->grabTextFrom('~<input value=(.*?)]~sgi'); // match with a regex
  * `return` array|mixed|null|string
 
 
+### have
+ 
+Use Lumen's model factory to create a model.
+Can only be used with Lumen 5.1 and later.
+
+``` php
+<?php
+$I->have('App\User');
+$I->have('App\User', ['name' => 'John Doe']);
+$I->have('App\User', [], 'admin');
+?>
+```
+
+ * `see`  https://lumen.laravel.com/docs/master/testing#model-factories
+ * `param string` $model
+ * `param array` $attributes
+ * `param string` $name
+ * `[Part]` orm
+
+
 ### haveHttpHeader
  
 Sets the HTTP header to the passed value - which is used on
@@ -714,6 +744,27 @@ $I->amOnPage('test-headers.php');
  * `param string` $name the name of the request header
  * `param string` $value the value to set it to for subsequent
        requests
+
+
+### haveMultiple
+ 
+Use Laravel's model factory to create multiple models.
+Can only be used with Lumen 5.1 and later.
+
+``` php
+<?php
+$I->haveMultiple('App\User', 10);
+$I->haveMultiple('App\User', 10, ['name' => 'John Doe']);
+$I->haveMultiple('App\User', 10, [], 'admin');
+?>
+```
+
+ * `see`  https://lumen.laravel.com/docs/master/testing#model-factories
+ * `param string` $model
+ * `param int` $times
+ * `param array` $attributes
+ * `param string` $name
+ * `[Part]` orm
 
 
 ### haveRecord
@@ -733,11 +784,6 @@ $user = $I->haveRecord('App\User', array('name' => 'Davert')); // returns Eloque
  * `param array` $attributes
  * `return` integer|EloquentModel
  * `[Part]` orm
-
-
-### logout
- 
-Logs user out
 
 
 ### moveBack
@@ -791,7 +837,7 @@ For checking the raw source code, use `seeInSource()`.
 
 ### seeAuthentication
  
-Checks that user is authenticated
+Checks that user is authenticated.
 
 
 ### seeCheckboxIsChecked
@@ -974,15 +1020,6 @@ $I->seeInFormFields('//form[ * `id=my-form]',`  $form);
  * `param` $params
 
 
-### seeInSession
- 
-Assert that the session has a given list of values.
-
- * `param`  string|array $key
- * `param`  mixed $value
- * `return` void
-
-
 ### seeInSource
  
 Checks that the current page contains the given string in its
@@ -1094,14 +1131,6 @@ $I->seeResponseCodeIs(\Codeception\Util\HttpCode::OK);
  * `param` $code
 
 
-### seeSessionHasValues
- 
-Assert that the session has a given list of values.
-
- * `param`  array $bindings
- * `return` void
-
-
 ### selectOption
  
 Selects an option in a select tag or in radio button group.
@@ -1186,6 +1215,11 @@ $I->sendAjaxRequest('PUT', '/posts/7', array('title' => 'new title'));
  * `param` $method
  * `param` $uri
  * `param` $params
+
+
+### setApplication
+ 
+ * `param \Laravel\Lumen\Application` $app
 
 
 ### setCookie

--- a/docs/modules/Memcache.md
+++ b/docs/modules/Memcache.md
@@ -9,18 +9,27 @@ Performs a cleanup by flushing all values after each test run.
 
 * Maintainer: **davert**
 * Stability: **beta**
-* Contact: codecept@davert.mail.ua
+* Contact: davert@codeception.com
 
 ## Configuration
 
-* host: localhost - memcached host to connect
-* port: 11211 - default memcached port.
+* **`host`** (`string`, default `'localhost'`) - The memcached host
+* **`port`** (`int`, default `11211`) - The memcached port
+
+### Example (`unit.suite.yml`)
+
+```yaml
+   modules:
+       - Memcache:
+           host: 'localhost'
+           port: 11211
+```
 
 Be sure you don't use the production server to connect.
 
 ## Public Properties
 
-* memcache - instance of Memcache object
+* **memcache** - instance of _Memcache_ or _Memcached_ object
 
 
 
@@ -35,13 +44,25 @@ Flushes all Memcached data.
  
 Checks item in Memcached doesn't exist or is the same as expected.
 
+Examples:
+
+``` php
+<?php
+// With only one argument, only checks the key does not exist
+$I->dontSeeInMemcached('users_count');
+
+// Checks a 'users_count' exists does not exist or its value is not the one provided
+$I->dontSeeInMemcached('users_count', 200);
+?>
+```
+
  * `param` $key
- * `param bool` $value
+ * `param` $value
 
 
 ### grabValueFromMemcached
  
-Grabs value from memcached by key
+Grabs value from memcached by key.
 
 Example:
 
@@ -55,9 +76,30 @@ $users_count = $I->grabValueFromMemcached('users_count');
  * `return` array|string
 
 
+### haveInMemcached
+ 
+Stores an item `$value` with `$key` on the Memcached server.
+
+ * `param string` $key
+ * `param mixed` $value
+ * `param int` $expiration
+
+
 ### seeInMemcached
  
 Checks item in Memcached exists and the same as expected.
+
+Examples:
+
+``` php
+<?php
+// With only one argument, only checks the key exists
+$I->seeInMemcached('users_count');
+
+// Checks a 'users_count' exists and has the value 200
+$I->seeInMemcached('users_count', 200);
+?>
+```
 
  * `param` $key
  * `param` $value

--- a/docs/modules/MongoDb.md
+++ b/docs/modules/MongoDb.md
@@ -18,6 +18,8 @@ The DB preparation should as following:
 Connection is done by MongoDb driver, which is stored in Codeception\Lib\Driver namespace.
 Check out the driver if you get problems loading dumps and cleaning databases.
 
+HINT: This module can be used with [Mongofill](https://github.com/mongofill/mongofill) library which is Mongo client written in PHP without extension.
+
 ## Status
 
 * Maintainer: **judgedim**, **davert**
@@ -77,12 +79,12 @@ Grabs a data from collection
 
 ``` php
 <?php
-$cursor = $I->grabFromCollection('users', array('name' => 'miles'));
+$user = $I->grabFromCollection('users', array('name' => 'miles'));
 ```
 
  * `param` $collection
  * `param array` $criteria
- * `return` \MongoCursor
+ * `return` array
 
 
 ### haveInCollection

--- a/docs/modules/SOAP.md
+++ b/docs/modules/SOAP.md
@@ -30,10 +30,6 @@ If you use PHP SoapServer with framework, try to block call to this method in te
 * xmlRequest - last SOAP request (DOMDocument)
 * xmlResponse - last SOAP response (DOMDocument)
 
-## Conflicts
-
-Conflicts with REST module
-
 
 
 ## Actions
@@ -126,6 +122,11 @@ Will produce header:
 
 
 ### seeResponseCodeIs
+ 
+ * `deprecated`  use seeSoapResponseCodeIs instead
+
+
+### seeSoapResponseCodeIs
  
 Checks response code from server.
 

--- a/docs/modules/WebDriver.md
+++ b/docs/modules/WebDriver.md
@@ -761,7 +761,7 @@ If no parameters are provided, the full URI is returned.
 
 ``` php
 <?php
-$user_id = $I->grabFromCurrentUrl('~^/user/(\d+)/~');
+$user_id = $I->grabFromCurrentUrl('~$/user/(\d+)/~');
 $uri = $I->grabFromCurrentUrl();
 ?>
 ```
@@ -916,7 +916,7 @@ $I->pressKey('#name', array('ctrl', 'a'), \Facebook\WebDriver\WebDriverKeys::DEL
 ```
 
  * `param` $element
- * `param` $char Can be char or array with modifier. You can provide several chars.
+ * `param` $char string|array Can be char or array with modifier. You can provide several chars.
  * `throws`  \Codeception\Exception\ElementNotFound
 
 
@@ -1482,6 +1482,24 @@ $I->submitForm('#my-form', [
     ]
 ]);
 ```
+
+The `$button` parameter can be either a string, an array or an instance
+of Facebook\WebDriver\WebDriverBy. When it is a string, the
+button will be found by its "name" attribute. If $button is an
+array then it will be treated as a strict selector and a WebDriverBy
+will be used verbatim.
+
+For example, given the following HTML:
+
+``` html
+<input type="submit" name="submitButton" value="Submit" />
+```
+
+`$button` could be any one of the following:
+  - 'submitButton'
+  - ['name' => 'submitButton']
+  - WebDriverBy::name('submitButton')
+
  * `param` $selector
  * `param` $params
  * `param` $button

--- a/docs/modules/Yii2.md
+++ b/docs/modules/Yii2.md
@@ -68,6 +68,28 @@ modules:
             entryScript: index-test.php
 ```
 
+## Fixtures
+
+This module allows to use [fixtures](http://www.yiiframework.com/doc-2.0/guide-test-fixtures.html) inside a test. There are two options for that.
+Fixtures can be loaded using [haveFixtures](#haveFixtures) method inside a test:
+
+```php
+<?php
+$I->haveFixtures(['posts' => PostsFixture::className()]);
+```
+
+or, if you need to load fixtures before the test (probably before the cleanup transaction is started), you
+can specify fixtures with `_fixtures` method of a testcase:
+
+```php
+<?php
+// inside Cest file or Codeception\TestCase\Unit
+public function _fixtures()
+{
+    return ['posts' => PostsFixture::className()]
+}
+```
+
 ## Status
 
 Maintainer: **samdark**
@@ -801,13 +823,13 @@ Signature is the same as for `fixtures()` method of `yii\test\FixtureTrait`
 
 ```php
 <?php
-$I->haveFixtures(,
+$I->haveFixtures([
     'posts' => PostsFixture::className(),
     'user' => [
         'class' => UserFixture::className(),
-        'dataFile' => ' * `tests/_data/models/user.php'` 
+        'dataFile' => ' * `tests/_data/models/user.php',` 
      ],
-);
+]);
 ```
 
  * `param` $fixtures

--- a/docs/modules/ZF2.md
+++ b/docs/modules/ZF2.md
@@ -1,9 +1,9 @@
 # ZF2
 
 
-This module allows you to run tests inside Zend Framework 2.
+This module allows you to run tests inside Zend Framework 2 and Zend Framework 3.
 
-File `init_autoloader` in project's root is required.
+File `init_autoloader` in project's root is required by Zend Framework 2.
 Uses `tests/application.config.php` config file by default.
 
 Note: services part and Doctrine integration is not compatible with ZF3 yet

--- a/docs/reference/Autoload.md
+++ b/docs/reference/Autoload.md
@@ -7,9 +7,15 @@ Autoloader, which is fully compatible with PSR-4,
 and can be used to autoload your `Helper`, `Page`, and `Step` classes.
 
 
-### addNamespace 
+#### __construct()
 
-*static*
+ *private* __construct() 
+
+[See source](https://github.com/Codeception/Codeception/blob/2.2/src/Codeception/Util/Autoload.php#L18)
+
+#### addNamespace()
+
+ *public static* addNamespace($prefix, $base_dir, $prepend = null) 
 
 Adds a base directory for a namespace prefix.
 
@@ -31,30 +37,46 @@ Autoload::addNamespace('app\Codeception', '/path/to/controllers');
  * `param string` $base_dir A base directory for class files in the namespace.
  * `param bool` $prepend If true, prepend the base directory to the stack instead of appending it;
                      this causes it to be searched first rather than last.
- * `return`  void
+ * `return` void
 
 [See source](https://github.com/Codeception/Codeception/blob/2.2/src/Codeception/Util/Autoload.php#L45)
 
-### load 
+#### load()
 
-*static*
+ *public static* load($class) 
 
 [See source](https://github.com/Codeception/Codeception/blob/2.2/src/Codeception/Util/Autoload.php#L88)
 
-### register 
+#### loadMappedFile()
 
-*static*
+ *protected static* loadMappedFile($prefix, $relative_class) 
 
- * `deprecated`  Use self::addNamespace() instead.
+Load the mapped file for a namespace prefix and relative class.
+
+ * `param string` $prefix The namespace prefix.
+ * `param string` $relative_class The relative class name.
+ * `return` mixed Boolean false if no mapped file can be loaded, or the name of the mapped file that was loaded.
+
+[See source](https://github.com/Codeception/Codeception/blob/2.2/src/Codeception/Util/Autoload.php#L136)
+
+#### register()
+
+ *public static* register($namespace, $suffix, $path) 
+ * `deprecated` Use self::addNamespace() instead.
 
 [See source](https://github.com/Codeception/Codeception/blob/2.2/src/Codeception/Util/Autoload.php#L75)
 
-### registerSuffix 
+#### registerSuffix()
 
-*static*
-
- * `deprecated`  Use self::addNamespace() instead.
+ *public static* registerSuffix($suffix, $path) 
+ * `deprecated` Use self::addNamespace() instead.
 
 [See source](https://github.com/Codeception/Codeception/blob/2.2/src/Codeception/Util/Autoload.php#L83)
 
-<p>&nbsp;</p><div class="alert alert-warning">Reference is taken from the source code. <a href="https://github.com/Codeception/Codeception/blob/2.2/src/Codeception/Util/Autoload.php">Help us to improve documentation. Edit module reference</a></div>
+#### requireFile()
+
+ *protected static* requireFile($file) 
+
+[See source](https://github.com/Codeception/Codeception/blob/2.2/src/Codeception/Util/Autoload.php#L156)
+
+<p>&nbsp;</p><div class="alert alert-warning">Reference is taken from the source code. <a href="https://github.com/Codeception/Codeception/blob/2.2/src//Codeception/Util/Autoload.php">Help us to improve documentation. Edit module reference</a></div>

--- a/docs/reference/Commands.md
+++ b/docs/reference/Commands.md
@@ -71,11 +71,32 @@ Executes tests.
 
 Usage:
 
-* `codecept run acceptance` - run all acceptance tests
-* `codecept run tests/acceptance/MyCept.php` - run only MyCept
-* `codecept run acceptance MyCept` - same as above
-* `codecept run acceptance MyCest:myTestInIt` - run one test from a Cest
-* `codecept run acceptance checkout.feature` - run feature-file
+* `codecept run acceptance`: run all acceptance tests
+* `codecept run tests/acceptance/MyCept.php`: run only MyCept
+* `codecept run acceptance MyCept`: same as above
+* `codecept run acceptance MyCest:myTestInIt`: run one test from a Cest
+* `codecept run acceptance checkout.feature`: run feature-file
+* `codecept run acceptance -g slow`: run tests from *slow* group
+* `codecept run unit,functional`: run only unit and functional suites
+
+Verbosity modes:
+
+* `codecept run -v`:
+* `codecept run --steps`: print step-by-step execution
+* `codecept run -vv`:
+* `codecept run --debug`: print steps and debug information
+* `codecept run -vvv`: print internal debug information
+
+Load config:
+
+* `codecept run -c path/to/another/config`: from another dir
+* `codecept run -c another_config.yml`: from another config file
+
+Override config values:
+
+* `codecept run -o "settings: shuffle: true"`: enable shuffle
+* `codecept run -o "settings: lint: false"`: disable linting
+* `codecept run -o "reporters: report: \Custom\Reporter" --report`: use custom reporter
 
 Full reference:
 ```
@@ -84,6 +105,7 @@ Arguments:
  test                  test to be run
 
 Options:
+ -o, --override=OVERRIDE Override config values (multiple values allowed)
  --config (-c)         Use custom path for config
  --report              Show output in compact style
  --html                Generate html with results (default: "report.html")

--- a/docs/reference/Fixtures.md
+++ b/docs/reference/Fixtures.md
@@ -15,22 +15,22 @@ Fixtures::get('user1');
 
 
 
-### add 
+#### add()
 
-*static*
+ *public static* add($name, $data) 
 
 [See source](https://github.com/Codeception/Codeception/blob/2.2/src/Codeception/Util/Fixtures.php#L20)
 
-### cleanup 
+#### cleanup()
 
-*static*
+ *public static* cleanup() 
 
 [See source](https://github.com/Codeception/Codeception/blob/2.2/src/Codeception/Util/Fixtures.php#L34)
 
-### get 
+#### get()
 
-*static*
+ *public static* get($name) 
 
 [See source](https://github.com/Codeception/Codeception/blob/2.2/src/Codeception/Util/Fixtures.php#L25)
 
-<p>&nbsp;</p><div class="alert alert-warning">Reference is taken from the source code. <a href="https://github.com/Codeception/Codeception/blob/2.2/src/Codeception/Util/Fixtures.php">Help us to improve documentation. Edit module reference</a></div>
+<p>&nbsp;</p><div class="alert alert-warning">Reference is taken from the source code. <a href="https://github.com/Codeception/Codeception/blob/2.2/src//Codeception/Util/Fixtures.php">Help us to improve documentation. Edit module reference</a></div>

--- a/docs/reference/HttpCode.md
+++ b/docs/reference/HttpCode.md
@@ -20,9 +20,9 @@ $I->dontSeeResponseCodeIs(HttpCode::NOT_FOUND);
 
 
 
-### getDescription 
+#### getDescription()
 
-*static*
+ *public static* getDescription($code) 
 
 Returns string with HTTP code and its description
 
@@ -33,8 +33,8 @@ HttpCode::getDescription(401); // '401 (Unauthorized)'
 ```
 
  * `param` $code
- * `return`  mixed
+ * `return` mixed
 
 [See source](https://github.com/Codeception/Codeception/blob/2.2/src/Codeception/Util/HttpCode.php#L155)
 
-<p>&nbsp;</p><div class="alert alert-warning">Reference is taken from the source code. <a href="https://github.com/Codeception/Codeception/blob/2.2/src/Codeception/Util/HttpCode.php">Help us to improve documentation. Edit module reference</a></div>
+<p>&nbsp;</p><div class="alert alert-warning">Reference is taken from the source code. <a href="https://github.com/Codeception/Codeception/blob/2.2/src//Codeception/Util/HttpCode.php">Help us to improve documentation. Edit module reference</a></div>

--- a/docs/reference/JsonType.md
+++ b/docs/reference/JsonType.md
@@ -28,7 +28,9 @@ Class JsonType
 @package Codeception\Util
 
 
-### __construct 
+#### __construct()
+
+ *public* __construct($jsonArray) 
 
 Creates instance of JsonType
 Pass an array or `\Codeception\Util\JsonArray` with data.
@@ -38,9 +40,9 @@ If non-associative array is passed - the very first element of it will be used f
 
 [See source](https://github.com/Codeception/Codeception/blob/2.2/src/Codeception/Util/JsonType.php#L42)
 
-### addCustomFilter 
+#### addCustomFilter()
 
-*static*
+ *public static* addCustomFilter($name, callable $callable) 
 
 Adds custom filter to JsonType list.
 You should specify a name and parameters of a filter.
@@ -69,23 +71,37 @@ JsonType::addCustomFilter('/len\((.*?)\)/', function($value, $len) {
 
 [See source](https://github.com/Codeception/Codeception/blob/2.2/src/Codeception/Util/JsonType.php#L76)
 
-### cleanCustomFilters 
+#### cleanCustomFilters()
 
-*static*
+ *public static* cleanCustomFilters() 
 
 Removes all custom filters
 
 [See source](https://github.com/Codeception/Codeception/blob/2.2/src/Codeception/Util/JsonType.php#L84)
 
-### matches 
+#### matchFilter()
+
+ *protected* matchFilter($filter, $value) 
+
+[See source](https://github.com/Codeception/Codeception/blob/2.2/src/Codeception/Util/JsonType.php#L158)
+
+#### matches()
+
+ *public* matches(array $jsonType) 
 
 Checks data against passed JsonType.
 If matching fails function returns a string with a message describing failure.
 On success returns `true`.
 
  * `param array` $jsonType
- * `return`  bool|string
+ * `return` bool|string
 
 [See source](https://github.com/Codeception/Codeception/blob/2.2/src/Codeception/Util/JsonType.php#L97)
 
-<p>&nbsp;</p><div class="alert alert-warning">Reference is taken from the source code. <a href="https://github.com/Codeception/Codeception/blob/2.2/src/Codeception/Util/JsonType.php">Help us to improve documentation. Edit module reference</a></div>
+#### typeComparison()
+
+ *protected* typeComparison($data, $jsonType) 
+
+[See source](https://github.com/Codeception/Codeception/blob/2.2/src/Codeception/Util/JsonType.php#L116)
+
+<p>&nbsp;</p><div class="alert alert-warning">Reference is taken from the source code. <a href="https://github.com/Codeception/Codeception/blob/2.2/src//Codeception/Util/JsonType.php">Help us to improve documentation. Edit module reference</a></div>

--- a/docs/reference/Locator.md
+++ b/docs/reference/Locator.md
@@ -8,9 +8,9 @@ Please check them before writing complex functional or acceptance tests.
 
 
 
-### combine 
+#### combine()
 
-*static*
+ *public static* combine($selector1, $selector2) 
 
 Applies OR operator to any number of CSS or XPath selectors.
 You can mix up CSS and XPath selectors here.
@@ -35,18 +35,16 @@ $I->fillField(Locator::combine('form input[type=text]','//form/textarea[2]'), 'q
 ```
 
 As a result the Locator will produce a mixed XPath value that will be used in fillField action.
-
- * `static` 
- * `param` $selector1
+ * `static`  * `param` $selector1
  * `param` $selector2
- * `throws`  \Exception
- * `return`  string
+ * `throws` \Exception
+ * `return` string
 
 [See source](https://github.com/Codeception/Codeception/blob/2.2/src/Codeception/Util/Locator.php#L46)
 
-### contains 
+#### contains()
 
-*static*
+ *public static* contains($element, $text) 
 
 Locates an element containing a text inside.
 Either CSS or XPath locator can be passed, however they will be converted to XPath.
@@ -56,18 +54,18 @@ Either CSS or XPath locator can be passed, however they will be converted to XPa
 use Codeception\Util\Locator;
 
 Locator::contains('label', 'Name'); // label containing name
-Locator::contains('div[ * `contenteditable=true]',`  'hello world');
+Locator::contains('div[@contenteditable=true]', 'hello world');
 ```
 
  * `param` $element
  * `param` $text
- * `return`  string
+ * `return` string
 
 [See source](https://github.com/Codeception/Codeception/blob/2.2/src/Codeception/Util/Locator.php#L233)
 
-### elementAt 
+#### elementAt()
 
-*static*
+ *public static* elementAt($element, $position) 
 
 Locates element at position.
 Either CSS or XPath locator can be passed as locator,
@@ -85,13 +83,13 @@ Locator::elementAt('table#grind>tr', -2); // previous than last row
 
  * `param` $element CSS or XPath locator
  * `param` $position xpath index
- * `return`  mixed
+ * `return` mixed
 
 [See source](https://github.com/Codeception/Codeception/blob/2.2/src/Codeception/Util/Locator.php#L258)
 
-### find 
+#### find()
 
-*static*
+ *public static* find($element, array $attributes) 
 
 Finds element by it's attribute(s)
 
@@ -101,19 +99,16 @@ use \Codeception\Util\Locator;
 
 $I->seeElement(Locator::find('img', ['title' => 'diagram']));
 ```
-
  * `static` 
-
  * `param` $element
  * `param` $attributes
-
- * `return`  string
+ * `return` string
 
 [See source](https://github.com/Codeception/Codeception/blob/2.2/src/Codeception/Util/Locator.php#L151)
 
-### firstElement 
+#### firstElement()
 
-*static*
+ *public static* firstElement($element) 
 
 Locates first element of group elements.
 Either CSS or XPath locator can be passed as locator,
@@ -127,13 +122,13 @@ Locator::firstElement('//table/tr');
 ```
 
  * `param` $element
- * `return`  mixed
+ * `return` mixed
 
 [See source](https://github.com/Codeception/Codeception/blob/2.2/src/Codeception/Util/Locator.php#L287)
 
-### href 
+#### href()
 
-*static*
+ *public static* href($url) 
 
 Matches the *a* element with given URL
 
@@ -144,27 +139,25 @@ use \Codeception\Util\Locator;
 $I->see('Log In', Locator::href('/login.php'));
 ?>
 ```
-
- * `static` 
- * `param` $url
- * `return`  string
+ * `static`  * `param` $url
+ * `return` string
 
 [See source](https://github.com/Codeception/Codeception/blob/2.2/src/Codeception/Util/Locator.php#L73)
 
-### humanReadableString 
+#### humanReadableString()
 
-*static*
+ *public static* humanReadableString($selector) 
 
 Transforms strict locator, \Facebook\WebDriver\WebDriverBy into a string represenation
 
  * `param` $selector
- * `return`  string
+ * `return` string
 
 [See source](https://github.com/Codeception/Codeception/blob/2.2/src/Codeception/Util/Locator.php#L318)
 
-### isCSS 
+#### isCSS()
 
-*static*
+ *public static* isCSS($selector) 
 
 Checks that provided string is CSS selector
 
@@ -176,23 +169,23 @@ Locator::isCSS('//body/p/user') => false
 ```
 
  * `param` $selector
- * `return`  bool
+ * `return` bool
 
 [See source](https://github.com/Codeception/Codeception/blob/2.2/src/Codeception/Util/Locator.php#L177)
 
-### isID 
+#### isID()
 
-*static*
+ *public static* isID($id) 
 
 Checks that string and CSS selector for element by ID
  * `param` $id
- * `return`  bool
+ * `return` bool
 
 [See source](https://github.com/Codeception/Codeception/blob/2.2/src/Codeception/Util/Locator.php#L212)
 
-### isXPath 
+#### isXPath()
 
-*static*
+ *public static* isXPath($locator) 
 
 Checks that locator is an XPath
 
@@ -204,13 +197,13 @@ Locator::isCSS('//body/p/user') => true
 ```
 
  * `param` $locator
- * `return`  bool
+ * `return` bool
 
 [See source](https://github.com/Codeception/Codeception/blob/2.2/src/Codeception/Util/Locator.php#L200)
 
-### lastElement 
+#### lastElement()
 
-*static*
+ *public static* lastElement($element) 
 
 Locates last element of group elements.
 Either CSS or XPath locator can be passed as locator,
@@ -224,13 +217,13 @@ Locator::lastElement('//table/tr');
 ```
 
  * `param` $element
- * `return`  mixed
+ * `return` mixed
 
 [See source](https://github.com/Codeception/Codeception/blob/2.2/src/Codeception/Util/Locator.php#L307)
 
-### option 
+#### option()
 
-*static*
+ *public static* option($value) 
 
 Matches option by text:
 
@@ -242,14 +235,13 @@ $I->seeElement(Locator::option('Male'), '#select-gender');
 ```
 
  * `param` $value
-
- * `return`  string
+ * `return` string
 
 [See source](https://github.com/Codeception/Codeception/blob/2.2/src/Codeception/Util/Locator.php#L116)
 
-### tabIndex 
+#### tabIndex()
 
-*static*
+ *public static* tabIndex($index) 
 
 Matches the element with given tab index
 
@@ -264,11 +256,15 @@ $I->fillField(Locator::tabIndex(2) , 'qwerty');
 $I->click('Login');
 ?>
 ```
-
- * `static` 
- * `param` $index
- * `return`  string
+ * `static`  * `param` $index
+ * `return` string
 
 [See source](https://github.com/Codeception/Codeception/blob/2.2/src/Codeception/Util/Locator.php#L97)
 
-<p>&nbsp;</p><div class="alert alert-warning">Reference is taken from the source code. <a href="https://github.com/Codeception/Codeception/blob/2.2/src/Codeception/Util/Locator.php">Help us to improve documentation. Edit module reference</a></div>
+#### toXPath()
+
+ *protected static* toXPath($selector) 
+
+[See source](https://github.com/Codeception/Codeception/blob/2.2/src/Codeception/Util/Locator.php#L121)
+
+<p>&nbsp;</p><div class="alert alert-warning">Reference is taken from the source code. <a href="https://github.com/Codeception/Codeception/blob/2.2/src//Codeception/Util/Locator.php">Help us to improve documentation. Edit module reference</a></div>

--- a/docs/reference/Module.md
+++ b/docs/reference/Module.md
@@ -1,0 +1,678 @@
+
+## Codeception\Module
+
+
+* *Uses* `Codeception\Util\Shared\Asserts`
+
+Basic class for Modules and Helpers.
+You must extend from it while implementing own helpers.
+
+Public methods of this class start with `_` prefix in order to ignore them in actor classes.
+Module contains **HOOKS** which allow to handle test execution routine.
+
+
+
+
+#### $includeInheritedActions
+
+*public static* **$includeInheritedActions**
+
+By setting it to false module wan't inherit methods of parent class.
+
+type `bool`
+
+
+#### $onlyActions
+
+*public static* **$onlyActions**
+
+Allows to explicitly set what methods have this class.
+
+type `array`
+
+
+#### $excludeActions
+
+*public static* **$excludeActions**
+
+Allows to explicitly exclude actions from module.
+
+type `array`
+
+
+#### $aliases
+
+*public static* **$aliases**
+
+Allows to rename actions
+
+type `array`
+#### __construct()
+
+ *public* __construct($moduleContainer, $config = null) 
+
+Module constructor.
+
+Requires module container (to provide access between modules of suite) and config.
+
+ * `param ModuleContainer` $moduleContainer
+ * `param null` $config
+
+[See source](https://github.com/Codeception/Codeception/blob/2.2/src/Codeception/Module.php#L70)
+
+#### _after()
+
+ *public* _after($test) 
+
+**HOOK** executed after test
+
+ * `param TestInterface` $test
+
+[See source](https://github.com/Codeception/Codeception/blob/2.2/src/Codeception/Module.php#L257)
+
+#### _afterStep()
+
+ *public* _afterStep($step) 
+
+**HOOK** executed after step
+
+ * `param Step` $step
+
+[See source](https://github.com/Codeception/Codeception/blob/2.2/src/Codeception/Module.php#L239)
+
+#### _afterSuite()
+
+ *public* _afterSuite() 
+
+**HOOK** executed after suite
+
+[See source](https://github.com/Codeception/Codeception/blob/2.2/src/Codeception/Module.php#L221)
+
+#### _before()
+
+ *public* _before($test) 
+
+**HOOK** executed before test
+
+ * `param TestInterface` $test
+
+[See source](https://github.com/Codeception/Codeception/blob/2.2/src/Codeception/Module.php#L248)
+
+#### _beforeStep()
+
+ *public* _beforeStep($step) 
+
+**HOOK** executed before step
+
+ * `param Step` $step
+
+[See source](https://github.com/Codeception/Codeception/blob/2.2/src/Codeception/Module.php#L230)
+
+#### _beforeSuite()
+
+ *public* _beforeSuite($settings = null) 
+
+**HOOK** executed before suite
+
+ * `param array` $settings
+
+[See source](https://github.com/Codeception/Codeception/blob/2.2/src/Codeception/Module.php#L214)
+
+#### _cleanup()
+
+ *public* _cleanup() 
+
+[See source](https://github.com/Codeception/Codeception/blob/2.2/src/Codeception/Module.php#L205)
+
+#### _failed()
+
+ *public* _failed($test, $fail) 
+
+**HOOK** executed when test fails but before `_after`
+
+ * `param TestInterface` $test
+ * `param \Exception` $fail
+
+[See source](https://github.com/Codeception/Codeception/blob/2.2/src/Codeception/Module.php#L267)
+
+#### _getConfig()
+
+ *public* _getConfig($key = null) 
+
+Get config values or specific config item.
+
+ * `param null` $key
+ * `return` array|mixed|null
+
+[See source](https://github.com/Codeception/Codeception/blob/2.2/src/Codeception/Module.php#L342)
+
+#### _getName()
+
+ *public* _getName() 
+
+Returns a module name for a Module, a class name for Helper
+ * `return` string
+
+[See source](https://github.com/Codeception/Codeception/blob/2.2/src/Codeception/Module.php#L177)
+
+#### _hasRequiredFields()
+
+ *public* _hasRequiredFields() 
+
+Checks if a module has required fields
+ * `return` bool
+
+[See source](https://github.com/Codeception/Codeception/blob/2.2/src/Codeception/Module.php#L193)
+
+#### _initialize()
+
+ *public* _initialize() 
+
+**HOOK** triggered after module is created and configuration is loaded
+
+[See source](https://github.com/Codeception/Codeception/blob/2.2/src/Codeception/Module.php#L201)
+
+#### _reconfigure()
+
+ *public* _reconfigure($config) 
+
+Allows to redefine config for a specific test.
+Config is restored at the end of a test.
+
+```php
+<?php
+// cleanup DB only for specific group of tests
+public function _before(Test $test) {
+    if (in_array('cleanup', $test->getMetadata()->getGroups()) {
+        $this->getModule('Db')->_reconfigure(['cleanup' => true]);
+    }
+}
+```
+
+ * `param` $config
+ * `throws` Exception\ModuleConfigException
+ * `throws` ModuleException
+
+[See source](https://github.com/Codeception/Codeception/blob/2.2/src/Codeception/Module.php#L119)
+
+#### _resetConfig()
+
+ *public* _resetConfig() 
+
+Reverts config changed by `_reconfigure`
+
+[See source](https://github.com/Codeception/Codeception/blob/2.2/src/Codeception/Module.php#L137)
+
+#### _setConfig()
+
+ *public* _setConfig($config) 
+
+Allows to define initial module config.
+Can be used in `_beforeSuite` hook of Helpers or Extensions
+
+```php
+<?php
+public function _beforeSuite($settings = []) {
+    $this->getModule('otherModule')->_setConfig($this->myOtherConfig);
+}
+```
+
+ * `param` $config
+ * `throws` Exception\ModuleConfigException
+ * `throws` ModuleException
+
+[See source](https://github.com/Codeception/Codeception/blob/2.2/src/Codeception/Module.php#L95)
+
+#### assert()
+
+ *protected* assert($arguments, $not = null) 
+
+[See source](https://github.com/Codeception/Codeception/blob/2.2/src/Codeception/Util/Shared/Asserts.php#L6)
+
+#### assertArrayHasKey()
+
+ *protected* assertArrayHasKey($key, $actual, $description = null) 
+
+ * `param` $key
+ * `param` $actual
+ * `param` $description
+
+[See source](https://github.com/Codeception/Codeception/blob/2.2/src/Codeception/Util/Shared/Asserts.php#L341)
+
+#### assertArrayNotHasKey()
+
+ *protected* assertArrayNotHasKey($key, $actual, $description = null) 
+
+ * `param` $key
+ * `param` $actual
+ * `param` $description
+
+[See source](https://github.com/Codeception/Codeception/blob/2.2/src/Codeception/Util/Shared/Asserts.php#L351)
+
+#### assertContains()
+
+ *protected* assertContains($needle, $haystack, $message = null) 
+
+Checks that haystack contains needle
+
+ * `param`        $needle
+ * `param`        $haystack
+ * `param string` $message
+
+[See source](https://github.com/Codeception/Codeception/blob/2.2/src/Codeception/Util/Shared/Asserts.php#L151)
+
+#### assertEmpty()
+
+ *protected* assertEmpty($actual, $message = null) 
+
+Checks that variable is empty.
+
+ * `param`        $actual
+ * `param string` $message
+
+[See source](https://github.com/Codeception/Codeception/blob/2.2/src/Codeception/Util/Shared/Asserts.php#L199)
+
+#### assertEquals()
+
+ *protected* assertEquals($expected, $actual, $message = null) 
+
+Checks that two variables are equal.
+
+ * `param`        $expected
+ * `param`        $actual
+ * `param string` $message
+ * `return` mixed
+
+[See source](https://github.com/Codeception/Codeception/blob/2.2/src/Codeception/Util/Shared/Asserts.php#L36)
+
+#### assertFalse()
+
+ *protected* assertFalse($condition, $message = null) 
+
+Checks that condition is negative.
+
+ * `param`        $condition
+ * `param string` $message
+
+[See source](https://github.com/Codeception/Codeception/blob/2.2/src/Codeception/Util/Shared/Asserts.php#L254)
+
+#### assertFileExists()
+
+ *protected* assertFileExists($filename, $message = null) 
+
+Checks if file exists
+
+ * `param string` $filename
+ * `param string` $message
+
+[See source](https://github.com/Codeception/Codeception/blob/2.2/src/Codeception/Util/Shared/Asserts.php#L290)
+
+#### assertFileNotExists()
+
+ *protected* assertFileNotExists($filename, $message = null) 
+
+Checks if file doesn't exist
+
+ * `param string` $filename
+ * `param string` $message
+
+[See source](https://github.com/Codeception/Codeception/blob/2.2/src/Codeception/Util/Shared/Asserts.php#L302)
+
+#### assertGreaterOrEquals()
+
+ *protected* assertGreaterOrEquals($expected, $actual, $description = null) 
+
+ * `param` $expected
+ * `param` $actual
+ * `param` $description
+
+[See source](https://github.com/Codeception/Codeception/blob/2.2/src/Codeception/Util/Shared/Asserts.php#L312)
+
+#### assertGreaterThan()
+
+ *protected* assertGreaterThan($expected, $actual, $message = null) 
+
+Checks that actual is greater than expected
+
+ * `param`        $expected
+ * `param`        $actual
+ * `param string` $message
+
+[See source](https://github.com/Codeception/Codeception/blob/2.2/src/Codeception/Util/Shared/Asserts.php#L86)
+
+#### assertGreaterThanOrEqual()
+
+ *protected* assertGreaterThanOrEqual($expected, $actual, $message = null) 
+
+Checks that actual is greater or equal than expected
+
+ * `param`        $expected
+ * `param`        $actual
+ * `param string` $message
+
+[See source](https://github.com/Codeception/Codeception/blob/2.2/src/Codeception/Util/Shared/Asserts.php#L106)
+
+#### assertGreaterThen()
+
+ *protected* assertGreaterThen($expected, $actual, $message = null) 
+ * `deprecated` 
+[See source](https://github.com/Codeception/Codeception/blob/2.2/src/Codeception/Util/Shared/Asserts.php#L94)
+
+#### assertGreaterThenOrEqual()
+
+ *protected* assertGreaterThenOrEqual($expected, $actual, $message = null) 
+ * `deprecated` 
+[See source](https://github.com/Codeception/Codeception/blob/2.2/src/Codeception/Util/Shared/Asserts.php#L114)
+
+#### assertInstanceOf()
+
+ *protected* assertInstanceOf($class, $actual, $description = null) 
+
+ * `param` $class
+ * `param` $actual
+ * `param` $description
+
+[See source](https://github.com/Codeception/Codeception/blob/2.2/src/Codeception/Util/Shared/Asserts.php#L361)
+
+#### assertInternalType()
+
+ *protected* assertInternalType($type, $actual, $description = null) 
+
+ * `param` $type
+ * `param` $actual
+ * `param` $description
+
+[See source](https://github.com/Codeception/Codeception/blob/2.2/src/Codeception/Util/Shared/Asserts.php#L381)
+
+#### assertIsEmpty()
+
+ *protected* assertIsEmpty($actual, $description = null) 
+
+ * `param` $actual
+ * `param` $description
+
+[See source](https://github.com/Codeception/Codeception/blob/2.2/src/Codeception/Util/Shared/Asserts.php#L331)
+
+#### assertLessOrEquals()
+
+ *protected* assertLessOrEquals($expected, $actual, $description = null) 
+
+ * `param` $expected
+ * `param` $actual
+ * `param` $description
+
+[See source](https://github.com/Codeception/Codeception/blob/2.2/src/Codeception/Util/Shared/Asserts.php#L322)
+
+#### assertLessThan()
+
+ *protected* assertLessThan($expected, $actual, $message = null) 
+
+Checks that actual is less than expected
+
+ * `param`        $expected
+ * `param`        $actual
+ * `param string` $message
+
+[See source](https://github.com/Codeception/Codeception/blob/2.2/src/Codeception/Util/Shared/Asserts.php#L126)
+
+#### assertLessThanOrEqual()
+
+ *protected* assertLessThanOrEqual($expected, $actual, $message = null) 
+
+Checks that actual is less or equal than expected
+
+ * `param`        $expected
+ * `param`        $actual
+ * `param string` $message
+
+[See source](https://github.com/Codeception/Codeception/blob/2.2/src/Codeception/Util/Shared/Asserts.php#L138)
+
+#### assertNot()
+
+ *protected* assertNot($arguments) 
+
+[See source](https://github.com/Codeception/Codeception/blob/2.2/src/Codeception/Util/Shared/Asserts.php#L22)
+
+#### assertNotContains()
+
+ *protected* assertNotContains($needle, $haystack, $message = null) 
+
+Checks that haystack doesn't contain needle.
+
+ * `param`        $needle
+ * `param`        $haystack
+ * `param string` $message
+
+[See source](https://github.com/Codeception/Codeception/blob/2.2/src/Codeception/Util/Shared/Asserts.php#L163)
+
+#### assertNotEmpty()
+
+ *protected* assertNotEmpty($actual, $message = null) 
+
+Checks that variable is not empty.
+
+ * `param`        $actual
+ * `param string` $message
+
+[See source](https://github.com/Codeception/Codeception/blob/2.2/src/Codeception/Util/Shared/Asserts.php#L210)
+
+#### assertNotEquals()
+
+ *protected* assertNotEquals($expected, $actual, $message = null) 
+
+Checks that two variables are not equal
+
+ * `param`        $expected
+ * `param`        $actual
+ * `param string` $message
+
+[See source](https://github.com/Codeception/Codeception/blob/2.2/src/Codeception/Util/Shared/Asserts.php#L48)
+
+#### assertNotInstanceOf()
+
+ *protected* assertNotInstanceOf($class, $actual, $description = null) 
+
+ * `param` $class
+ * `param` $actual
+ * `param` $description
+
+[See source](https://github.com/Codeception/Codeception/blob/2.2/src/Codeception/Util/Shared/Asserts.php#L371)
+
+#### assertNotNull()
+
+ *protected* assertNotNull($actual, $message = null) 
+
+Checks that variable is not NULL
+
+ * `param`        $actual
+ * `param string` $message
+
+[See source](https://github.com/Codeception/Codeception/blob/2.2/src/Codeception/Util/Shared/Asserts.php#L232)
+
+#### assertNotRegExp()
+
+ *protected* assertNotRegExp($pattern, $string, $message = null) 
+
+Checks that string not match with pattern
+
+ * `param string` $pattern
+ * `param string` $string
+ * `param string` $message
+
+[See source](https://github.com/Codeception/Codeception/blob/2.2/src/Codeception/Util/Shared/Asserts.php#L187)
+
+#### assertNotSame()
+
+ *protected* assertNotSame($expected, $actual, $message = null) 
+
+Checks that two variables are not same
+
+ * `param`        $expected
+ * `param`        $actual
+ * `param string` $message
+
+[See source](https://github.com/Codeception/Codeception/blob/2.2/src/Codeception/Util/Shared/Asserts.php#L74)
+
+#### assertNull()
+
+ *protected* assertNull($actual, $message = null) 
+
+Checks that variable is NULL
+
+ * `param`        $actual
+ * `param string` $message
+
+[See source](https://github.com/Codeception/Codeception/blob/2.2/src/Codeception/Util/Shared/Asserts.php#L221)
+
+#### assertRegExp()
+
+ *protected* assertRegExp($pattern, $string, $message = null) 
+
+Checks that string match with pattern
+
+ * `param string` $pattern
+ * `param string` $string
+ * `param string` $message
+
+[See source](https://github.com/Codeception/Codeception/blob/2.2/src/Codeception/Util/Shared/Asserts.php#L175)
+
+#### assertSame()
+
+ *protected* assertSame($expected, $actual, $message = null) 
+
+Checks that two variables are same
+
+ * `param`        $expected
+ * `param`        $actual
+ * `param string` $message
+ * `return` mixed
+
+[See source](https://github.com/Codeception/Codeception/blob/2.2/src/Codeception/Util/Shared/Asserts.php#L62)
+
+#### assertThat()
+
+ *protected* assertThat($haystack, $constraint, $message = null) 
+
+
+ * `param`        $haystack
+ * `param`        $constraint
+ * `param string` $message
+
+[See source](https://github.com/Codeception/Codeception/blob/2.2/src/Codeception/Util/Shared/Asserts.php#L265)
+
+#### assertThatItsNot()
+
+ *protected* assertThatItsNot($haystack, $constraint, $message = null) 
+
+Checks that haystack doesn't attend
+
+ * `param`        $haystack
+ * `param`        $constraint
+ * `param string` $message
+
+[See source](https://github.com/Codeception/Codeception/blob/2.2/src/Codeception/Util/Shared/Asserts.php#L277)
+
+#### assertTrue()
+
+ *protected* assertTrue($condition, $message = null) 
+
+Checks that condition is positive.
+
+ * `param`        $condition
+ * `param string` $message
+
+[See source](https://github.com/Codeception/Codeception/blob/2.2/src/Codeception/Util/Shared/Asserts.php#L243)
+
+#### debug()
+
+ *protected* debug($message) 
+
+Print debug message to the screen.
+
+ * `param` $message
+
+[See source](https://github.com/Codeception/Codeception/blob/2.2/src/Codeception/Module.php#L276)
+
+#### debugSection()
+
+ *protected* debugSection($title, $message) 
+
+Print debug message with a title
+
+ * `param` $title
+ * `param` $message
+
+[See source](https://github.com/Codeception/Codeception/blob/2.2/src/Codeception/Module.php#L287)
+
+#### fail()
+
+ *protected* fail($message) 
+
+Fails the test with message.
+
+ * `param` $message
+
+[See source](https://github.com/Codeception/Codeception/blob/2.2/src/Codeception/Util/Shared/Asserts.php#L391)
+
+#### getModule()
+
+ *protected* getModule($name) 
+
+Get another module by its name:
+
+```php
+<?php
+$this->getModule('WebDriver')->_findElements('.items');
+```
+
+ * `param` $name
+ * `return` Module
+ * `throws` ModuleException
+
+[See source](https://github.com/Codeception/Codeception/blob/2.2/src/Codeception/Module.php#L328)
+
+#### getModules()
+
+ *protected* getModules() 
+
+Get all enabled modules
+ * `return` array
+
+[See source](https://github.com/Codeception/Codeception/blob/2.2/src/Codeception/Module.php#L311)
+
+#### hasModule()
+
+ *protected* hasModule($name) 
+
+Checks that module is enabled.
+
+ * `param` $name
+ * `return` bool
+
+[See source](https://github.com/Codeception/Codeception/blob/2.2/src/Codeception/Module.php#L301)
+
+#### onReconfigure()
+
+ *protected* onReconfigure() 
+
+HOOK to be executed when config changes with `_reconfigure`.
+
+[See source](https://github.com/Codeception/Codeception/blob/2.2/src/Codeception/Module.php#L129)
+
+#### scalarizeArray()
+
+ *protected* scalarizeArray($array) 
+
+[See source](https://github.com/Codeception/Codeception/blob/2.2/src/Codeception/Module.php#L353)
+
+#### validateConfig()
+
+ *protected* validateConfig() 
+
+Validates current config for required fields and required packages.
+ * `throws` Exception\ModuleConfigException
+ * `throws` ModuleException
+
+[See source](https://github.com/Codeception/Codeception/blob/2.2/src/Codeception/Module.php#L148)
+
+<p>&nbsp;</p><div class="alert alert-warning">Reference is taken from the source code. <a href="https://github.com/Codeception/Codeception/blob/2.2/src/Codeception/Module.php">Help us to improve documentation. Edit module reference</a></div>

--- a/docs/reference/Stub.md
+++ b/docs/reference/Stub.md
@@ -4,9 +4,13 @@
 
 
 
-#### *public static* magicMethods### atLeastOnce 
 
-*static*
+#### $magicMethods
+
+*modifiers* $magicMethods
+#### atLeastOnce()
+
+ *public static* atLeastOnce($params = null) 
 
 Checks if a method has been invoked at least one
 time.
@@ -28,14 +32,28 @@ $user->getName();
 ```
 
  * `param mixed` $params
-
- * `return`  StubMarshaler
+ * `return` StubMarshaler
 
 [See source](https://github.com/Codeception/Codeception/blob/2.2/src/Codeception/Util/Stub.php#L695)
 
-### consecutive 
+#### bindParameters()
 
-*static*
+ *protected static* bindParameters($mock, $params) 
+
+ * `param \PHPUnit_Framework_MockObject_MockObject` $mock
+ * `param array` $params
+
+[See source](https://github.com/Codeception/Codeception/blob/2.2/src/Codeception/Util/Stub.php#L515)
+
+#### closureIfNull()
+
+ *private static* closureIfNull($params) 
+
+[See source](https://github.com/Codeception/Codeception/blob/2.2/src/Codeception/Util/Stub.php#L739)
+
+#### consecutive()
+
+ *public static* consecutive() 
 
 Stubbing a method call to return a list of values in the specified order.
 
@@ -48,14 +66,13 @@ $user->getName(); //sam
 $user->getName(); //amy
 ?>
 ```
-
- * `return`  ConsecutiveMap
+ * `return` ConsecutiveMap
 
 [See source](https://github.com/Codeception/Codeception/blob/2.2/src/Codeception/Util/Stub.php#L764)
 
-### construct 
+#### construct()
 
-*static*
+ *public static* construct($class, $constructorParams = null, $params = null, $testCase = null) 
 
 Instantiates a class instance by running constructor.
 Parameters for constructor passed as second argument
@@ -91,14 +108,13 @@ Stub::construct('User', array(), array('save' => true }));
  * `param array` $constructorParams
  * `param array` $params
  * `param bool|\PHPUnit_Framework_TestCase` $testCase
-
- * `return`  object
+ * `return` object
 
 [See source](https://github.com/Codeception/Codeception/blob/2.2/src/Codeception/Util/Stub.php#L286)
 
-### constructEmpty 
+#### constructEmpty()
 
-*static*
+ *public static* constructEmpty($class, $constructorParams = null, $params = null, $testCase = null) 
 
 Instantiates a class instance by running constructor with all methods replaced with dummies.
 Parameters for constructor passed as second argument
@@ -134,14 +150,13 @@ Stub::constructEmpty('User', array(), array('save' => true }));
  * `param array` $constructorParams
  * `param array` $params
  * `param bool|\PHPUnit_Framework_TestCase` $testCase
-
- * `return`  object
+ * `return` object
 
 [See source](https://github.com/Codeception/Codeception/blob/2.2/src/Codeception/Util/Stub.php#L338)
 
-### constructEmptyExcept 
+#### constructEmptyExcept()
 
-*static*
+ *public static* constructEmptyExcept($class, $method, $constructorParams = null, $params = null, $testCase = null) 
 
 Instantiates a class instance by running constructor with all methods replaced with dummies, except one.
 Parameters for constructor passed as second argument
@@ -178,27 +193,31 @@ Stub::constructEmptyExcept('User', 'save', array(), array('save' => true }));
  * `param array` $constructorParams
  * `param array` $params
  * `param bool|\PHPUnit_Framework_TestCase` $testCase
-
- * `return`  object
+ * `return` object
 
 [See source](https://github.com/Codeception/Codeception/blob/2.2/src/Codeception/Util/Stub.php#L395)
 
-### copy 
+#### copy()
 
-*static*
+ *public static* copy($obj, $params = null) 
 
 Clones an object and redefines it's properties (even protected and private)
 
  * `param`       $obj
  * `param array` $params
-
- * `return`  mixed
+ * `return` mixed
 
 [See source](https://github.com/Codeception/Codeception/blob/2.2/src/Codeception/Util/Stub.php#L240)
 
-### exactly 
+#### doGenerateMock()
 
-*static*
+ *private static* doGenerateMock($args, $isAbstract = null) 
+
+[See source](https://github.com/Codeception/Codeception/blob/2.2/src/Codeception/Util/Stub.php#L458)
+
+#### exactly()
+
+ *public static* exactly($count, $params = null) 
 
 Checks if a method has been invoked a certain amount
 of times.
@@ -224,28 +243,77 @@ $user->getName();
 
  * `param int` $count
  * `param mixed` $params
-
- * `return`  StubMarshaler
+ * `return` StubMarshaler
 
 [See source](https://github.com/Codeception/Codeception/blob/2.2/src/Codeception/Util/Stub.php#L731)
 
-### factory 
+#### extractTestCaseFromArgs()
 
-*static*
+ *private static* extractTestCaseFromArgs($args) 
+
+[See source](https://github.com/Codeception/Codeception/blob/2.2/src/Codeception/Util/Stub.php#L480)
+
+#### factory()
+
+ *public static* factory($class, $num = null, $params = null) 
 
 Creates $num instances of class through `Stub::make`.
 
  * `param mixed` $class
  * `param int` $num
  * `param array` $params
-
- * `return`  array
+ * `return` array
 
 [See source](https://github.com/Codeception/Codeception/blob/2.2/src/Codeception/Util/Stub.php#L94)
 
-### make 
+#### generateMock()
 
-*static*
+ *private static* generateMock() 
+
+[See source](https://github.com/Codeception/Codeception/blob/2.2/src/Codeception/Util/Stub.php#L430)
+
+#### generateMockForAbstractClass()
+
+ *private static* generateMockForAbstractClass() 
+
+Returns a mock object for the specified abstract class with all abstract
+methods of the class mocked. Concrete methods to mock can be specified with
+the last parameter
+
+ * `param`  string $originalClassName
+ * `param`  array $arguments
+ * `param`  string $mockClassName
+ * `param`  boolean $callOriginalConstructor
+ * `param`  boolean $callOriginalClone
+ * `param`  boolean $callAutoload
+ * `param`  array $mockedMethods
+ * `param`  boolean $cloneArguments
+ * `return` object
+ * `since`  Method available since Release 1.0.0
+ * `throws` \InvalidArgumentException
+
+[See source](https://github.com/Codeception/Codeception/blob/2.2/src/Codeception/Util/Stub.php#L453)
+
+#### getClassname()
+
+ *protected static* getClassname($object) 
+ * `todo` should be simplified
+
+[See source](https://github.com/Codeception/Codeception/blob/2.2/src/Codeception/Util/Stub.php#L583)
+
+#### getMethodsToReplace()
+
+ *protected static* getMethodsToReplace($reflection, $params) 
+
+ * `param \ReflectionClass` $reflection
+ * `param` $params
+ * `return` array
+
+[See source](https://github.com/Codeception/Codeception/blob/2.2/src/Codeception/Util/Stub.php#L601)
+
+#### make()
+
+ *public static* make($class, $params = null, $testCase = null) 
 
 Instantiates a class without executing a constructor.
 Properties and methods can be set as a second parameter.
@@ -279,15 +347,14 @@ Stub::make('User', array('save' => true }));
  * `param mixed` $class - A class to be mocked
  * `param array` $params - properties and methods to set
  * `param bool|\PHPUnit_Framework_TestCase` $testCase
-
- * `return`  object - mock
- * `throws`  \RuntimeException when class does not exist
+ * `return` object - mock
+ * `throws` \RuntimeException when class does not exist
 
 [See source](https://github.com/Codeception/Codeception/blob/2.2/src/Codeception/Util/Stub.php#L45)
 
-### makeEmpty 
+#### makeEmpty()
 
-*static*
+ *public static* makeEmpty($class, $params = null, $testCase = null) 
 
 Instantiates class having all methods replaced with dummies.
 Constructor is not triggered.
@@ -322,14 +389,13 @@ Stub::makeEmpty('User', array('save' => true }));
  * `param mixed` $class
  * `param array` $params
  * `param bool|\PHPUnit_Framework_TestCase` $testCase
-
- * `return`  object
+ * `return` object
 
 [See source](https://github.com/Codeception/Codeception/blob/2.2/src/Codeception/Util/Stub.php#L214)
 
-### makeEmptyExcept 
+#### makeEmptyExcept()
 
-*static*
+ *public static* makeEmptyExcept($class, $method, $params = null, $testCase = null) 
 
 Instantiates class having all methods replaced with dummies except one.
 Constructor is not triggered.
@@ -365,14 +431,25 @@ Stub::makeEmptyExcept('User', 'save', array('isValid' => true }));
  * `param string` $method
  * `param array` $params
  * `param bool|\PHPUnit_Framework_TestCase` $testCase
-
- * `return`  object
+ * `return` object
 
 [See source](https://github.com/Codeception/Codeception/blob/2.2/src/Codeception/Util/Stub.php#L142)
 
-### never 
+#### markAsMock()
 
-*static*
+ *private static* markAsMock($mock, $reflection) 
+
+Set __mock flag, if at all possible
+
+ * `param object` $mock
+ * `param \ReflectionClass` $reflection
+ * `return` object
+
+[See source](https://github.com/Codeception/Codeception/blob/2.2/src/Codeception/Util/Stub.php#L77)
+
+#### never()
+
+ *public static* never($params = null) 
 
 Checks if a method never has been invoked
 
@@ -387,14 +464,13 @@ $user->someMethod();
 ```
 
  * `param mixed` $params
-
- * `return`  StubMarshaler
+ * `return` StubMarshaler
 
 [See source](https://github.com/Codeception/Codeception/blob/2.2/src/Codeception/Util/Stub.php#L630)
 
-### once 
+#### once()
 
-*static*
+ *public static* once($params = null) 
 
 Checks if a method has been invoked exactly one
 time.
@@ -417,23 +493,21 @@ $this->assertEquals('Davert', $userName);
 ```
 
  * `param mixed` $params
-
- * `return`  StubMarshaler
+ * `return` StubMarshaler
 
 [See source](https://github.com/Codeception/Codeception/blob/2.2/src/Codeception/Util/Stub.php#L663)
 
-### update 
+#### update()
 
-*static*
+ *public static* update($mock, array $params) 
 
 Replaces properties of current stub
 
  * `param \PHPUnit_Framework_MockObject_MockObject` $mock
  * `param array` $params
-
- * `return`  mixed
- * `throws`  \LogicException
+ * `return` mixed
+ * `throws` \LogicException
 
 [See source](https://github.com/Codeception/Codeception/blob/2.2/src/Codeception/Util/Stub.php#L499)
 
-<p>&nbsp;</p><div class="alert alert-warning">Reference is taken from the source code. <a href="https://github.com/Codeception/Codeception/blob/2.2/src/Codeception/Util/Stub.php">Help us to improve documentation. Edit module reference</a></div>
+<p>&nbsp;</p><div class="alert alert-warning">Reference is taken from the source code. <a href="https://github.com/Codeception/Codeception/blob/2.2/src//Codeception/Util/Stub.php">Help us to improve documentation. Edit module reference</a></div>

--- a/docs/reference/XmlBuilder.md
+++ b/docs/reference/XmlBuilder.md
@@ -66,66 +66,76 @@ Export:
 [Source code](https://github.com/Codeception/Codeception/blob/master/src/Codeception/Util/XmlBuilder.php)
 
 
-### __construct 
+#### __construct()
+
+ *public* __construct() 
 
 [See source](https://github.com/Codeception/Codeception/blob/2.2/src/Codeception/Util/XmlBuilder.php#L80)
 
-### __get 
+#### __get()
+
+ *public* __get($tag) 
 
 Appends child node
 
  * `param` $tag
-
- * `return`  XmlBuilder
+ * `return` XmlBuilder
 
 [See source](https://github.com/Codeception/Codeception/blob/2.2/src/Codeception/Util/XmlBuilder.php#L93)
 
-### __toString 
+#### __toString()
+
+ *public* __toString() 
 
 [See source](https://github.com/Codeception/Codeception/blob/2.2/src/Codeception/Util/XmlBuilder.php#L165)
 
-### attr 
+#### attr()
+
+ *public* attr($attr, $val) 
 
 Sets attribute for current node
 
  * `param` $attr
  * `param` $val
-
- * `return`  XmlBuilder
+ * `return` XmlBuilder
 
 [See source](https://github.com/Codeception/Codeception/blob/2.2/src/Codeception/Util/XmlBuilder.php#L120)
 
-### getDom 
+#### getDom()
 
- * `return`  \DOMDocument
+ *public* getDom() 
+ * `return` \DOMDocument
 
 [See source](https://github.com/Codeception/Codeception/blob/2.2/src/Codeception/Util/XmlBuilder.php#L173)
 
-### parent 
+#### parent()
+
+ *public* parent() 
 
 Traverses to parent
-
- * `return`  XmlBuilder
+ * `return` XmlBuilder
 
 [See source](https://github.com/Codeception/Codeception/blob/2.2/src/Codeception/Util/XmlBuilder.php#L131)
 
-### parents 
+#### parents()
+
+ *public* parents($tag) 
 
 Traverses to parent with $name
 
  * `param` $tag
-
- * `return`  XmlBuilder
- * `throws`  \Exception
+ * `return` XmlBuilder
+ * `throws` \Exception
 
 [See source](https://github.com/Codeception/Codeception/blob/2.2/src/Codeception/Util/XmlBuilder.php#L145)
 
-### val 
+#### val()
+
+ *public* val($val) 
 
  * `param` $val
-
- * `return`  XmlBuilder
+ * `return` XmlBuilder
 
 [See source](https://github.com/Codeception/Codeception/blob/2.2/src/Codeception/Util/XmlBuilder.php#L106)
 
-<p>&nbsp;</p><div class="alert alert-warning">Reference is taken from the source code. <a href="https://github.com/Codeception/Codeception/blob/2.2/src/Codeception/Util/XmlBuilder.php">Help us to improve documentation. Edit module reference</a></div>
+<p>&nbsp;</p><div class="alert alert-warning">Reference is taken from the source code. <a href="https://github.com/Codeception/Codeception/blob/2.2/src//Codeception/Util/XmlBuilder.php">Help us to improve documentation. Edit module reference</a></div>


### PR DESCRIPTION
I think it is time to add reference of public API classes. 
I started with `Codeception\Module` and created `build:docs-api` robo command to generate docs from it.

Most importantly I updated documentation generators to print Util classes and API classes nicely.
Regenerated all docs with recent updates.