### PR TITLE
[Webdriver] fixed attachFile messages when the file does not exist

### DIFF
--- a/src/Codeception/Lib/InnerBrowser.php
+++ b/src/Codeception/Lib/InnerBrowser.php
@@ -1050,17 +1050,21 @@ class InnerBrowser extends Module implements Web, PageSourceSaver, ElementLocato
     public function attachFile($field, $filename)
     {
         $form = $this->getFormFor($field = $this->getFieldByLabelOrCss($field));
-        $path = Configuration::dataDir() . $filename;
-        $name = $field->attr('name');
-        if (!is_readable($path)) {
-            $this->fail("file $filename not found in Codeception data path. Only files stored in data path accepted");
+        $filePath = codecept_data_dir() . $filename;
+        if (!file_exists($filePath)) {
+            throw new \InvalidArgumentException("File does not exist: $filePath");
         }
+        if (!is_readable($filePath)) {
+            throw new \InvalidArgumentException("File is not readable: $filePath");
+        }
+
+        $name = $field->attr('name');
         $formField = $this->matchFormField($name, $form, new FileFormField($field->getNode(0)));
         if (is_array($formField)) {
             $this->fail("Field $name is ignored on upload, field $name is treated as array.");
         }
 
-        $formField->upload($path);
+        $formField->upload($filePath);
     }
 
     /**

--- a/src/Codeception/Module/WebDriver.php
+++ b/src/Codeception/Module/WebDriver.php
@@ -1389,9 +1389,12 @@ class WebDriver extends CodeceptionModule implements
     {
         $el = $this->findField($field);
         // in order to be compatible on different OS
-        $filePath = realpath(codecept_data_dir() . $filename);
+        $filePath = codecept_data_dir() . $filename;
+        if (!file_exists($filePath)) {
+            throw new \InvalidArgumentException("File does not exist: $filePath");
+        }
         if (!is_readable($filePath)) {
-            throw new \InvalidArgumentException("file not found or not readable: $filePath");
+            throw new \InvalidArgumentException("File is not readable: $filePath");
         }
         // in order for remote upload to be enabled
         $el->setFileDetector(new LocalFileDetector());
@@ -1400,7 +1403,7 @@ class WebDriver extends CodeceptionModule implements
         if ($this->isPhantom()) {
             $el->setFileDetector(new UselessFileDetector());
         }
-        $el->sendKeys($filePath);
+        $el->sendKeys(realpath($filePath));
     }
 
     /**

--- a/tests/unit/Codeception/Module/TestsForWeb.php
+++ b/tests/unit/Codeception/Module/TestsForWeb.php
@@ -1623,4 +1623,14 @@ abstract class TestsForWeb extends \Codeception\TestCase\Test
         $this->module->click('Relative Form');
         $this->module->seeCurrentUrlEquals('/form/example5');
     }
+
+    public function testAttachFileThrowsCorrectMessageWhenFileDoesNotExist()
+    {
+        $filename = 'does-not-exist.jpg';
+        $expectedMessage = 'File does not exist: ' . codecept_data_dir($filename);
+        $this->setExpectedException('InvalidArgumentException', $expectedMessage);
+
+        $this->module->amOnPage('/form/file');
+        $this->module->attachFile('Avatar', $filename);
+    }
 }

--- a/tests/web/WebDriverTest.php
+++ b/tests/web/WebDriverTest.php
@@ -998,4 +998,14 @@ class WebDriverTest extends TestsForBrowsers
         $this->module->switchToIFrame();
         $this->module->see('Iframe test');
     }
+
+    public function testAttachFileThrowsCorrectMessageWhenFileDoesNotExist()
+    {
+        $filename = 'does-not-exist.jpg';
+        $expectedMessage = 'File does not exist: ' . codecept_data_dir($filename);
+        $this->setExpectedException('InvalidArgumentException', $expectedMessage);
+
+        $this->module->amOnPage('/form/file');
+        $this->module->attachFile('Avatar', $filename);
+    }
 }

--- a/tests/web/WebDriverTest.php
+++ b/tests/web/WebDriverTest.php
@@ -998,14 +998,4 @@ class WebDriverTest extends TestsForBrowsers
         $this->module->switchToIFrame();
         $this->module->see('Iframe test');
     }
-
-    public function testAttachFileThrowsCorrectMessageWhenFileDoesNotExist()
-    {
-        $filename = 'does-not-exist.jpg';
-        $expectedMessage = 'File does not exist: ' . codecept_data_dir($filename);
-        $this->setExpectedException('InvalidArgumentException', $expectedMessage);
-
-        $this->module->amOnPage('/form/file');
-        $this->module->attachFile('Avatar', $filename);
-    }
 }


### PR DESCRIPTION
attachFile method of WebDriver throws confusing message `[InvalidArgumentException] file not found or not readable:  ` when the file does not exist #4091 .
It was a fault of `realpath` function which returns FALSE when the file does not exist.
I fixed it to throw `[InvalidArgumentException] File does not exist: /path/to/tests/_data/filename.ext`.

And a different message `[InvalidArgumentException] File is not readable: /path/to/tests/_data/filename.ext`
when the file exists but is not readable.

Also I updated InnerBrowser to throw the same messages,
it used to throw `PHPUnit_Framework_AssertionFailedError` `file filename.ext not found in Codeception data path. Only files stored in data path accepted`