### PR TITLE
FIX log path override

### DIFF
--- a/src/Codeception/Configuration.php
+++ b/src/Codeception/Configuration.php
@@ -570,7 +570,14 @@ class Configuration
      */
     public static function append(array $config = [])
     {
-        return self::$config = self::mergeConfigs(self::$config, $config);
+        self::$config = self::mergeConfigs(self::$config, $config);
+
+        self::$logDir = self::$config['paths']['log'];
+        self::$dataDir = self::$config['paths']['data'];
+        self::$supportDir = self::$config['paths']['support'];
+        self::$testsDir = self::$config['paths']['tests'];
+
+        return self::$config;
     }
 
     public static function mergeConfigs($a1, $a2)

--- a/src/Codeception/Configuration.php
+++ b/src/Codeception/Configuration.php
@@ -571,12 +571,20 @@ class Configuration
     public static function append(array $config = [])
     {
         self::$config = self::mergeConfigs(self::$config, $config);
-
-        self::$logDir = self::$config['paths']['log'];
-        self::$dataDir = self::$config['paths']['data'];
-        self::$supportDir = self::$config['paths']['support'];
-        self::$testsDir = self::$config['paths']['tests'];
-
+        
+        if (isset(self::$config['paths']['log'])) {
+            self::$logDir = self::$config['paths']['log'];
+        }
+        if (isset(self::$config['paths']['data'])) {
+            self::$dataDir = self::$config['paths']['data'];
+        }
+        if (isset(self::$config['paths']['support'])) {
+            self::$supportDir = self::$config['paths']['support'];
+        }
+        if (isset(self::$config['paths']['tests'])) {
+            self::$testsDir = self::$config['paths']['tests'];
+        }
+        
         return self::$config;
     }
 


### PR DESCRIPTION
When you run:
`php vendor\codeception\codeception\codecept run -vvv --override="paths: log: tests/_output/Acceptance_TestCest_test" --xml=report.xml tests\acceptance\TestCest:test`
it generates report and error screenshots to tests/_output and not to tests/_output/Acceptance_TestCest_test

... and override by configuration also does not work - this commit fix only override by parameter. Try add to tests/acceptance.suite.yml:
```yml
env:
    development:
        paths:
            log: tests/_output/runner1
```
and run:
`php vendor\codeception\codeception\codecept run -vvv --env=development --xml=report.xml tests\acceptance\TestCest:test`
it generates report and error screenshots to tests/_output and not to tests/_output/Acceptance_TestCest_test