### PR TITLE
Deleted example for *public* dataprovider function

### DIFF
--- a/docs/07-AdvancedUsage.md
+++ b/docs/07-AdvancedUsage.md
@@ -249,7 +249,7 @@ You can also use the `@dataprovider` annotation for creating dynamic examples, u
     /**
      * @return array
      */
-    protected function pageProvider()
+    protected function pageProvider() // alternatively, if you want the function to be public, be sure to prefix it with `_`
     {
         return [
             ['url'=>"/", 'title'=>"Welcome"],
@@ -257,24 +257,6 @@ You can also use the `@dataprovider` annotation for creating dynamic examples, u
             ['url'=>"/about", 'title'=>"About Us"],
             ['url'=>"/contact", 'title'=>"Contact Us"]
         ];
-    }
-```
-
-Alternatively, the `@dataprovider` can also be a public method starting with `_` prefix so it will not be considered a test:
-
-```php
-<?php
-   /**
-    * @dataprovider _pageProvider
-    */
-    public function staticPages(AcceptanceTester $I, \Codeception\Example $example)
-    {
-        // ...
-    }
-
-    public function _pageProvider()
-    {
-        // ...
     }
 ```
 


### PR DESCRIPTION
See https://github.com/Codeception/Codeception/pull/4225#issuecomment-302549188

BTW: Is http://codeception.com/docs/07-AdvancedUsage not updated in real-time from `07-AdvancedUsage.md`? I still see the old version there...