### PR TITLE
Add in Doctrine module the possibility to grab Doctrine entities

### DIFF
--- a/docs/09-Data.md
+++ b/docs/09-Data.md
@@ -200,6 +200,7 @@ Doctrine2 also provides methods to create and check data:
 
 * `haveInRepository`
 * `grabFromRepository`
+* `grabEntitiesFromRepository`
 * `seeInRepository`
 * `dontSeeInRepository`
 

--- a/docs/modules/Doctrine2.md
+++ b/docs/modules/Doctrine2.md
@@ -90,6 +90,25 @@ $email = $I->grabFromRepository('User', 'email', array('name' => 'davert'));
  * `param array` $params
  * `return` array
 
+ ### grabEntitiesFromRepository
+ 
+Selects entities from repository.
+It builds query based on array of parameters.
+You can use entity associations to build complex queries.
+
+Example:
+
+``` php
+<?php
+$users = $I->grabEntitiesFromRepository('User', array('name' => 'davert'));
+?>
+```
+
+ * `Available since` 1.1
+ * `param` $entity
+ * `param array` $params
+ * `return` array
+
 
 ### haveFakeRepository
  

--- a/src/Codeception/Lib/Interfaces/DataMapper.php
+++ b/src/Codeception/Lib/Interfaces/DataMapper.php
@@ -10,6 +10,4 @@ interface DataMapper extends ORM, DoctrineProvider
     public function dontSeeInRepository($entity, $params = []);
 
     public function grabFromRepository($entity, $field, $params = []);
-
-    public function grabEntitiesFromRepository($entity, $params = []);
 }

--- a/src/Codeception/Lib/Interfaces/DataMapper.php
+++ b/src/Codeception/Lib/Interfaces/DataMapper.php
@@ -10,4 +10,6 @@ interface DataMapper extends ORM, DoctrineProvider
     public function dontSeeInRepository($entity, $params = []);
 
     public function grabFromRepository($entity, $field, $params = []);
+
+    public function grabEntitiesFromRepository($entity, $params = []);
 }

