### PR TITLE
WebDriver: added actions for managing tabs

### DIFF
--- a/src/Codeception/Module/WebDriver.php
+++ b/src/Codeception/Module/WebDriver.php
@@ -2751,4 +2751,88 @@ class WebDriver extends CodeceptionModule implements
         $y = $el->getLocation()->getY() + $offsetY;
         $this->webDriver->executeScript("window.scrollTo($x, $y)");
     }
+
+    /**
+     * Opens a new browser tab (wherever it is possible) and switches to it.
+     *
+     * ```php
+     * <?php
+     * $I->openNewTab();
+     * ```
+     * Tab is opened by sending `ctrl-t` key into browser.
+     * If ctrl-t does not open a tab in current browser, nothing happens.
+     *
+     */
+    public function openNewTab()
+    {
+        $this->pressKey('body', array('ctrl','t'));
+        $this->switchToNextTab();
+    }
+
+    /**
+     * Closes current browser tab and switches to previous active tab.
+     *
+     * ```php
+     * <?php
+     * $I->closeTab();
+     * ```
+     */
+    public function closeTab()
+    {
+        $prevTab = $this->getRelativeTabHandle(-1);
+        $this->webDriver->close();
+        $this->webDriver->switchTo()->window($prevTab);
+    }
+
+    /**
+     * Switches to next browser tab.
+     * An offset can be specified.
+     *
+     * ```php
+     * <?php
+     * // switch to next tab
+     * $I->switchToNextTab();
+     * // switch to 2nd next tab
+     * $I->switchToNextTab();
+     * ```
+     *
+     * @param int $offset 1
+     */
+    public function switchToNextTab($offset = 1)
+    {
+        $tab = $this->getRelativeTabHandle($offset);
+        $this->webDriver->switchTo()->window($tab);
+    }
+
+    /**
+     * Switches to next browser tab.
+     * An offset can be specified.
+     *
+     * ```php
+     * <?php
+     * // switch to previous tab
+     * $I->switchToNextTab();
+     * // switch to 2nd previous tab
+     * $I->switchToNextTab(-2);
+     * ```
+     *
+     * @param int $offset 1
+     */
+    public function switchToPreviousTab($offset = 1)
+    {
+        $this->switchToNextTab(0 - $offset);
+    }
+
+    protected function getRelativeTabHandle($offset)
+    {
+        if ($this->isPhantom()) {
+            throw new ModuleException($this, "PhantomJS doesn't support tab actions");
+        }
+        $handle = $this->webDriver->getWindowHandle();
+        $handles = $this->webDriver->getWindowHandles();
+        $idx = array_search($handle, $handles);
+        return $handles[($idx + $offset) % count($handles)];
+    }
+
+
 }

--- a/src/Codeception/Module/WebDriver.php
+++ b/src/Codeception/Module/WebDriver.php
@@ -2765,7 +2765,7 @@ class WebDriver extends CodeceptionModule implements
      */
     public function openNewTab()
     {
-        $this->pressKey('body', array('ctrl','t'));
+        $this->executeJS("window.open('about:blank','_blank');");
         $this->switchToNextTab();
     }
 

--- a/tests/web/WebDriverTest.php
+++ b/tests/web/WebDriverTest.php
@@ -872,4 +872,28 @@ class WebDriverTest extends TestsForBrowsers
         $this->module->clickWithRightButton('#element2', 70, 75);
         $this->module->see('context, offsetX: 78 - offsetY: 183');
     }
+
+    public function testBrowserTabs()
+    {
+        $this->notForPhantomJS();
+        $this->module->amOnPage('/form/example1');
+        $this->module->openNewTab();
+        $this->module->amOnPage('/form/example2');
+        $this->module->openNewTab();
+        $this->module->amOnPage('/form/example3');
+        $this->module->openNewTab();
+        $this->module->amOnPage('/form/example4');
+        $this->module->openNewTab();
+        $this->module->amOnPage('/form/example5');
+        $this->module->closeTab();
+        $this->module->seeInCurrentUrl('example4');
+        $this->module->switchToPreviousTab(2);
+        $this->module->seeInCurrentUrl('example2');
+        $this->module->switchToNextTab();
+        $this->module->seeInCurrentUrl('example3');
+        $this->module->closeTab();
+        $this->module->seeInCurrentUrl('example2');
+        $this->module->switchToNextTab(2);
+        $this->module->seeInCurrentUrl('example1');
+    }
 }


### PR DESCRIPTION
Browser tabs can be managed from withing WebDriveri module. Not supported in PhantomJS

* openNewTab
* closeTab
* switchToNextTab
* switchToPreviousTab

Closes #2975