### PR TITLE
Fix bug with docblock causing incorrect parameter error in IDE

### DIFF
--- a/src/Codeception/Util/Locator.php
+++ b/src/Codeception/Util/Locator.php
@@ -1,6 +1,7 @@
 <?php
 namespace Codeception\Util;
 
+use Facebook\WebDriver\WebDriverBy;
 use Symfony\Component\CssSelector\CssSelectorConverter;
 use Symfony\Component\CssSelector\Exception\ParseException;
 use Symfony\Component\CssSelector\XPath\Translator;
@@ -228,8 +229,7 @@ class Locator
     /**
      * Checks that a string is valid CSS class
      *
-     * @param $id
-     *
+     * @param $class
      * @return bool
      */
     public static function isClass($class)
@@ -275,8 +275,8 @@ class Locator
      * Locator::elementAt('table#grind>tr', -2); // previous than last row
      * ```
      *
-     * @param $element CSS or XPath locator
-     * @param $position xpath index
+     * @param string $element CSS or XPath locator
+     * @param int $position xpath index
      *
      * @return mixed
      */
@@ -354,7 +354,7 @@ class Locator
             return "$type '$locator'";
         }
         if (class_exists('\Facebook\WebDriver\WebDriverBy')) {
-            if ($selector instanceof \Facebook\WebDriver\WebDriverBy) {
+            if ($selector instanceof WebDriverBy) {
                 $type = $selector->getMechanism();
                 $locator = $selector->getValue();
                 return "$type '$locator'";


### PR DESCRIPTION
When using the following code in a test

```
Locator::elementAt('.my-selector', 2)
```

PhpStorm reports a parameter type mismatch error due to reading the words immediately after the parameter names in the docblock as a type. This can be fixed by adding scalar types to the docblock which makes no change to the code operation.

Also fixed another warning about an unneeded fully qualified class name in the same file.