### PR TITLE
Issue #3987. Add option cleanup for skip cleanup

### DIFF
--- a/docs/modules/DataFactory.md
+++ b/docs/modules/DataFactory.md
@@ -44,6 +44,7 @@ modules:
         - DataFactory:
             factories: tests/_support/factories
             depends: Yii2
+            cleanup: true
 ```
 
 (you can also use Laravel5 and Phalcon).

--- a/src/Codeception/Module/DataFactory.php
+++ b/src/Codeception/Module/DataFactory.php
@@ -176,7 +176,7 @@ EOF;
      */
     protected function getStore()
     {
-        return $this->ormModule instanceof DataMappe
+        return $this->ormModule instanceof DataMapper
             ? new RepositoryStore($this->ormModule->_getEntityManager()) // for Doctrine
             : new ModelStore();
     }

--- a/src/Codeception/Module/DataFactory.php
+++ b/src/Codeception/Module/DataFactory.php
@@ -157,10 +157,7 @@ EOF;
 
     public function _beforeSuite($settings = [])
     {
-        $store = null;
-        if ($this->ormModule instanceof DataMapper) { // for Doctrine
-            $store = new RepositoryStore($this->ormModule->_getEntityManager());
-        }
+        $store = $this->getStore();
         $this->factoryMuffin = new FactoryMuffin($store);
 
         if ($this->config['factories']) {
@@ -173,6 +170,16 @@ EOF;
             }
         }
     }
+    
+    /**
+     * @return StoreInterface
+     */
+    protected function getStore()
+    {
+        return $this->ormModule instanceof DataMappe
+            ? new RepositoryStore($this->ormModule->_getEntityManager()) // for Doctrine
+            : new ModelStore();
+    }
 
     public function _inject(ORM $orm)
     {
@@ -181,8 +188,9 @@ EOF;
 
     public function _after(TestInterface $test)
     {
-        if ($this->ormModule->_getConfig('cleanup')) {
-            return; // don't delete records if ORM is set with cleanup
+        $skipCleanup = array_key_exists('cleanup', $this->config) && $this->config['cleanup'] === false;
+        if ($skipCleanup || $this->ormModule->_getConfig('cleanup')) {
+            return; // don't delete records if ORM is set with cleanup or set flag cleanup false
         }
         $this->factoryMuffin->deleteSaved();
     }

--- a/src/Codeception/Module/DataFactory.php
+++ b/src/Codeception/Module/DataFactory.php
@@ -190,7 +190,7 @@ EOF;
     {
         $skipCleanup = array_key_exists('cleanup', $this->config) && $this->config['cleanup'] === false;
         if ($skipCleanup || $this->ormModule->_getConfig('cleanup')) {
-            return; // don't delete records if ORM is set with cleanup or set flag cleanup false
+            return;
         }
         $this->factoryMuffin->deleteSaved();
     }

--- a/src/Codeception/Module/DataFactory.php
+++ b/src/Codeception/Module/DataFactory.php
@@ -172,13 +172,13 @@ EOF;
     }
     
     /**
-     * @return StoreInterface
+     * @return StoreInterface|null
      */
     protected function getStore()
     {
         return $this->ormModule instanceof DataMapper
             ? new RepositoryStore($this->ormModule->_getEntityManager()) // for Doctrine
-            : new ModelStore();
+            : null;
     }
 
     public function _inject(ORM $orm)


### PR DESCRIPTION
Add option cleanup for DataFactory. If option cleanup in DataFactory config set to FALSE that don`t need delete records by self.
Also move create default story for new method for more flexible extend it. 

Default option cleanup is TRUE for save old behavior.