### PR TITLE
Fixing error

### DIFF
--- a/src/Codeception/Lib/Interfaces/Web.php
+++ b/src/Codeception/Lib/Interfaces/Web.php
@@ -109,7 +109,7 @@ interface Web
     public function dontSeeInSource($raw);
 
     /**
-     * Submits the given form on the page, optionally with the given form
+     * Submits the given form on the page, with the given form
      * values.  Pass the form field's values as an array in the second
      * parameter.
      *


### PR DESCRIPTION
params are not optional, but mandatory: https://github.com/Codeception/Codeception/blob/2.3/src/Codeception/Lib/Interfaces/Web.php#L282