### PR TITLE
Db cleanup fix

### DIFF
--- a/src/Codeception/Module.php
+++ b/src/Codeception/Module.php
@@ -202,10 +202,6 @@ abstract class Module
     {
     }
 
-    public function _cleanup()
-    {
-    }
-
     /**
      * **HOOK** executed before suite
      *

--- a/src/Codeception/Module/Cli.php
+++ b/src/Codeception/Module/Cli.php
@@ -2,6 +2,7 @@
 namespace Codeception\Module;
 
 use Codeception\Module as CodeceptionModule;
+use Codeception\TestInterface;
 
 /**
  * Wrapper for basic shell commands and shell output
@@ -19,7 +20,7 @@ class Cli extends CodeceptionModule
 
     public $result = null;
 
-    public function _cleanup()
+    public function _before(TestInterface $test)
     {
         $this->output = '';
     }

--- a/src/Codeception/Module/Db.php
+++ b/src/Codeception/Module/Db.php
@@ -372,7 +372,7 @@ class Db extends CodeceptionModule implements DbInterface
     protected function loadDumpUsingDriver()
     {
         if (!$this->sql) {
-            $this->debugSection('Db','No SQL loaded, loading dump skipped');
+            $this->debugSection('Db', 'No SQL loaded, loading dump skipped');
             return;
         }
         $this->driver->load($this->sql);

--- a/src/Codeception/Module/Db.php
+++ b/src/Codeception/Module/Db.php
@@ -372,6 +372,7 @@ class Db extends CodeceptionModule implements DbInterface
     protected function loadDumpUsingDriver()
     {
         if (!$this->sql) {
+            $this->debugSection('Db','No SQL loaded, loading dump skipped');
             return;
         }
         $this->driver->load($this->sql);

--- a/src/Codeception/Subscriber/Module.php
+++ b/src/Codeception/Subscriber/Module.php
@@ -53,7 +53,6 @@ class Module implements EventSubscriberInterface
         }
 
         foreach ($this->modules as $module) {
-            $module->_cleanup();
             $module->_resetConfig();
             $module->_before($event->getTest());
         }

--- a/tests/unit/Codeception/Module/PhpBrowserTest.php
+++ b/tests/unit/Codeception/Module/PhpBrowserTest.php
@@ -21,7 +21,6 @@ class PhpBrowserTest extends TestsForBrowsers
         $url = 'http://localhost:8000';
         $this->module->_setConfig(array('url' => $url));
         $this->module->_initialize();
-        $this->module->_cleanup();
         $this->module->_before($this->makeTest());
         if (class_exists('GuzzleHttp\Url')) {
             $this->history = new \GuzzleHttp\Subscriber\History();

--- a/tests/unit/Codeception/Module/TestsForWeb.php
+++ b/tests/unit/Codeception/Module/TestsForWeb.php
@@ -20,7 +20,6 @@ abstract class TestsForWeb extends \Codeception\TestCase\Test
         $this->module->amOnPage('/');
         $this->module->see('Welcome to test app!');
 
-        $this->module->_cleanup();
         $this->module->amOnPage('/info');
         $this->module->see('Information');
     }


### PR DESCRIPTION
While refactoring Db module I accidentally hit the old API and this made accidentally call database cleanups before each test without considering a `cleanup` option. This happened because `_cleanup` method was called before each test as part of the initialization process of a module (no one used it actually).

