### PR TITLE
Auto-Inject into Test\Unit

### DIFF
--- a/src/Codeception/Test/Unit.php
+++ b/src/Codeception/Test/Unit.php
@@ -45,10 +45,10 @@ class Unit extends \PHPUnit_Framework_TestCase implements
         $di = $this->getMetadata()->getService('di');
         $di->set(new Scenario($this));
 
-        // DEPRECATED: auto-inject int $tester property
-        // this will be removed from documentation but still can be used in old projects
-        $property = lcfirst(Configuration::config()['actor']);
-        $this->$property = $di->get($this->getMetadata()->getCurrent('actor'));
+        // auto-inject $tester property
+        if (($this->getMetadata()->getCurrent('actor')) && ($property = lcfirst(Configuration::config()['actor']))) {
+            $this->$property = $di->instantiate($this->getMetadata()->getCurrent('actor'));
+        }
 
         // Auto inject into the _inject method
         $di->injectDependencies($this); // injecting dependencies

--- a/src/Codeception/Test/Unit.php
+++ b/src/Codeception/Test/Unit.php
@@ -3,6 +3,7 @@ namespace Codeception\Test;
 
 use Codeception\Configuration;
 use Codeception\Exception\ModuleException;
+use Codeception\Lib\Di;
 use Codeception\Scenario;
 use Codeception\TestInterface;
 
@@ -39,14 +40,18 @@ class Unit extends \PHPUnit_Framework_TestCase implements
             }
             return;
         }
-        $scenario = new Scenario($this);
-        $actorClass = $this->getMetadata()->getCurrent('actor');
-        if ($actorClass) {
-            $I = new $actorClass($scenario);
-            $property = lcfirst(Configuration::config()['actor']);
-            $this->$property = $I;
-        }
-        $this->getMetadata()->getService('di')->injectDependencies($this); // injecting dependencies
+
+        /** @var $di Di  **/
+        $di = $this->getMetadata()->getService('di');
+        $di->set(new Scenario($this));
+
+        // DEPRECATED: auto-inject int $tester property
+        // this will be removed from documentation but still can be used in old projects
+        $property = lcfirst(Configuration::config()['actor']);
+        $this->$property = $di->get($this->getMetadata()->getCurrent('actor'));
+
+        // Auto inject into the _inject method
+        $di->injectDependencies($this); // injecting dependencies
         $this->_before();
     }
 


### PR DESCRIPTION
This is the new recommended approach to use actor classes inside unit tests:

```php
function _inject(UnitTester $I)
{
    $this->i = $I;
}

function testRobotUserIsInsideDatabase()
{
    $this->i->seeInDatabase('users', ['id' => 1, 'name' => 'robot']);
}
```
`$this->tester` injection into Test\Unit classes happen in a very mysterious way. While this injection still happens it should be done explicitly, using `_inject` method we already have. This will allow to specify and name properties in predictable names. This will also allow to use classes based on Actor, like PageObjects, or StepObjects.

This new recommended way will be added to docs, while old one will be removed. However, property-based old-style injection will be kept till 3.0 and probably even after it.