### PR TITLE
Use local composer installation if available

### DIFF
--- a/autoload.php
+++ b/autoload.php
@@ -1,10 +1,24 @@
 <?php
-// for phar
-if (file_exists(__DIR__.'/vendor/autoload.php')) {
-    require_once(__DIR__.'/vendor/autoload.php');
-} elseif (file_exists(__DIR__.'/../../autoload.php')) {
+
+$autoloadFile = './vendor/codeception/codeception/autoload.php';
+if (file_exists('./vendor/autoload.php') && file_exists($autoloadFile) && __FILE__ != realpath($autoloadFile)) {
+    //for global installation or phar file
+    fwrite(
+        STDERR,
+        "\n==== Redirecting to Composer-installed version in vendor/codeception ====\n"
+    );
+    require $autoloadFile;
+    //require package/bin instead of codecept to avoid printing hashbang line
+    require './vendor/codeception/codeception/package/bin';
+    die;
+} elseif (file_exists(__DIR__ . '/vendor/autoload.php')) {
+    // for phar
+    require_once(__DIR__ . '/vendor/autoload.php');
+} elseif (file_exists(__DIR__ . '/../../autoload.php')) {
+    //for composer
     require_once __DIR__ . '/../../autoload.php';
 }
+unset($autoloadFile);
 
 // @codingStandardsIgnoreStart
 // loading WebDriver aliases


### PR DESCRIPTION
A popular cause of Codeception issues is incompatibility between locally installed dependency of the project and globally installed or packaged in phar file dependency of Codeception.

This is an attempt to eliminate one of the causes - when there is a local Codeception, but developer runs a globally installed version.

Example with phar file:
```
user@pc:~$ php codecept.phar 
Codeception 2.2.8
...

user@pc:~$ cd project
user@pc:~/project$ php ~/codecept.phar

==== Redirecting to Composer-installed version in vendor/codeception ====
Codeception version 2.2.6
``` 

Inspired by https://github.com/sebastianbergmann/phpunit/commit/4fe95a5b44de678315775743125518ce41610a19