### PR TITLE
Adds transaction capability to Db.php and boolean transactions config

### DIFF
--- a/src/Codeception/Module/Db.php
+++ b/src/Codeception/Module/Db.php
@@ -142,7 +142,8 @@ class Db extends CodeceptionModule implements DbInterface
         'populate' => true,
         'cleanup' => true,
         'reconnect' => false,
-        'dump' => null
+        'dump' => null,
+        'transactions' => false
     ];
 
     /**
@@ -237,6 +238,9 @@ class Db extends CodeceptionModule implements DbInterface
         if ($this->config['reconnect']) {
             $this->connect();
         }
+        if ($this->config['transactions']) {
+            $this->dbh->beginTransaction();
+        }
         if ($this->config['cleanup'] && !$this->populated) {
             $this->cleanup();
             $this->loadDump();
@@ -247,7 +251,11 @@ class Db extends CodeceptionModule implements DbInterface
     public function _after(TestInterface $test)
     {
         $this->populated = false;
-        $this->removeInserted();
+        if ($this->config['transactions']) {
+            $this->dbh->rollBack();
+        } else {
+            $this->removeInserted();
+        }
         if ($this->config['reconnect']) {
             $this->disconnect();
         }


### PR DESCRIPTION
Allow the Db module to utilize database transactions by config.

The default is false and everything will work as usual.