### PR TITLE
close transaction create by the controller-action

### DIFF
--- a/src/Codeception/Lib/Connector/Yii2.php
+++ b/src/Codeception/Lib/Connector/Yii2.php
@@ -58,6 +58,9 @@ class Yii2 extends Client
 
     public function resetApplication()
     {
+        if ($this->app->db !== null && $this->app->db->transaction !== null) {
+            $this->app->db->transaction->rollBack();
+        }
         $this->app = null;
     }
 


### PR DESCRIPTION
When an action is interrupted by an unexpected exception without closing the create transactions, a new application without closing the transactions is created. Some tables are locked and the test-run is stuck. This is the solution to this problem, just close the open transaction.