### PR TITLE
Bugfix for Symfony Module

### DIFF
--- a/src/Codeception/Module/Symfony.php
+++ b/src/Codeception/Module/Symfony.php
@@ -97,7 +97,7 @@ class Symfony extends Framework implements DoctrineProvider, PartedModule
 
     public $config = [
         'app_path' => 'app',
-        'var_path' => 'app',
+        'var_path' => 'var',
         'environment' => 'test',
         'debug' => true,
         'cache_router' => false,


### PR DESCRIPTION
Bugfix for 
"Symfony bootstrap file not found... Please specify path to bootstrap file using `var_path`"