### PR TITLE
Codeception\Step\Comment::__toString() must return a string

### DIFF
--- a/src/Codeception/Step/Comment.php
+++ b/src/Codeception/Step/Comment.php
@@ -8,17 +8,17 @@ class Comment extends CodeceptionStep
 {
     public function __toString()
     {
-        return $this->getAction();
+        return (string)$this->getAction();
     }
 
     public function toString($maxLength)
     {
-        return $this->getAction();
+        return (string)$this->getAction();
     }
 
     public function getHumanizedAction()
     {
-        return $this->getAction();
+        return (string)$this->getAction();
     }
 
     public function getHtml($highlightColor = '#732E81')

--- a/src/Codeception/Step/Comment.php
+++ b/src/Codeception/Step/Comment.php
@@ -8,17 +8,12 @@ class Comment extends CodeceptionStep
 {
     public function __toString()
     {
-        return (string)$this->getAction();
+        return (string) $this->getAction();
     }
 
     public function toString($maxLength)
     {
-        return (string)$this->getAction();
-    }
-
-    public function getHumanizedAction()
-    {
-        return (string)$this->getAction();
+        return mb_strcut($this->__toString(), 0, $maxLength);
     }
 
     public function getHtml($highlightColor = '#732E81')

--- a/src/Codeception/Step/Comment.php
+++ b/src/Codeception/Step/Comment.php
@@ -13,7 +13,7 @@ class Comment extends CodeceptionStep
 
     public function toString($maxLength)
     {
-        return mb_strcut($this->__toString(), 0, $maxLength);
+        return mb_strcut($this->__toString(), 0, $maxLength, 'utf-8');
     }
 
     public function getHtml($highlightColor = '#732E81')


### PR DESCRIPTION
Method Codeception\Step\Comment::__toString() must return a string
Fixes #3296 