### PR TITLE
Added new method seeOptionValueIsSelected

### DIFF
--- a/src/Codeception/Lib/InnerBrowser.php
+++ b/src/Codeception/Lib/InnerBrowser.php
@@ -1408,6 +1408,15 @@ class InnerBrowser extends Module implements Web, PageSourceSaver, ElementLocato
         $this->assertEquals($optionText, $value);
     }
 
+    public function seeOptionValueIsSelected($selector, $optionText)
+    {
+        $selected = $this->matchSelectedOption($selector);
+        $this->assertDomContains($selected, 'selected option');
+
+        $value = $selected->getNode(0)->getAttribute('value');
+        $this->assertEquals($optionText, $value);
+    }
+
     public function dontSeeOptionIsSelected($selector, $optionText)
     {
         $selected = $this->matchSelectedOption($selector);
@@ -1419,6 +1428,18 @@ class InnerBrowser extends Module implements Web, PageSourceSaver, ElementLocato
         $value = $selected->getNode(0)->tagName == 'option'
             ? $selected->text()
             : $selected->getNode(0)->getAttribute('value');
+        $this->assertNotEquals($optionText, $value);
+    }
+
+    public function dontseeOptionValueIsSelected($selector, $optionText)
+    {
+        $selected = $this->matchSelectedOption($selector);
+        if (!$selected->count()) {
+            $this->assertEquals(0, $selected->count());
+            return;
+        }
+
+        $value = $selected->getNode(0)->getAttribute('value');
         $this->assertNotEquals($optionText, $value);
     }
 

--- a/tests/unit/Codeception/Module/TestsForWeb.php
+++ b/tests/unit/Codeception/Module/TestsForWeb.php
@@ -296,8 +296,8 @@ abstract class TestsForWeb extends \Codeception\TestCase\Test
     public function testSeeSelectedOptionValue()
     {
         $this->module->amOnPage('/form/select');
-        $this->module->seeOptionIsSelected('#age', 'oldfag');
-        $this->module->dontSeeOptionIsSelected('#age', 'child');
+        $this->module->seeOptionValueIsSelected('#age', 'oldfag');
+        $this->module->dontSeeOptionValueIsSelected('#age', 'child');
     }
 
     public function testSeeSelectedOptionForRadioButton()

--- a/tests/unit/Codeception/Module/TestsForWeb.php
+++ b/tests/unit/Codeception/Module/TestsForWeb.php
@@ -290,6 +290,16 @@ abstract class TestsForWeb extends \Codeception\TestCase\Test
         $this->module->dontSeeOptionIsSelected('#age', '100-210');
     }
 
+    /**
+     * @Issue https://github.com/Codeception/Codeception/issues/3498
+     */
+    public function testSeeSelectedOptionValue()
+    {
+        $this->module->amOnPage('/form/select');
+        $this->module->seeOptionIsSelected('#age', 'oldfag');
+        $this->module->dontSeeOptionIsSelected('#age', 'child');
+    }
+
     public function testSeeSelectedOptionForRadioButton()
     {
         $this->module->amOnPage('/form/example6');


### PR DESCRIPTION
This method checks only in the value attribute of the selected option. Probably naming it 'seeSelectedOptionHasValue' could be more meaningful but i used the former for legacy reasons.