### PR TITLE
cleanup use statements

### DIFF
--- a/RoboFile.php
+++ b/RoboFile.php
@@ -2,7 +2,7 @@
 require_once __DIR__.'/vendor/autoload.php';
 
 use Symfony\Component\Finder\Finder;
-use \Robo\Task\Development\GenerateMarkdownDoc as Doc;
+use Robo\Task\Development\GenerateMarkdownDoc as Doc;
 
 class RoboFile extends \Robo\Tasks
 {

--- a/src/Codeception/Command/Bootstrap.php
+++ b/src/Codeception/Command/Bootstrap.php
@@ -9,7 +9,6 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Yaml\Yaml;
-use Symfony\Component\Console\Question\Question;
 
 /**
  * Creates default config, tests directory and sample suites for current project.

--- a/src/Codeception/Command/Build.php
+++ b/src/Codeception/Command/Build.php
@@ -6,7 +6,6 @@ use Codeception\Lib\Generator\Actions as ActionsGenerator;
 use Codeception\Lib\Generator\Actor as ActorGenerator;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
-use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
 /**

--- a/src/Codeception/Command/Clean.php
+++ b/src/Codeception/Command/Clean.php
@@ -5,7 +5,6 @@ use Codeception\Configuration;
 use Codeception\Util\FileSystem;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
-use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
 /**

--- a/src/Codeception/Command/DryRun.php
+++ b/src/Codeception/Command/DryRun.php
@@ -9,7 +9,6 @@ use Codeception\Subscriber\Bootstrap as BootstrapLoader;
 use Codeception\Subscriber\Console as ConsolePrinter;
 use Codeception\SuiteManager;
 use Codeception\Test\Interfaces\ScenarioDriven;
-use Codeception\Test\Loader;
 use Codeception\Test\Test;
 use Codeception\Util\Maybe;
 use Symfony\Component\Console\Command\Command;

--- a/src/Codeception/Command/GenerateCept.php
+++ b/src/Codeception/Command/GenerateCept.php
@@ -5,7 +5,6 @@ use Codeception\Lib\Generator\Cept;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
-use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
 /**

--- a/src/Codeception/Command/GenerateCest.php
+++ b/src/Codeception/Command/GenerateCest.php
@@ -5,7 +5,6 @@ use Codeception\Lib\Generator\Cest as CestGenerator;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
-use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
 /**

--- a/src/Codeception/Command/GenerateEnvironment.php
+++ b/src/Codeception/Command/GenerateEnvironment.php
@@ -6,7 +6,6 @@ use Codeception\Exception\ConfigurationException;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
-use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
 /**

--- a/src/Codeception/Command/GenerateGroup.php
+++ b/src/Codeception/Command/GenerateGroup.php
@@ -6,7 +6,6 @@ use Codeception\Lib\Generator\Group as GroupGenerator;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
-use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
 /**

--- a/src/Codeception/Command/GenerateHelper.php
+++ b/src/Codeception/Command/GenerateHelper.php
@@ -6,7 +6,6 @@ use Codeception\Lib\Generator\Helper;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
-use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
 /**

--- a/src/Codeception/Command/GeneratePageObject.php
+++ b/src/Codeception/Command/GeneratePageObject.php
@@ -6,7 +6,6 @@ use Codeception\Lib\Generator\PageObject as PageObjectGenerator;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
-use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
 /**

--- a/src/Codeception/Command/GeneratePhpUnit.php
+++ b/src/Codeception/Command/GeneratePhpUnit.php
@@ -5,7 +5,6 @@ use Codeception\Lib\Generator\PhpUnit as PhpUnitGenerator;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
-use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
 /**

--- a/src/Codeception/Command/GenerateTest.php
+++ b/src/Codeception/Command/GenerateTest.php
@@ -5,7 +5,6 @@ use Codeception\Lib\Generator\Test as TestGenerator;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
-use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
 /**

--- a/src/Codeception/Lib/Connector/Guzzle6.php
+++ b/src/Codeception/Lib/Connector/Guzzle6.php
@@ -1,8 +1,6 @@
 <?php
 namespace Codeception\Lib\Connector;
 
-use Codeception\Exception\ConfigurationException;
-use Codeception\Exception\ModuleConfigException;
 use Codeception\Util\Uri;
 use GuzzleHttp\Client as GuzzleClient;
 use GuzzleHttp\Cookie\CookieJar;

--- a/src/Codeception/Lib/Connector/Yii2.php
+++ b/src/Codeception/Lib/Connector/Yii2.php
@@ -4,7 +4,6 @@ namespace Codeception\Lib\Connector;
 use Codeception\Lib\Connector\Yii2\Logger;
 use Codeception\Lib\Connector\Yii2\TestMailer;
 use Codeception\Util\Debug;
-use Codeception\Util\Stub;
 use Symfony\Component\BrowserKit\Client;
 use Symfony\Component\BrowserKit\Cookie;
 use Symfony\Component\BrowserKit\Response;

--- a/src/Codeception/Lib/Connector/Yii2/TestMailer.php
+++ b/src/Codeception/Lib/Connector/Yii2/TestMailer.php
@@ -2,7 +2,6 @@
 namespace Codeception\Lib\Connector\Yii2;
 
 use yii\mail\BaseMailer;
-use yii\mail\BaseMessage;
 
 class TestMailer extends BaseMailer
 {

--- a/src/Codeception/Lib/Connector/ZendExpressive.php
+++ b/src/Codeception/Lib/Connector/ZendExpressive.php
@@ -7,7 +7,6 @@ use Symfony\Component\BrowserKit\Request;
 use Symfony\Component\BrowserKit\Response;
 use Symfony\Component\BrowserKit\Request as BrowserKitRequest;
 use Zend\Diactoros\ServerRequest;
-use Zend\Diactoros\Response as ZendResponse;
 use Zend\Expressive\Application;
 use Zend\Diactoros\UploadedFile;
 

--- a/src/Codeception/Lib/Console/MessageFactory.php
+++ b/src/Codeception/Lib/Console/MessageFactory.php
@@ -2,7 +2,6 @@
 namespace Codeception\Lib\Console;
 
 use SebastianBergmann\Comparator\ComparisonFailure;
-use Symfony\Component\Console\Output\OutputInterface;
 
 /**
  * MessageFactory

--- a/src/Codeception/Lib/Generator/GherkinSnippets.php
+++ b/src/Codeception/Lib/Generator/GherkinSnippets.php
@@ -6,7 +6,6 @@ use Codeception\Test\Loader\Gherkin;
 use Codeception\Util\Template;
 use Symfony\Component\Finder\Finder;
 
-use Symfony\Component\Console\Output\OutputInterface;
 
 class GherkinSnippets
 {

--- a/src/Codeception/Lib/GroupManager.php
+++ b/src/Codeception/Lib/GroupManager.php
@@ -3,7 +3,6 @@ namespace Codeception\Lib;
 
 use Codeception\Configuration;
 use Codeception\Test\Interfaces\Reported;
-use Codeception\Test\Interfaces\Configurable;
 use Codeception\Test\Descriptor;
 use Codeception\TestInterface;
 use Symfony\Component\Finder\Finder;

--- a/src/Codeception/Module/Doctrine2.php
+++ b/src/Codeception/Module/Doctrine2.php
@@ -7,7 +7,6 @@ use Codeception\Exception\ModuleConfigException;
 use Codeception\Lib\Interfaces\DependsOnModule;
 use Codeception\Lib\Interfaces\DoctrineProvider;
 use Codeception\TestInterface;
-use Doctrine\ORM\EntityManagerInterface;
 use Codeception\Util\Stub;
 
 /**

--- a/src/Codeception/Module/FTP.php
+++ b/src/Codeception/Module/FTP.php
@@ -1,7 +1,6 @@
 <?php
 namespace Codeception\Module;
 
-use Codeception\Module\Filesystem;
 use Codeception\TestInterface;
 
 /**

--- a/src/Codeception/Module/Lumen.php
+++ b/src/Codeception/Module/Lumen.php
@@ -9,7 +9,6 @@ use Codeception\Lib\Framework;
 use Codeception\Lib\Interfaces\ActiveRecord;
 use Codeception\Lib\Interfaces\PartedModule;
 use Codeception\Lib\ModuleContainer;
-use Codeception\Step;
 use Codeception\TestInterface;
 use Codeception\Util\ReflectionHelper;
 use Illuminate\Contracts\Auth\Authenticatable;

--- a/src/Codeception/Module/PhpBrowser.php
+++ b/src/Codeception/Module/PhpBrowser.php
@@ -1,8 +1,6 @@
 <?php
 namespace Codeception\Module;
 
-use Codeception\Exception\ModuleConfigException;
-use Codeception\Exception\ModuleException;
 use Codeception\Lib\Connector\Guzzle6;
 use Codeception\Lib\InnerBrowser;
 use Codeception\Lib\Interfaces\MultiSession;

--- a/src/Codeception/Module/REST.php
+++ b/src/Codeception/Module/REST.php
@@ -15,7 +15,6 @@ use Codeception\Lib\Interfaces\PartedModule;
 use Codeception\Util\JsonArray;
 use Codeception\Util\JsonType;
 use Codeception\Util\XmlStructure;
-use Symfony\Component\BrowserKit\Cookie;
 use Codeception\Util\Soap as XmlUtils;
 
 /**

--- a/src/Codeception/Module/ZendExpressive.php
+++ b/src/Codeception/Module/ZendExpressive.php
@@ -5,7 +5,6 @@ use Codeception\Lib\Framework;
 use Codeception\TestInterface;
 use Codeception\Configuration;
 use Codeception\Lib\Connector\ZendExpressive as ZendExpressiveConnector;
-use Psr\Http\Message\ResponseInterface;
 
 /**
  * This module allows you to run tests inside Zend Expressive.

--- a/src/Codeception/Scenario.php
+++ b/src/Codeception/Scenario.php
@@ -3,8 +3,6 @@ namespace Codeception;
 
 use Codeception\Event\StepEvent;
 use Codeception\Exception\ConditionalAssertionFailed;
-use Codeception\Lib\Notification;
-use Codeception\Step;
 use Codeception\Test\Metadata;
 
 class Scenario

--- a/src/Codeception/Step.php
+++ b/src/Codeception/Step.php
@@ -4,7 +4,6 @@ namespace Codeception;
 use Codeception\Lib\ModuleContainer;
 use Codeception\Step\Meta as MetaStep;
 use Codeception\Util\Locator;
-use Codeception\Lib\Console\Message;
 
 abstract class Step
 {

--- a/src/Codeception/Subscriber/BeforeAfterTest.php
+++ b/src/Codeception/Subscriber/BeforeAfterTest.php
@@ -3,7 +3,6 @@ namespace Codeception\Subscriber;
 
 use Codeception\Event\SuiteEvent;
 use Codeception\Events;
-use Codeception\TestInterface;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
 class BeforeAfterTest implements EventSubscriberInterface

--- a/src/Codeception/SuiteManager.php
+++ b/src/Codeception/SuiteManager.php
@@ -5,7 +5,6 @@ use Codeception\Lib\Di;
 use Codeception\Lib\GroupManager;
 use Codeception\Lib\ModuleContainer;
 use Codeception\Lib\Notification;
-use Codeception\Test\Interfaces\Configurable;
 use Codeception\Test\Interfaces\ScenarioDriven;
 use Codeception\Test\Loader;
 use Codeception\Test\Descriptor;

--- a/src/Codeception/Test/Gherkin.php
+++ b/src/Codeception/Test/Gherkin.php
@@ -6,7 +6,6 @@ use Behat\Gherkin\Node\ScenarioNode;
 use Behat\Gherkin\Node\ScenarioInterface;
 use Behat\Gherkin\Node\StepNode;
 use Behat\Gherkin\Node\TableNode;
-use Codeception\Exception\TestParseException;
 use Codeception\Lib\Di;
 use Codeception\Scenario;
 use Codeception\Step\Comment;

--- a/src/Codeception/Test/Interfaces/ScenarioDriven.php
+++ b/src/Codeception/Test/Interfaces/ScenarioDriven.php
@@ -1,7 +1,6 @@
 <?php
 namespace Codeception\Test\Interfaces;
 
-use Codeception\Step;
 
 interface ScenarioDriven
 {

--- a/src/Codeception/Test/Loader/Cest.php
+++ b/src/Codeception/Test/Loader/Cest.php
@@ -2,10 +2,8 @@
 namespace Codeception\Test\Loader;
 
 use Codeception\Exception\TestParseException;
-use Codeception\Lib\ExampleSuite;
 use Codeception\Lib\Parser;
 use Codeception\Test\Cest as CestFormat;
-use Codeception\Test\Descriptor;
 use Codeception\Util\Annotation;
 use Codeception\Util\ReflectionHelper;
 

--- a/tests/data/included/jazz/pianist/tests/_helpers/_generated/TestGuyActions.php
+++ b/tests/data/included/jazz/pianist/tests/_helpers/_generated/TestGuyActions.php
@@ -6,7 +6,6 @@ namespace Jazz\Pianist\_generated;
 // @codingStandardsIgnoreFile
 
 use Codeception\Module\Filesystem;
-use Jazz\Pianist\TestHelper;
 
 trait TestGuyActions
 {

--- a/tests/data/included/jazz/pianist/tests/functional/TestGuy.php
+++ b/tests/data/included/jazz/pianist/tests/functional/TestGuy.php
@@ -6,7 +6,6 @@
 
 namespace Jazz\Pianist;
 use Codeception\Module\Filesystem;
-use Jazz\Pianist\Codeception\Module\TestHelper;
 
 /**
  * Inherited Methods

--- a/tests/data/included/jazz/tests/functional/TestGuy.php
+++ b/tests/data/included/jazz/tests/functional/TestGuy.php
@@ -6,7 +6,6 @@
 
 namespace Jazz;
 use Codeception\Module\Filesystem;
-use Jazz\Codeception\Module\TestHelper;
 
 /**
  * Inherited Methods

--- a/tests/data/included/shire/tests/functional/TestGuy.php
+++ b/tests/data/included/shire/tests/functional/TestGuy.php
@@ -6,7 +6,6 @@
 
 namespace Shire;
 use Codeception\Module\Filesystem;
-use Shire\Codeception\Module\TestHelper;
 
 /**
  * Inherited Methods

--- a/tests/data/included_w/src/bar/Sub/EwokPack/tests/_support/_generated/UnitTesterActions.php
+++ b/tests/data/included_w/src/bar/Sub/EwokPack/tests/_support/_generated/UnitTesterActions.php
@@ -5,7 +5,6 @@ namespace EwokPack\_generated;
 // You should not change it manually as it will be overwritten on next build
 // @codingStandardsIgnoreFile
 
-use Codeception\Module\Asserts;
 
 trait UnitTesterActions
 {

--- a/tests/data/included_w/src/bar/ToastPack/tests/_support/_generated/UnitTesterActions.php
+++ b/tests/data/included_w/src/bar/ToastPack/tests/_support/_generated/UnitTesterActions.php
@@ -5,7 +5,6 @@ namespace ToastPack\_generated;
 // You should not change it manually as it will be overwritten on next build
 // @codingStandardsIgnoreFile
 
-use Codeception\Module\Asserts;
 
 trait UnitTesterActions
 {

--- a/tests/data/included_w/src/foo/AcmePack/tests/_support/_generated/UnitTesterActions.php
+++ b/tests/data/included_w/src/foo/AcmePack/tests/_support/_generated/UnitTesterActions.php
@@ -5,7 +5,6 @@ namespace AcmePack\_generated;
 // You should not change it manually as it will be overwritten on next build
 // @codingStandardsIgnoreFile
 
-use Codeception\Module\Asserts;
 
 trait UnitTesterActions
 {

--- a/tests/unit/Codeception/Command/GenerateEnvironmentTest.php
+++ b/tests/unit/Codeception/Command/GenerateEnvironmentTest.php
@@ -1,5 +1,4 @@
 <?php
-use Codeception\Util\Stub;
 
 require_once __DIR__ . DIRECTORY_SEPARATOR . 'BaseCommandRunner.php';
 

--- a/tests/unit/Codeception/ConfigurationTest.php
+++ b/tests/unit/Codeception/ConfigurationTest.php
@@ -1,6 +1,5 @@
 <?php
 
-use Codeception\Util\Stub;
 
 class ConfigurationTest extends \PHPUnit_Framework_TestCase
 {

--- a/tests/unit/Codeception/Lib/Console/DiffFactoryTest.php
+++ b/tests/unit/Codeception/Lib/Console/DiffFactoryTest.php
@@ -1,7 +1,6 @@
 <?php
 namespace Codeception\Lib\Console;
 
-use Codeception\Util\Stub;
 use SebastianBergmann\Comparator\ComparisonFailure;
 
 /**

--- a/tests/unit/Codeception/Module/AMQPTest.php
+++ b/tests/unit/Codeception/Module/AMQPTest.php
@@ -1,6 +1,5 @@
 <?php
 
-use Codeception\Util\Stub as Stub;
 
 class AMQPTest extends \PHPUnit_Framework_TestCase
 {


### PR DESCRIPTION
Use `phpcs-fixer` to cleanup unused use statements in entire code base.

```
php-cs-fixer fix . --fixers=unused_use
```