### PR TITLE
Add a method to `Codeception\Lib\Interfaces\Web`

### DIFF
--- a/src/Codeception/Lib/InnerBrowser.php
+++ b/src/Codeception/Lib/InnerBrowser.php
@@ -1332,6 +1332,18 @@ class InnerBrowser extends Module implements Web, PageSourceSaver, ElementLocato
         return $cookies->getValue();
     }
 
+    /**
+     * Grabs current page source code.
+     *
+     * @throws ModuleException if no page was opened.
+     *
+     * @return string Current page source code.
+     */
+    public function grabPageSource()
+    {
+        return $this->_getResponseContent();
+    }
+
     public function seeCookie($cookie, array $params = [])
     {
         $params = array_merge($this->defaultCookieParameters, $params);

--- a/src/Codeception/Lib/Interfaces/Web.php
+++ b/src/Codeception/Lib/Interfaces/Web.php
@@ -975,4 +975,11 @@ interface Web
      * @return mixed
      */
     public function grabCookie($cookie, array $params = []);
+
+    /**
+     * Grabs current page source code.
+     *
+     * @return string Current page source code.
+     */
+    public function grabPageSource();
 }

--- a/src/Codeception/Module/WebDriver.php
+++ b/src/Codeception/Module/WebDriver.php
@@ -707,6 +707,21 @@ class WebDriver extends CodeceptionModule implements
         return $cookie['value'];
     }
 
+    /**
+     * Grabs current page source code.
+     *
+     * @throws ModuleException if no page was opened.
+     *
+     * @return string Current page source code.
+     */
+    public function grabPageSource()
+    {
+        // Make sure that some page was opened.
+        $this->_getCurrentUri();
+
+        return $this->webDriver->getPageSource();
+    }
+
     protected function filterCookies($cookies, $params = [])
     {
         foreach (['domain', 'path', 'name'] as $filter) {

--- a/tests/data/app/controllers.php
+++ b/tests/data/app/controllers.php
@@ -259,3 +259,9 @@ class jserroronload {
         include __DIR__.'/view/jserroronload.php';
     }
 }
+
+class minimal {
+    function GET() {
+        include __DIR__.'/view/minimal.php';
+    }
+}

--- a/tests/data/app/index.php
+++ b/tests/data/app/index.php
@@ -46,7 +46,8 @@ $urls = array(
     '/external_url' => 'external_url',
     '/iframe' => 'iframe',
     '/basehref' => 'basehref',
-    '/jserroronload' => 'jserroronload'
+    '/jserroronload' => 'jserroronload',
+    '/minimal' => 'minimal',
 );
 
 glue::stick($urls);

--- a/tests/data/app/view/minimal.php
+++ b/tests/data/app/view/minimal.php
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <title>
+            Minimal page
+        </title>
+    </head>
+    <body>
+        <h1>
+            Minimal page
+        </h1>
+    </body>
+</html>

--- a/tests/unit/Codeception/Module/PhpBrowserTest.php
+++ b/tests/unit/Codeception/Module/PhpBrowserTest.php
@@ -641,4 +641,38 @@ class PhpBrowserTest extends TestsForBrowsers
         $this->assertEquals('two', $params['select_name']);
         $this->assertEquals('searchterm', $params['search_name']);
     }
+
+    public function testGrabPageSourceWhenNotOnPage()
+    {
+        $this->setExpectedException(
+            '\Codeception\Exception\ModuleException',
+            'Page not loaded. Use `$I->amOnPage` (or hidden API methods `_request` and `_loadPage`) to open it'
+        );
+        $this->module->grabPageSource();
+    }
+
+    public function testGrabPageSourceWhenOnPage()
+    {
+        $this->module->amOnPage('/minimal');
+        $sourceExpected =
+<<<HTML
+<!DOCTYPE html>
+<html>
+    <head>
+        <title>
+            Minimal page
+        </title>
+    </head>
+    <body>
+        <h1>
+            Minimal page
+        </h1>
+    </body>
+</html>
+
+HTML
+        ;
+        $sourceActual = $this->module->grabPageSource();
+        $this->assertXmlStringEqualsXmlString($sourceExpected, $sourceActual);
+    }
 }

--- a/tests/web/WebDriverTest.php
+++ b/tests/web/WebDriverTest.php
@@ -998,4 +998,40 @@ class WebDriverTest extends TestsForBrowsers
         $this->module->switchToIFrame();
         $this->module->see('Iframe test');
     }
+
+    public function testGrabPageSourceWhenNotOnPage()
+    {
+        $this->setExpectedException(
+            '\Codeception\Exception\ModuleException',
+            'Current url is blank, no page was opened'
+        );
+        $this->module->grabPageSource();
+    }
+
+    public function testGrabPageSourceWhenOnPage()
+    {
+        $this->module->amOnPage('/minimal');
+        $sourceExpected =
+<<<HTML
+<!DOCTYPE html>
+<html>
+    <head>
+        <title>
+            Minimal page
+        </title>
+    </head>
+    <body>
+        <h1>
+            Minimal page
+        </h1>
+    </body>
+</html>
+
+HTML
+        ;
+        $sourceActualRaw = $this->module->grabPageSource();
+        // `Selenium` adds the `xmlns` attribute while `PhantomJS` does not do that.
+        $sourceActual = str_replace('xmlns="http://www.w3.org/1999/xhtml"', '', $sourceActualRaw);
+        $this->assertXmlStringEqualsXmlString($sourceExpected, $sourceActual);
+    }
 }


### PR DESCRIPTION
Extracted from #4136.

Added `Codeception\Lib\Interfaces\Web::grabPageSource()` method. Implemented the method in `Codeception\Lib\InnerBrowser` and `Codeception\Module\WebDriver`. Added test coverage for scenarios when page is and is not loaded.

I tried to be consistent with the rest of the code base. Is `grabPageSource()` OK?

There's one problem: `Selenium` adds `xmlns="http://www.w3.org/1999/xhtml"` while `PhantomJS` does not do that. I'm not quite sure how to handle that gracefully. I'm not quite happy with the 
```php
$sourceActualRaw = $this->module->grabPageSource();
$sourceActual = str_replace('xmlns="http://www.w3.org/1999/xhtml"', '', $sourceActualRaw);
```
and `isPhantom()` is `protected`...