### PR TITLE
fix deprecation warning in cli test suite

### DIFF
--- a/tests/cli/BuildCept.php
+++ b/tests/cli/BuildCept.php
@@ -1,5 +1,5 @@
 <?php
-$scenario->group('core');
+// @group core
 
 $I = new CliGuy($scenario);
 $I->wantToTest('build command');


### PR DESCRIPTION
The following command `./codecept run cli tests/cli/BuildCept.php` gives deprecation warning.

```
DEPRECATION: Codeception: $scenario->group() has been deprecated and removed. Use annotations to pass scenario params /home/gfranke/Codeception/src/Codeception/Scenario.php:150
```