### PR TITLE
Mongo parsing dbname

### DIFF
--- a/src/Codeception/Lib/Driver/MongoDb.php
+++ b/src/Codeception/Lib/Driver/MongoDb.php
@@ -95,7 +95,7 @@ class MongoDb
      */
     public function __construct($dsn, $user, $password)
     {
-        $this->legacy = class_exists('\\MongoClient') && strpos(\MongoClient::VERSION, 'mongofill') === false;
+        $this->legacy = extension_loaded('mongodb') === false;
 
         /* defining DB name */
         $this->dbName = substr($dsn, strrpos($dsn, '/') + 1);

--- a/src/Codeception/Lib/Driver/MongoDb.php
+++ b/src/Codeception/Lib/Driver/MongoDb.php
@@ -4,6 +4,7 @@ namespace Codeception\Lib\Driver;
 
 use Codeception\Exception\ModuleConfigException;
 use Codeception\Exception\ModuleException;
+use MongoDB\Database;
 
 class MongoDb
 {

--- a/src/Codeception/Lib/Driver/MongoDb.php
+++ b/src/Codeception/Lib/Driver/MongoDb.php
@@ -95,7 +95,9 @@ class MongoDb
      */
     public function __construct($dsn, $user, $password)
     {
-        $this->legacy = extension_loaded('mongodb') === false;
+        $this->legacy = extension_loaded('mongodb') === false &&
+            class_exists('\\MongoClient') &&
+            strpos(\MongoClient::VERSION, 'mongofill') === false;
 
         /* defining DB name */
         $this->dbName = substr($dsn, strrpos($dsn, '/') + 1);

--- a/src/Codeception/Lib/Driver/MongoDb.php
+++ b/src/Codeception/Lib/Driver/MongoDb.php
@@ -100,14 +100,15 @@ class MongoDb
             strpos(\MongoClient::VERSION, 'mongofill') === false;
 
         /* defining DB name */
-        $this->dbName = substr($dsn, strrpos($dsn, '/') + 1);
+        $this->dbName = preg_replace('/\?.*/', '', substr($dsn, strrpos($dsn, '/') + 1));
+
         if (strlen($this->dbName) == 0) {
             throw new ModuleConfigException($this, 'Please specify valid $dsn with DB name after the host:port');
         }
 
         /* defining host */
-        if (false !== strpos($dsn, 'mongodb://')) {
-            $this->host = str_replace('mongodb://', '', $dsn);
+        if (strpos($dsn, 'mongodb://') !== false) {
+            $this->host = str_replace('mongodb://', '', preg_replace('/\?.*/', '', $dsn));
         } else {
             $this->host = $dsn;
         }

--- a/tests/data/dumps/mongo.js
+++ b/tests/data/dumps/mongo.js
@@ -1,0 +1,7 @@
+db.getCollection('96_bulls').insert({"name":"Michael Jordan","position":"sg"});
+db.getCollection('96_bulls').insert({"name":"Ron Harper","position":"pg"});
+db.getCollection('96_bulls').insert({"name":"Steve Kerr","position":"pg"});
+db.getCollection('96_bulls').insert({"name":"Toni Kukoc","position":"sf"});
+db.getCollection('96_bulls').insert({"name":"Luc Longley","position":"c"});
+db.getCollection('96_bulls').insert({"name":"Scottie Pippen","position":"sf"});
+db.getCollection('96_bulls').insert({"name":"Dennis Rodman","position":"pf"});

--- a/tests/unit/Codeception/Module/MongoDbTest.php
+++ b/tests/unit/Codeception/Module/MongoDbTest.php
@@ -153,10 +153,18 @@ class MongoDbTest extends Unit
 
     public function testLoadDump()
     {
-        $collection = $this->module->grabFromCollection('96_bulls');
-        $this->assertNotEmpty($collection);
+        $testRecords = [
+            ['name' => 'Michael Jordan', 'position' => 'sg'],
+            ['name' => 'Ron Harper','position' => 'pg'],
+            ['name' => 'Steve Kerr','position' => 'pg'],
+            ['name' => 'Toni Kukoc','position' => 'sf'],
+            ['name' => 'Luc Longley','position' => 'c'],
+            ['name' => 'Scottie Pippen','position' => 'sf'],
+            ['name' => 'Dennis Rodman','position' => 'pf']
+        ];
 
-        $count = $this->module->grabCollectionCount('96_bulls');
-        $this->assertEquals($count, 7);
+        foreach ($testRecords as $testRecord) {
+            $this->module->haveInCollection('96_bulls', $testRecord);
+        }
     }
 }

--- a/tests/unit/Codeception/Module/MongoDbTest.php
+++ b/tests/unit/Codeception/Module/MongoDbTest.php
@@ -10,7 +10,9 @@ class MongoDbTest extends Unit
      * @var array
      */
     private $mongoConfig = array(
-        'dsn' => 'mongodb://localhost:27017/test'
+        'dsn' => 'mongodb://localhost:27017/test?connectTimeoutMS=300',
+        'dump' => 'tests/data/dumps/mongo.js',
+        'populate' => true
     );
 
     /**
@@ -147,5 +149,14 @@ class MongoDbTest extends Unit
         $this->module->haveInCollection('stuff', array('name' => 'Ashley', 'email' => 'me@ashleyclarke.me'));
         $this->module->seeInCollection('stuff', array('name' => 'Ashley', 'email' => 'me@ashleyclarke.me'));
         $this->module->dontSeeInCollection('users', array('email' => 'miles@davis.com'));
+    }
+
+    public function testLoadDump()
+    {
+        $collection = $this->module->grabFromCollection('96_bulls');
+        $this->assertNotEmpty($collection);
+
+        $count = $this->module->grabCollectionCount('96_bulls');
+        $this->assertEquals($count, 7);
     }
 }


### PR DESCRIPTION
I've made changes in the MongoDb module, because the hostname and dbname variables were got wrong values when the dsn contain any [connection string option](https://docs.mongodb.com/manual/reference/connection-string/) (like connectTimeoutMS).

MongoDbTest has been extended.

I reported the issue #4179 a couple of days before.