### PR TITLE
Add methods to bind an (non-existent) exchange to a (non-existent) queue in AMPQ module

### DIFF
--- a/docs/modules/AMQP.md
+++ b/docs/modules/AMQP.md
@@ -114,6 +114,45 @@ $I->pushToQueue('queue.jobs', new AMQPMessage('create'));
  * `param` $message string|AMQPMessage
 
 
+### declareExchange
+
+Declares an exchange. This is an alias of method `exchange_declare` of `PhpAmqpLib\Channel\AMQPChannel`.
+
+```php
+<?php
+$I->declareExchange(
+   'nameOfMyExchange', // exchange name
+   'topic' // exchange type
+   //.. see the original method for more options
+)
+```
+
+### declareQueue
+
+Declares a queue. This is an alias of method `queue_declare` of `PhpAmqpLib\Channel\AMQPChannel`.
+
+```php
+<?php
+$I->declareQueue(
+    'nameOfMyQueue', // exchange name
+    //.. see the original method for more options
+)
+```
+
+### bindQueueToExchange
+
+Binds a queue to an exchange. This is an alias of method `queue_bind` of `PhpAmqpLib\Channel\AMQPChannel`.
+
+```php
+<?php
+$I->bindQueueToExchange(
+    'nameOfMyQueueToBind', // name of the queue
+    'transactionTracking.transaction', // exchange name to bind to
+    'your.routing.key' // Optionally, provide a binding key
+  //.. see the original method for more options
+)
+```
+
 ### seeMessageInQueueContainsText
  
 Checks if message containing text received.

--- a/src/Codeception/Module/AMQP.php
+++ b/src/Codeception/Module/AMQP.php
@@ -155,6 +155,63 @@ class AMQP extends CodeceptionModule implements RequiresPackage
     }
 
     /**
+     * Declares an exchange
+     *
+     * This is an alias of method `exchange_declare` of `PhpAmqpLib\Channel\AMQPChannel`.
+     *
+     * ```php
+     * <?php
+     * $I->declareExchange(
+     *     'nameOfMyExchange', // exchange name
+     *     'topic' // exchange type
+     *     //.. see the original method for more options
+     * )
+     * ```
+     */
+    public function declareExchange()
+    {
+        return call_user_func_array([$this->connection->channel(), 'exchange_declare'], func_get_args());
+    }
+
+    /**
+     * Declares a queue
+     *
+     * This is an alias of method `queue_declare` of `PhpAmqpLib\Channel\AMQPChannel`.
+     *
+     * ```php
+     * <?php
+     * $I->declareQueue(
+     *     'nameOfMyQueue', // exchange name
+     *     //.. see the original method for more options
+     * )
+     * ```
+     */
+    public function declareQueue()
+    {
+        return call_user_func_array([$this->connection->channel(), 'queue_declare'], func_get_args());
+    }
+
+    /**
+     * Binds a queue to an exchange
+     *
+     * This is an alias of method `queue_bind` of `PhpAmqpLib\Channel\AMQPChannel`.
+     *
+     * ```php
+     * <?php
+     * $I->bindQueueToExchange(
+     *     'nameOfMyQueueToBind', // name of the queue
+     *     'transactionTracking.transaction', // exchange name to bind to
+     *     'your.routing.key' // Optionally, provide a binding key
+     *     //.. see the original method for more options
+     * )
+     * ```
+     */
+    public function bindQueueToExchange()
+    {
+        return call_user_func_array([$this->connection->channel(), 'queue_bind'], func_get_args());
+    }
+
+    /**
      * Checks if message containing text received.
      *
      * **This method drops message from queue**


### PR DESCRIPTION
The added methods allow users to bind an (non-existent) exchange to a (non-existent) queue in AMPQ module. This is useful when you want to test some pub/sub implementation with a producer that pushes messages to an exchange (and not directly to a queue).