### PR TITLE
support dataProvider - fix case

### DIFF
--- a/docs/07-AdvancedUsage.md
+++ b/docs/07-AdvancedUsage.md
@@ -230,12 +230,12 @@ These examples can be written using Doctrine-style annotation syntax as well:
   }
 ```
 
-You can also use the `@dataprovider` annotation for creating dynamic examples, using a protected method for providing example data:
+You can also use the `@dataProvider` annotation for creating dynamic examples, using a protected method for providing example data:
 
 ```php
 <?php
    /**
-    * @dataprovider pageProvider
+    * @dataProvider pageProvider
     */
     public function staticPages(AcceptanceTester $I, \Codeception\Example $example)
     {
@@ -258,12 +258,12 @@ You can also use the `@dataprovider` annotation for creating dynamic examples, u
     }
 ```
 
-Alternatively, the `@dataprovider` can also be a public method starting with `_` prefix so it will not be considered as a test:
+Alternatively, the `@dataProvider` can also be a public method starting with `_` prefix so it will not be considered as a test:
 
 ```php
 <?php
    /**
-    * @dataprovider _pageProvider
+    * @dataProvider _pageProvider
     */
     public function staticPages(AcceptanceTester $I, \Codeception\Example $example)
     {

--- a/src/Codeception/Test/Loader/Cest.php
+++ b/src/Codeception/Test/Loader/Cest.php
@@ -53,8 +53,13 @@ class Cest implements LoaderInterface
                     );
                 }
 
-                // dataprovider Annotation
-                $dataMethod = Annotation::forMethod($testClass, $method)->fetch('dataprovider');
+                // dataProvider Annotation
+                $dataMethod = Annotation::forMethod($testClass, $method)->fetch('dataProvider');
+                // lowercase for back compatible
+                if (empty($dataMethod)) {
+                    $dataMethod = Annotation::forMethod($testClass, $method)->fetch('dataprovider');
+                }
+
                 if (!empty($dataMethod)) {
                     try {
                         $data = ReflectionHelper::invokePrivateMethod($unit, $dataMethod);

--- a/tests/data/claypit/tests/scenario/DataProviderCest.php
+++ b/tests/data/claypit/tests/scenario/DataProviderCest.php
@@ -5,7 +5,7 @@ class DataProviderCest
 {
      /**
       * @group dataprovider
-      * @dataprovider __exampleDataSource
+      * @dataProvider __exampleDataSource
       */
       public function withDataProvider(ScenarioGuy $I, Example $example)
       {
@@ -25,7 +25,7 @@ class DataProviderCest
 
       /**
        * @group dataprovider
-       * @dataprovider __exampleDataSource
+       * @dataProvider __exampleDataSource
        * @example(path=".", file="skipped.suite.yml")
        */
        public function withDataProviderAndExample(ScenarioGuy $I, Example $example)


### PR DESCRIPTION
https://phpunit.de/manual/current/en/writing-tests-for-phpunit.html
default in phpunit is "dataProvider" support both for now ("dataprovider" need mark deprecated?)