### PR TITLE
[WIP] Generate Actions class in a thread-safe way

### DIFF
--- a/src/Codeception/Command/Build.php
+++ b/src/Codeception/Command/Build.php
@@ -39,7 +39,7 @@ class Build extends Command
         $this->output = $output;
         $this->buildActorsForConfig();
     }
-    
+
     private function buildActor(array $settings)
     {
         $actorGenerator = new ActorGenerator($settings);
@@ -47,7 +47,7 @@ class Build extends Command
             '<info>' . Configuration::config()['namespace'] . '\\' . $actorGenerator->getActorName()
             . "</info> includes modules: " . implode(', ', $actorGenerator->getModules())
         );
-        
+
         $content = $actorGenerator->produce();
 
         $file = $this->buildPath(
@@ -57,7 +57,7 @@ class Build extends Command
         $file .=  '.php';
         return $this->save($file, $content);
     }
-    
+
     private function buildActions(array $settings)
     {
         $actionsGenerator = new ActionsGenerator($settings);
@@ -65,9 +65,9 @@ class Build extends Command
             " -> {$settings['class_name']}Actions.php generated successfully. "
             . $actionsGenerator->getNumMethods() . " methods added"
         );
-        
+
         $content = $actionsGenerator->produce();
-        
+
         $file = $this->buildPath(Configuration::supportDir() . '_generated', $settings['class_name']);
         $file .= $this->getClassName($settings['class_name']) . 'Actions.php';
         return $this->save($file, $content, true);
@@ -83,17 +83,17 @@ class Build extends Command
             $settings = $this->getSuiteConfig($suite);
             $this->buildActions($settings);
             $actorBuilt = $this->buildActor($settings);
-            
+
             if ($actorBuilt) {
                 $this->output->writeln("{$settings['class_name']}.php created.");
             }
         }
     }
-    
+
     protected function buildActorsForConfig($configFile = null)
     {
         $config = $this->getGlobalConfig($configFile);
-        
+
         $dir = Configuration::projectDir();
         $this->buildSuiteActors();
 

--- a/src/Codeception/Command/Build.php
+++ b/src/Codeception/Command/Build.php
@@ -39,7 +39,7 @@ class Build extends Command
         $this->output = $output;
         $this->buildActorsForConfig();
     }
-
+    
     private function buildActor(array $settings)
     {
         $actorGenerator = new ActorGenerator($settings);
@@ -47,7 +47,7 @@ class Build extends Command
             '<info>' . Configuration::config()['namespace'] . '\\' . $actorGenerator->getActorName()
             . "</info> includes modules: " . implode(', ', $actorGenerator->getModules())
         );
-
+        
         $content = $actorGenerator->produce();
 
         $file = $this->buildPath(
@@ -57,7 +57,7 @@ class Build extends Command
         $file .=  '.php';
         return $this->save($file, $content);
     }
-
+    
     private function buildActions(array $settings)
     {
         $actionsGenerator = new ActionsGenerator($settings);
@@ -65,9 +65,9 @@ class Build extends Command
             " -> {$settings['class_name']}Actions.php generated successfully. "
             . $actionsGenerator->getNumMethods() . " methods added"
         );
-
+        
         $content = $actionsGenerator->produce();
-
+        
         $file = $this->buildPath(Configuration::supportDir() . '_generated', $settings['class_name']);
         $file .= $this->getClassName($settings['class_name']) . 'Actions.php';
         return $this->save($file, $content, true);
@@ -83,17 +83,17 @@ class Build extends Command
             $settings = $this->getSuiteConfig($suite);
             $this->buildActions($settings);
             $actorBuilt = $this->buildActor($settings);
-
+            
             if ($actorBuilt) {
                 $this->output->writeln("{$settings['class_name']}.php created.");
             }
         }
     }
-
+    
     protected function buildActorsForConfig($configFile = null)
     {
         $config = $this->getGlobalConfig($configFile);
-
+        
         $dir = Configuration::projectDir();
         $this->buildSuiteActors();
 

--- a/src/Codeception/Command/Shared/FileSystem.php
+++ b/src/Codeception/Command/Shared/FileSystem.php
@@ -66,8 +66,8 @@ trait FileSystem
             return false;
         }
 
-        //writing in a temporary file in order to reduce time between the file acquisition
-        //and the wrting, it should recude risk to occur `Bus Error` when running tests in parallel.
+        //Write in a locked temporary file in order to reduce non thread-safe disk instructions,
+        //  and reduce risk of `Bus Errors` when running tests in parallel.
         //@see https://github.com/Codeception/Codeception/issues/2054#event-1046859271
         $tmpFilename = $filename . '.tmp';
         $success = @file_put_contents($tmpFilename, $contents, LOCK_EX);

--- a/src/Codeception/Command/Shared/FileSystem.php
+++ b/src/Codeception/Command/Shared/FileSystem.php
@@ -82,9 +82,6 @@ trait FileSystem
             for ($i = 0; ($i < 3 && !$success); $i++) {
                 usleep(500000);
                 $success = @rename($tmpFilename, $filename);
-                if ($success) {
-                    break;
-                }
             }
             if (false === $success) {
                 throw new \RuntimeException(sprintf('Unable to move class from %s to %s(tried 3 times)', $tmpFilename, $filename));

--- a/src/Codeception/Command/Shared/FileSystem.php
+++ b/src/Codeception/Command/Shared/FileSystem.php
@@ -60,12 +60,18 @@ trait FileSystem
         return preg_replace("~$suffix$~", '', $classname);
     }
 
