### PR TITLE
Fixed Facebook test, removed _cleanup() from module docs

### DIFF
--- a/docs/06-ModulesAndHelpers.md
+++ b/docs/06-ModulesAndHelpers.md
@@ -318,39 +318,43 @@ All hooks are defined in [Codeception\Module](http://codeception.com/docs/refere
 <?php
 
     // HOOK: used after configuration is loaded
-    public function _initialize() {
-    }
-
-    // HOOK: on every Actor class initialization
-    public function _cleanup() {
+    public function _initialize() 
+    {
     }
 
     // HOOK: before each suite
-    public function _beforeSuite($settings = array()) {
+    public function _beforeSuite($settings = array()) 
+    {
     }
 
     // HOOK: after suite
-    public function _afterSuite() {
+    public function _afterSuite() 
+    {
     }
 
     // HOOK: before each step
-    public function _beforeStep(\Codeception\Step $step) {
+    public function _beforeStep(\Codeception\Step $step) 
+    {
     }
 
     // HOOK: after each step
-    public function _afterStep(\Codeception\Step $step) {
+    public function _afterStep(\Codeception\Step $step) 
+    {
     }
 
     // HOOK: before test
-    public function _before(\Codeception\TestInterface $test) {
+    public function _before(\Codeception\TestInterface $test) 
+    {
     }
 
     // HOOK: after test
-    public function _after(\Codeception\TestInterface $test) {
+    public function _after(\Codeception\TestInterface $test) 
+    {
     }
 
     // HOOK: on fail
-    public function _failed(\Codeception\TestInterface $test, $fail) {
+    public function _failed(\Codeception\TestInterface $test, $fail) 
+    {
     }
 ```
 

--- a/tests/facebook/FacebookTest.php
+++ b/tests/facebook/FacebookTest.php
@@ -162,7 +162,6 @@ class FacebookTest extends \PHPUnit_Framework_TestCase
     {
         $browserModule->_setConfig($params);
         $browserModule->_initialize();
-        $browserModule->_cleanup();
         $browserModule->_before($this->makeTest());
     }
 }


### PR DESCRIPTION
Removed `_cleanup()` in  Facebook tests and in reference