### PR TITLE
- g:step gives ambigous warning. add distinct command to docs

### DIFF
--- a/docs/reference/Commands.md
+++ b/docs/reference/Commands.md
@@ -265,8 +265,8 @@ Generates user-friendly text scenarios from scenario-driven tests (Cest, Cept).
 
 Generates StepObject class. You will be asked for steps you want to implement.
 
-* `codecept g:step acceptance AdminSteps`
-* `codecept g:step acceptance UserSteps --silent` - skip action questions
+* `codecept g:stepobject acceptance AdminSteps`
+* `codecept g:stepobject acceptance UserSteps --silent` - skip action questions
 
 
 


### PR DESCRIPTION
If you execute g:step you get an ambigous error:

> [Symfony\Component\Console\Exception\CommandNotFoundException]       
>   Command "g:step" is ambiguous (generate:stepobject, gherkin:steps). 

I corrected the docs from g:step to g:stepobject