### PR TITLE
Add DELETE method to supported form data request methods in Guzzle6::extractFormData

### DIFF
--- a/src/Codeception/Lib/Connector/Guzzle6.php
+++ b/src/Codeception/Lib/Connector/Guzzle6.php
@@ -226,7 +226,7 @@ class Guzzle6 extends Client
 
     protected function extractFormData(BrowserKitRequest $request)
     {
-        if (!in_array(strtoupper($request->getMethod()), ['POST', 'PUT', 'PATCH'])) {
+        if (!in_array(strtoupper($request->getMethod()), ['POST', 'PUT', 'PATCH', 'DELETE'])) {
             return null;
         }
 


### PR DESCRIPTION
Codeception\Lib\Connector\Guzzle6::extractFormData did not support DELETE form data.

This PR fixes #4164