### PR TITLE
Fixed textual representation of cant steps

### DIFF
--- a/src/Codeception/Step/ConditionalAssertion.php
+++ b/src/Codeception/Step/ConditionalAssertion.php
@@ -17,7 +17,9 @@ class ConditionalAssertion extends Assertion
 
     public function getAction()
     {
-        return 'can' . ucfirst($this->action);
+        $action = 'can' . ucfirst($this->action);
+        $action = preg_replace('/^canDont/', 'cant', $action);
+        return $action;
     }
 
     public function getHumanizedAction()

--- a/tests/unit/Codeception/Step/ConditionalAssertionTest.php
+++ b/tests/unit/Codeception/Step/ConditionalAssertionTest.php
@@ -1,0 +1,12 @@
+<?php
+
+use \Codeception\Step\ConditionalAssertion;
+
+class ConditionalAssertionTest extends \PHPUnit_Framework_TestCase
+{
+    public function testCantSeeToString()
+    {
+        $assertion = new ConditionalAssertion('dontSee', ['text']);
+        $this->assertEquals('cant see "text"', $assertion->toString(200));
+    }
+}


### PR DESCRIPTION
Fixes #3860 

Output before:
```
1) CloseWindowCept: Close current window
 Test  tests/web/CloseWindowCept.php
 Step  Can dont see "Close Window"
 Fail  Failed asserting that  on page /form/close_window
--> Page 2
Close Window
--> does not contain "close window".

Scenario Steps:

 8. $I->see("Open Window") at tests/web/CloseWindowCept.php:11
 7. $I->switchToPreviousTab() at tests/web/CloseWindowCept.php:10
 6. $I->click("Close Window") at tests/web/CloseWindowCept.php:9
 5. $I->seeCurrentUrlEquals("/form/close_window") at tests/web/CloseWindowCept.php:8
 4. $I->canDontSee("Close Window") at tests/web/CloseWindowCept.php:7
 3. $I->switchToNextTab() at tests/web/CloseWindowCept.php:6
```

Output after:
```
1) CloseWindowCept: Close current window
 Test  tests/web/CloseWindowCept.php
 Step  Cant see "Close Window"
 Fail  Failed asserting that  on page /form/close_window
--> Page 2
Close Window
--> does not contain "close window".

Scenario Steps:

 8. $I->see("Open Window") at tests/web/CloseWindowCept.php:11
 7. $I->switchToPreviousTab() at tests/web/CloseWindowCept.php:10
 6. $I->click("Close Window") at tests/web/CloseWindowCept.php:9
 5. $I->seeCurrentUrlEquals("/form/close_window") at tests/web/CloseWindowCept.php:8
 4. $I->cantSee("Close Window") at tests/web/CloseWindowCept.php:7
 3. $I->switchToNextTab() at tests/web/CloseWindowCept.php:6
```