### PR TITLE
[InnerBrowser] If form has no id, use action attribute as identifier

### DIFF
--- a/src/Codeception/Lib/InnerBrowser.php
+++ b/src/Codeception/Lib/InnerBrowser.php
@@ -814,14 +814,14 @@ class InnerBrowser extends Module implements Web, PageSourceSaver, ElementLocato
      * DOM wouldn't expect them.
      *
      * @param Crawler $form the form
-     * @param string $action the form's absolute URL action
      * @return Form
      */
-    private function getFormFromCrawler(Crawler $form, $action)
+    private function getFormFromCrawler(Crawler $form)
     {
         $fakeDom = new \DOMDocument();
         $fakeDom->appendChild($fakeDom->importNode($form->getNode(0), true));
         $node = $fakeDom->documentElement;
+        $action = (string)$this->getFormUrl($form);
         $cloned = new Crawler($node, $action, $this->getBaseUrl());
         $shouldDisable = $cloned->filter(
             'input:disabled:not([disabled]),select option:disabled,select optgroup:disabled option:not([disabled])'
@@ -849,10 +849,10 @@ class InnerBrowser extends Module implements Web, PageSourceSaver, ElementLocato
         if (!$form) {
             $this->fail('The selected node is not a form and does not have a form ancestor.');
         }
-        $action = (string)$this->getFormUrl($form);
-        $identifier = $form->attr('id') ?: $action;
+
+        $identifier = $form->attr('id') ?: $form->attr('action');
         if (!isset($this->forms[$identifier])) {
-            $this->forms[$identifier] = $this->getFormFromCrawler($form, $action);
+            $this->forms[$identifier] = $this->getFormFromCrawler($form);
         }
         return $this->forms[$identifier];
     }

--- a/tests/data/app/controllers.php
+++ b/tests/data/app/controllers.php
@@ -162,6 +162,7 @@ class facebookController {
 
 class form {
     function GET($matches) {
+        data::set('query', $_GET);
         $url = strtolower($matches[1]);
         if (empty($matches[1])) {
             $url = 'index';

--- a/tests/data/app/view/form/bug3953.php
+++ b/tests/data/app/view/form/bug3953.php
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <title>issue #3983</title>
+</head>
+<body>
+<form method="get" action="/form/bug3953">
+    <select name="select_name" id="select_id">
+        <option value="one">first</option>
+        <option value="two">second</option>
+    </select>
+    <input type="text" name="search_name">
+    <button>Submit</button>
+</form>
+</body>
+</html>

--- a/tests/unit/Codeception/Module/PhpBrowserTest.php
+++ b/tests/unit/Codeception/Module/PhpBrowserTest.php
@@ -628,4 +628,17 @@ class PhpBrowserTest extends TestsForBrowsers
         $this->module->dontSee('ERROR');
     }
 
+    /**
+     * @issue https://github.com/Codeception/Codeception/issues/3953
+     */
+    public function testFillFieldInGetFormWithoutId()
+    {
+        $this->module->amOnPage('/form/bug3953');
+        $this->module->selectOption('select_name', 'two');
+        $this->module->fillField('search_name', 'searchterm');
+        $this->module->click('Submit');
+        $params = data::get('query');
+        $this->assertEquals('two', $params['select_name']);
+        $this->assertEquals('searchterm', $params['search_name']);
+    }
 }


### PR DESCRIPTION
Fixes #3953