### PR TITLE
Fixed output of failed step

### DIFF
--- a/src/Codeception/Subscriber/Console.php
+++ b/src/Codeception/Subscriber/Console.php
@@ -410,6 +410,9 @@ class Console implements EventSubscriberInterface
             $failedStep = (string) array_shift($this->conditionalFails);
         } else {
             $failedStep = (string) $failedTest->getScenario()->getMetaStep();
+            if ($failedStep === '') {
+                $failedStep = (string)$this->failedStep;
+            }
         }
 
         $this->printException($fail, $failedStep);

--- a/tests/cli/RunCest.php
+++ b/tests/cli/RunCest.php
@@ -469,4 +469,13 @@ EOF
         $I->executeCommand('run scenario -g dataprovider --steps');
         $I->seeInShellOutput('OK (15 tests');
     }
+
+    public function runFailedTestAndCheckOutput(CliGuy $I)
+    {
+        $I->executeCommand('run scenario FailedCept', false);
+        $I->seeInShellOutput('1) FailedCept: Fail when file is not found');
+        $I->seeInShellOutput('Test  tests/scenario/FailedCept.php');
+        $I->seeInShellOutput('Step  See file found "games.zip"');
+        $I->seeInShellOutput('Fail  File "games.zip" not found at ""');
+    }
 }

--- a/tests/cli/RunCest.php
+++ b/tests/cli/RunCest.php
@@ -473,8 +473,9 @@ EOF
     public function runFailedTestAndCheckOutput(CliGuy $I)
     {
         $I->executeCommand('run scenario FailedCept', false);
+        $testPath = implode(DIRECTORY_SEPARATOR, ['tests', 'scenario', 'FailedCept.php']);
         $I->seeInShellOutput('1) FailedCept: Fail when file is not found');
-        $I->seeInShellOutput('Test  tests/scenario/FailedCept.php');
+        $I->seeInShellOutput('Test  ' . $testPath);
         $I->seeInShellOutput('Step  See file found "games.zip"');
         $I->seeInShellOutput('Fail  File "games.zip" not found at ""');
     }


### PR DESCRIPTION
This part of output was missing for regular steps.
```
 Step  See file found "games.zip"
 Fail
```

http://phptest.club/t/seeelement-wierd-fail-message/1470