### PR TITLE
Fix exception WebDriver not connected and Yii2 enabled

### DIFF
--- a/src/Codeception/Module/Yii2.php
+++ b/src/Codeception/Module/Yii2.php
@@ -192,7 +192,9 @@ class Yii2 extends Framework implements ActiveRecord, PartedModule
             $this->transaction->rollback();
         }
 
-        $this->client->resetPersistentVars();
+        if ($this->client) {
+            $this->client->resetPersistentVars();
+        }
 
         if (isset(\Yii::$app) && \Yii::$app->has('session', true)) {
             \Yii::$app->session->close();


### PR DESCRIPTION
I this exception while WebDriver and Yii2 enabled, but WebDriver not connected since I forgot to start it.
```
  [Symfony\Component\Debug\Exception\FatalThrowableError]  
  Call to a member function resetPersistentVars() on null 

Exception trace:
 () at /home/[...]/vendor/codeception/codeception/src/Codeception/Module/Yii2.php:221
 Codeception\Module\Yii2->_after() at /home/[...]/vendor/codeception/codeception/src/Codeception/Subscriber/Module.php:68
```

acceptance.suite.yml:
```
class_name: AcceptanceTester
modules:
    enabled:
        - WebDriver:
            url: http://localhost/app/web
            browser: chrome
            restart: false
            window_size: 1360x768
        - Yii2:
            part: init
```