### PR TITLE
Fix autoloading with PHPUnit 6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -64,7 +64,10 @@
         "psr-4":{
             "Codeception\\": "src\\Codeception",
             "Codeception\\Extension\\": "ext"
-        }
+        },
+        "files": [
+            "shim.php"
+        ]
     },
     "extra": {
         "branch-alias": {


### PR DESCRIPTION
My builds on Travis are failing because composer autoloading doesn't work correctly for PHPUnit 6.

```
PHP Fatal error:  Interface 'PHPUnit_Framework_Test' not found in ...\vendor\codeception\codeception\src\Codeception\TestInterface.php on line 7
```

So far the only fix I found was to add `"files": ["vendor/codeception/codeception/shim.php"]` to my `autoload-dev` in composer.json. This commit should fix the issue.