### PR TITLE
Display the location of unexpected exceptions

### DIFF
--- a/src/Codeception/Subscriber/Console.php
+++ b/src/Codeception/Subscriber/Console.php
@@ -394,6 +394,7 @@ class Console implements EventSubscriberInterface
 
         if (!$isFailure) {
             $message->prepend("[$class] ")->block('error');
+            $message->append("\n" . OutputFormatter::escape($e->getFile()) . ":" . $e->getLine());
         }
 
         if ($isFailure && $cause) {


### PR DESCRIPTION
When an unexpected exception occured, there was no indication of the
file where it was raised. This commit displays the file and line number
in the console report, just under the exception name.

See #4145.

I could not run Codecept's test, because it complained of a missing mongodb extension, though `php -i` confirms that ext/mongo is available. I did not want to spend too much time on this.