### PR TITLE
use user_* views rather than all_* views

### DIFF
--- a/src/Codeception/Lib/Driver/Oci.php
+++ b/src/Codeception/Lib/Driver/Oci.php
@@ -78,7 +78,7 @@ class Oci extends Db
         if (!isset($this->primaryKeys[$tableName])) {
             $primaryKey = [];
             $query = "SELECT cols.column_name
-                FROM all_constraints cons, all_cons_columns cols
+                FROM user_constraints cons, user_cons_columns cols
                 WHERE cols.table_name = ?
                 AND cons.constraint_type = 'P'
                 AND cons.constraint_name = cols.constraint_name


### PR DESCRIPTION
Querying the `all_*` views can result in false matches.  In our context, we're only interested in what the `user_*` views can return, since it is "us" that created the objects in the first place (`dump.sql`).