### PR TITLE
Add parse error to TestParseException in PHP7

### DIFF
--- a/src/Codeception/Test/Cept.php
+++ b/src/Codeception/Test/Cept.php
@@ -41,7 +41,7 @@ class Cept extends Test implements Interfaces\Plain, Interfaces\ScenarioDriven, 
         try {
             require $testFile;
         } catch (\ParseError $e) {
-            throw new TestParseException($testFile);
+            throw new TestParseException($testFile, $e->getMessage());
         }
     }
 


### PR DESCRIPTION
When \ParseError was thrown during test execution , the actual message was lost.

This change helps to debug issues like #4002