### PR TITLE
Fixed action inclusion when includeInheritedActions is set to false

### DIFF
--- a/src/Codeception/Lib/ModuleContainer.php
+++ b/src/Codeception/Lib/ModuleContainer.php
@@ -173,14 +173,11 @@ class ModuleContainer
         // Do not include inherited actions if the static $includeInheritedActions property is set to false.
         // However, if an inherited action is also specified in the static $onlyActions property
         // it should be included as an action.
-        if (!$module::$includeInheritedActions) {
-            if (!in_array($method->name, $module::$onlyActions)) {
-                return false;
-            }
-
-            if ($method->getDeclaringClass()->getName() == get_class($module)) {
-                return false;
-            }
+        if (!$module::$includeInheritedActions &&
+            !in_array($method->name, $module::$onlyActions) &&
+            $method->getDeclaringClass()->getName() != get_class($module)
+        ) {
+            return false;
         }
 
         // Do not include hidden methods, methods with a name starting with an underscore

--- a/tests/support/UniversalFramework.php
+++ b/tests/support/UniversalFramework.php
@@ -9,4 +9,9 @@ class UniversalFramework extends \Codeception\Lib\Framework
         $this->client = new \Codeception\Lib\Connector\Universal();
         $this->client->setIndex(\Codeception\Configuration::dataDir().$index);
     }
+
+    public function useUniversalFramework()
+    {
+
+    }
 }

--- a/tests/unit/Codeception/Lib/ModuleContainerTest.php
+++ b/tests/unit/Codeception/Lib/ModuleContainerTest.php
@@ -80,6 +80,7 @@ class ModuleContainerTest extends \PHPUnit_Framework_TestCase
         $this->assertArrayNotHasKey('amOnPage', $actions);
         $this->assertArrayNotHasKey('see', $actions);
         $this->assertArrayNotHasKey('click', $actions);
+        $this->assertArrayHasKey('useUniversalFramework', $actions);
     }
 
     /**


### PR DESCRIPTION
When you set in your $includeInheritedActions = false, then no actions are included at all.

This PR fixes that