### PR TITLE
WIP: Implement markup validator module (#4134)

### DIFF
--- a/src/Codeception/Lib/InnerBrowser.php
+++ b/src/Codeception/Lib/InnerBrowser.php
@@ -10,6 +10,7 @@ use Codeception\Exception\TestRuntimeException;
 use Codeception\Lib\Interfaces\ConflictsWithModule;
 use Codeception\Lib\Interfaces\ElementLocator;
 use Codeception\Lib\Interfaces\PageSourceSaver;
+use Codeception\Lib\Interfaces\PageSourceViewer;
 use Codeception\Lib\Interfaces\Web;
 use Codeception\Module;
 use Codeception\PHPUnit\Constraint\Crawler as CrawlerConstraint;
@@ -30,7 +31,7 @@ use Symfony\Component\DomCrawler\Field\TextareaFormField;
 use Symfony\Component\DomCrawler\Form;
 use Symfony\Component\DomCrawler\Link;
 
-class InnerBrowser extends Module implements Web, PageSourceSaver, ElementLocator, ConflictsWithModule
+class InnerBrowser extends Module implements Web, PageSourceViewer, PageSourceSaver, ElementLocator, ConflictsWithModule
 {
     /**
      * @var \Symfony\Component\DomCrawler\Crawler
@@ -261,6 +262,11 @@ class InnerBrowser extends Module implements Web, PageSourceSaver, ElementLocato
             );
         }
         return $this->client;
+    }
+
+    public function _getPageSource()
+    {
+        return $this->_getResponseContent();
     }
 
     public function _savePageSource($filename)
@@ -1239,7 +1245,7 @@ class InnerBrowser extends Module implements Web, PageSourceSaver, ElementLocato
     {
         $result = [];
         $nodes = $this->match($cssOrXpath);
-        
+
         foreach ($nodes as $node) {
             if ($attribute !== null) {
                 $result[] = $node->getAttribute($attribute);

--- a/src/Codeception/Lib/Interfaces/PageSourceViewer.php
+++ b/src/Codeception/Lib/Interfaces/PageSourceViewer.php
@@ -1,0 +1,16 @@
+<?php
+namespace Codeception\Lib\Interfaces;
+
+interface PageSourceViewer
+{
+    /**
+     * Returns current page source code.
+     *
+     * ```php
+     * $this->getModule('{{MODULE_NAME}}')->_getPageSource();
+     * ```
+     * @api
+     * @return string Current page source code.
+     */
+    public function _getPageSource();
+}

--- a/src/Codeception/Module/MarkupValidator.php
+++ b/src/Codeception/Module/MarkupValidator.php
@@ -1,0 +1,216 @@
+<?php
+namespace Codeception\Module;
+
+use Exception;
+use stdClass;
+use Codeception\Module;
+use Codeception\Module\PhpBrowser;
+use Codeception\Module\WebDriver;
+use GuzzleHttp\Client;
+
+/**
+ * A module which validates current page markup via the W3C Markup Validation Service.
+ * Requires either the `PhpBrowser` or the `WebDriver` module.
+ *
+ * Configuration options:
+ *  - ignoreWarnings
+ *  - ignoredErrors
+ */
+class MarkupValidator extends Module
+{
+    const W3C_MARKUP_VALIDATION_SERVICE_BASE_URI = 'https://validator.w3.org';
+
+    const W3C_MARKUP_VALIDATION_SERVICE_ENDPOINT = '/nu/';
+
+    /**
+     * Validates current page markup via the W3C Markup Validation Service.
+     *
+     * @param bool|null $ignoreWarnings Whether to ignore warnings or not.
+     * If `null`, module-wide value is used. If module-wide value is `null` too
+     * then warnings are not ignored by default.
+     */
+    public function validateMarkup($ignoreWarnings = null)
+    {
+        $markup = $this->getCurrentPageMarkup();
+        $validationData = $this->sendMarkupValidationRequest($markup);
+        foreach ($validationData->messages as $message) {
+            $this->processMarkupValidationMessage($message, $ignoreWarnings);
+        }
+    }
+
+    /**
+     * Returns current page markup.
+     *
+     * @return string Current page markup.
+     */
+    protected function getCurrentPageMarkup()
+    {
+        try {
+            $markup = $this->getMarkupFromPhpBrowser();
+            return $markup;
+        } catch (Exception $exception) {
+            // Wasn't able to get markup from the PhpBrowser.
+        }
+
+        try {
+            $markup = $this->getMarkupFromWebDriver();
+            return $markup;
+        } catch (Exception $exception) {
+            // Wasn't able to get markup from the WebDriver.
+        }
+
+        throw new Exception('Unable to obtain current page markup.');
+    }
+
+    /**
+     * Send a markup validation request to the W3C Markup Validation Service
+     * and returns response data.
+     *
+     * @param string $markup Page markup to validate.
+     * @return stdClass W3C Markup Validation Service response data.
+     */
+    protected function sendMarkupValidationRequest($markup)
+    {
+        $сlient = new Client([
+            'base_uri' => self::W3C_MARKUP_VALIDATION_SERVICE_BASE_URI,
+        ]);
+        $reponse = $сlient->post(self::W3C_MARKUP_VALIDATION_SERVICE_ENDPOINT, [
+            'headers' => [
+                'Content-Type' => 'text/html; charset=UTF-8;',
+            ],
+            'query' => [
+                'out' => 'json',
+            ],
+            'body' => $markup,
+        ]);
+        $responseContents = $reponse->getBody()->getContents();
+        $responseData = json_decode($responseContents);
+        if ($responseData === null) {
+            throw new Exception('Unable to parse W3C Markup Validation Service response.');
+        }
+
+        return $responseData;
+    }
+
+    /**
+     * Processes a document markup validation message.
+     *
+     * @param stdClass $message Markup validation message.
+     * @param bool|null $ignoreWarnings Whether to ignore warnings or not.
+     */
+    protected function processMarkupValidationMessage(stdClass $message, $ignoreWarnings)
+    {
+        $type = $message->type;
+        $summary = $message->message;
+        $details = isset($message->extract)
+                    ? $message->extract
+                    : 'unavailable';
+        if ($type === 'error' ||
+            $type === 'info' && !$this->getIgnoreWarnings($ignoreWarnings)
+        ) {
+            $errorIsIgnored = $this->getErrorIsIgnored($summary);
+            if (!$errorIsIgnored) {
+                $this->reportMarkupValidationError($summary, $details);
+            }
+        }
+    }
+
+    /**
+     * Reports a document markup validation error.
+     *
+     * @param string $summary Markup validation error summary.
+     * @param string $details Markup validation error details.
+     */
+    protected function reportMarkupValidationError($summary, $details)
+    {
+        $template = 'Markup validation error. %s. Details: %s';
+        $message = sprintf($template, $summary, $details);
+        $this->fail($message);
+    }
+
+    /**
+     * Returns an actual value of the `ignoreWarnings` parameter.
+     * If local value is `null`, module-wide value is used.
+     * If module-wide value is `null` too then warnings are not ignored by default.
+     * @param bool|null $ignoreWarnings A local value of the `ignoreWarnings` parameter.
+     */
+    private function getIgnoreWarnings($ignoreWarnings)
+    {
+        if (is_bool($ignoreWarnings)) {
+            return $ignoreWarnings;
+        }
+
+        $ignoreWarningsConfigKey = 'ignoreWarnings';
+        if (isset($this->config[$ignoreWarningsConfigKey]) &&
+            is_bool($this->config[$ignoreWarningsConfigKey])
+        ) {
+            return $this->config[$ignoreWarningsConfigKey];
+        }
+
+        return false;
+    }
+
+    /**
+     * Returns a boolean indicating whether an error is ignored or not.
+     *
+     * @param string $summary Error summary.
+     * @return boolean Whether an error is ignored or not.
+     */
+    private function getErrorIsIgnored($summary)
+    {
+        $ignoredErrorsConfigKey = 'ignoredErrors';
+        if (!isset($this->config[$ignoredErrorsConfigKey]) ||
+            !is_array($this->config[$ignoredErrorsConfigKey])
+        ) {
+            return false;
+        }
+
+        $ignoredErrors = $this->config[$ignoredErrorsConfigKey];
+        foreach ($ignoredErrors as $ignoredError) {
+            $erorIsIgnored = preg_match($ignoredError, $summary) === 1;
+            if ($erorIsIgnored) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Returns current page markup form the PhpBrowser.
+     *
+     * @return string Current page markup.
+     */
+    private function getMarkupFromPhpBrowser()
+    {
+        $moduleName = 'PhpBrowser';
+        if (!$this->hasModule($moduleName)) {
+            throw new Exception(sprintf('"%s" module is not enabled.'));
+        }
+
+        /* @var $phpBrowser PhpBrowser */
+        $phpBrowser = $this->getModule($moduleName);
+        $markup = $phpBrowser->_getResponseContent();
+
+        return $markup;
+    }
+
+    /**
+     * Returns current page markup form the WebDriver.
+     *
+     * @return string Current page markup.
+     */
+    private function getMarkupFromWebDriver()
+    {
+        $moduleName = 'WebDriver';
+        if (!$this->hasModule($moduleName)) {
+            throw new Exception(sprintf('"%s" module is not enabled.'));
+        }
+
+        /* @var $webDriver WebDriver */
+        $webDriver = $this->getModule($moduleName);
+        $markup = $webDriver->webDriver->getPageSource();
+
+        return $markup;
+    }
+}

--- a/src/Codeception/Module/WebDriver.php
+++ b/src/Codeception/Module/WebDriver.php
@@ -12,6 +12,7 @@ use Codeception\Lib\Interfaces\ConflictsWithModule;
 use Codeception\Lib\Interfaces\ElementLocator;
 use Codeception\Lib\Interfaces\MultiSession as MultiSessionInterface;
 use Codeception\Lib\Interfaces\PageSourceSaver;
+use Codeception\Lib\Interfaces\PageSourceViewer;
 use Codeception\Lib\Interfaces\Remote as RemoteInterface;
 use Codeception\Lib\Interfaces\RequiresPackage;
 use Codeception\Lib\Interfaces\ScreenshotSaver;
@@ -253,6 +254,7 @@ class WebDriver extends CodeceptionModule implements
     MultiSessionInterface,
     SessionSnapshot,
     ScreenshotSaver,
+    PageSourceViewer,
     PageSourceSaver,
     ElementLocator,
     ConflictsWithModule,
@@ -587,6 +589,15 @@ class WebDriver extends CodeceptionModule implements
     public function _findElements($locator)
     {
         return $this->match($this->webDriver, $locator);
+    }
+
+    public function _getPageSource()
+    {
+        if (!isset($this->webDriver)) {
+            throw new \Exception('WebDriver::_getPageSource method has been called when webDriver is not set.');
+        }
+
+        return $this->webDriver->getPageSource();
     }
 
     /**

--- a/tests/unit/Codeception/Module/MarkupValidatorTest.php
+++ b/tests/unit/Codeception/Module/MarkupValidatorTest.php
@@ -1,0 +1,403 @@
+<?php
+
+use Codeception\Module\MarkupValidator;
+
+class MarkupValidatorTest extends PHPUnit_Framework_TestCase
+{
+    /**
+     * @var W3CValidator
+     */
+    protected $module;
+
+    protected function setUp()
+    {
+        $this->module = $this
+            ->getMockBuilder('\Codeception\Module\MarkupValidator')
+            ->setConstructorArgs(array(make_container()))
+            ->setMethods(array(
+                'getCurrentPageMarkup',
+            ))
+            ->getMock()
+        ;
+
+        $this->module->_initialize();
+    }
+
+    protected function tearDown()
+    {
+        $this->module->_cleanup();
+    }
+
+    public function testGetCurrentPageMarkupNoPhpBrowserNoWebDriver()
+    {
+        $this->module = $this
+            ->getMockBuilder('\Codeception\Module\MarkupValidator')
+            ->setConstructorArgs(array(make_container()))
+            ->enableProxyingToOriginalMethods()
+            ->getMock()
+        ;
+
+        $this->expectException('Exception');
+        $this->assertValidMakup();
+    }
+
+    public function testGetCurrentPageMarkupOnlyPhpBrowser()
+    {
+        $phpBrowserMock = $this
+            ->getMockBuilder('\Codeception\Module\PhpBrowser')
+            ->setConstructorArgs(array(make_container()))
+            ->setMethods(array(
+                '_getResponseContent',
+            ))
+            ->getMock()
+        ;
+        $phpBrowserMock
+            ->method('_getResponseContent')
+            ->will($this->returnValue(
+<<<HTML
+                <!DOCTYPE HTML>
+                <html>
+                    <head>
+                        <title>
+                            A valid page.
+                        </title>
+                    </head>
+                </html>
+HTML
+            ))
+        ;
+
+        $this->module = $this
+            ->getMockBuilder('\Codeception\Module\MarkupValidator')
+            ->setConstructorArgs(array(make_container()))
+            ->setMethods(array(
+                'hasModule',
+                'getModule',
+            ))
+            ->getMock()
+        ;
+        $this->module
+            ->method('hasModule')
+            ->will($this->returnValueMap(array(
+                array('PhpBrowser', true)
+            )))
+        ;
+        $this->module
+            ->method('getModule')
+            ->will($this->returnValueMap(array(
+                array('PhpBrowser', $phpBrowserMock)
+            )))
+        ;
+
+        $this->assertValidMakup();
+    }
+
+    public function testGetCurrentPageMarkupOnlyWebDriver()
+    {
+        $remoteWebDriverMock = $this
+            ->getMockBuilder('\Facebook\WebDriver\Remote\RemoteWebDriver')
+            ->disableOriginalConstructor()
+            ->setMethods(array(
+                'getPageSource',
+            ))
+            ->getMock()
+        ;
+        $remoteWebDriverMock
+            ->method('getPageSource')
+            ->will($this->returnValue(
+<<<HTML
+                <!DOCTYPE HTML>
+                <html>
+                    <head>
+                        <title>
+                            A valid page.
+                        </title>
+                    </head>
+                </html>
+HTML
+            ))
+        ;
+
+        $webDriverMock = $this
+            ->getMockBuilder('\Codeception\Module\WebDriver')
+            ->setConstructorArgs(array(make_container()))
+            ->getMock()
+        ;
+        $webDriverMock->webDriver = $remoteWebDriverMock;
+
+        $this->module = $this
+            ->getMockBuilder('\Codeception\Module\MarkupValidator')
+            ->setConstructorArgs(array(make_container()))
+            ->setMethods(array(
+                'hasModule',
+                'getModule',
+            ))
+            ->getMock()
+        ;
+        $this->module
+            ->method('hasModule')
+            ->will($this->returnValueMap(array(
+                array('WebDriver', true)
+            )))
+        ;
+        $this->module
+            ->method('getModule')
+            ->will($this->returnValueMap(array(
+                array('WebDriver', $webDriverMock)
+            )))
+        ;
+
+        $this->assertValidMakup();
+    }
+
+    public function testValidateValidPage()
+    {
+        $this->mockGetCurrentPageMarkup(
+<<<HTML
+            <!DOCTYPE HTML>
+            <html>
+                <head>
+                    <title>
+                        A valid page.
+                    </title>
+                </head>
+            </html>
+HTML
+        );
+
+        $this->assertValidMakup(false);
+    }
+
+    public function testValidateInvalidPageDoNotIgnoreErrors()
+    {
+        $this->mockGetCurrentPageMarkup(
+<<<HTML
+            <!DOCTYPE HTML>
+            <html>
+                <head>
+                </head>
+            </html>
+HTML
+        );
+
+        $expectedError = '/Element “head” is missing a required instance of child element “title”/';
+        $this->assertInvalidMarkup($expectedError, false);
+    }
+
+    public function testValidateInvalidPageIgnoreErrors()
+    {
+        $this->mockGetCurrentPageMarkup(
+<<<HTML
+            <!DOCTYPE HTML>
+            <html>
+                <head>
+                </head>
+            </html>
+HTML
+        );
+
+        $this->module->_reconfigure(array(
+            'ignoredErrors' => array(
+                '/Element “head” is missing a required instance of child element “title”/',
+            ),
+        ));
+
+        $this->assertValidMakup();
+    }
+
+    public function testValidateInvalidPageIgnoreMultipleErrors()
+    {
+        $this->mockGetCurrentPageMarkup(
+<<<HTML
+            <!DOCTYPE HTML>
+            <html>
+                <head>
+                </head>
+                <body>
+                    <form>
+                        <button role="button">
+                        </button>
+                    </form>
+                </body>
+            </html>
+HTML
+        );
+
+        $this->module->_reconfigure(array(
+            'ignoredErrors' => array(
+                '/Element “head” is missing a required instance of child element “title”/',
+                '/The “button” role is unnecessary for element “button”/',
+            ),
+        ));
+
+        $this->assertValidMakup();
+    }
+
+    public function testValidatePageWithWarningsDoNotIgnoreWarnings()
+    {
+        $this->mockGetCurrentPageMarkup(
+<<<HTML
+            <!DOCTYPE HTML>
+            <html>
+                <head>
+                    <title>
+                        A page with a warning.
+                    </title>
+                </head>
+                <body>
+                    <form>
+                        <button role="button">
+                        </button>
+                    </form>
+                </body>
+            </html>
+HTML
+        );
+
+        $expectedError = '/The “button” role is unnecessary for element “button”/';
+        $this->assertInvalidMarkup($expectedError, false);
+    }
+
+    public function testValidatePageWithWarningsIgnoreWarningsLocal()
+    {
+        $this->mockGetCurrentPageMarkup(
+<<<HTML
+            <!DOCTYPE HTML>
+            <html>
+                <head>
+                    <title>
+                        A page with a warning.
+                    </title>
+                </head>
+                <body>
+                    <form>
+                        <button role="button" type="submit">
+                        </button>
+                    </form>
+                </body>
+            </html>
+HTML
+        );
+
+        $this->assertValidMakup(true);
+    }
+
+    public function testValidatePageWithWarningsIgnoreWarningsModuleWide()
+    {
+        $this->mockGetCurrentPageMarkup(
+<<<HTML
+            <!DOCTYPE HTML>
+            <html>
+                <head>
+                    <title>
+                        A page with a warning.
+                    </title>
+                </head>
+                <body>
+                    <form>
+                        <button role="button" type="submit">
+                        </button>
+                    </form>
+                </body>
+            </html>
+HTML
+        );
+
+        $this->module->_reconfigure(array(
+            'ignoreWarnings' => true,
+        ));
+
+        $this->assertValidMakup();
+    }
+
+    public function testValidatePageWithWarningsIgnoreWarningsLocalOverrideModuleWideFalse()
+    {
+        $this->mockGetCurrentPageMarkup(
+<<<HTML
+            <!DOCTYPE HTML>
+            <html>
+                <head>
+                    <title>
+                        A page with a warning.
+                    </title>
+                </head>
+                <body>
+                    <form>
+                        <button role="button" type="submit">
+                        </button>
+                    </form>
+                </body>
+            </html>
+HTML
+        );
+
+        $this->module->_reconfigure(array(
+            'ignoreWarnings' => false,
+        ));
+
+        $this->assertValidMakup(true);
+    }
+
+    public function testValidatePageWithWarningsIgnoreWarningsLocalOverrideModuleWideTrue()
+    {
+        $this->mockGetCurrentPageMarkup(
+<<<HTML
+            <!DOCTYPE HTML>
+            <html>
+                <head>
+                    <title>
+                        A page with a warning.
+                    </title>
+                </head>
+                <body>
+                    <form>
+                        <button role="button" type="submit">
+                        </button>
+                    </form>
+                </body>
+            </html>
+HTML
+        );
+
+        $this->module->_reconfigure(array(
+            'ignoreWarnings' => true,
+        ));
+
+        $this->assertInvalidMarkup('/The “button” role is unnecessary for element “button”/', false);
+    }
+
+    private function mockGetCurrentPageMarkup($markup)
+    {
+        $this->module
+            ->method('getCurrentPageMarkup')
+            ->will($this->returnValue($markup))
+        ;
+    }
+
+    private function assertValidMakup($ignoreWarnings = null)
+    {
+        $this->module->validateMarkup($ignoreWarnings);
+    }
+
+    private function assertInvalidMarkup($expectedError = null, $ignoreWarnings = null)
+    {
+        $errorReported = false;
+
+        try {
+            $this->module->validateMarkup($ignoreWarnings);
+        } catch (Exception $exception) {
+            if ($expectedError !== null) {
+                $actualError = $exception->getMessage();
+                $errorsMatch = preg_match($expectedError, $actualError) === 1;
+                if (!$errorsMatch) {
+                    $this->fail('Expected error was not reported.');
+                }
+            }
+            $errorReported = true;
+        }
+
+        if (!$errorReported) {
+            $this->fail('No errors were reported.');
+        }
+    }
+}

--- a/tests/unit/Codeception/Module/MarkupValidatorTest.php
+++ b/tests/unit/Codeception/Module/MarkupValidatorTest.php
@@ -5,7 +5,7 @@ use Codeception\Module\MarkupValidator;
 class MarkupValidatorTest extends PHPUnit_Framework_TestCase
 {
     /**
-     * @var W3CValidator
+     * @var MarkupValidator
      */
     protected $module;
 
@@ -47,12 +47,12 @@ class MarkupValidatorTest extends PHPUnit_Framework_TestCase
             ->getMockBuilder('\Codeception\Module\PhpBrowser')
             ->setConstructorArgs(array(make_container()))
             ->setMethods(array(
-                '_getResponseContent',
+                '_getPageSource',
             ))
             ->getMock()
         ;
         $phpBrowserMock
-            ->method('_getResponseContent')
+            ->method('_getPageSource')
             ->will($this->returnValue(
 <<<HTML
                 <!DOCTYPE HTML>
@@ -88,22 +88,25 @@ HTML
                 array('PhpBrowser', $phpBrowserMock)
             )))
         ;
+        $this->module->_reconfigure(array(
+            'pageSourceViewer' => 'PhpBrowser',
+        ));
 
         $this->assertValidMakup();
     }
 
     public function testGetCurrentPageMarkupOnlyWebDriver()
     {
-        $remoteWebDriverMock = $this
-            ->getMockBuilder('\Facebook\WebDriver\Remote\RemoteWebDriver')
-            ->disableOriginalConstructor()
+        $webDriverMock = $this
+            ->getMockBuilder('\Codeception\Module\WebDriver')
+            ->setConstructorArgs(array(make_container()))
             ->setMethods(array(
-                'getPageSource',
+                '_getPageSource',
             ))
             ->getMock()
         ;
-        $remoteWebDriverMock
-            ->method('getPageSource')
+        $webDriverMock
+            ->method('_getPageSource')
             ->will($this->returnValue(
 <<<HTML
                 <!DOCTYPE HTML>
@@ -117,13 +120,6 @@ HTML
 HTML
             ))
         ;
-
-        $webDriverMock = $this
-            ->getMockBuilder('\Codeception\Module\WebDriver')
-            ->setConstructorArgs(array(make_container()))
-            ->getMock()
-        ;
-        $webDriverMock->webDriver = $remoteWebDriverMock;
 
         $this->module = $this
             ->getMockBuilder('\Codeception\Module\MarkupValidator')
@@ -146,6 +142,9 @@ HTML
                 array('WebDriver', $webDriverMock)
             )))
         ;
