### PR TITLE
Wedriver pageload timeout

### DIFF
--- a/docs/modules/WebDriver.md
+++ b/docs/modules/WebDriver.md
@@ -114,6 +114,7 @@ you should use a tunnel application provided by a service.
 * `capabilities` - Sets Selenium2 [desired capabilities](https://github.com/SeleniumHQ/selenium/wiki/DesiredCapabilities). Should be a key-value array.
 * `connection_timeout` - timeout for opening a connection to remote selenium server (30 seconds by default).
 * `request_timeout` - timeout for a request to return something from remote selenium server (30 seconds by default).
+* `pageload_timeout` - amount of time to wait for a page load to complete before throwing an error (default 0 seconds).
 * `http_proxy` - sets http proxy server url for testing a remote server.
 * `http_proxy_port` - sets http proxy server port
 * `debug_log_entries` - how many selenium entries to print with `debugWebDriverLogs` or on fail (15 by default).

--- a/src/Codeception/Module/WebDriver.php
+++ b/src/Codeception/Module/WebDriver.php
@@ -1194,7 +1194,7 @@ class WebDriver extends CodeceptionModule implements
             );
             $this->sessions[] = $this->_backupSession();
             $this->webDriver->manage()->timeouts()->implicitlyWait($this->config['wait']);
-            if(!is_null($this->config['pageload_timeout'])) {
+            if (!is_null($this->config['pageload_timeout'])) {
                 $this->webDriver->manage()->timeouts()->pageLoadTimeout($this->config['pageload_timeout']);
             }
             $this->initialWindowSize();

--- a/src/Codeception/Module/WebDriver.php
+++ b/src/Codeception/Module/WebDriver.php
@@ -160,6 +160,7 @@ use Symfony\Component\DomCrawler\Crawler;
  * * `capabilities` - Sets Selenium2 [desired capabilities](https://github.com/SeleniumHQ/selenium/wiki/DesiredCapabilities). Should be a key-value array.
  * * `connection_timeout` - timeout for opening a connection to remote selenium server (30 seconds by default).
  * * `request_timeout` - timeout for a request to return something from remote selenium server (30 seconds by default).
+ * * `pageload_timeout` - amount of time to wait for a page load to complete before throwing an error (default 0 seconds).
  * * `http_proxy` - sets http proxy server url for testing a remote server.
  * * `http_proxy_port` - sets http proxy server port
  * * `debug_log_entries` - how many selenium entries to print with `debugWebDriverLogs` or on fail (15 by default).
@@ -258,6 +259,7 @@ class WebDriver extends CodeceptionModule implements
         'capabilities'       => [],
         'connection_timeout' => null,
         'request_timeout'    => null,
+        'pageload_timeout'   => null,
         'http_proxy'         => null,
         'http_proxy_port'    => null,
         'ssl_proxy'          => null,
@@ -1192,6 +1194,9 @@ class WebDriver extends CodeceptionModule implements
             );
             $this->sessions[] = $this->_backupSession();
             $this->webDriver->manage()->timeouts()->implicitlyWait($this->config['wait']);
+            if(!is_null($this->config['pageload_timeout'])) {
+                $this->webDriver->manage()->timeouts()->implicitlyWait($this->config['pageload_timeout']);
+            }
             $this->initialWindowSize();
         } catch (WebDriverCurlException $e) {
             throw new ConnectionException("Can't connect to Webdriver at {$this->wd_host}. Please make sure that Selenium Server or PhantomJS is running.");

--- a/src/Codeception/Module/WebDriver.php
+++ b/src/Codeception/Module/WebDriver.php
@@ -1195,7 +1195,7 @@ class WebDriver extends CodeceptionModule implements
             $this->sessions[] = $this->_backupSession();
             $this->webDriver->manage()->timeouts()->implicitlyWait($this->config['wait']);
             if(!is_null($this->config['pageload_timeout'])) {
-                $this->webDriver->manage()->timeouts()->implicitlyWait($this->config['pageload_timeout']);
+                $this->webDriver->manage()->timeouts()->pageLoadTimeout($this->config['pageload_timeout']);
             }
             $this->initialWindowSize();
         } catch (WebDriverCurlException $e) {


### PR DESCRIPTION
adds support of pageload_timeout config to WebDriver

the amount of time to wait for a page load to complete before throwing an error
calls facebook/webdriver/lib/WebDriverTimeouts.php::pageLoadTimeout($seconds)


This patch allows to reduce issues from phantomjs random freezing, especially within CI environment 
https://github.com/ariya/phantomjs/issues/11526

patch based on suggestion from  https://github.com/ariya/phantomjs/issues/11526#issuecomment-115135376

