### PR TITLE
Add dataprovider annotation

### DIFF
--- a/docs/07-AdvancedUsage.md
+++ b/docs/07-AdvancedUsage.md
@@ -230,6 +230,56 @@ These examples can be written using Doctrine-style annotation syntax as well:
   }
 ```
 
+You can also use the `@dataprovider` annotation for creating dynamic examples, using a protected method for providing example data:
+```php
+   /**
+    * @dataprovider pageProvider
+    */
+    public function staticPages(AcceptanceTester $I, \Codeception\Example $example)
+    {
+        $I->amOnPage($example['url']);
+        $I->see($example['title'], 'h1');
+        $I->seeInTitle($example['title']);
+    }
+
+    /**
+     * @return array
+     */
+    protected function pageProvider()
+    {
+        return [
+            ['url'=>"/", 'title'=>"Welcome"],
+            ['url'=>"/info", 'title'=>"Info"],
+            ['url'=>"/about", 'title'=>"About Us"],
+            ['url'="/contact", 'title'="Contact Us"]
+        ];
+    }
+```
+
+Alternatively, the `@dataprovider` can also be a public method starting with `_` prefix so it will not be considered as a test:
+
+```php
+   /**
+    * @dataprovider _pageProvider
+    */
+    public function staticPages(AcceptanceTester $I, \Codeception\Example $example)
+    {
+        $I->amOnPage($example['url']);
+        $I->see($example['title'], 'h1');
+        $I->seeInTitle($example['title']);
+    }
+
+    /**
+     * @return array
+     */
+    public function _pageProvider()
+    {
+        return [
+            ['url'=>"/", 'title'=>"Welcome"],
+            ['url'=>"/info", 'title'=>"Info"],
+        ];
+    }
+```
 
 ### Before/After Annotations
 

--- a/src/Codeception/Test/Loader/Cest.php
+++ b/src/Codeception/Test/Loader/Cest.php
@@ -60,13 +60,12 @@ class Cest implements LoaderInterface
                 if (!empty($dataMethod)) {
                     try {
                         $data = ReflectionHelper::invokePrivateMethod($unit, $dataMethod);
-                        // allow to mix axample and dataprovider annotations
+                        // allow to mix example and dataprovider annotations
                         $examples = array_merge($examples, $data);
                     } catch (\Exception $e) {
                         throw new TestParseException(
                             $file,
-                            "DataProvider '$dataMethod' for $testClass->$method is invalid or not callable."
-                            . PHP_EOL .
+                            "DataProvider '$dataMethod' for $testClass->$method is invalid or not callable.\n"
                             "Make sure that the dataprovider exist within the test class."
                         );
                     }

--- a/src/Codeception/Test/Loader/Cest.php
+++ b/src/Codeception/Test/Loader/Cest.php
@@ -65,7 +65,7 @@ class Cest implements LoaderInterface
                     } catch (\Exception $e) {
                         throw new TestParseException(
                             $file,
-                            "DataProvider '$dataMethod' for $testClass->$method is invalid or not callable.\n"
+                            "DataProvider '$dataMethod' for $testClass->$method is invalid or not callable.\n" .
                             "Make sure that the dataprovider exist within the test class."
                         );
                     }

--- a/src/Codeception/Test/Loader/Cest.php
+++ b/src/Codeception/Test/Loader/Cest.php
@@ -7,6 +7,7 @@ use Codeception\Lib\Parser;
 use Codeception\Test\Cest as CestFormat;
 use Codeception\Test\Descriptor;
 use Codeception\Util\Annotation;
+use Codeception\Util\ReflectionHelper;
 
 class Cest implements LoaderInterface
 {
@@ -41,7 +42,9 @@ class Cest implements LoaderInterface
                 if (strpos($method, '_') === 0) {
                     continue;
                 }
+                $examples = [];
 
+                // example Annotation
                 $rawExamples = Annotation::forMethod($unit, $method)->fetchAll('example');
                 if (count($rawExamples)) {
                     $examples = array_map(
@@ -50,6 +53,26 @@ class Cest implements LoaderInterface
                         },
                         $rawExamples
                     );
+                }
+
+                // dataprovider Annotation
+                $dataMethod = Annotation::forMethod($testClass, $method)->fetch('dataprovider');
+                if (!empty($dataMethod)) {
+                    try {
+                        $data = ReflectionHelper::invokePrivateMethod($unit, $dataMethod);
+                        // allow to mix axample and dataprovider annotations
+                        $examples = array_merge($examples, $data);
+                    } catch (\Exception $e) {
+                        throw new TestParseException(
+                            $file,
+                            "DataProvider '$dataMethod' for $testClass->$method is invalid or not callable."
+                            . PHP_EOL .
+                            "Make sure that the dataprovider exist within the test class."
+                        );
+                    }
+                }
+
+                if (count($examples)) {
                     $dataProvider = new \PHPUnit_Framework_TestSuite_DataProvider();
                     foreach ($examples as $k => $example) {
                         if ($example === null) {

--- a/tests/cli/RunCest.php
+++ b/tests/cli/RunCest.php
@@ -430,4 +430,10 @@ EOF
         $I->seeInShellOutput('Fail  File "not-a-dir" not found');
         $I->seeInShellOutput('Fail  File "nothing" not found');
     }
+
+    public function runTestWithAnnotationDataprovider(CliGuy $I)
+    {
+        $I->executeCommand('run scenario DataProviderCest --steps');
+        $I->seeInShellOutput('OK (10 tests');
+    }
 }

--- a/tests/data/claypit/tests/scenario/DataProviderCest.php
+++ b/tests/data/claypit/tests/scenario/DataProviderCest.php
@@ -1,0 +1,57 @@
+<?php
+use Codeception\Example;
+
+class DataProviderCest
+{
+     /**
+      * @dataprovider __exampleDataSource
+      */
+      public function withDataProvider(ScenarioGuy $I, Example $example)
+      {
+          $I->amInPath($example['path']);
+          $I->seeFileFound($example['file']);
+      }
+
+      /**
+       * @dataprovider protectedDataSource
+       */
+       public function withProtectedDataProvider(ScenarioGuy $I, Example $example)
+       {
+           $I->amInPath($example['path']);
+           $I->seeFileFound($example['file']);
+       }
+
+      /**
+       * @dataprovider __exampleDataSource
+       * @example(path=".", file="skipped.suite.yml")
+       */
+       public function withDataProviderAndExample(ScenarioGuy $I, Example $example)
+       {
+           $I->amInPath($example['path']);
+           $I->seeFileFound($example['file']);
+       }
+
+      /**
+       * @return array
+       */
+      public function __exampleDataSource()
+      {
+          return[
+              ['path' => ".", 'file' => "scenario.suite.yml"],
+              ['path' => ".",  'file' => "dummy.suite.yml"],
+              ['path' => ".",  'file' => "unit.suite.yml"]
+          ];
+      }
+
+      /**
+       * @return array
+       */
+      protected function protectedDataSource()
+      {
+          return[
+              ['path' => ".", 'file' => "scenario.suite.yml"],
+              ['path' => ".",  'file' => "dummy.suite.yml"],
+              ['path' => ".",  'file' => "unit.suite.yml"]
+          ];
+      }
+}


### PR DESCRIPTION
Core implementation of the `@dataprovider` annotation based on the extension **[codeception-dataprovider](https://github.com/edno/codeception-dataprovider/issues/2)**.

This implementation includes changes proposed in PR #3730.

```php
     /**
      * @dataprovider fileSource
      */
      public function filesExists(AcceptanceTester $I, Codeception\Example $example)
      {
          $I->amInPath($example['path']);
          $I->seeFileFound($example['file']);
      }

      /**
       * @return array
       */
      protected function fileSource()
      {
          return[
              ['path' => ".", 'file' => "scenario.suite.yml"],
              ['path' => ".",  'file' => "dummy.suite.yml"],
              ['path' => ".",  'file' => "unit.suite.yml"]
          ];
      }
```

Unlikely the extenstion, the core implemention supports the mix of **@dataprovider** and **@example** annotations for a test.
```php
      /**
       * @dataprovider fileSource
       * @example(path=".", file="skipped.suite.yml")
       */
       public function fileExists(AcceptanceTester $I, Codeception\Example $example)
       {
           $I->amInPath($example['path']);
           $I->seeFileFound($example['file']);
       }
```

This implementation is 100% backward compatible with tests using **codeception-dataprovider**.

❕  This will deprecate the extension **codeception-dataprovider** once released.