### PR TITLE
try to get terminal width from ENV variable (bash), fixes #3788

### DIFF
--- a/src/Codeception/Subscriber/Console.php
+++ b/src/Codeception/Subscriber/Console.php
@@ -528,7 +528,12 @@ class Console implements EventSubscriberInterface
             && (getenv('TERM'))
             && (getenv('TERM') != 'unknown')
         ) {
-            $this->width = (int) (`command -v tput >> /dev/null 2>&1 && tput cols`) - 2;
+            // try to get terminal width from ENV variable (bash), see also https://github.com/Codeception/Codeception/issues/3788
+            if (getenv('COLUMNS')) {
+                $this->width = getenv('COLUMNS');
+            } else {
+                $this->width = (int) (`command -v tput >> /dev/null 2>&1 && tput cols`) - 2;
+            }
         } elseif ($this->isWin() && (php_sapi_name() === "cli")) {
             exec('mode con', $output);
             preg_match('/^ +.* +(\d+)$/', $output[4], $matches);


### PR DESCRIPTION
an additional improvement might be paring the output of `stty -a`