### PR TITLE
Fixing error

### DIFF
--- a/src/Codeception/Module/Doctrine2.php
+++ b/src/Codeception/Module/Doctrine2.php
@@ -461,7 +461,7 @@ EOF;
      * @version 1.1
      * @param $entity
      * @param array $params
-     * @return array
+     * @return object
      */
     public function grabEntityFromRepository($entity, $params = [])
     {


### PR DESCRIPTION
`getSingleResult()` does not return an array, but a single entity (as object): http://docs.doctrine-project.org/projects/doctrine-orm/en/latest/reference/dql-doctrine-query-language.html#query-result-formats