### PR TITLE
fix printScenarioFail with multiple scenarios

### DIFF
--- a/src/Codeception/Scenario.php
+++ b/src/Codeception/Scenario.php
@@ -151,10 +151,18 @@ class Scenario
     }
 
     /**
-     * @param null $metaStep
+     * @param Step\Meta $metaStep
      */
     public function setMetaStep($metaStep)
     {
         $this->metaStep = $metaStep;
+    }
+
+    /**
+     * @return Step\Meta
+     */
+    public function getMetaStep()
+    {
+        return $this->metaStep;
     }
 }

--- a/src/Codeception/Subscriber/Console.php
+++ b/src/Codeception/Subscriber/Console.php
@@ -409,7 +409,7 @@ class Console implements EventSubscriberInterface
         if ($this->conditionalFails) {
             $failedStep = (string) array_shift($this->conditionalFails);
         } else {
-            $failedStep = (string) $this->failedStep;
+            $failedStep = (string) $failedTest->getScenario()->getMetaStep();
         }
 
         $this->printException($fail, $failedStep);

--- a/tests/cli/RunCest.php
+++ b/tests/cli/RunCest.php
@@ -355,11 +355,18 @@ EOF
         $I->seeInShellOutput('PASSED');
     }
 
-    public function runIncompleteGherkinTest(CliGuy $I)
+    public function reportsCorrectFailedStep(CliGuy $I)
     {
         $I->executeCommand('run scenario File.feature -v');
         $I->seeInShellOutput('OK, but incomplete');
         $I->seeInShellOutput('Step definition for `I have only idea of what\'s going on here` not found in contexts');
+    }
+
+    public function runFailingGherkinTest(CliGuy $I)
+    {
+        $I->executeCommand('run scenario Fail.feature -v --no-exit');
+        $I->seeInShellOutput('Step  I see file "games.zip"');
+        $I->seeInShellOutput('Step  I see file "tools.zip"');
     }
 
     public function runGherkinScenarioWithMultipleStepDefinitions(CliGuy $I)

--- a/tests/data/claypit/tests/scenario/Fail.feature
+++ b/tests/data/claypit/tests/scenario/Fail.feature
@@ -1,0 +1,10 @@
+Feature: Run gherkin
+  In order to test a feature
+  As a user
+  I need to be able to see output
+
+  Scenario: Fail because file games.zip not exist
+    Then I see file "games.zip"
+
+  Scenario: Fail because file tools.zip not exist
+    Then I see file "tools.zip"


### PR DESCRIPTION
When you have run a feature file and mulitple scenarios fails.
Then in the exception message the step is always the last one.

I am not sure what `conditionalFails` means. See change.