### PR TITLE
Explain the naming philosophy

### DIFF
--- a/docs/02-GettingStarted.md
+++ b/docs/02-GettingStarted.md
@@ -5,6 +5,30 @@ and bootstrapped your first test suites. Codeception has generated three of them
 They are well described in the [previous chapter](http://codeception.com/docs/01-Introduction). Inside your __/tests__ folder you will have three `.yml` config files and three directories
 with names corresponding to these suites: `unit`, `functional`, `acceptance`. Suites are independent groups of tests with a common purpose.
 
+## The Codeception Syntax
+
+Codeception follows simple naming rules to make it easy to remember (as well as easy to understand) its method names.
+
+* **Actions** start with a plain english verb, like "click" or "fill". Examples:
+    ```php
+    $I->click('Login');
+    $I->fillFiled('#input-username', 'John Dough');
+    $i->pressKey('#input-remarks', 'foo');
+    ```
+* **Assertions** always start with "see" or "dontSee". Examples:
+    ```php
+    $I->see('Welcome');
+    $I->seeInTitle('My Company');
+    $i->seeElement('nav');
+    $i->dontSeeElement('#error-message');
+    $i->dontSeeInPageSource('<section class="foo">');
+    ```
+* Methods that just *grab* something off the page, but don't process it, start with "grab". The return value of those are meant to be saved as variables and used later. Example:
+    ```php
+    $method = $I->grabAttributeFrom('#login-form', 'method');
+    $I->assertEquals('post', $method);
+    ```
+
 ## Actors
 
 One of the main concepts of Codeception is representation of tests as actions of a person.

--- a/docs/02-GettingStarted.md
+++ b/docs/02-GettingStarted.md
@@ -39,7 +39,7 @@ We have a UnitTester, who executes functions and tests the code. We also have a 
 who tests the application as a whole, with knowledge of its internals. Lastly we have an AcceptanceTester, a user who works with our application
 through an interface that we provide.
 
-Actor classes are not written but generated from suite configuration. **Methods of actor classes are generally taken from [Codeception Modules](http://codeception.com/docs/06-ModulesAndHelpers)**.
+**Methods of actor classes are generally taken from [Codeception Modules](http://codeception.com/docs/06-ModulesAndHelpers)**.
 Each module provides predefined actions for different testing purposes, and they can be combined to fit the testing environment.
 Codeception tries to solve 90% of possible testing issues in its modules, so you don't have to reinvent the wheel.
 We think that you can spend more time on writing tests and less on writing support code to make those tests run.

--- a/docs/02-GettingStarted.md
+++ b/docs/02-GettingStarted.md
@@ -11,20 +11,23 @@ Codeception follows simple naming rules to make it easy to remember (as well as 
 
 * **Actions** start with a plain english verb, like "click" or "fill". Examples:
     ```php
+    <?php
     $I->click('Login');
     $I->fillFiled('#input-username', 'John Dough');
     $i->pressKey('#input-remarks', 'foo');
     ```
 * **Assertions** always start with "see" or "dontSee". Examples:
     ```php
+    <?php
     $I->see('Welcome');
     $I->seeInTitle('My Company');
     $i->seeElement('nav');
     $i->dontSeeElement('#error-message');
     $i->dontSeeInPageSource('<section class="foo">');
     ```
-* Methods that just *grab* something off the page, but don't process it, start with "grab". The return value of those are meant to be saved as variables and used later. Example:
+* **Grabbers** just *read* something from the page, but don't process it. The return value of those are meant to be saved as variables and used later. Example:
     ```php
+    <?php
     $method = $I->grabAttributeFrom('#login-form', 'method');
     $I->assertEquals('post', $method);
     ```


### PR DESCRIPTION
I don't know if this is the right place. But there should be a short introduction like this. Please make this section (i.e. anchor) the link target for codeception.com "User Centric Tests => Learn more"

Details:

* grab: Is there an easier exmple you can think of? One that doesn't require the Asserts Module?

* Missing in the list is "have" and maybe "expect". Maybe I can convince you to change those :-) See https://github.com/Codeception/Codeception/issues/4257

I'd like to rewrite the next section (Actors) too. Questions:

* I guess the term "Actor" is a leftover from previous versions of Codeception? More precise: Today, it's not really important (anymore) to know the term "Actor", is it?

* What do you mean by "Actor classes are not written but generated from suite configuration." => That they are *generated* automatically?