### PR TITLE
Yii2: remove mockAssetManager

### DIFF
--- a/src/Codeception/Lib/Connector/Yii2.php
+++ b/src/Codeception/Lib/Connector/Yii2.php
@@ -70,7 +70,7 @@ class Yii2 extends Client
         /** @var \yii\web\Application $app */
         $this->app = Yii::createObject($config);
         $this->persistDb();
-        $this->mockMailer($config);       
+        $this->mockMailer($config);
         \Yii::setLogger(new Logger());
     }
 

--- a/src/Codeception/Lib/Connector/Yii2.php
+++ b/src/Codeception/Lib/Connector/Yii2.php
@@ -70,8 +70,7 @@ class Yii2 extends Client
         /** @var \yii\web\Application $app */
         $this->app = Yii::createObject($config);
         $this->persistDb();
-        $this->mockMailer($config);
-        $this->mockAssetManager();
+        $this->mockMailer($config);       
         \Yii::setLogger(new Logger());
     }
 
@@ -271,10 +270,5 @@ class Yii2 extends Client
         } elseif ($this->app->has('db')) {
             static::$db = $this->app->get('db');
         }
-    }
-
-    private function mockAssetManager()
-    {
-        $this->app->set('assetManager', Stub::make('yii\web\AssetManager', ['bundles' => false]));
     }
 }


### PR DESCRIPTION
`mockAssetManager` prevents setting from test.config file.

https://github.com/yiisoft/yii2-app-advanced/pull/219
https://github.com/yiisoft/yii2-app-basic/pull/95

Now code from PR's doesn't work.

P.S. mock was introduced in [here](https://github.com/Codeception/Codeception/pull/3343/commits/6add1042ef297110c63adbb4281cada4e129b119)