### PR TITLE
FIX broken HTML report

### DIFF
--- a/src/Codeception/Step.php
+++ b/src/Codeception/Step.php
@@ -218,7 +218,7 @@ abstract class Step
             return sprintf('%s %s', ucfirst($this->prefix), $this->humanize($this->getAction()));
         }
 
-        return sprintf('%s %s <span style="color: %s">%s</span>', ucfirst($this->prefix), $this->humanize($this->getAction()), $highlightColor, $this->getHumanizedArguments());
+        return sprintf('%s %s <span style="color: %s">%s</span>', ucfirst($this->prefix), htmlspecialchars($this->humanize($this->getAction())), $highlightColor, htmlspecialchars($this->getHumanizedArguments()));
     }
 
     public function getHumanizedActionWithoutArguments()

--- a/tests/unit/Codeception/Command/GenerateScenarioTest.php
+++ b/tests/unit/Codeception/Command/GenerateScenarioTest.php
@@ -65,7 +65,7 @@ class GenerateScenarioTest extends BaseCommandRunner
         $this->assertArrayHasKey($file, $this->saved);
         $content = $this->saved[$file];
         $this->assertContains('<html><body><h3>I WANT TO CHECK CONFIG EXISTS</h3>', $content);
-        $this->assertContains('I see file found "$codeception"', strip_tags($content));
+        $this->assertContains('I see file found &quot;$codeception&quot;', strip_tags($content));
         $this->assertContains('* File_Exists generated', $this->output);
     }
 

--- a/tests/unit/Codeception/ScenarioTest.php
+++ b/tests/unit/Codeception/ScenarioTest.php
@@ -19,7 +19,7 @@ class ScenarioTest extends \PHPUnit_Framework_TestCase
         $scenario->setFeature('Do some testing');
 
         $this->assertSame(
-            '<h3>I WANT TO DO SOME TESTING</h3>I do some testing <span style="color: #732E81">"arg1","arg2"</span>'
+            '<h3>I WANT TO DO SOME TESTING</h3>I do some testing <span style="color: #732E81">&quot;arg1&quot;,&quot;arg2&quot;</span>'
             . '<br/>I do even more testing without args<br/>',
             $scenario->getHtml()
         );

--- a/tests/unit/Codeception/StepTest.php
+++ b/tests/unit/Codeception/StepTest.php
@@ -37,7 +37,7 @@ class StepTest extends \PHPUnit_Framework_TestCase
     public function testGetHtml()
     {
         $step = $this->getStep(['Do some testing', ['arg1', 'arg2']]);
-        $this->assertSame('I do some testing <span style="color: #732E81">"arg1","arg2"</span>', $step->getHtml());
+        $this->assertSame('I do some testing <span style="color: #732E81">&quot;arg1&quot;,&quot;arg2&quot;</span>', $step->getHtml());
 
         $step = $this->getStep(['Do some testing', []]);
         $this->assertSame('I do some testing', $step->getHtml());


### PR DESCRIPTION
When you add e.g.:
```php
$I->executeJS('/* AAA </td> BBB <td> CCC */');
```
to test it will broke HTML report because "td" end tag will be generated like is.