### PR TITLE
Command Cleanup

### DIFF
--- a/src/Codeception/Command/Bootstrap.php
+++ b/src/Codeception/Command/Bootstrap.php
@@ -140,16 +140,6 @@ class Bootstrap extends Command
             ],
             'extensions' => [
                 'enabled' => ['Codeception\Extension\RunFailed']
-            ],
-            'modules'  => [
-                'config' => [
-                    'Db' => [
-                        'dsn'      => '',
-                        'user'     => '',
-                        'password' => '',
-                        'dump'     => 'tests/_data/dump.sql'
-                    ]
-                ]
             ]
         ];
 

--- a/src/Codeception/Command/Build.php
+++ b/src/Codeception/Command/Build.php
@@ -40,7 +40,7 @@ class Build extends Command
     protected function execute(InputInterface $input, OutputInterface $output)
     {
         $this->output = $output;
-        $this->buildActorsForConfig($input->getOption('config'));
+        $this->buildActorsForConfig();
     }
     
     private function buildActor(array $settings)
@@ -76,14 +76,14 @@ class Build extends Command
         return $this->save($file, $content, true);
     }
 
-    private function buildSuiteActors($configFile)
+    private function buildSuiteActors()
     {
-        $suites = $this->getSuites($configFile);
+        $suites = $this->getSuites();
         if (!empty($suites)) {
             $this->output->writeln("<info>Building Actor classes for suites: " . implode(', ', $suites) . '</info>');
         }
         foreach ($suites as $suite) {
-            $settings = $this->getSuiteConfig($suite, $configFile);
+            $settings = $this->getSuiteConfig($suite);
             $this->buildActions($settings);
             $actorBuilt = $this->buildActor($settings);
             
@@ -93,17 +93,16 @@ class Build extends Command
         }
     }
     
-    protected function buildActorsForConfig($configFile)
+    protected function buildActorsForConfig($configFile = null)
     {
         $config = $this->getGlobalConfig($configFile);
         
-        $path = pathinfo($configFile);
-        $dir = isset($path['dirname']) ? $path['dirname'] : getcwd();
+        $dir = Configuration::projectDir();
 
         foreach ($config['include'] as $subConfig) {
             $this->output->writeln("<comment>Included Configuration: $subConfig</comment>");
             $this->buildActorsForConfig($dir . DIRECTORY_SEPARATOR . $subConfig);
         }
-        $this->buildSuiteActors($configFile);
+        $this->buildSuiteActors();
     }
 }

--- a/src/Codeception/Command/Build.php
+++ b/src/Codeception/Command/Build.php
@@ -95,7 +95,7 @@ class Build extends Command
         $config = $this->getGlobalConfig($configFile);
         
         $dir = Configuration::projectDir();
-        $this->buildSuiteActors($configFile);
+        $this->buildSuiteActors();
 
         foreach ($config['include'] as $subConfig) {
             $this->output->writeln("\n<comment>Included Configuration: $subConfig</comment>");

--- a/src/Codeception/Command/Clean.php
+++ b/src/Codeception/Command/Clean.php
@@ -23,13 +23,8 @@ class Clean extends Command
         return 'Cleans or creates _output directory';
     }
 
-    protected function configure()
-    {
-    }
-
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        $this->getGlobalConfig($input->getOption('config'));
         $output->writeln("<info>Cleaning up " . Configuration::outputDir() . "...</info>");
         FileSystem::doEmptyDir(Configuration::outputDir());
         $output->writeln("Done");

--- a/src/Codeception/Command/ConfigValidate.php
+++ b/src/Codeception/Command/ConfigValidate.php
@@ -67,7 +67,7 @@ class ConfigValidate extends Command
         }
 
         $output->write("Validating global config... ");
