### PR TITLE
Laravel5 module fixes

### DIFF
--- a/src/Codeception/Module/Laravel5.php
+++ b/src/Codeception/Module/Laravel5.php
@@ -175,7 +175,7 @@ class Laravel5 extends Framework implements ActiveRecord, PartedModule
             $this->callArtisan('db:seed', ['--class' => $this->config['database_seeder_class']]);
         }
 
-        if (isset($this->app['db']) && $this->config['cleanup']) {
+        if ($this->applicationUsesDatabase() && $this->config['cleanup']) {
             $this->app['db']->beginTransaction();
         }
     }
@@ -187,6 +187,10 @@ class Laravel5 extends Framework implements ActiveRecord, PartedModule
      */
     public function _after(\Codeception\TestInterface $test)
     {
+        if (! $this->applicationUsesDatabase()) {
+            return;
+        }
+
         if (isset($this->app['db']) && $this->config['cleanup']) {
             $this->app['db']->rollback();
         }
@@ -195,6 +199,16 @@ class Laravel5 extends Framework implements ActiveRecord, PartedModule
         if (isset($this->app['db'])) {
             $this->app['db']->disconnect();
         }
+    }
+
+    /**
+     * Does the application use the database?
+     *
+     * @return bool
+     */
+    private function applicationUsesDatabase()
+    {
+        return ! empty($this->app['config']['database.default']);
     }
 
     /**

--- a/src/Codeception/Module/Laravel5.php
+++ b/src/Codeception/Module/Laravel5.php
@@ -166,17 +166,17 @@ class Laravel5 extends Framework implements ActiveRecord, PartedModule
     {
         $this->client = new LaravelConnector($this);
 
-        // Database migrations and seeder should run before database cleanup transaction starts
+        // Database migrations should run before database cleanup transaction starts
         if ($this->config['run_database_migrations']) {
             $this->callArtisan('migrate', ['--path' => $this->config['database_migrations_path']]);
         }
 
-        if ($this->config['run_database_seeder']) {
-            $this->callArtisan('db:seed', ['--class' => $this->config['database_seeder_class']]);
-        }
-
         if ($this->applicationUsesDatabase() && $this->config['cleanup']) {
             $this->app['db']->beginTransaction();
+        }
+
+        if ($this->config['run_database_seeder']) {
+            $this->callArtisan('db:seed', ['--class' => $this->config['database_seeder_class']]);
         }
     }
 


### PR DESCRIPTION
There was a problem using the Laravel5 module with an application that does not use a database, see #3942. This is fixed by commit a15da6b44e6b44bd0319bff7dc2f59a51bf3b30b.

There also was a problem with the implementation of the `run_database_seeder` functionality, see #3948. This is fixed by commit 5976db3f4e53cf56160964cd4a64a1aef20bd1ab, the database seeder now runs after the database cleanup transaction is started.