### PR TITLE
[Parser] Use function_exists to check that exec is disabled

### DIFF
--- a/src/Codeception/Lib/Parser.php
+++ b/src/Codeception/Lib/Parser.php
@@ -126,11 +126,11 @@ class Parser
         if (empty($config['settings']['lint'])) { // lint disabled in config
             return;
         }
-        @exec("php -l " . escapeshellarg($file) . " 2>&1", $output, $code);
-        if (!isset($code)) {
-            //probably exec function is disabled #3324
+        if (!function_exists('exec')) {
+            //exec function is disabled #3324
             return;
         }
+        exec("php -l " . escapeshellarg($file) . " 2>&1", $output, $code);
         if ($code !== 0) {
             throw new TestParseException($file, implode("\n", $output));
         }


### PR DESCRIPTION
A better alternative to `@exec`
Thanks to @mklemarczyk