### PR TITLE
$app['exception_handler']->disable() fails

### DIFF
--- a/docs/modules/Silex.md
+++ b/docs/modules/Silex.md
@@ -25,7 +25,7 @@ Bootstrap is the same as [WebTestCase.createApplication](http://silex.sensiolabs
 <?
 $app = require __DIR__.'/path/to/app.php';
 $app['debug'] = true;
-$app['exception_handler']->disable();
+unset($app['exception_handler']);
 
 return $app; // optionally
 ?>

--- a/src/Codeception/Module/Silex.php
+++ b/src/Codeception/Module/Silex.php
@@ -33,7 +33,7 @@ use Symfony\Component\HttpKernel\Client;
  * <?
  * $app = require __DIR__.'/path/to/app.php';
  * $app['debug'] = true;
- * $app['exception_handler']->disable();
+ * unset($app['exception_handler']);
  *
  * return $app; // optionally
  * ?>


### PR DESCRIPTION
The recommended way to disable the exception handler in Silex 1.3 and Silex 2.0 docs is:

unset($app['exception_handler']);

#4082