### PR TITLE
[REST] seeResponseContainsJson doesn't crash when json response is not array

### DIFF
--- a/src/Codeception/Util/JsonArray.php
+++ b/src/Codeception/Util/JsonArray.php
@@ -35,6 +35,10 @@ class JsonArray
                 json_last_error()
             );
         }
+
+        if (!is_array($this->jsonArray)) {
+            throw new \PHPUnit_Framework_AssertionFailedError('JSON response is not an array: ' . $jsonString);
+        }
     }
 
     public function toXml()

--- a/tests/unit/Codeception/Module/PhpBrowserRestTest.php
+++ b/tests/unit/Codeception/Module/PhpBrowserRestTest.php
@@ -124,6 +124,16 @@ class PhpBrowserRestTest extends Unit
         $this->module->seeResponseContainsJson(array('id' => 1));
     }
 
+    /**
+     * @issue https://github.com/Codeception/Codeception/issues/4202
+     */
+    public function testSeeResponseContainsJsonFailsGracefullyWhenJsonResultIsNotArray()
+    {
+        $this->shouldFail();
+        $this->setStubResponse(json_encode('no_status'));
+        $this->module->seeResponseContainsJson(array('id' => 1));
+    }
+
     public function testDontSeeInJson()
     {
         $this->setStubResponse('{"ticket": {"title": "Bug should be fixed", "user": {"name": "Davert"}}}');

--- a/tests/unit/Codeception/Module/PhpBrowserRestTest.php
+++ b/tests/unit/Codeception/Module/PhpBrowserRestTest.php
@@ -19,7 +19,7 @@ class PhpBrowserRestTest extends Unit
     {
         $this->phpBrowser = new \Codeception\Module\PhpBrowser(make_container());
         $url = 'http://localhost:8010';
-        $this->phpBrowser->_setConfig(array('url' => $url));
+        $this->phpBrowser->_setConfig(['url' => $url]);
         $this->phpBrowser->_initialize();
 
         $this->module = Stub::make('\Codeception\Module\REST');
@@ -42,7 +42,7 @@ class PhpBrowserRestTest extends Unit
         $this->module->sendGET('/rest/user/');
         $this->module->seeResponseIsJson();
         $this->module->seeResponseContains('davert');
-        $this->module->seeResponseContainsJson(array('name' => 'davert'));
+        $this->module->seeResponseContainsJson(['name' => 'davert']);
         $this->module->seeResponseCodeIs(200);
         $this->module->dontSeeResponseCodeIs(404);
     }
@@ -55,9 +55,9 @@ class PhpBrowserRestTest extends Unit
 
     public function testPost()
     {
-        $this->module->sendPOST('/rest/user/', array('name' => 'john'));
+        $this->module->sendPOST('/rest/user/', ['name' => 'john']);
         $this->module->seeResponseContains('john');
-        $this->module->seeResponseContainsJson(array('name' => 'john'));
+        $this->module->seeResponseContainsJson(['name' => 'john']);
     }
 
     public function testValidJson()
@@ -98,10 +98,10 @@ class PhpBrowserRestTest extends Unit
             '{"ticket": {"title": "Bug should be fixed", "user": {"name": "Davert"}, "labels": null}}'
         );
         $this->module->seeResponseIsJson();
-        $this->module->seeResponseContainsJson(array('name' => 'Davert'));
-        $this->module->seeResponseContainsJson(array('user' => array('name' => 'Davert')));
-        $this->module->seeResponseContainsJson(array('ticket' => array('title' => 'Bug should be fixed')));
-        $this->module->seeResponseContainsJson(array('ticket' => array('user' => array('name' => 'Davert'))));
+        $this->module->seeResponseContainsJson(['name' => 'Davert']);
+        $this->module->seeResponseContainsJson(['user' => ['name' => 'Davert']]);
+        $this->module->seeResponseContainsJson(['ticket' => ['title' => 'Bug should be fixed']]);
+        $this->module->seeResponseContainsJson(['ticket' => ['user' => ['name' => 'Davert']]]);
         $this->module->seeResponseContainsJson(array('ticket' => array('labels' => null)));
     }
 
@@ -115,7 +115,6 @@ class PhpBrowserRestTest extends Unit
         $this->module->seeResponseContainsJson(array('tags' => array('web-dev', 'java')));
         $this->module->seeResponseContainsJson(array('user' => 'John Doe', 'age' => 27));
     }
-
 
     public function testArrayJson()
     {


### PR DESCRIPTION
Replaced fatal error with Assertion Failed "JSON response is not an array: ...".

Fixes #4202