-    protected function save($filename, $contents, $force = false, $flags = null)
+    protected function save($filename, $contents, $force = false)
     {
         if (file_exists($filename) && !$force) {
             return false;
         }
-        file_put_contents($filename, $contents, $flags);
-        return true;
+
+        //writing in a temporary file in order to reduce time between the file acquisition
+        //and the wrting, it should recude risk to occur `Bus Error` when running tests in parallel.
+        //@see https://github.com/Codeception/Codeception/issues/2054#event-1046859271
+        $tmpFilename = $filename . '.tmp';
+        file_put_contents($tmpFilename, $contents, LOCK_EX);
+
+        return rename($tmpFilename, $filename);
     }
 }

--- a/src/Codeception/Command/Shared/FileSystem.php
+++ b/src/Codeception/Command/Shared/FileSystem.php
@@ -70,8 +70,16 @@ trait FileSystem
         //and the wrting, it should recude risk to occur `Bus Error` when running tests in parallel.
         //@see https://github.com/Codeception/Codeception/issues/2054#event-1046859271
         $tmpFilename = $filename . '.tmp';
-        file_put_contents($tmpFilename, $contents, LOCK_EX);
+        $success = @file_put_contents($tmpFilename, $contents, LOCK_EX);
+        if (false === $success) {
+            throw new \RuntimeException(sprintf('Unable to generate temporary class %s', $tmpFilename));
+        }
 
-        return rename($tmpFilename, $filename);
+        $success = @rename($tmpFilename, $filename);
+        if (false === $success) {
+            throw new \RuntimeException(sprintf('Unable to generate class %s', $filename));
+        }
+
+        return true;
     }
 }

--- a/tests/unit/Codeception/Command/Shared/FileSystemTest.php
+++ b/tests/unit/Codeception/Command/Shared/FileSystemTest.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace Tests\Codeception\Command\Shared;
+
+use Codeception\Command\Shared\FileSystem;
+
+class FileSystemTest extends \PHPUnit_Framework_TestCase
+{
+    public function setUp()
+    {
+    }
+
+    /**
+     * Call protected/private method of a class.
+     *
+     * @param object &$object    Instantiated object that we will run method on.
+     * @param string $methodName Method name to call
+     * @param array  $parameters Array of parameters to pass into method.
+     *
+     * @return mixed Method return.
+     */
+    protected function invokeMethod(&$object, $methodName, array $parameters = array())
+    {
+        $reflection = new \ReflectionClass(get_class($object));
+        $method = $reflection->getMethod($methodName);
+        $method->setAccessible(true);
+
+        return $method->invokeArgs($object, $parameters);
+    }
+
+    public function testSave()
+    {
+        //be sure to have a unique filename
+        $filename = sys_get_temp_dir() . '/MyClass.'.uniqid().'.php' ;
+        $fileSystem = new MyClassUsingFileSystemTrait();
+        $content = '1234';
+
+        $result = $this->invokeMethod($fileSystem, 'save', [$filename, $content]);
+
+        $this->assertTrue($result);
+        $this->assertTrue(file_exists($filename));
+        $this->assertEquals('1234', file_get_contents($filename));
+    }
+
+    public function testSaveIfFileExists()
+    {
+        //be sure to have a unique filename
+        $filename = sys_get_temp_dir() . '/MyClass.'.uniqid().'.php' ;
+        $fileSystem = new MyClassUsingFileSystemTrait();
+        $content = '1234';
+
+        //the file already exists
+        touch($filename);
+
+        $result = $this->invokeMethod($fileSystem, 'save', [$filename, $content]);
+
+        $this->assertFalse($result);
+        $this->assertNotEquals('1234', file_get_contents($filename));
+    }
+
+    public function testForcedSaveIfFileExists()
+    {
+        //be sure to have a unique filename
+        $filename = sys_get_temp_dir() . '/MyClass.'.uniqid().'.php' ;
+        $fileSystem = new MyClassUsingFileSystemTrait();
+        $content = '1234';
+
+        //the file already exists
+        touch($filename);
+
+        $result = $this->invokeMethod($fileSystem, 'save', [$filename, $content, true]);
+
+        $this->assertTrue($result);
+        $this->assertTrue(file_exists($filename));
+        $this->assertEquals('1234', file_get_contents($filename));
+    }
+}
+
+class MyClassUsingFileSystemTrait
+{
+    use FileSystem;
+}


### PR DESCRIPTION
It intends to fix following issue : https://github.com/Codeception/Codeception/issues/2054

It writes content on a temporary locked file before erasing the main class file (less non thread-safe disk instructions).

I need some concerned people to test it and confirm `Bus Errors` do not occur anymore.
Sorry it's it very empirical...

On your project, to quickly switch to this branch :

```
composer config repositories.codeception/codeception git git@github.com:pitpit/Codeception.git
composer require codeception/codeception:dev-bugfix/bus-error
```