### PR TITLE
Added missing @part json and xml to deleteHeader

### DIFF
--- a/src/Codeception/Module/REST.php
+++ b/src/Codeception/Module/REST.php
@@ -172,6 +172,8 @@ EOF;
      * ```
      *
      * @param string $name the name of the header to delete.
+     * @part json
+     * @part xml
      */
     public function deleteHeader($name)
     {


### PR DESCRIPTION
Generated Actions class is missing `deleteHeader` when using REST module with `part` option