### PR TITLE
Temporary constraint for symfony/console to stop builds breaking

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         "guzzlehttp/guzzle": ">=4.1.4 <7.0",
         "guzzlehttp/psr7": "~1.0",
         "symfony/finder": ">=2.7 <4.0",
-        "symfony/console": ">=2.7 <4.0",
+        "symfony/console": ">=2.7 <3.3",
         "symfony/event-dispatcher": ">=2.7 <4.0",
         "symfony/yaml": ">=2.7 <4.0",
         "symfony/browser-kit": ">=2.7 <4.0",


### PR DESCRIPTION
#4277

A real fix is necessary, but this is good as a temporary measure.