### PR TITLE
added ability to use custom params from console in tests

### DIFF
--- a/src/Codeception/Command/Run.php
+++ b/src/Codeception/Command/Run.php
@@ -114,6 +114,8 @@ class Run extends Command
             new InputArgument('suite', InputArgument::OPTIONAL, 'suite to be tested'),
             new InputArgument('test', InputArgument::OPTIONAL, 'test to be run'),
             new InputOption('override', 'o', InputOption::VALUE_IS_ARRAY  | InputOption::VALUE_REQUIRED, 'Override config values'),
+            new InputOption('params', 'p', InputOption::VALUE_IS_ARRAY  | InputOption::VALUE_REQUIRED, 'Add custom 
+            params in tests'),
             new InputOption('report', '', InputOption::VALUE_NONE, 'Show output in compact style'),
             new InputOption('html', '', InputOption::VALUE_OPTIONAL, 'Generate html with results', 'report.html'),
             new InputOption('xml', '', InputOption::VALUE_OPTIONAL, 'Generate JUnit XML Log', 'report.xml'),
@@ -214,6 +216,11 @@ class Run extends Command
         // update config from options
         if (count($this->options['override'])) {
             $config = $this->overrideConfig($this->options['override']);
+        }
+
+        if (count($this->options['params'])) {
+            $this->options['params'] = $this->parseParams($this->options['params']);
+            Configuration::attachParams($this->options['params']);
         }
 
         if (!$this->options['colors']) {

--- a/src/Codeception/Command/Shared/Config.php
+++ b/src/Codeception/Command/Shared/Config.php
@@ -24,13 +24,35 @@ trait Config
         return Configuration::suites();
     }
 
+    protected function parseParams($params)
+    {
+        $updatedParams = [];
+
+        foreach ($params as $match) {
+            $match = explode(',', str_replace(array(', '), ',', $match));
+
+            if (is_array($match) && count($match) > 0) {
+                foreach ($match as $k => $param) {
+                    $keys = explode(': ', $param);
+                    if (count($keys) < 2) {
+                        throw new \InvalidArgumentException('--param option should have config passed as "key: value"');
+                    }
+
+                    $updatedParams[$keys[0]] = $keys[1];
+                }
+            }
+        }
+
+        return $updatedParams;
+     }
+
     protected function overrideConfig($configOptions)
     {
         $updatedConfig = [];
         foreach ($configOptions as $option) {
             $keys = explode(': ', $option);
             if (count($keys) < 2) {
-                throw new \InvalidArgumentException('--config-option should have config passed as "key:value"');
+                throw new \InvalidArgumentException('--config-option should have config passed as "key: value"');
             }
             $value = array_pop($keys);
             $yaml = '';

--- a/src/Codeception/Command/Shared/Config.php
+++ b/src/Codeception/Command/Shared/Config.php
@@ -44,7 +44,7 @@ trait Config
         }
 
         return $updatedParams;
-     }
+    }
 
     protected function overrideConfig($configOptions)
     {

--- a/src/Codeception/Configuration.php
+++ b/src/Codeception/Configuration.php
@@ -596,7 +596,8 @@ class Configuration
         return $res;
     }
 
-    public static function getParam($key) {
+    public static function getParam($key)
+    {
         if (isset(self::$userParams[$key])) {
             return self::$userParams[$key];
         }

--- a/src/Codeception/Configuration.php
+++ b/src/Codeception/Configuration.php
@@ -21,6 +21,11 @@ class Configuration
     protected static $config = null;
 
     /**
+     * @var array params attached by user.
+     */
+    protected static $userParams = [];
+
+    /**
      * @var array environmental files configuration cache
      */
     protected static $envConfig = [];
@@ -564,6 +569,39 @@ class Configuration
     public static function append(array $config = [])
     {
         return self::$config = self::mergeConfigs(self::$config, $config);
+    }
+
+    public static function attachParams(array $params = [])
+    {
+        return self::$userParams = self::mergeParams(self::$userParams, $params);
+    }
+
+    protected static function mergeParams($current, $new)
+    {
+        if (!is_array($current)) {
+            return $new;
+        }
+
+        if (!is_array($new)) {
+            return $current;
+        }
+
+        $res = $current;
+        foreach ($new as $k => $param) {
+            if (!isset($res[$k]) || $param != $res[$k]) {
+                $res[$k] = $param;
+            }
+        }
+
+        return $res;
+    }
+
+    public static function getParam($key) {
+        if (isset(self::$userParams[$key])) {
+            return self::$userParams[$key];
+        }
+
+        return null;
     }
 
     public static function mergeConfigs($a1, $a2)


### PR DESCRIPTION
It is small test plan for this.

1. Run test with option -p or --params
```
php codecept run -p "site-id: 123456, group: admin" -p "duty: free"
```

In the test it should be available like following: 

```
$I = new AcceptanceTester($scenario);
.....
$I->amOnPage('/');
.....
$I->fillField('.site-id-input', \Codeception\Configuration::getParam('site-id'));
.....
```

Also I updated file tests/_support/Helper/Acceptance.php like so

```
namespace Helper;

use Codeception\Configuration;

// here you can define custom actions
// all public methods declared in helper class will be available in $I

class Acceptance extends \Codeception\Module
{

    public function getParam($key)
    {
        return Configuration::getParam($key);
    }
}
```


And I was able to use this: 


```
$I = new AcceptanceTester($scenario);
.....
$I->amOnPage('/');
.....
$I->fillField('.site-id-input', $I->getParam('site-id'));
.....
```

It probably is better way how to use params in the tests, and if you have ideas how to do it better let me know.
