### PR TITLE
Fixed calling flush on null

### DIFF
--- a/CHANGELOG-2.2.md
+++ b/CHANGELOG-2.2.md
@@ -14,6 +14,7 @@
 * [PhpBrowser][Frameworks] If form has no id, use action attribute as identifier by @Naktibalda. Fixes #3953
 * Fixed test coloring output when a Feature title has some special chars in it like `/` or `-`
 * [REST] Added missing @part `json` and `xml` to `deleteHeader` by @freezy-sk 
+* [MEMCACHE] Fixed calling flush on null by @Jurigag
 
 #### 2.2.8
 

--- a/src/Codeception/Module/Memcache.php
+++ b/src/Codeception/Module/Memcache.php
@@ -78,6 +78,10 @@ class Memcache extends CodeceptionModule
      */
     public function _after(TestInterface $test)
     {
+        if (empty($this->memcache)) {
+            return;
+        }
+
         $this->memcache->flush();
         switch (get_class($this->memcache)) {
             case 'Memcache':


### PR DESCRIPTION
Sometimes when some exception happens during tests and before `_before` method is run in memcache module then in `_after` method flush is done on null causing other error.