### PR TITLE
Symfony::extractRawRoles() failed on security collector from Symfony >= 3.3

### DIFF
--- a/src/Codeception/Module/Symfony.php
+++ b/src/Codeception/Module/Symfony.php
@@ -521,8 +521,7 @@ class Symfony extends Framework implements DoctrineProvider, PartedModule
      */
     private function extractRawRoles(Data $data)
     {
-        // prior to Symfony 3.3
-        if (method_exists($data, 'getValue')) {
+        if ($this->dataIsFromSymfony3_3($data)) {
             $roles = $data->getValue();
         } else {
             $raw = $data->getRawData();
@@ -578,5 +577,17 @@ class Symfony extends Framework implements DoctrineProvider, PartedModule
         if ($this->client) {
             $this->client->rebootKernel();
         }
+    }
+
+    /**
+     * Public API from Data changed from Symfony 3.2 to 3.3.
+     *
+     * @param \Symfony\Component\VarDumper\Cloner\Data $data
+     *
+     * @return bool
+     */
+    private function dataIsFromSymfony3_3(Data $data): bool
+    {
+        return method_exists($data, 'getValue');
     }
 }

--- a/src/Codeception/Module/Symfony.php
+++ b/src/Codeception/Module/Symfony.php
@@ -521,7 +521,7 @@ class Symfony extends Framework implements DoctrineProvider, PartedModule
      */
     private function extractRawRoles(Data $data)
     {
-        if ($this->dataIsFromSymfony33($data)) {
+        if ($this->dataRevealsValue($data)) {
             $roles = $data->getValue();
         } else {
             $raw = $data->getRawData();
@@ -586,7 +586,7 @@ class Symfony extends Framework implements DoctrineProvider, PartedModule
      *
      * @return bool
      */
-    private function dataIsFromSymfony33(Data $data)
+    private function dataRevealsValue(Data $data)
     {
         return method_exists($data, 'getValue');
     }

--- a/src/Codeception/Module/Symfony.php
+++ b/src/Codeception/Module/Symfony.php
@@ -521,9 +521,16 @@ class Symfony extends Framework implements DoctrineProvider, PartedModule
      */
     private function extractRawRoles(Data $data)
     {
-        $raw = $data->getRawData();
+        // prior to Symfony 3.3
+        if (method_exists($data, 'getValue')) {
+            $roles = $data->getValue();
+        }
+        else {
+            $raw = $data->getRawData();
+            $roles = isset($raw[1]) ? $raw[1] : [];
+        }
 
-        return isset($raw[1]) ? $raw[1] : [];
+        return $roles;
     }
 
     /**

--- a/src/Codeception/Module/Symfony.php
+++ b/src/Codeception/Module/Symfony.php
@@ -524,8 +524,7 @@ class Symfony extends Framework implements DoctrineProvider, PartedModule
         // prior to Symfony 3.3
         if (method_exists($data, 'getValue')) {
             $roles = $data->getValue();
-        }
-        else {
+        } else {
             $raw = $data->getRawData();
             $roles = isset($raw[1]) ? $raw[1] : [];
         }

--- a/src/Codeception/Module/Symfony.php
+++ b/src/Codeception/Module/Symfony.php
@@ -521,7 +521,7 @@ class Symfony extends Framework implements DoctrineProvider, PartedModule
      */
     private function extractRawRoles(Data $data)
     {
-        if ($this->dataIsFromSymfony3_3($data)) {
+        if ($this->dataIsFromSymfony33($data)) {
             $roles = $data->getValue();
         } else {
             $raw = $data->getRawData();
@@ -586,7 +586,7 @@ class Symfony extends Framework implements DoctrineProvider, PartedModule
      *
      * @return bool
      */
-    private function dataIsFromSymfony3_3(Data $data): bool
+    private function dataIsFromSymfony33(Data $data)
     {
         return method_exists($data, 'getValue');
     }


### PR DESCRIPTION
When extracting roles from security collector, you can simply utilize the getValue method of Data class, when it exists.