### PR TITLE
Update WebDriver:makeScreenshot to accept noname

### DIFF
--- a/src/Codeception/Module/WebDriver.php
+++ b/src/Codeception/Module/WebDriver.php
@@ -640,13 +640,16 @@ class WebDriver extends CodeceptionModule implements
      * $I->amOnPage('/user/edit');
      * $I->makeScreenshot('edit_page');
      * // saved to: tests/_output/debug/edit_page.png
+     * $I->makeScreenshot();
+     * // saved to: tests/_output/debug/2017-05-26_14-24-11.png
      * ?>
      * ```
      *
      * @param $name
      */
-    public function makeScreenshot($name)
+    public function makeScreenshot($name = null)
     {
+        $name = ($name) ? $name : date("Y-m-d_H-i-s");
         $debugDir = codecept_log_dir() . 'debug';
         if (!is_dir($debugDir)) {
             mkdir($debugDir, 0777);

--- a/src/Codeception/Module/WebDriver.php
+++ b/src/Codeception/Module/WebDriver.php
@@ -649,7 +649,9 @@ class WebDriver extends CodeceptionModule implements
      */
     public function makeScreenshot($name = null)
     {
-        $name = ($name) ? $name : date("Y-m-d_H-i-s");
+        if (empty($name)) {
+            $name = uniqid(date("Y-m-d_H-i-s"));
+        }
         $debugDir = codecept_log_dir() . 'debug';
         if (!is_dir($debugDir)) {
             mkdir($debugDir, 0777);

--- a/src/Codeception/Module/WebDriver.php
+++ b/src/Codeception/Module/WebDriver.php
@@ -641,7 +641,7 @@ class WebDriver extends CodeceptionModule implements
      * $I->makeScreenshot('edit_page');
      * // saved to: tests/_output/debug/edit_page.png
      * $I->makeScreenshot();
-     * // saved to: tests/_output/debug/2017-05-26_14-24-11.png
+     * // saved to: tests/_output/debug/2017-05-26_14-24-11_4b3403665fea6.png
      * ?>
      * ```
      *
@@ -650,7 +650,7 @@ class WebDriver extends CodeceptionModule implements
     public function makeScreenshot($name = null)
     {
         if (empty($name)) {
-            $name = uniqid(date("Y-m-d_H-i-s"));
+            $name = uniqid(date("Y-m-d_H-i-s_"));
         }
         $debugDir = codecept_log_dir() . 'debug';
         if (!is_dir($debugDir)) {


### PR DESCRIPTION
Hello,

Currently, makeScreenshot of WebDriver require a name to save a file.

This little PR accept noname.

$I->makeScreenshot('edit_page'); //saved to: tests/_output/debug/edit_page.png
$I->makeScreenshot(); //saved to: tests/_output/debug/2017-05-26_14-24-11.png

What do you think ?

 