+        $this->module->_reconfigure(array(
+            'pageSourceViewer' => 'WebDriver',
+        ));
 
         $this->assertValidMakup();
     }


### PR DESCRIPTION
### Implemented markup validator module (#4134)

#### Implementation details
A new `PageSourceViewer` interface is added to be able to retrieve page source from abstract configurable module. If you don't want to introduce a new interface we can rollback to the first commit where page source retrieval process is hardcoded inside the `MarkupValidatorModule`.

#### Module configuration
- `pageSourceViewer` - a string representing a name of a page source viewer. E.g. `PhpBrowser` or `WebDriver` or any other module implementing `PageSourceViewer`.
- `ignoredErrors` - a list of ignored errors (matching by a regular expression).
- `ignoreWarnings` - a boolean indicating whether to ignore warnings or not.

#### Roadmap
- [x] Add `PageSourceViewer` to be able to get page source from.
- [x] Implement `PageSourceViewer` in `PhpBrowser`.
- [x] Implement `PageSourceViewer` in `WebDriver`.
- [x] Implement `MarkupValidatorModule`.
- [x] Add tests coverage of the `MarkupValidatorModule`.
- [ ] Add tests coverage of the `PhpBrowser::_getPageSource()`.
- [ ] Add tests coverage of the `WebDriver::_getPageSource()`.
- [ ] Approve `PageSourceViewer` name.
- [ ] Approve `MarkupValidatorModule` name.
- [ ] Approve module configuration options.
- [ ] Review and approve code.
- [ ] Review and approve tests.
- [ ] Update documentation.
- [ ] Update changelog.
