### PR TITLE
Allow to make requests end with slash

### DIFF
--- a/src/Codeception/Lib/Connector/Yii1.php
+++ b/src/Codeception/Lib/Connector/Yii1.php
@@ -54,7 +54,7 @@ class Yii1 extends Client
         }
 
         // Parse url parts
-        $uriPath = trim(parse_url($request->getUri(), PHP_URL_PATH), '/');
+        $uriPath = ltrim(parse_url($request->getUri(), PHP_URL_PATH), '/');
         $uriQuery = ltrim(parse_url($request->getUri(), PHP_URL_QUERY), '?');
         $scriptName = trim(parse_url($this->url, PHP_URL_PATH), '/');
         if (!empty($uriQuery)) {


### PR DESCRIPTION
When you try to make request end with slash
`$I->amOnPage('/en/sign-in/');`
you will get changed request to `/index-test.php/en/sign-in`