### PR TITLE
WebDriver: added search by class to fuzzy search (may improve speed)

### DIFF
--- a/src/Codeception/Module/WebDriver.php
+++ b/src/Codeception/Module/WebDriver.php
@@ -2386,6 +2386,10 @@ class WebDriver extends CodeceptionModule implements
                 $isValidLocator = true;
                 $nodes = $page->findElements(WebDriverBy::id(substr($selector, 1)));
             }
+            if (Locator::isClass($selector)) {
+                $isValidLocator = true;
+                $nodes = $page->findElements(WebDriverBy::className(substr($selector, 1)));
+            }
             if (empty($nodes) and Locator::isCSS($selector)) {
                 $isValidLocator = true;
                 $nodes = $page->findElements(WebDriverBy::cssSelector($selector));

--- a/src/Codeception/Util/Locator.php
+++ b/src/Codeception/Util/Locator.php
@@ -214,7 +214,7 @@ class Locator
     }
 
     /**
-     * Checks that string and CSS selector for element by ID
+     * Checks that a string is valid CSS ID
      *
      * @param $id
      *
@@ -223,6 +223,18 @@ class Locator
     public static function isID($id)
     {
         return (bool)preg_match('~^#[\w\.\-\[\]\=\^\~\:]+$~', $id);
+    }
+
+    /**
+     * Checks that a string is valid CSS class
+     *
+     * @param $id
+     *
+     * @return bool
+     */
+    public static function isClass($class)
+    {
+        return (bool)preg_match('~^\.[\w\.\-\[\]\=\^\~\:]+$~', $class);
     }
 
     /**

--- a/tests/unit/Codeception/Util/LocatorTest.php
+++ b/tests/unit/Codeception/Util/LocatorTest.php
@@ -57,6 +57,16 @@ class LocatorTest extends PHPUnit_Framework_TestCase
         $this->assertFalse(Locator::isID('hello'));
     }
 
+    public function testIsClass()
+    {
+        $this->assertTrue(Locator::isClass('.username'));
+        $this->assertTrue(Locator::isClass('.name'));
+        $this->assertTrue(Locator::isClass('.user-name'));
+        $this->assertFalse(Locator::isClass('.user-name .field'));
+        $this->assertFalse(Locator::isClass('#field'));
+        $this->assertFalse(Locator::isClass('hello'));
+    }
+
     public function testContains()
     {
         $this->assertEquals(


### PR DESCRIPTION
If `.classname` is passed, WebDriver will search for element using `WebDriverBy::className`

Closes #3196