### PR TITLE
Added option --repeat for executing tests repeatedly

### DIFF
--- a/src/Codeception/Command/Run.php
+++ b/src/Codeception/Command/Run.php
@@ -77,6 +77,7 @@ use Symfony\Component\Console\Output\OutputInterface;
  *  --ansi                Force ANSI output.
  *  --no-ansi             Disable ANSI output.
  *  --no-interaction (-n) Do not ask any interactive question.
+ *  --repeat (-r)         Runs the test(s) repeatedly.
  * ```
  *
  */
@@ -191,6 +192,7 @@ class Run extends Command
             ),
             new InputOption('fail-fast', 'f', InputOption::VALUE_NONE, 'Stop after first failure'),
             new InputOption('no-rebuild', '', InputOption::VALUE_NONE, 'Do not rebuild actor classes on start'),
+            new InputOption('repeat', 'r', InputOption::VALUE_REQUIRED, 'Runs the test(s) repeatedly'),
         ]);
 
         parent::configure();
@@ -261,6 +263,9 @@ class Run extends Command
         }
         if (!$userOptions['ansi'] && $input->getOption('colors')) {
             $userOptions['colors'] = true; // turn on colors even in non-ansi mode if strictly passed
+        }
+        if ($this->options['repeat']) {
+            $userOptions['repeat'] = (int)$this->options['repeat'];
         }
 
         $suite = $input->getArgument('suite');

--- a/src/Codeception/PHPUnit/Runner.php
+++ b/src/Codeception/PHPUnit/Runner.php
@@ -95,7 +95,13 @@ class Runner extends \PHPUnit_TextUI_TestRunner
             $result->addListener($listener);
         }
 
-        $suite->run($result);
+        $repeatCount = isset($arguments['repeat']) && $arguments['repeat'] > 0
+            ? $arguments['repeat']
+            : 1;
+
+        foreach (range(1, $repeatCount) as $iteration) {
+            $suite->run($result);
+        }
         unset($suite);
 
         foreach ($arguments['listeners'] as $listener) {


### PR DESCRIPTION
Added --repeat (-r as short version) option for executing tests repeatedly

`codecept run unit tests/unit/UserTest.php:getUserByName --repeat 3`
`codecept run unit tests/unit/UserTest.php:getUserByName -r 3`