### PR TITLE
[Db] loadDump reports sql statement which caused error

### DIFF
--- a/src/Codeception/Lib/Driver/Db.php
+++ b/src/Codeception/Lib/Driver/Db.php
@@ -1,6 +1,8 @@
 <?php
 namespace Codeception\Lib\Driver;
 
+use Codeception\Exception\ModuleException;
+
 class Db
 {
     /**
@@ -212,7 +214,14 @@ class Db
 
     protected function sqlQuery($query)
     {
-        $this->dbh->exec($query);
+        try {
+            $this->dbh->exec($query);
+        } catch (\PDOException $e) {
+            throw new ModuleException(
+                'Codeception\Module\Db',
+                $e->getMessage() . "\nSQL query being executed: " . $query
+            );
+        }
     }
 
     public function executeQuery($query, array $params)

--- a/src/Codeception/Module/Db.php
+++ b/src/Codeception/Module/Db.php
@@ -291,14 +291,7 @@ class Db extends CodeceptionModule implements DbInterface
         if (!$this->sql) {
             return;
         }
-        try {
-            $this->driver->load($this->sql);
-        } catch (\PDOException $e) {
-            throw new ModuleException(
-                __CLASS__,
-                $e->getMessage() . "\nSQL query being executed: " . $this->driver->sqlToRun
-            );
-        }
+        $this->driver->load($this->sql);
     }
 
     /**

--- a/tests/unit/Codeception/Lib/Driver/MysqlTest.php
+++ b/tests/unit/Codeception/Lib/Driver/MysqlTest.php
@@ -14,6 +14,9 @@ class MysqlTest extends \PHPUnit_Framework_TestCase
     ];
 
     protected static $sql;
+    /**
+     * @var \Codeception\Lib\Driver\MySql
+     */
     protected $mysql;
     
     public static function setUpBeforeClass()
@@ -125,5 +128,15 @@ class MysqlTest extends \PHPUnit_Framework_TestCase
             [5,'insert.test','insert.test@mail.ua',false,'2012-02-01 21:17:47']
         );
         $this->assertEquals(1, $res->rowCount());
+    }
+
+    public function testLoadThrowsExceptionWhenDumpFileContainsSyntaxError()
+    {
+        $sql = "INSERT INTO `users` (`name`) VALS('')";
+        $expectedMessage = 'SQLSTATE[42000]: Syntax error or access violation: 1064 You have an error in your SQL ' .
+            'syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near ' .
+            "'VALS('')' at line 1\nSQL query being executed: \n" . $sql;
+        $this->setExpectedException('Codeception\Exception\ModuleException', $expectedMessage);
+        $this->mysql->load([$sql]);
     }
 }

--- a/tests/unit/Codeception/Lib/Driver/MysqlTest.php
+++ b/tests/unit/Codeception/Lib/Driver/MysqlTest.php
@@ -133,8 +133,8 @@ class MysqlTest extends \PHPUnit_Framework_TestCase
     public function testLoadThrowsExceptionWhenDumpFileContainsSyntaxError()
     {
         $sql = "INSERT INTO `users` (`name`) VALS('')";
-        $expectedMessage = 'SQLSTATE[42000]: Syntax error or access violation: 1064 You have an error in your SQL ' .
-            'syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near ' .
+        $expectedMessage = 'You have an error in your SQL syntax; ' .
+            'check the manual that corresponds to your MySQL server version for the right syntax to use near ' .
             "'VALS('')' at line 1\nSQL query being executed: \n" . $sql;
         $this->setExpectedException('Codeception\Exception\ModuleException', $expectedMessage);
         $this->mysql->load([$sql]);


### PR DESCRIPTION
This functionality was accidently broken by removal of sqlToRun property in 2.2.10
Replaces #4115