### PR TITLE
Looking for group files can be really slow

### DIFF
--- a/src/Codeception/Lib/GroupManager.php
+++ b/src/Codeception/Lib/GroupManager.php
@@ -42,14 +42,13 @@ class GroupManager
             }
             $files = Finder::create()->files()
                 ->name(basename($pattern))
-                ->path(dirname($pattern))
                 ->sortByName()
-                ->in(Configuration::projectDir());
+                ->in(Configuration::projectDir().dirname($pattern));
 
             $i = 1;
             foreach ($files as $file) {
                 /** @var SplFileInfo $file * */
-                $this->configuredGroups[str_replace('*', $i, $group)] = $file->getRelativePathname();
+                $this->configuredGroups[str_replace('*', $i, $group)] = dirname($pattern).DIRECTORY_SEPARATOR.$file->getRelativePathname();
                 $i++;
             }
             unset($this->configuredGroups[$group]);


### PR DESCRIPTION
This is caused by use of `Finder::path()` at https://github.com/Codeception/Codeception/blob/2.2/src/Codeception/Lib/GroupManager.php#L43-L47 when `groups` parameter is set in codeception.yml

Finder is referencing every files in project root dir, then filters them according to string passed to `path()`. If a lot of files stand in project root dir, it can takes more than 2minutes to find a few group files.

Here's a patch to get rid of `Finder::path()`. It reduces elapsed time from several minutes to few seconds.
