### PR TITLE
Run suite by its path

### DIFF
--- a/src/Codeception/Command/Run.php
+++ b/src/Codeception/Command/Run.php
@@ -373,9 +373,13 @@ class Run extends Command
     protected function matchTestFromFilename($filename, $tests_path)
     {
         $filename = str_replace(['//', '\/', '\\'], '/', $filename);
-        $res = preg_match("~^$tests_path/(.*?)/(.*)$~", $filename, $matches);
+        $res = preg_match("~^$tests_path/(.*?)(?>/(.*))?$~", $filename, $matches);
+
         if (!$res) {
             throw new \InvalidArgumentException("Test file can't be matched");
+        }
+        if (!isset($matches[2])) {
+            $matches[2] = null;
         }
 
         return $matches;


### PR DESCRIPTION
Supports running

```
codecept run tests/unit
```

Improves recent [PhpStorm integration](https://blog.jetbrains.com/phpstorm/2017/03/codeception-support-comes-to-phpstorm-2017-1/). Now you can run a suite tests by running tests on a suite directory.