### PR TITLE
PHP 7.1 - Used new pcntl_async_signals function to handle graceful termination

### DIFF
--- a/src/Codeception/Subscriber/GracefulTermination.php
+++ b/src/Codeception/Subscriber/GracefulTermination.php
@@ -18,8 +18,11 @@ class GracefulTermination implements EventSubscriberInterface
 
     public function handleSuite(SuiteEvent $event)
     {
-        if (PHP_MAJOR_VERSION === 7 and PHP_MINOR_VERSION === 0) {
-            return; // skip for PHP 7.0: https://github.com/Codeception/Codeception/issues/3607
+        if (PHP_MAJOR_VERSION === 7) {
+            if (PHP_MINOR_VERSION === 0) {
+                return; // skip for PHP 7.0: https://github.com/Codeception/Codeception/issues/3607
+            }
+            pcntl_async_signals(true);
         }
         if (function_exists(self::SIGNAL_FUNC)) {
             pcntl_signal(SIGTERM, [$this, 'terminate']);


### PR DESCRIPTION
Hi,

This PR is related to #3607 and it should enable graceful termination for PHP >= 7.1
PHP 7.1 introduced the new way to handle signals asynchronously [pcntl_async_signals](http://php.net/manual/en/migration71.new-features.php#migration71.new-features.asynchronous-signal-handling)