### PR TITLE
Use alpine base for docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,8 @@ MAINTAINER Tobias Munk tobias@diemeisterei.de
 RUN apk update --no-cache && \
     apk add --no-cache \
         git \
-        zlib-dev
+        zlib-dev \
+        openssl-dev
 
 # Install php extensions
 RUN docker-php-ext-install \
@@ -20,7 +21,6 @@ RUN apk add --no-cache  --virtual .ext-deps \
         git \
         make \
         musl-dev \
-        openssl-dev \
         re2c && \
     pecl install mongodb xdebug && \
     docker-php-ext-enable mongodb && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,26 +1,32 @@
-FROM php:7.0-cli
+FROM php:7.0-alpine
 
 MAINTAINER Tobias Munk tobias@diemeisterei.de
 
 # Install required system packages
-RUN apt-get update && \
-    apt-get -y install \
-            git \
-            zlib1g-dev \
-            libssl-dev \
-        --no-install-recommends && \
-        apt-get clean && \
-        rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+RUN apk update --no-cache && \
+    apk add --no-cache \
+        git \
+        zlib-dev
 
 # Install php extensions
 RUN docker-php-ext-install \
-    bcmath \
-    zip
+        bcmath \
+        zip
 
 # Install pecl extensions
-RUN pecl install mongodb xdebug && \
+RUN apk add --no-cache  --virtual .ext-deps \
+        autoconf \
+        gcc \
+        git \
+        make \
+        musl-dev \
+        openssl-dev \
+        re2c && \
+    pecl install mongodb xdebug && \
     docker-php-ext-enable mongodb && \
-    docker-php-ext-enable xdebug
+    docker-php-ext-enable xdebug && \
+    apk del --no-cache --purge -r .ext-deps && \
+    rm -rf /var/cache/apk/* /var/tmp/* /tmp/*
 
 # Configure php
 RUN echo "date.timezone = UTC" >> /usr/local/etc/php/php.ini


### PR DESCRIPTION
Use `php:7.0-alpine` instead of `php:7.0-cli` as a base, so it could have a lot smaller image (60 MB instead of 187 MB).