### PR TITLE
[Asserts] Add delta parameter to assertEquals() assertNotEquals() methods

### DIFF
--- a/src/Codeception/Module/Asserts.php
+++ b/src/Codeception/Module/Asserts.php
@@ -10,27 +10,57 @@ class Asserts extends CodeceptionModule
 {
 
     /**
-     * Checks that two variables are equal.
+     * Checks that two variables are equal. If you're comparing floating-point values,
+     * you can specify the optional "delta" parameter which dictates how great of a precision
+     * error are you willing to tolerate in order to consider the two values equal.
+     *
+     * Regular example:
+     * ```php
+     * <?php
+     * $I->assertEquals($element->getChildrenCount(), 5);
+     * ```
+     *
+     * Floating-point example:
+     * ```php
+     * <?php
+     * $I->assertEquals($calculator->add(0.1, 0.2), 0.3, 'Calculator should add the two numbers correctly.', 0.01);
+     * ```
      *
      * @param        $expected
      * @param        $actual
      * @param string $message
+     * @param float  $delta
      */
-    public function assertEquals($expected, $actual, $message = '')
+    public function assertEquals($expected, $actual, $message = '', $delta = 0.0)
     {
-        parent::assertEquals($expected, $actual, $message);
+        parent::assertEquals($expected, $actual, $message, $delta);
     }
 
     /**
-     * Checks that two variables are not equal
+     * Checks that two variables are not equal. If you're comparing floating-point values,
+     * you can specify the optional "delta" parameter which dictates how great of a precision
+     * error are you willing to tolerate in order to consider the two values not equal.
+     *
+     * Regular example:
+     * ```php
+     * <?php
+     * $I->assertNotEquals($element->getChildrenCount(), 0);
+     * ```
+     *
+     * Floating-point example:
+     * ```php
+     * <?php
+     * $I->assertNotEquals($calculator->add(0.1, 0.2), 0.4, 'Calculator should add the two numbers correctly.', 0.01);
+     * ```
      *
      * @param        $expected
      * @param        $actual
      * @param string $message
+     * @param float  $delta
      */
-    public function assertNotEquals($expected, $actual, $message = '')
+    public function assertNotEquals($expected, $actual, $message = '', $delta = 0.0)
     {
-        parent::assertNotEquals($expected, $actual, $message);
+        parent::assertNotEquals($expected, $actual, $message, $delta);
     }
 
     /**
@@ -39,7 +69,6 @@ class Asserts extends CodeceptionModule
      * @param        $expected
      * @param        $actual
      * @param string $message
-     * @return mixed|void
      */
     public function assertSame($expected, $actual, $message = '')
     {

--- a/src/Codeception/Util/Shared/Asserts.php
+++ b/src/Codeception/Util/Shared/Asserts.php
@@ -30,12 +30,11 @@ trait Asserts
      * @param        $expected
      * @param        $actual
      * @param string $message
-     *
-     * @return mixed
+     * @param float  $delta
      */
-    protected function assertEquals($expected, $actual, $message = '')
+    protected function assertEquals($expected, $actual, $message = '', $delta = 0.0)
     {
-        \PHPUnit_Framework_Assert::assertEquals($expected, $actual, $message);
+        \PHPUnit_Framework_Assert::assertEquals($expected, $actual, $message, $delta);
     }
 
     /**
@@ -44,10 +43,11 @@ trait Asserts
      * @param        $expected
      * @param        $actual
      * @param string $message
+     * @param float  $delta
      */
-    protected function assertNotEquals($expected, $actual, $message = '')
+    protected function assertNotEquals($expected, $actual, $message = '', $delta = 0.0)
     {
-        \PHPUnit_Framework_Assert::assertNotEquals($expected, $actual, $message);
+        \PHPUnit_Framework_Assert::assertNotEquals($expected, $actual, $message, $delta);
     }
 
     /**
@@ -56,8 +56,6 @@ trait Asserts
      * @param        $expected
      * @param        $actual
      * @param string $message
-     *
-     * @return mixed
      */
     protected function assertSame($expected, $actual, $message = '')
     {


### PR DESCRIPTION
Currently it's not possible to assert floating-point numbers reliably using the `assertEquals` and `assertNotEquals` methods inside the **Asserts** module.

This commit adds an additional default parameter to the above mentioned methods while following PHPUnit's method prototypes. There shouldn't be any backwards incompatible changes introduced here.