### PR TITLE
Fix small refactoring issue

### DIFF
--- a/src/Codeception/Module/WebDriver.php
+++ b/src/Codeception/Module/WebDriver.php
@@ -2178,6 +2178,7 @@ class WebDriver extends CodeceptionModule implements
     {
         if (is_null($name)) {
             $this->webDriver->switchTo()->defaultContent();
+            return;
         }
         $this->webDriver->switchTo()->frame($name);
     }

--- a/tests/web/WebDriverTest.php
+++ b/tests/web/WebDriverTest.php
@@ -964,5 +964,12 @@ class WebDriverTest extends TestsForBrowsers
         $this->module->performOn('.rememberMe', ['see' => 'Login']);
     }
 
-
+    public function testSwitchToIframe()
+    {
+        $this->module->amOnPage('iframe');
+        $this->module->switchToIFrame('content');
+        $this->module->see('Lots of valuable data here');
+        $this->module->switchToIFrame();
+        $this->module->see('Iframe test');
+    }
 }


### PR DESCRIPTION
On ed549a9d2c5b6d4ccf940a6dcfa671cd042e8f99 an `else` statement was removed (awesome) but the author forgot to interrupt the execution flow and that is causing our test suite to fail :sob: but this fixes it.

Fixes #4001 