### PR TITLE
Add ability to load the dump using a tool/command

### DIFF
--- a/src/Codeception/SuiteManager.php
+++ b/src/Codeception/SuiteManager.php
@@ -75,7 +75,10 @@ class SuiteManager
 
     public function initialize()
     {
-        $this->dispatcher->dispatch(Events::MODULE_INIT, new Event\SuiteEvent($this->suite, null, $this->settings));
+        $this->dispatcher->dispatch(
+            Events::MODULE_INIT,
+            new Event\SuiteEvent($this->suite, null, $this->settings)
+        );
         foreach ($this->moduleContainer->all() as $module) {
             $module->_initialize();
         }
@@ -85,8 +88,10 @@ class SuiteManager
                 . " class doesn't exist in suite folder.\nRun the 'build' command to generate it"
             );
         }
-        $this->dispatcher->dispatch(Events::SUITE_INIT, new Event\SuiteEvent($this->suite, null, $this->settings));
-        ini_set('xdebug.show_exception_trace', 0); // Issue https://github.com/symfony/symfony/issues/7646
+        $this->dispatcher->dispatch(
+            Events::SUITE_INIT,
+            new Event\SuiteEvent($this->suite, null, $this->settings)
+        );
     }
 
     public function loadTests($path = null)
@@ -133,7 +138,8 @@ class SuiteManager
     protected function createSuite($name)
     {
         $suite = new Suite();
-        $suite->setBaseName(preg_replace('~\s.+$~', '', $name)); // replace everything after space (env name)
+        // replace everything after space (env name)
+        $suite->setBaseName(preg_replace('~\s.+$~', '', $name));
         if ($this->settings['namespace']) {
             $name = $this->settings['namespace'] . ".$name";
         }
@@ -142,8 +148,12 @@ class SuiteManager
             $suite->setBackupGlobals((bool) $this->settings['backup_globals']);
         }
 
-        if (isset($this->settings['be_strict_about_changes_to_global_state']) && method_exists($suite, 'setbeStrictAboutChangesToGlobalState')) {
-            $suite->setbeStrictAboutChangesToGlobalState((bool)$this->settings['be_strict_about_changes_to_global_state']);
+        if (isset($this->settings['be_strict_about_changes_to_global_state'])
+            && method_exists($suite, 'setbeStrictAboutChangesToGlobalState')
+        ) {
+            $suite->setbeStrictAboutChangesToGlobalState(
+                (bool)$this->settings['be_strict_about_changes_to_global_state']
+            );
         }
         $suite->setModules($this->moduleContainer->all());
         return $suite;
@@ -153,9 +163,15 @@ class SuiteManager
     public function run(PHPUnit\Runner $runner, \PHPUnit_Framework_TestResult $result, $options)
     {
         $runner->prepareSuite($this->suite, $options);
-        $this->dispatcher->dispatch(Events::SUITE_BEFORE, new Event\SuiteEvent($this->suite, $result, $this->settings));
+        $this->dispatcher->dispatch(
+            Events::SUITE_BEFORE,
+            new Event\SuiteEvent($this->suite, $result, $this->settings)
+        );
         $runner->doEnhancedRun($this->suite, $result, $options);
-        $this->dispatcher->dispatch(Events::SUITE_AFTER, new Event\SuiteEvent($this->suite, $result, $this->settings));
+        $this->dispatcher->dispatch(
+            Events::SUITE_AFTER,
+            new Event\SuiteEvent($this->suite, $result, $this->settings)
+        );
     }
 
     /**
@@ -188,14 +204,20 @@ class SuiteManager
             return;
         }
         if (!isset($this->settings['env'])) {
-            Notification::warning("Environments are not configured", Descriptor::getTestFullName($test));
+            Notification::warning(
+                "Environments are not configured",
+                Descriptor::getTestFullName($test)
+            );
             return;
         }
         $availableEnvironments = array_keys($this->settings['env']);
         $listedEnvironments = explode(',', implode(',', $envs));
         foreach ($listedEnvironments as $env) {
             if (!in_array($env, $availableEnvironments)) {
-                Notification::warning("Environment $env was not configured but used in test", Descriptor::getTestFullName($test));
+                Notification::warning(
+                    "Environment $env was not configured but used in test",
+                    Descriptor::getTestFullName($test)
+                );
             }
         }
     }

--- a/tests/unit/Codeception/Lib/Driver/SqliteTest.php
+++ b/tests/unit/Codeception/Lib/Driver/SqliteTest.php
@@ -8,7 +8,7 @@ class SqliteTest extends Unit
     protected static $config = array(
         'dsn' => 'sqlite:tests/data/sqlite.db',
         'user' => 'root',
-        'password' => ''
+        'password' => '',
     );
 
     /**
@@ -16,7 +16,7 @@ class SqliteTest extends Unit
      */
     protected static $sqlite;
     protected static $sql;
-    
+
     public static function setUpBeforeClass()
     {
         if (version_compare(PHP_VERSION, '5.5.0', '<')) {
@@ -28,11 +28,12 @@ class SqliteTest extends Unit
         $sql = file_get_contents(\Codeception\Configuration::dataDir() . $dumpFile);
         $sql = preg_replace('%/\*(?:(?!\*/).)*\*/%s', "", $sql);
         self::$sql = explode("\n", $sql);
-        try {
-            self::$sqlite = Db::create(self::$config['dsn'], self::$config['user'], self::$config['password']);
-            self::$sqlite->cleanup();
-        } catch (\Exception $e) {
-        }
+        self::$sqlite = Db::create(
+            self::$config['dsn'],
+            self::$config['user'],
+            self::$config['password']
+        );
+        self::$sqlite->cleanup();
     }
 
     public function setUp()
@@ -42,7 +43,7 @@ class SqliteTest extends Unit
         }
         self::$sqlite->load(self::$sql);
     }
-    
+
     public function tearDown()
     {
         if (isset(self::$sqlite)) {
@@ -54,14 +55,20 @@ class SqliteTest extends Unit
     {
         $this->assertGreaterThan(
             0,
-            count(self::$sqlite->getDbh()->query('SELECT name FROM sqlite_master WHERE type = "table";')->fetchAll())
+            count(
+                self::$sqlite->getDbh()
+                ->query('SELECT name FROM sqlite_master WHERE type = "table";')
+                ->fetchAll()
+            )
         );
         self::$sqlite->cleanup();
         $this->assertEmpty(
-            self::$sqlite->getDbh()->query('SELECT name FROM sqlite_master WHERE type = "table";')->fetchAll()
+            self::$sqlite->getDbh()
+            ->query('SELECT name FROM sqlite_master WHERE type = "table";')
+            ->fetchAll()
         );
     }
-    
+
     public function testLoadDump()
     {
         $res = self::$sqlite->getDbh()->query("select * from users where name = 'davert'");


### PR DESCRIPTION
The db module now accepts a `dumptool` configuration item
where the user can enter a command to execute his/her prefered
tool or wrapper script.
The dsn is parsed into variables and are made available, with
the variables from the module configuration, to the command
for interpolation, allowing the executing of commands like:

`dumptool: 'mysql -u $user -p $password -h $host -D $dbname < $dump'`

The Db module has been structured a bit more in order to make sense of the suite & test events rather than having spaghetti like code all around the place. 

The sqlite module has been cleaned up to respect the reconnect
settings and to aviod dependency on the order of the execution
of its parent method. Mainly because there is no need to "reload"
the connection when touching the sqlite db file...