### PR TITLE
[2.2] Support php files in ParamsLoader.php

### DIFF
--- a/src/Codeception/Lib/ParamsLoader.php
+++ b/src/Codeception/Lib/ParamsLoader.php
@@ -28,16 +28,20 @@ class ParamsLoader
         }
 
         try {
-            if (preg_match('~(\.env(\.|$))~', $paramStorage)) {
-                return $this->loadDotEnvFile();
-            }
-
             if (preg_match('~\.yml$~', $paramStorage)) {
                 return $this->loadYamlFile();
             }
 
             if (preg_match('~\.ini$~', $paramStorage)) {
                 return $this->loadIniFile();
+            }
+
+            if (preg_match('~\.php$~', $paramStorage)) {
+                return $this->loadPhpFile();
+            }
+
+            if (preg_match('~(\.env(\.|$))~', $paramStorage)) {
+                return $this->loadDotEnvFile();
             }
         } catch (\Exception $e) {
             throw new ConfigurationException("Failed loading params from $paramStorage\n" . $e->getMessage());
@@ -54,6 +58,11 @@ class ParamsLoader
     protected function loadIniFile()
     {
         return parse_ini_file($this->paramsFile);
+    }
+
+    protected function loadPhpFile()
+    {
+        return require $this->paramsFile;
     }
 
     protected function loadYamlFile()


### PR DESCRIPTION
My use case: In a project we use simple `.env.php` file instead of `vlucas/phpdotenv` and want to load params (specifically APP_URL) from it instead of duplicating configs.

It also fixes a bug when trying to load params from `.env.yml` and `.env.ini` results in an error "vlucas/phpdotenv library is required to parse .env files." which makes little sense to me.