### PR TITLE
Fix test coloring

### DIFF
--- a/src/Codeception/Subscriber/Console.php
+++ b/src/Codeception/Subscriber/Console.php
@@ -560,7 +560,7 @@ class Console implements EventSubscriberInterface
         $prefix = ($this->output->isInteractive() and !$this->isDetailed($test) and $inProgress) ? '- ' : '';
 
         $testString = Descriptor::getTestAsString($test);
-        $testString = preg_replace('~^([\s\w\\\]+):\s~', "<focus>$1{$this->chars['of']}</focus> ", $testString);
+        $testString = preg_replace('~^([^:]+):\s~', "<focus>$1{$this->chars['of']}</focus> ", $testString);
 
         $this
             ->message($testString)

--- a/src/Codeception/Test/Descriptor.php
+++ b/src/Codeception/Test/Descriptor.php
@@ -26,10 +26,6 @@ class Descriptor
 
     public static function getTestAsString(\PHPUnit_Framework_SelfDescribing $testCase)
     {
-        if ($testCase instanceof Descriptive) {
-            return $testCase->toString();
-        }
-
         if ($testCase instanceof \PHPUnit_Framework_TestCase) {
             $text = $testCase->getName();
             $text = preg_replace('/([A-Z]+)([A-Z][a-z])/', '\\1 \\2', $text);
@@ -39,6 +35,7 @@ class Descriptor
             $text = str_replace(['::', 'with data set'], [':', '|'], $text);
             return ReflectionHelper::getClassShortName($testCase) . ': ' . $text;
         }
+
         return $testCase->toString();
     }
 

--- a/tests/cli/RunCest.php
+++ b/tests/cli/RunCest.php
@@ -14,6 +14,14 @@ class RunCest
         $I->seeInShellOutput("OK (");
     }
 
+    public function runOneFileWithColors(\CliGuy $I)
+    {
+        $I->wantTo('execute one test');
+        $I->executeCommand('run --colors tests/dummy/FileExistsCept.php');
+        $I->seeInShellOutput("OK (");
+        $I->seeInShellOutput("\033[35;1mFileExistsCept:\033[39;22m Check config exists");
+    }
+
     /**
      * @group reports
      * @group core


### PR DESCRIPTION
When a Feature title has some special chars in it like `/` or `-` the test coloring is broken.
```
Feature: Tests-special chars

  Scenario: test 1
    Given I am on "/"
```