### PR TITLE
Allow to set only host

### DIFF
--- a/src/Codeception/Lib/Connector/Yii1.php
+++ b/src/Codeception/Lib/Connector/Yii1.php
@@ -67,7 +67,7 @@ class Yii1 extends Client
         }
 
         // Add script name to request if none
-        if (strpos($uriPath, $scriptName) === false) {
+        if ($scriptName AND strpos($uriPath, $scriptName) === false) {
             $uriPath = "/{$scriptName}/{$uriPath}";
         }
 

--- a/src/Codeception/Lib/Connector/Yii1.php
+++ b/src/Codeception/Lib/Connector/Yii1.php
@@ -67,7 +67,7 @@ class Yii1 extends Client
         }
 
         // Add script name to request if none
-        if ($scriptName AND strpos($uriPath, $scriptName) === false) {
+        if ($scriptName and strpos($uriPath, $scriptName) === false) {
             $uriPath = "/{$scriptName}/{$uriPath}";
         }
 


### PR DESCRIPTION
If you have enabled pretty url and try to set only host in url
```
modules:
    enabled:
      - Yii1:
          appPath: ./../../public/index-test.php
          url: http://localhost/
```
you will get warning (and exception in error handler) `strpos(): Empty needle`