### PR TITLE
fix click on links with only numbers DOM Exception 12

### DIFF
--- a/src/Codeception/Module/WebDriver.php
+++ b/src/Codeception/Module/WebDriver.php
@@ -2264,7 +2264,11 @@ class WebDriver extends CodeceptionModule implements
             }
             if (empty($nodes) and Locator::isCSS($selector)) {
                 $isValidLocator = true;
-                $nodes = $page->findElements(WebDriverBy::cssSelector($selector));
+                try {
+                    $nodes = $page->findElements(WebDriverBy::cssSelector($selector));
+                } catch (InvalidElementStateException $e) {
+                    $nodes = $page->findElements(WebDriverBy::linkText($selector));
+                }
             }
             if (empty($nodes) and Locator::isXPath($selector)) {
                 $isValidLocator = true;


### PR DESCRIPTION
When you try to click on a link that has only numbers `$I->click('222')` you get a invalid css selector exception.

Exception
```
[Facebook\WebDriver\Exception\InvalidElementStateException] {"errorMessage":"SyntaxError: DOM Exception 12","request":{"headers":{"Accept":"application/json","Content-Length":"38","Content-Type":"application/json;charset=UTF-8","Host":"127.0.0.1:8910"},"httpVersion":"1.1","method":"POST","post":"{\"using\":\"css selector\",\"value\":\"217\"}","url":"/elements","urlParsed":{"anchor":"","query":"","file":"elements","directory":"/","path":"/elements","relative":"/elements","port":"","host":"","password":"","user":"","userInfo":"","authority":"","protocol":"","source":"/elements","queryKey":{},"chunks":["elements"]},"urlOriginal":"/session/d2fe7e50-c80e-11e6-afe3-9d1eec0f3e94/elements"}}
```

The Problem is that phantom think it is a id and ids are not allowed to start with numbers.

See also
http://phptest.club/t/i-click-on-link-that-is-a-number-webdriver/261
http://stackoverflow.com/questions/7315162/syntax-err-dom-exception-12-hmmm