### PR TITLE
Added procesing for native url formats of Yii2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * [Phalcon] **Refactored**. Moved in-memory session adapter to the separated namespace. By @sergeyklay
 * [Phalcon] Fixed overwriting server parameters on requests. By @sergeyklay
 * [Yii2] Fixed unintentional DB connection drop during exception logging, #3696 by @ivokund
+* [Yii2] Added procesing for native url formats of Yii2 #3725 by @githubjeka
 
 #### 2.2.6 (October 2016)
 

--- a/src/Codeception/Lib/InnerBrowser.php
+++ b/src/Codeception/Lib/InnerBrowser.php
@@ -147,7 +147,7 @@ class InnerBrowser extends Module implements Web, PageSourceSaver, ElementLocato
         return (string)$this->getRunningClient()->getInternalResponse()->getContent();
     }
 
-    protected function clientRequest($method, $uri, array $parameters = array(), array $files = array(), array $server = array(), $content = null, $changeHistory = true)
+    protected function clientRequest($method, $uri, array $parameters = [], array $files = [], array $server = [], $content = null, $changeHistory = true)
     {
         $this->debugSection("Request Headers", $this->headers);
 

--- a/src/Codeception/Module/Yii2.php
+++ b/src/Codeception/Module/Yii2.php
@@ -103,6 +103,18 @@ use yii\db\ActiveRecordInterface;
  * }
  * ```
  *
+ * ## URL
+ * This module provide to use native URL formats of Yii2 for all codeception commands that use url for work.
+ * This commands allows input like:
+ *
+ * ```php
+ * <?php
+ * $I->amOnPage(['site/view','page'=>'about']);
+ * $I->amOnPage('index-test.php?site/index');
+ * $I->amOnPage('http://localhost/index-test.php?site/index');
+ * $I->sendAjaxPostRequest(['/user/update', 'id' => 1], ['UserForm[name]' => 'G.Hopper');
+ * ```
+ *
  * ## Status
  *
  * Maintainer: **samdark**
@@ -446,28 +458,6 @@ class Yii2 extends Framework implements ActiveRecord, PartedModule
     }
 
     /**
-     * Converting $page to valid Yii 2 URL
-     *
-     * Allows input like:
-     *
-     * ```php
-     * <?php
-     * $I->amOnPage(['site/view','page'=>'about']);
-     * $I->amOnPage('index-test.php?site/index');
-     * $I->amOnPage('http://localhost/index-test.php?site/index');
-     * ```
-     *
-     * @param $page string|array parameter for \yii\web\UrlManager::createUrl()
-     */
-    public function amOnPage($page)
-    {
-        if (is_array($page)) {
-            $page = Yii::$app->getUrlManager()->createUrl($page);
-        }
-        parent::amOnPage($page);
-    }
-
-    /**
      * Similar to amOnPage but accepts route as first argument and params as second
      *
      * ```
@@ -479,6 +469,26 @@ class Yii2 extends Framework implements ActiveRecord, PartedModule
     {
         array_unshift($params, $route);
         $this->amOnPage($params);
+    }
+    
+    /**
+     * To support to use the behavior of urlManager component
+     * for the methods like this: amOnPage(), sendAjaxRequest() and etc. 
+     * @param $method
+     * @param $uri
+     * @param array $parameters
+     * @param array $files
+     * @param array $server
+     * @param null $content
+     * @param bool $changeHistory
+     * @return mixed
+     */
+    protected function clientRequest($method, $uri, array $parameters = array(), array $files = array(), array $server = array(), $content = null, $changeHistory = true)
+    {
+        if (is_array($uri)) {
+            $uri = Yii::$app->getUrlManager()->createUrl($uri);
+        }
+        return parent::clientRequest($method, $uri, $parameters, $files, $server, $content, $changeHistory);
     }
 
     /**

--- a/src/Codeception/Module/Yii2.php
+++ b/src/Codeception/Module/Yii2.php
@@ -473,7 +473,7 @@ class Yii2 extends Framework implements ActiveRecord, PartedModule
     
     /**
      * To support to use the behavior of urlManager component
-     * for the methods like this: amOnPage(), sendAjaxRequest() and etc. 
+     * for the methods like this: amOnPage(), sendAjaxRequest() and etc.
      * @param $method
      * @param $uri
      * @param array $parameters

--- a/src/Codeception/Module/Yii2.php
+++ b/src/Codeception/Module/Yii2.php
@@ -483,7 +483,7 @@ class Yii2 extends Framework implements ActiveRecord, PartedModule
      * @param bool $changeHistory
      * @return mixed
      */
-    protected function clientRequest($method, $uri, array $parameters = array(), array $files = array(), array $server = array(), $content = null, $changeHistory = true)
+    protected function clientRequest($method, $uri, array $parameters = [], array $files = [], array $server = [], $content = null, $changeHistory = true)
     {
         if (is_array($uri)) {
             $uri = Yii::$app->getUrlManager()->createUrl($uri);


### PR DESCRIPTION
For expample I can't use now:
```php
 $I->sendAjaxPostRequest( [/*...*/], $dataPost); 
 ```

This fix allow to do this