### PR TITLE
Redis module default configuration must be more foolproof.

### DIFF
--- a/docs/01-Introduction.md
+++ b/docs/01-Introduction.md
@@ -10,10 +10,10 @@ but with tests you can cover the most important parts of your app and at least b
 
 There are plenty of ways to test your application.
 The most popular paradigm is [Unit Testing](http://en.wikipedia.org/wiki/Unit_testing).
-For web applications, testing just the controller and / or the model doesn't prove that your application is working.
+For web applications, testing just the controller and/or the model doesn't prove that your application is working.
 To test the behavior of your application as a whole, you should write functional or acceptance tests.
 
-Codeception supports these testing types.
+Codeception supports all three testing types.
 Out of the box you have tools for writing unit, functional, and acceptance tests in a unified framework.
 
 Let's review the listed testing paradigms in reverse order.
@@ -22,7 +22,7 @@ Let's review the listed testing paradigms in reverse order.
 
 How does your client, manager, tester, or any other non-technical person know your website is working?
 By opening the browser, accessing a site, clicking on links, filling in the forms,
-and actually seeing the content on a web page. They has no idea of the framework, database, web-server,
+and actually seeing the content on a web page. They have no idea of the framework, database, web-server,
 or programming language you use or why the application did not behave as expected.
 
 Acceptance tests can cover standard but complex scenarios from a user's perspective.
@@ -137,9 +137,9 @@ not a pure unit test)
 
 ## Conclusion
 
-Despite the wide popularity of *TDD* (Test Driven Development), some PHP developers never write automated tests for their applications mostly because they think it's hard, slow or boring..
+Despite the wide popularity of *TDD* (Test Driven Development), some PHP developers never write automated tests for their applications mostly because they think it's hard, slow or boring.
 The Codeception framework was developed to actually make testing fun.
-It allows writing unit, functional, integration, and acceptance tests, in a single, coherent style.
+It allows writing unit, functional, integration, and acceptance tests in a single, coherent style.
 
 It can be called a *BDD* (Behavior Driven Development) framework. All Codeception tests are written in a descriptive manner.
 Just by looking at the test body, you can clearly understand what is being tested and how it is performed.

--- a/src/Codeception/Module/Redis.php
+++ b/src/Codeception/Module/Redis.php
@@ -20,8 +20,8 @@ use Predis\Client as RedisDriver;
  *
  * * **`host`** (`string`, default `'127.0.0.1'`) - The Redis host
  * * **`port`** (`int`, default `6379`) - The Redis port
- * * **`database`** (`int`, no default) - The Redis database. Needs to be explicitly specified.
- * * **`cleanupBefore`**: (`string`, default `'suite'`) - Whether/when to flush the database:
+ * * **`database`** (`int`, no default) - The Redis database. Needs to be specified.
+ * * **`cleanupBefore`**: (`string`, default `'never'`) - Whether/when to flush the database:
  *     * `suite`: at the beginning of every suite
  *     * `test`: at the beginning of every test
  *     * Any other value: never
@@ -34,7 +34,7 @@ use Predis\Client as RedisDriver;
  *            host: '127.0.0.1'
  *            port: 6379
  *            database: 0
- *            cleanupBefore: 'test'
+ *            cleanupBefore: 'never'
  * ```
  *
  * ## Public Properties
@@ -48,13 +48,12 @@ class Redis extends CodeceptionModule implements RequiresPackage
     /**
      * {@inheritdoc}
      *
-     * No default value is set for the database, as this module will delete
-     * every data in it. The user is required to explicitly set this parameter.
+     * No default value is set for the database, using this parameter.
      */
     protected $config = [
         'host'          => '127.0.0.1',
         'port'          => 6379,
-        'cleanupBefore' => 'test'
+        'cleanupBefore' => 'never'
     ];
 
     /**


### PR DESCRIPTION
According to Document ( http://codeception.com/docs/modules/Redis ) and comments of module source, it says Codeception flushes the database "At the beginning of every suite" ( `cleanupBefore: 'suite'` ) . However default setting of `cleanupBefore` is set to "At the beginning of every test" ( `cleanupBefore: 'test'` ), so description of documentation is not actually true.

And flushing database without any attention seems dangerous behavior, so I turned default configuration to safe-side.

* If this change accepted, Document ( http://codeception.com/docs/modules/Redis ) have be updated.
