### PR TITLE
improve mongo legacy check

### DIFF
--- a/src/Codeception/Lib/Driver/MongoDb.php
+++ b/src/Codeception/Lib/Driver/MongoDb.php
@@ -95,7 +95,7 @@ class MongoDb
      */
     public function __construct($dsn, $user, $password)
     {
-        $this->legacy = class_exists('\\MongoClient') && strpos(\MongoClient::VERSION, 'mongofill') === false;
+        $this->legacy = extension_loaded('mongodb') === false;
 
         /* defining DB name */
         $this->dbName = substr($dsn, strrpos($dsn, '/') + 1);

--- a/src/Codeception/Lib/Driver/MongoDb.php
+++ b/src/Codeception/Lib/Driver/MongoDb.php
@@ -95,7 +95,9 @@ class MongoDb
      */
     public function __construct($dsn, $user, $password)
     {
-        $this->legacy = extension_loaded('mongodb') === false;
+        $this->legacy = extension_loaded('mongodb') === false &&
+            class_exists('\\MongoClient') &&
+            strpos(\MongoClient::VERSION, 'mongofill') === false;
 
         /* defining DB name */
         $this->dbName = substr($dsn, strrpos($dsn, '/') + 1);


### PR DESCRIPTION
Hello,

I think this is a better way for decide wich mongo have to use. If you use both legacy _mongo_ and the current _mongodb_, the legacy value will be false.

Issue #4174 