-        $config = Configuration::config($input->getOption('config'));
+        $config = $this->getGlobalConfig();
         $output->writeln($input->getOption('override'));
         if (count($input->getOption('override'))) {
             $config = $this->overrideConfig($input->getOption('override'));
@@ -89,7 +89,7 @@ class ConfigValidate extends Command
 
         foreach ($suites as $suite) {
             $output->write("Validating suite <bold>$suite</bold>... ");
-            $this->getSuiteConfig($suite, $input->getOption('config'));
+            $this->getSuiteConfig($suite);
             $output->writeln('Ok');
         }
 

--- a/src/Codeception/Command/Console.php
+++ b/src/Codeception/Command/Console.php
@@ -52,7 +52,7 @@ class Console extends Command
         $suiteName = $input->getArgument('suite');
         $this->output = $output;
 
-        $config = Configuration::config($input->getOption('config'));
+        $config = Configuration::config();
         $settings = Configuration::suiteSettings($suiteName, $config);
 
         $options = $input->getOptions();

--- a/src/Codeception/Command/DryRun.php
+++ b/src/Codeception/Command/DryRun.php
@@ -38,7 +38,6 @@ class DryRun extends Command
             [
                 new InputArgument('suite', InputArgument::REQUIRED, 'suite to scan for feature files'),
                 new InputArgument('test', InputArgument::OPTIONAL, 'tests to be loaded'),
-                new InputOption('config', 'c', InputOption::VALUE_OPTIONAL, 'Use custom path for config'),
             ]
         );
         parent::configure();
@@ -55,11 +54,11 @@ class DryRun extends Command
         $suite = $input->getArgument('suite');
         $test = $input->getArgument('test');
 
-        $config = Configuration::config($input->getOption('config'));
+        $config = $this->getGlobalConfig();
         if (! Configuration::isEmpty() && ! $test && strpos($suite, $config['paths']['tests']) === 0) {
             list(, $suite, $test) = $this->matchTestFromFilename($suite, $config['paths']['tests']);
         }
