### PR TITLE
Removed session_write_close() from ZF2 module (#4112)

### DIFF
--- a/src/Codeception/Module/ZF2.php
+++ b/src/Codeception/Module/ZF2.php
@@ -121,10 +121,6 @@ class ZF2 extends Framework implements DoctrineProvider, PartedModule
             StaticEventManager::resetInstance();
         }
 
-        //Close the session, if any are open
-        if (session_status() == PHP_SESSION_ACTIVE) {
-            session_write_close();
-        }
         $this->queries = 0;
         $this->time = 0;
 


### PR DESCRIPTION
In Cest test format suit generates exception if suit contains more than one public method:
`[PHPUnit_Framework_Exception] session_regenerate_id(): Cannot regenerate session id - session is not active`