### PR TITLE
Pass error message from wait*() methods to until()

### DIFF
--- a/src/Codeception/Module/WebDriver.php
+++ b/src/Codeception/Module/WebDriver.php
@@ -1951,15 +1951,16 @@ class WebDriver extends CodeceptionModule implements
      * @param $element
      * @param \Closure $callback
      * @param int $timeout seconds
+     * @param string $errorMessage
      * @throws \Codeception\Exception\ElementNotFound
      */
-    public function waitForElementChange($element, \Closure $callback, $timeout = 30)
+    public function waitForElementChange($element, \Closure $callback, $timeout = 30, $errorMessage = '')
     {
         $el = $this->matchFirstOrFail($this->webDriver, $element);
         $checker = function () use ($el, $callback) {
             return $callback($el);
         };
-        $this->webDriver->wait($timeout)->until($checker);
+        $this->webDriver->wait($timeout)->until($checker, $errorMessage);
     }
 
     /**
@@ -1975,12 +1976,13 @@ class WebDriver extends CodeceptionModule implements
      *
      * @param $element
      * @param int $timeout seconds
+     * @param string $errorMessage
      * @throws \Exception
      */
-    public function waitForElement($element, $timeout = 10)
+    public function waitForElement($element, $timeout = 10, $errorMessage = '')
     {
         $condition = WebDriverExpectedCondition::presenceOfElementLocated($this->getLocator($element));
-        $this->webDriver->wait($timeout)->until($condition);
+        $this->webDriver->wait($timeout)->until($condition, $errorMessage);
     }
 
     /**
@@ -1996,12 +1998,13 @@ class WebDriver extends CodeceptionModule implements
      *
      * @param $element
      * @param int $timeout seconds
+     * @param string $errorMessage
      * @throws \Exception
      */
-    public function waitForElementVisible($element, $timeout = 10)
+    public function waitForElementVisible($element, $timeout = 10, $errorMessage = '')
     {
         $condition = WebDriverExpectedCondition::visibilityOfElementLocated($this->getLocator($element));
-        $this->webDriver->wait($timeout)->until($condition);
+        $this->webDriver->wait($timeout)->until($condition, $errorMessage);
     }
 
     /**
@@ -2016,12 +2019,13 @@ class WebDriver extends CodeceptionModule implements
      *
      * @param $element
      * @param int $timeout seconds
+     * @param string $errorMessage
      * @throws \Exception
      */
-    public function waitForElementNotVisible($element, $timeout = 10)
+    public function waitForElementNotVisible($element, $timeout = 10, $errorMessage = '')
     {
         $condition = WebDriverExpectedCondition::invisibilityOfElementLocated($this->getLocator($element));
-        $this->webDriver->wait($timeout)->until($condition);
+        $this->webDriver->wait($timeout)->until($condition, $errorMessage);
     }
 
     /**
@@ -2041,18 +2045,19 @@ class WebDriver extends CodeceptionModule implements
      * @param string $text
      * @param int $timeout seconds
      * @param null $selector
+     * @param string $errorMessage
      * @throws \Exception
      */
-    public function waitForText($text, $timeout = 10, $selector = null)
+    public function waitForText($text, $timeout = 10, $selector = null, $errorMessage = '')
     {
         if (!$selector) {
             $condition = WebDriverExpectedCondition::textToBePresentInElement(WebDriverBy::xpath('//body'), $text);
-            $this->webDriver->wait($timeout)->until($condition);
+            $this->webDriver->wait($timeout)->until($condition, $errorMessage);
             return;
         }
 
         $condition = WebDriverExpectedCondition::textToBePresentInElement($this->getLocator($selector), $text);
-        $this->webDriver->wait($timeout)->until($condition);
+        $this->webDriver->wait($timeout)->until($condition, $errorMessage);
     }
 
     /**
@@ -2178,13 +2183,14 @@ class WebDriver extends CodeceptionModule implements
      *
      * @param string $script
      * @param int $timeout seconds
+     * @param string $errorMessage
      */