-        $settings = $this->getSuiteConfig($suite, $input->getOption('config'));
+        $settings = $this->getSuiteConfig($suite);
 
         $dispatcher = new EventDispatcher();
         $dispatcher->addSubscriber(new ConsolePrinter([

--- a/src/Codeception/Command/GenerateCept.php
+++ b/src/Codeception/Command/GenerateCept.php
@@ -38,7 +38,7 @@ class GenerateCept extends Command
         $suite = $input->getArgument('suite');
         $filename = $input->getArgument('test');
 
-        $config = $this->getSuiteConfig($suite, $input->getOption('config'));
+        $config = $this->getSuiteConfig($suite);
         $this->buildPath($config['path'], $filename);
 
         $filename = $this->completeSuffix($filename, 'Cept');

--- a/src/Codeception/Command/GenerateCest.php
+++ b/src/Codeception/Command/GenerateCest.php
@@ -39,7 +39,7 @@ class GenerateCest extends Command
         $suite = $input->getArgument('suite');
         $class = $input->getArgument('class');
 
-        $config = $this->getSuiteConfig($suite, $input->getOption('config'));
+        $config = $this->getSuiteConfig($suite);
         $className = $this->getClassName($class);
         $path = $this->buildPath($config['path'], $class);
 

--- a/src/Codeception/Command/GenerateEnvironment.php
+++ b/src/Codeception/Command/GenerateEnvironment.php
@@ -34,7 +34,7 @@ class GenerateEnvironment extends Command
 
     public function execute(InputInterface $input, OutputInterface $output)
     {
-        $conf = $this->getGlobalConfig($input->getOption('config'));
+        $conf = $this->getGlobalConfig();
         if (!Configuration::envsDir()) {
             throw new ConfigurationException(
                 "Path for environments configuration is not set.\n"

--- a/src/Codeception/Command/GenerateFeature.php
+++ b/src/Codeception/Command/GenerateFeature.php
@@ -40,7 +40,7 @@ class GenerateFeature extends Command
         $suite = $input->getArgument('suite');
         $filename = $input->getArgument('feature');
 
-        $config = $this->getSuiteConfig($suite, $input->getOption('config'));
+        $config = $this->getSuiteConfig($suite);
         $this->buildPath($config['path'], $filename);
 
         $gen = new Feature(basename($filename));

--- a/src/Codeception/Command/GenerateGroup.php
+++ b/src/Codeception/Command/GenerateGroup.php
@@ -32,7 +32,7 @@ class GenerateGroup extends Command
 
     public function execute(InputInterface $input, OutputInterface $output)
     {
-        $config = $this->getGlobalConfig($input->getOption('config'));
+        $config = $this->getGlobalConfig();
         $group = $input->getArgument('group');
 
         $class = ucfirst($group);

--- a/src/Codeception/Command/GenerateHelper.php
+++ b/src/Codeception/Command/GenerateHelper.php
@@ -35,7 +35,7 @@ class GenerateHelper extends Command
     public function execute(InputInterface $input, OutputInterface $output)
     {
         $name = ucfirst($input->getArgument('name'));
-        $config = Configuration::config($input->getOption('config'));
+        $config = $this->getGlobalConfig();
 
         $path = $this->buildPath(Configuration::supportDir() . 'Helper', $name);
         $filename = $path . $this->getClassName($name) . '.php';

--- a/src/Codeception/Command/GeneratePageObject.php
+++ b/src/Codeception/Command/GeneratePageObject.php
@@ -46,8 +46,8 @@ class GeneratePageObject extends Command
         }
 
         $conf = $suite
-            ? $this->getSuiteConfig($suite, $input->getOption('config'))
-            : $this->getGlobalConfig($input->getOption('config'));
+            ? $this->getSuiteConfig($suite)
+            : $this->getGlobalConfig();
 
         if ($suite) {
             $suite = DIRECTORY_SEPARATOR . ucfirst($suite);

--- a/src/Codeception/Command/GeneratePhpUnit.php
+++ b/src/Codeception/Command/GeneratePhpUnit.php
@@ -39,7 +39,7 @@ class GeneratePhpUnit extends Command
         $suite = $input->getArgument('suite');
         $class = $input->getArgument('class');
 
-        $config = $this->getSuiteConfig($suite, $input->getOption('config'));
+        $config = $this->getSuiteConfig($suite);
 
         $path = $this->buildPath($config['path'], $class);
 

--- a/src/Codeception/Command/GenerateScenarios.php
+++ b/src/Codeception/Command/GenerateScenarios.php
@@ -44,7 +44,7 @@ class GenerateScenarios extends Command
     {
         $suite = $input->getArgument('suite');
 
-        $suiteConf = $this->getSuiteConfig($suite, $input->getOption('config'));
+        $suiteConf = $this->getSuiteConfig($suite);
 
         $path = $input->getOption('path')
             ? $input->getOption('path')

--- a/src/Codeception/Command/GenerateStepObject.php
+++ b/src/Codeception/Command/GenerateStepObject.php
@@ -40,7 +40,7 @@ class GenerateStepObject extends Command
     {
         $suite = $input->getArgument('suite');
         $step = $input->getArgument('step');
-        $config = $this->getSuiteConfig($suite, $input->getOption('config'));
+        $config = $this->getSuiteConfig($suite);
 
         $class = $this->getClassName($step);
 

--- a/src/Codeception/Command/GenerateSuite.php
+++ b/src/Codeception/Command/GenerateSuite.php
@@ -50,7 +50,7 @@ class GenerateSuite extends Command
             return;
         }
 
-        $config = \Codeception\Configuration::config($input->getOption('config'));
+        $config = $this->getGlobalConfig();
         if (!$actor) {
             $actor = ucfirst($suite) . $config['actor'];
         }

--- a/src/Codeception/Command/GenerateSuite.php
+++ b/src/Codeception/Command/GenerateSuite.php
@@ -67,7 +67,7 @@ class GenerateSuite extends Command
             // generate bootstrap
             $this->save(
                 $dir . $suite . DIRECTORY_SEPARATOR . $config['settings']['bootstrap'],
-                "<?php\n// Here you can initialize variables that will be available to your tests\n",
+                "<?php\n",
                 true
             );
         }

--- a/src/Codeception/Command/GenerateSuite.php
+++ b/src/Codeception/Command/GenerateSuite.php
@@ -61,6 +61,17 @@ class GenerateSuite extends Command
             throw new \Exception("Suite configuration file '$suite.suite.yml' already exists.");
         }
 
+        if ($config['settings']['bootstrap']) {
+            $this->buildPath($dir . $suite . DIRECTORY_SEPARATOR, $config['settings']['bootstrap']);
+
+            // generate bootstrap
+            $this->save(
+                $dir . $suite . DIRECTORY_SEPARATOR . $config['settings']['bootstrap'],
+                "<?php\n// Here you can initialize variables that will be available to your tests\n",
+                true
+            );
+        }
+
         $actorName = $this->removeSuffix($actor, $config['actor']);
         $config['class_name'] = $actorName . $config['actor'];
 

--- a/src/Codeception/Command/GenerateSuite.php
+++ b/src/Codeception/Command/GenerateSuite.php
@@ -61,14 +61,6 @@ class GenerateSuite extends Command
             throw new \Exception("Suite configuration file '$suite.suite.yml' already exists.");
         }
 
-        $this->buildPath($dir . $suite . DIRECTORY_SEPARATOR, $config['settings']['bootstrap']);
-
-        // generate bootstrap
-        $this->save(
-            $dir . $suite . DIRECTORY_SEPARATOR . $config['settings']['bootstrap'],
-            "<?php\n// Here you can initialize variables that will be available to your tests\n",
-            true
-        );
         $actorName = $this->removeSuffix($actor, $config['actor']);
         $config['class_name'] = $actorName . $config['actor'];
 

--- a/src/Codeception/Command/GenerateTest.php
+++ b/src/Codeception/Command/GenerateTest.php
@@ -39,7 +39,7 @@ class GenerateTest extends Command
         $suite = $input->getArgument('suite');
         $class = $input->getArgument('class');
 
-        $config = $this->getSuiteConfig($suite, $input->getOption('config'));
+        $config = $this->getSuiteConfig($suite);
 
         $className = $this->getClassName($class);
         $path = $this->buildPath($config['path'], $class);

--- a/src/Codeception/Command/GherkinSnippets.php
+++ b/src/Codeception/Command/GherkinSnippets.php
@@ -46,7 +46,7 @@ class GherkinSnippets extends Command
         $this->addStyles($output);
         $suite = $input->getArgument('suite');
         $test = $input->getArgument('test');
-        $config = $this->getSuiteConfig($suite, $input->getOption('config'));
+        $config = $this->getSuiteConfig($suite);
 
         $generator = new SnippetsGenerator($config, $test);
         $snippets = $generator->getSnippets();

--- a/src/Codeception/Command/GherkinSteps.php
+++ b/src/Codeception/Command/GherkinSteps.php
@@ -42,7 +42,7 @@ class GherkinSteps extends Command
     {
         $this->addStyles($output);
         $suite = $input->getArgument('suite');
-        $config = $this->getSuiteConfig($suite, $input->getOption('config'));
+        $config = $this->getSuiteConfig($suite);
         $config['describe_steps'] = true;
 
         $loader = new Gherkin($config);

--- a/src/Codeception/Command/Run.php
+++ b/src/Codeception/Command/Run.php
@@ -216,7 +216,7 @@ class Run extends Command
         $this->output = $output;
 
         // load config
-        $config = $this->getGlobalConfig($this->options['config']);
+        $config = $this->getGlobalConfig();
 
         // update config from options
         if (count($this->options['override'])) {

--- a/src/Codeception/Command/Shared/Config.php
+++ b/src/Codeception/Command/Shared/Config.php
@@ -7,20 +7,18 @@ use Symfony\Component\Yaml\Yaml;
 
 trait Config
 {
-    protected function getSuiteConfig($suite, $conf)
+    protected function getSuiteConfig($suite)
     {
-        $config = Configuration::config($conf);
-        return Configuration::suiteSettings($suite, $config);
+        return Configuration::suiteSettings($suite, $this->getGlobalConfig());
     }
 
-    protected function getGlobalConfig($conf)
+    protected function getGlobalConfig($conf = null)
     {
         return Configuration::config($conf);
     }
 
-    protected function getSuites($conf)
+    protected function getSuites($conf = null)
     {
-        Configuration::config($conf);
         return Configuration::suites();
     }
 

--- a/tests/unit/Codeception/Command/GenerateSuiteTest.php
+++ b/tests/unit/Codeception/Command/GenerateSuiteTest.php
@@ -14,7 +14,7 @@ class GenerateSuiteTest extends BaseCommandRunner
     {
         $this->execute(array('suite' => 'shire', 'actor' => 'Hobbit'), false);
 
-        $configFile = $this->log[2];
+        $configFile = $this->log[1];
 
         $this->assertEquals(\Codeception\Configuration::projectDir().'tests/shire.suite.yml', $configFile['filename']);
         $conf = \Symfony\Component\Yaml\Yaml::parse($configFile['content']);
@@ -22,12 +22,12 @@ class GenerateSuiteTest extends BaseCommandRunner
         $this->assertContains('\Helper\Hobbit', $conf['modules']['enabled']);
         $this->assertContains('Suite shire generated', $this->output);
 
-        $actor = $this->log[3];
+        $actor = $this->log[2];
         $this->assertEquals(\Codeception\Configuration::supportDir().'HobbitGuy.php', $actor['filename']);
         $this->assertContains('class HobbitGuy extends \Codeception\Actor', $actor['content']);
 
 
-        $helper = $this->log[1];
+        $helper = $this->log[0];
         $this->assertEquals(\Codeception\Configuration::supportDir().'Helper/Hobbit.php', $helper['filename']);
         $this->assertContains('namespace Helper;', $helper['content']);
         $this->assertContains('class Hobbit extends \Codeception\Module', $helper['content']);
@@ -37,12 +37,12 @@ class GenerateSuiteTest extends BaseCommandRunner
     {
         $this->execute(array('suite' => 'shire', 'actor' => 'HobbitGuy'), false);
 
-        $configFile = $this->log[2];
+        $configFile = $this->log[1];
         $conf = \Symfony\Component\Yaml\Yaml::parse($configFile['content']);
         $this->assertEquals('HobbitGuy', $conf['class_name']);
         $this->assertContains('\Helper\Hobbit', $conf['modules']['enabled']);
 
-        $helper = $this->log[1];
+        $helper = $this->log[0];
         $this->assertEquals(\Codeception\Configuration::supportDir().'Helper/Hobbit.php', $helper['filename']);
         $this->assertContains('class Hobbit extends \Codeception\Module', $helper['content']);
     }

--- a/tests/unit/Codeception/Command/GenerateSuiteTest.php
+++ b/tests/unit/Codeception/Command/GenerateSuiteTest.php
@@ -12,7 +12,7 @@ class GenerateSuiteTest extends BaseCommandRunner
 
     public function testBasic()
     {
-        $this->execute(array('suite' => 'shire', 'actor' => 'Hobbit'));
+        $this->execute(array('suite' => 'shire', 'actor' => 'Hobbit'), false);
 
         $configFile = $this->log[2];
 
@@ -31,17 +31,11 @@ class GenerateSuiteTest extends BaseCommandRunner
         $this->assertEquals(\Codeception\Configuration::supportDir().'Helper/Hobbit.php', $helper['filename']);
         $this->assertContains('namespace Helper;', $helper['content']);
         $this->assertContains('class Hobbit extends \Codeception\Module', $helper['content']);
-
-        $bootstrap = $this->log[0];
-        $this->assertEquals(
-            \Codeception\Configuration::projectDir().'tests/shire/_bootstrap.php',
-            $bootstrap['filename']
-        );
     }
 
     public function testGuyWithSuffix()
     {
-        $this->execute(array('suite' => 'shire', 'actor' => 'HobbitGuy'));
+        $this->execute(array('suite' => 'shire', 'actor' => 'HobbitGuy'), false);
 
         $configFile = $this->log[2];
         $conf = \Symfony\Component\Yaml\Yaml::parse($configFile['content']);


### PR DESCRIPTION
$input->getOption('config') no longer provides a config file, it is loaded inside Application, so it's always `null` inside a command class. The custom config is already loaded by that time. This is the reason why nothing was broken ).

Also I removed the `module: config:` section from the bootstrap template. They are never used and may be confusing