--- a/src/Codeception/Module/Doctrine2.php
+++ b/src/Codeception/Module/Doctrine2.php
@@ -397,6 +397,37 @@ EOF;
     }
 
     /**
+     * Selects entities from repository.
+     * It builds query based on array of parameters.
+     * You can use entity associations to build complex queries.
+     *
+     * Example:
+     *
+     * ``` php
+     * <?php
+     * $users = $I->grabEntitiesFromRepository('User', array('name' => 'davert'));
+     * ?>
+     * ```
+     *
+     * @version 1.1
+     * @param $entity
+     * @param array $params
+     * @return array
+     */
+    public function grabEntitiesFromRepository($entity, $params = [])
+    {
+        // we need to store to database...
+        $this->em->flush();
+        $data = $this->em->getClassMetadata($entity);
+        $qb = $this->em->getRepository($entity)->createQueryBuilder('s');
+        $qb->select('s');
+        $this->buildAssociationQuery($qb, $entity, 's', $params);
+        $this->debug($qb->getDQL());
+        
+        return $qb->getQuery()->getResult();
+    }
+
+    /**
      * It's Fuckin Recursive!
      *
      * @param $qb

--- a/src/Codeception/Module/Doctrine2.php
+++ b/src/Codeception/Module/Doctrine2.php
@@ -428,6 +428,39 @@ EOF;
     }
 
     /**
+     * Selects a single entity from repository.
+     * It builds query based on array of parameters.
+     * You can use entity associations to build complex queries.
+     *
+     * Example:
+     *
+     * ``` php
+     * <?php
+     * $users = $I->grabEntityFromRepository('User', array('name' => 'davert'));
+     * ?>
+     * ```
+     *
+     * @version 1.1
+     * @param $entity
+     * @param array $params
+     * @return array
+     */
+    public function grabEntityFromRepository($entity, $params = [])
+    {
+        // we need to store to database...
+        $this->em->flush();
+        $data = $this->em->getClassMetadata($entity);
+        $qb = $this->em->getRepository($entity)->createQueryBuilder('s');
+        $qb->select('s');
+        $this->buildAssociationQuery($qb, $entity, 's', $params);
+        $this->debug($qb->getDQL());
+        
+        return $qb->getQuery()->getSingleResult();
+    }
+
+    //git commit -m "Remove grabEntitiesFromRepository from interface + Single result for grabEntityRepository"
+
+    /**
      * It's Fuckin Recursive!
      *
      * @param $qb

--- a/src/Codeception/Module/Doctrine2.php
+++ b/src/Codeception/Module/Doctrine2.php
@@ -436,7 +436,7 @@ EOF;
      *
      * ``` php
      * <?php
-     * $users = $I->grabEntityFromRepository('User', array('name' => 'davert'));
+     * $user = $I->grabEntityFromRepository('User', array('id' => '1234'));
      * ?>
      * ```
      *
@@ -458,7 +458,7 @@ EOF;
         return $qb->getQuery()->getSingleResult();
     }
 
-    //git commit -m "Remove grabEntitiesFromRepository from interface + Single result for grabEntityRepository"
+    
 
     /**
      * It's Fuckin Recursive!


### PR DESCRIPTION
Hi,

using Codeception for a Symfony 2 project, I faced an issue with Doctrine association. 

In short, an entity "Car" have an association to an entity "Driver". I use gherkin syntax, and I have two "Given" directives to describe that:

```
Scenario: Karl drives a car
    Given I have these drivers:
    | id  | name |
    | d1 | Karl    |
    And I have these cars:
    | id | plate             | driverId |
    | c1 | AB-123-CD | d1           |
```

In my Tester code, these Given directives are runned by this code:
```
<?php
	/**
	 * @Given I have these drivers:
	 */
	public function theDriversExist(TableNode $table) {
	
		$hash = $table->getHash();
		foreach($hash as $row){
						
			$driverAttributes = [
				"id" => $row['id'],
				"name" => $row['name']
			];
			$this->haveInRepository(Driver::class, $driverAttributes);
	
		}
	}
	
	/**
	 * @Given I have these cars:
	 */
	public function theCarsExist(TableNode $table) {
	
		$hash = $table->getHash();
		foreach($hash as $row){
		
			$carAttributes = [
				"id" => $row['id'],
				"plate" => $row['plate'],
				"driver" => $row['driverId']
			];

			$this->haveInRepository(Car::class, $carAttributes);
	
		}
	
	}
```

The function "theCarsExist" triggers an error, because the "haveInRepository" method expect a Driver entity, and not just the driver id.

So, I need to fetch the Driver entity in "theCarsExist" method. But I do not have any way to do this.

I'm not the only one to run in this kind of problems, and no solution seems to be available : http://stackoverflow.com/questions/23626679/codeception-entity-associations-with-doctrine-2

I propose a solution to this : have a method that can fetch a whole entity instead of just fields value in database.

Here is the same working code:

```
<?php
	/**
	 * @Given I have these drivers:
	 */
	public function theDriversExist(TableNode $table) {
	
		$hash = $table->getHash();
		foreach($hash as $row){
						
			$driverAttributes = [
				"id" => $row['id'],
				"name" => $row['name']
			];
			$this->haveInRepository(Driver::class, $driverAttributes);
	
		}
	}
	
	/**
	 * @Given I have these cars:
	 */
	public function theCarsExist(TableNode $table) {
	
		$hash = $table->getHash();
		foreach($hash as $row){

			// Gets an array of corresponding drivers entities
			$drivers = $this->grabEntitiesFromRepository(Driver::class, array('id'=>$row['driverId']));

			// Check we found one
			if(count($drivers) == 1) {
				$driverEntity = $drivers[0];
			} else {
				throw new \Exception("No driver with id " . $row['driverId'] . " found");
			}
		
			$carAttributes = [
				"id" => $row['id'],
				"plate" => $row['plate'],
				"driver" => $driverEntity
			];

			$this->haveInRepository(Car::class, $carAttributes);
	
		}
	
	}
```

An alternative syntax is to keep the only "grabFromRepository" method, and return the whole entity if the $field parameter is null.