### PR TITLE
Handle joins such as INNER JOIN s.order order which fail with expecte…

### DIFF
--- a/src/Codeception/Module/Doctrine2.php
+++ b/src/Codeception/Module/Doctrine2.php
@@ -414,7 +414,7 @@ EOF;
                         $qb->innerJoin("$alias.$key", $key);
                         foreach ($val as $column => $v) {
                             if (is_array($v)) {
-                                $this->buildAssociationQuery($qb, $map['targetEntity'], $column, $v);
+                                $this->buildAssociationQuery($qb, $map['targetEntity'], '_'.$column, $v);
                                 continue;
                             }
                             $paramname = $key . '__' . $column;


### PR DESCRIPTION
…d literal due to reserved key words

Consider the following 

       $I->seeInRepository(
            'OrderItem',
            array(
                'order' => array(
                    'recipient_email'=> self::MEMBER_EMAIL
                )
            )
        );

Generates the following query:
SELECT s FROM  OrderItem s INNER JOIN s.order order WHERE order.recipient_email = :order__recipient_email

Currently fails with expected literal. 

The suggested change would produce
SELECT s FROM  OrderItem s INNER JOIN s.order _order WHERE _order.recipient_email = :_order__recipient_email