### PR TITLE
Update GroupManager.php

### DIFF
--- a/src/Codeception/Lib/GroupManager.php
+++ b/src/Codeception/Lib/GroupManager.php
@@ -28,10 +28,15 @@ class GroupManager
      * proceeds group names with asterisk:
      *
      * ```
-     * "tests/_log/g_*" => [
-     *      "tests/_log/group_1",
-     *      "tests/_log/group_2",
-     *      "tests/_log/group_3",
+     * "tests/groups/g*" => [
+     *      "tests/groups/g1",
+     *      "tests/groups/g2",
+     *      "tests/groups/ga",
+     *      "tests/groups/gb"
+     * ]
+     * "tests/groups/module*" => [
+     *      "tests/groups/moduleCore",
+     *      "tests/groups/moduleApi"
      * ]
      * ```
      */
@@ -47,11 +52,9 @@ class GroupManager
                 ->sortByName()
                 ->in(Configuration::projectDir());
 
-            $i = 1;
             foreach ($files as $file) {
                 /** @var SplFileInfo $file * */
-                $this->configuredGroups[str_replace('*', $i, $group)] = $file->getRelativePathname();
-                $i++;
+                $this->configuredGroups[$file->getBasename()] = $file->getRelativePathname();
             }
             unset($this->configuredGroups[$group]);
         }

--- a/tests/unit/Codeception/Lib/GroupManagerTest.php
+++ b/tests/unit/Codeception/Lib/GroupManagerTest.php
@@ -56,15 +56,6 @@ class GroupManagerTest extends \Codeception\Test\Unit
         $this->assertContains('group_2', $this->manager->groupsForTest($test2));
     }
 
-    public function testGroupsByDifferentPattern()
-    {
-        $this->manager = new GroupManager(['g_*' => 'tests/data/group_*']);
-        $test1 = $this->makeTestCase('tests/UserTest.php');
-        $test2 = $this->makeTestCase('tests/PostTest.php');
-        $this->assertContains('g_1', $this->manager->groupsForTest($test1));
-        $this->assertContains('g_2', $this->manager->groupsForTest($test2));
-    }
-
     public function testGroupsFileHandlesWhitespace()
     {
         $this->manager = new GroupManager(['whitespace_group_test' => 'tests/data/whitespace_group_test']);


### PR DESCRIPTION
1. Fixed comment to suite site documentation.
As of http://codeception.com/docs/07-AdvancedUsage#Group-Files
g_* pattern would not load any 'group_N' files

2. Fixed code so we now can not only load data groups, but also run these by their names.
Without this fix one with g1 and g9 files loaded by pattern would not be able to call -g g9 because internally g9 will be turned to g2 by iterator. 
Surprisingly enough we used old version without any issues for awhile. 

Thank you very much for the comment in the code. A rare treat.