### PR TITLE
add option text to seeInField

### DIFF
--- a/src/Codeception/Module/WebDriver.php
+++ b/src/Codeception/Module/WebDriver.php
@@ -1489,6 +1489,7 @@ class WebDriver extends CodeceptionModule implements
      * ```
      *
      * @param $selector
+     * @param array $attributes
      */
     public function seeElementInDOM($selector, $attributes = [])
     {
@@ -1502,6 +1503,7 @@ class WebDriver extends CodeceptionModule implements
      * Opposite of `seeElementInDOM`.
      *
      * @param $selector
+     * @param array $attributes
      */
     public function dontSeeElementInDOM($selector, $attributes = [])
     {
@@ -1629,6 +1631,8 @@ class WebDriver extends CodeceptionModule implements
      * as created by `window.alert`|`window.confirm`|`window.prompt`, contains the given string.
      *
      * @param $text
+     *
+     * @throws \Codeception\Exception\ModuleException
      */
     public function seeInPopup($text)
     {
@@ -1642,6 +1646,8 @@ class WebDriver extends CodeceptionModule implements
      * Enters text into a native JavaScript prompt popup, as created by `window.prompt`.
      *
      * @param $keys
+     *
+     * @throws \Codeception\Exception\ModuleException
      */
     public function typeInPopup($keys)
     {

--- a/src/Codeception/Module/WebDriver.php
+++ b/src/Codeception/Module/WebDriver.php
@@ -36,6 +36,7 @@ use Facebook\WebDriver\Interactions\WebDriverActions;
 use Facebook\WebDriver\Remote\LocalFileDetector;
 use Facebook\WebDriver\Remote\RemoteWebDriver;
 use Facebook\WebDriver\Remote\UselessFileDetector;
+use Facebook\WebDriver\Remote\RemoteWebElement;
 use Facebook\WebDriver\Remote\WebDriverCapabilityType;
 use Facebook\WebDriver\WebDriverBy;
 use Facebook\WebDriver\WebDriverDimension;
@@ -1057,12 +1058,17 @@ class WebDriver extends CodeceptionModule implements
         }
     }
 
+    /**
+     * @param RemoteWebElement[] $elements
+     * @param $value
+     * @return array
+     */
     protected function proceedSeeInField(array $elements, $value)
     {
         $strField = reset($elements)->getAttribute('name');
         if (reset($elements)->getTagName() === 'select') {
             $el = reset($elements);
-            $elements = $el->findElements(WebDriverBy::xpath('.//option[@selected]'));
+            $elements = $el->findElements(WebDriverBy::xpath('.//option'));
             if (empty($value) && empty($elements)) {
                 return ['True', true];
             }
@@ -1088,10 +1094,15 @@ class WebDriver extends CodeceptionModule implements
                         $currentValues[] = $el->getAttribute('value');
                     }
                     break;
-
+                case 'option':
+                    // no break we need the trim text and the value also
+                    if (!$el->isSelected()) {
+                        break;
+                    }
+                    $currentValues[] = $el->getText();
                 case 'textarea':
                     // we include trimmed and real value of textarea for check
-                    $currentValues[] = $el->getText(); // trimmed value
+                    $currentValues[] = trim($el->getText());
                 default:
                     $currentValues[] = $el->getAttribute('value'); // raw value
                     break;
@@ -1102,7 +1113,7 @@ class WebDriver extends CodeceptionModule implements
             'Contains',
             $value,
             $currentValues,
-            "Failed testing for '$value' in $strField's value: " . implode(', ', $currentValues)
+            "Failed testing for '$value' in $strField's value: '" . implode("', '", $currentValues) . "'"
         ];
     }
 

--- a/tests/data/app/view/form/field_values.php
+++ b/tests/data/app/view/form/field_values.php
@@ -46,6 +46,7 @@
         </select>
         
         <select name="select3">
+            <option value=""></option>
             <option value="not seen one">Nothing selected</option>
             <option value="not seen two">Not selected</option>
             <option value="not seen three">Not selected</option>

--- a/tests/data/app/view/form/select_second.php
+++ b/tests/data/app/view/form/select_second.php
@@ -7,6 +7,7 @@
     </select>
     <select id="select2">
         <option value="select2_value1">Value1</option>
+        <option value="white" selected>        no_whitespaces    </option>
     </select>
     <input type="submit" value="Submit" />
 </form>

--- a/tests/data/app/view/form/textarea.php
+++ b/tests/data/app/view/form/textarea.php
@@ -3,6 +3,8 @@
 <form action="/form/complex" method="POST">
     <label for="description">Description</label>
     <textarea name="description" id="description" cols="30" rows="10">sunrise</textarea>
+    <textarea name="whitespaces" id="whitespaces" cols="30" rows="10">
+        no_whitespaces    </textarea>
     <input type="submit" value="Submit" />
 </form>
 </body>

--- a/tests/web/WebDriverTest.php
+++ b/tests/web/WebDriverTest.php
@@ -651,10 +651,31 @@ class WebDriverTest extends TestsForBrowsers
         $this->module->amOnPage('/form/textarea');
         //make sure we see 'sunrise' which is the default text in the textarea
         $this->module->seeInField('#description', 'sunrise');
+
+        if ($this->notForSelenium()) {
+            $this->module->seeInField('#whitespaces', '        no_whitespaces    ');
+        }
+        $this->module->seeInField('#whitespaces', 'no_whitespaces');
+
         //fill in some new text and see if we can see it
         $textarea_value = 'test string';
         $this->module->fillField('#description', $textarea_value);
         $this->module->seeInField('#description', $textarea_value);
+    }
+
+    public function testSeeInFieldSelect()
+    {
+        $this->module->amOnPage('/form/select_second');
+
+        if ($this->notForSelenium()) {
+            $this->module->seeInField('#select2', '        no_whitespaces    ');
+        }
+        $this->module->seeInField('#select2', 'no_whitespaces');
+
+        // select new option and check it
+        $option_value = 'select2_value1';
+        $this->module->selectOption('#select2', $option_value);
+        $this->module->seeInField('#select2', $option_value);
     }
 
     public function testAppendFieldDiv()
@@ -701,6 +722,13 @@ class WebDriverTest extends TestsForBrowsers
     {
         if ($this->module->_getConfig('browser') == 'phantomjs') {
             $this->markTestSkipped('does not work for phantomjs');
+        }
+    }
+
+    protected function notForSelenium()
+    {
+        if ($this->module->_getConfig('browser') != 'phantom') {
+            $this->markTestSkipped('does not work for selenium');
         }
     }
 


### PR DESCRIPTION
* support option text in `seeInField` not only value
* fix bug match with and without whitespaces see also https://github.com/facebook/php-webdriver/pull/394
* fix bug `seeInField` not working after `selectOption` 