-    public function waitForJS($script, $timeout = 5)
+    public function waitForJS($script, $timeout = 5, $errorMessage = '')
     {
         $condition = function ($wd) use ($script) {
             return $wd->executeScript($script);
         };
-        $this->webDriver->wait($timeout)->until($condition);
+        $this->webDriver->wait($timeout)->until($condition, $errorMessage);
     }
 
     /**

--- a/src/Codeception/Module/WebDriver.php
+++ b/src/Codeception/Module/WebDriver.php
@@ -2045,7 +2045,8 @@ class WebDriver extends CodeceptionModule implements
      */
     public function waitForText($text, $timeout = 10, $selector = null)
     {
-        $message = sprintf('Waited for %d secs but text %s still not found',
+        $message = sprintf(
+            'Waited for %d secs but text %s still not found',
             $timeout,
             Locator::humanReadableString($text)
         );
@@ -2188,7 +2189,8 @@ class WebDriver extends CodeceptionModule implements
         $condition = function ($wd) use ($script) {
             return $wd->executeScript($script);
         };
-        $message = sprintf('Waited for %d secs but script %s still not executed',
+        $message = sprintf(
+            'Waited for %d secs but script %s still not executed',
             $timeout,
             Locator::humanReadableString($script)
         );

--- a/src/Codeception/Module/WebDriver.php
+++ b/src/Codeception/Module/WebDriver.php
@@ -1951,16 +1951,15 @@ class WebDriver extends CodeceptionModule implements
      * @param $element
      * @param \Closure $callback
      * @param int $timeout seconds
-     * @param string $errorMessage
      * @throws \Codeception\Exception\ElementNotFound
      */
-    public function waitForElementChange($element, \Closure $callback, $timeout = 30, $errorMessage = '')
+    public function waitForElementChange($element, \Closure $callback, $timeout = 30)
     {
         $el = $this->matchFirstOrFail($this->webDriver, $element);
         $checker = function () use ($el, $callback) {
             return $callback($el);
         };
-        $this->webDriver->wait($timeout)->until($checker, $errorMessage);
+        $this->webDriver->wait($timeout)->until($checker);
     }
 
     /**
@@ -1976,13 +1975,12 @@ class WebDriver extends CodeceptionModule implements
      *
      * @param $element
      * @param int $timeout seconds
-     * @param string $errorMessage
      * @throws \Exception
      */
-    public function waitForElement($element, $timeout = 10, $errorMessage = '')
+    public function waitForElement($element, $timeout = 10)
     {
         $condition = WebDriverExpectedCondition::presenceOfElementLocated($this->getLocator($element));
-        $this->webDriver->wait($timeout)->until($condition, $errorMessage);
+        $this->webDriver->wait($timeout)->until($condition);
     }
 
     /**
@@ -1998,13 +1996,12 @@ class WebDriver extends CodeceptionModule implements
      *
      * @param $element
      * @param int $timeout seconds
-     * @param string $errorMessage
      * @throws \Exception
      */
-    public function waitForElementVisible($element, $timeout = 10, $errorMessage = '')
+    public function waitForElementVisible($element, $timeout = 10)
     {
         $condition = WebDriverExpectedCondition::visibilityOfElementLocated($this->getLocator($element));
-        $this->webDriver->wait($timeout)->until($condition, $errorMessage);
+        $this->webDriver->wait($timeout)->until($condition);
     }
 
     /**
@@ -2019,13 +2016,12 @@ class WebDriver extends CodeceptionModule implements
      *
      * @param $element
      * @param int $timeout seconds
-     * @param string $errorMessage
      * @throws \Exception
      */
-    public function waitForElementNotVisible($element, $timeout = 10, $errorMessage = '')
+    public function waitForElementNotVisible($element, $timeout = 10)
     {
         $condition = WebDriverExpectedCondition::invisibilityOfElementLocated($this->getLocator($element));
-        $this->webDriver->wait($timeout)->until($condition, $errorMessage);
+        $this->webDriver->wait($timeout)->until($condition);
     }
 
     /**
@@ -2045,19 +2041,22 @@ class WebDriver extends CodeceptionModule implements
      * @param string $text
      * @param int $timeout seconds
      * @param null $selector
-     * @param string $errorMessage
      * @throws \Exception
      */
-    public function waitForText($text, $timeout = 10, $selector = null, $errorMessage = '')
+    public function waitForText($text, $timeout = 10, $selector = null)
     {
+        $message = sprintf('Waited for %d secs but text %s still not found',
+            $timeout,
+            Locator::humanReadableString($text)
+        );
         if (!$selector) {
             $condition = WebDriverExpectedCondition::textToBePresentInElement(WebDriverBy::xpath('//body'), $text);
-            $this->webDriver->wait($timeout)->until($condition, $errorMessage);
+            $this->webDriver->wait($timeout)->until($condition, $message);
             return;
         }
 
         $condition = WebDriverExpectedCondition::textToBePresentInElement($this->getLocator($selector), $text);
-        $this->webDriver->wait($timeout)->until($condition, $errorMessage);
+        $this->webDriver->wait($timeout)->until($condition, $message);
     }
 
     /**
@@ -2183,14 +2182,17 @@ class WebDriver extends CodeceptionModule implements
      *
      * @param string $script
      * @param int $timeout seconds
-     * @param string $errorMessage
      */
-    public function waitForJS($script, $timeout = 5, $errorMessage = '')
+    public function waitForJS($script, $timeout = 5)
     {
         $condition = function ($wd) use ($script) {
             return $wd->executeScript($script);
         };
-        $this->webDriver->wait($timeout)->until($condition, $errorMessage);
+        $message = sprintf('Waited for %d secs but script %s still not executed',
+            $timeout,
+            Locator::humanReadableString($script)
+        );
+        $this->webDriver->wait($timeout)->until($condition, $message);
     }
 
     /**


### PR DESCRIPTION
Sometimes, when test failed because some element on page is missing I receive TimeOutException exception with empty message. Now I will pass error message to wait*() methods like $I->waitForText('foo', 10, 'Text foo was not found');