### PR TITLE
Oci::cleanup() should be able to drop objects with case sensitive name

### DIFF
--- a/src/Codeception/Lib/Driver/Oci.php
+++ b/src/Codeception/Lib/Driver/Oci.php
@@ -10,7 +10,7 @@ class Oci extends Db
             "BEGIN
                         FOR i IN (SELECT trigger_name FROM user_triggers)
                           LOOP
-                            EXECUTE IMMEDIATE('DROP TRIGGER ' || user || '.' || i.trigger_name);
+                            EXECUTE IMMEDIATE('DROP TRIGGER ' || user || '.\"' || i.trigger_name || '\"');
                           END LOOP;
                       END;"
         );
@@ -18,7 +18,7 @@ class Oci extends Db
             "BEGIN
                         FOR i IN (SELECT table_name FROM user_tables)
                           LOOP
-                            EXECUTE IMMEDIATE('DROP TABLE ' || user || '.' || i.table_name || ' CASCADE CONSTRAINTS');
+                            EXECUTE IMMEDIATE('DROP TABLE ' || user || '.\"' || i.table_name || '\" CASCADE CONSTRAINTS');
                           END LOOP;
                       END;"
         );
@@ -26,7 +26,7 @@ class Oci extends Db
             "BEGIN
                         FOR i IN (SELECT sequence_name FROM user_sequences)
                           LOOP
-                            EXECUTE IMMEDIATE('DROP SEQUENCE ' || user || '.' || i.sequence_name);
+                            EXECUTE IMMEDIATE('DROP SEQUENCE ' || user || '.\"' || i.sequence_name || '\"');
                           END LOOP;
                       END;"
         );
@@ -34,7 +34,7 @@ class Oci extends Db
             "BEGIN
                         FOR i IN (SELECT view_name FROM user_views)
                           LOOP
-                            EXECUTE IMMEDIATE('DROP VIEW ' || user || '.' || i.view_name);
+                            EXECUTE IMMEDIATE('DROP VIEW ' || user || '.\"' || i.view_name || '\"');
                           END LOOP;
                       END;"
         );


### PR DESCRIPTION
Currently cleanup method throws exception when trying to drop object with case sensitive identifier.