### PR TITLE
Safe prefix aliases for buildAssociationQuery()

### DIFF
--- a/src/Codeception/Module/Doctrine2.php
+++ b/src/Codeception/Module/Doctrine2.php
@@ -411,14 +411,14 @@ EOF;
             if (isset($data->associationMappings)) {
                 if ($map = array_key_exists($key, $data->associationMappings)) {
                     if (is_array($val)) {
-                        $qb->innerJoin("$alias.$key", $key);
+                        $qb->innerJoin("$alias.$key", "_$key");
                         foreach ($val as $column => $v) {
                             if (is_array($v)) {
                                 $this->buildAssociationQuery($qb, $map['targetEntity'], $column, $v);
                                 continue;
                             }
-                            $paramname = $key . '__' . $column;
-                            $qb->andWhere("$key.$column = :$paramname");
+                            $paramname = "_$key" . '__' . $column;
+                            $qb->andWhere("_$key.$column = :$paramname");
                             $qb->setParameter($paramname, $v);
                         }
                         continue;


### PR DESCRIPTION
Consider the following

```php
$I->seeInRepository(
'OrderItem',
array(
'order' => array(
'recipient_email'=> self::MEMBER_EMAIL
)
)
);
```

Generates the following query:

```
SELECT s FROM OrderItem s INNER JOIN s.order order WHERE order.recipient_email = :order__recipient_email
```

Currently fails with expected literal due to the use of the word order as an alias.

The suggested change would produce

```
SELECT s FROM OrderItem s INNER JOIN s.order _order WHERE _order.recipient_email = :_order__recipient_email
```

Fixes #4194 