### PR TITLE
Changed package name to codeception/codeception

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name":"codeception/base",
+    "name":"codeception/codeception",
     "description":"BDD-style testing framework",
     "keywords":["BDD", "acceptance testing", "functional testing", "unit testing", "tdd"],
     "homepage":"http://codeception.com/",


### PR DESCRIPTION
The name used to be `codeception/codeception`, but it was changed to `codeception/base` by https://github.com/Codeception/Codeception/commit/d58d5547a7fa435ed61f8d6a9365067983709f83#diff-b5d0ee8c97c7abd7e3fa29b9a27d1780L2
which looks like an accident.

This change could fix #3855