### PR TITLE
Webdriver method for setting capabilities, starting and closing session

### DIFF
--- a/src/Codeception/Lib/Interfaces/MultiSession.php
+++ b/src/Codeception/Lib/Interfaces/MultiSession.php
@@ -9,7 +9,7 @@ interface MultiSession
 
     public function _backupSession();
 
-    public function _closeSession($session);
+    public function _closeSession($session = null);
 
     public function _getName();
 }

--- a/src/Codeception/Module/PhpBrowser.php
+++ b/src/Codeception/Module/PhpBrowser.php
@@ -281,7 +281,7 @@ class PhpBrowser extends InnerBrowser implements Remote, MultiSession, RequiresP
         }
     }
 
-    public function _closeSession($session)
+    public function _closeSession($session = null)
     {
         unset($session);
     }

--- a/src/Codeception/Module/WebDriver.php
+++ b/src/Codeception/Module/WebDriver.php
@@ -363,7 +363,7 @@ class WebDriver extends CodeceptionModule implements
      * }
      * ```
      *
-     * to make this work load `\Helper\Acceptance` before WebDriver in `acceptance.suite.yml`:
+     * to make this work load `\Helper\Acceptance` before `WebDriver` in `acceptance.suite.yml`:
      *
      * ```yaml
      * modules:
@@ -372,7 +372,6 @@ class WebDriver extends CodeceptionModule implements
      *         - WebDriver
      * ```
      *
-     * To change capabilities before each test this should be added used by a helper loaded before the WebDriver module.
      * For instance, [**BrowserStack** cloud service](https://www.browserstack.com/automate/capabilities) may require a test name to be set in capabilities.
      * This is how it can be done via `_capabilities` method from `Helper\Acceptance`:
      *
@@ -408,8 +407,8 @@ class WebDriver extends CodeceptionModule implements
         $this->setBaseElement();
 
         $test->getMetadata()->setCurrent([
-            'browser' => $this->config['browser'],
-            'capabilities' => $this->config['capabilities']
+            'browser' => $this->webDriver->getCapabilities()->getBrowserName(),
+            'capabilities' => $this->webDriver->getCapabilities()->toArray()
         ]);
     }
 
@@ -711,7 +710,6 @@ class WebDriver extends CodeceptionModule implements
      * // saved to: tests/_output/debug/edit_page.png
      * $I->makeScreenshot();
      * // saved to: tests/_output/debug/2017-05-26_14-24-11_4b3403665fea6.png
-     * ?>
      * ```
      *
      * @param $name

--- a/src/Codeception/Module/WebDriver.php
+++ b/src/Codeception/Module/WebDriver.php
@@ -196,6 +196,7 @@ use Symfony\Component\DomCrawler\Crawler;
  * * `host` - Selenium server host (127.0.0.1 by default).
  * * `port` - Selenium server port (4444 by default).
  * * `restart` - Set to `false` (default) to use the same browser window for all tests, or set to `true` to create a new window for each test. In any case, when all tests are finished the browser window is closed.
+ * * `start` - Autostart a browser for tests. Can be disabled if browser session is started with `_initializeSession` inside a Helper.
  * * `window_size` - Initial window size. Set to `maximize` or a dimension in the format `640x480`.
  * * `clear_cookies` - Set to false to keep cookies, or set to true (default) to delete all cookies between tests.
  * * `wait` - Implicit wait (default 0 seconds).
@@ -289,6 +290,7 @@ class WebDriver extends CodeceptionModule implements
         'host'               => '127.0.0.1',
         'port'               => '4444',
         'path'               => '/wd/hub',
+        'start'              => true,
         'restart'            => false,
         'wait'               => 0,
         'clear_cookies'      => true,
@@ -400,7 +402,7 @@ class WebDriver extends CodeceptionModule implements
 
     public function _before(TestInterface $test)
     {
-        if (!isset($this->webDriver)) {
+        if (!isset($this->webDriver) && $this->config['start']) {
             $this->_initializeSession();
         }
         $this->setBaseElement();

--- a/tests/web.suite.yml
+++ b/tests/web.suite.yml
@@ -35,13 +35,13 @@ env:
               args: ["--headless", "--disable-gpu", "--disable-extensions"]
               binary: "/usr/bin/google-chrome"
   chromedriver:
-modules:
-  config:
-    WebDriver:
-      browser: chrome
-      port: 9515 # ChromeDriver port
-      window_size: false
-      capabilities:
-        chromeOptions:
-          args: ["--headless", "--disable-gpu"]
-          binary: "/usr/bin/google-chrome"
+    modules:
+      config:
+        WebDriver:
+          browser: chrome
+          port: 9515 # ChromeDriver port
+          window_size: false
+          capabilities:
+            chromeOptions:
+              args: ["--headless", "--disable-gpu"]
+              binary: "/usr/bin/google-chrome"

--- a/tests/web/WebDriverTest.php
+++ b/tests/web/WebDriverTest.php
@@ -1034,4 +1034,15 @@ HTML
         $sourceActual = str_replace('xmlns="http://www.w3.org/1999/xhtml"', '', $sourceActualRaw);
         $this->assertXmlStringEqualsXmlString($sourceExpected, $sourceActual);
     }
+
+    public function testChangingCapabilities()
+    {
+        $this->notForPhantomJS();
+        $this->module->_closeSession();
+        $this->module->_capabilities(['unexpectedAlertBehaviour' => 'accept']);
+        $this->module->_initializeSession();
+        $this->module->amOnPage('/form/popup');
+        $this->module->click('Alert');
+
+    }
 }

--- a/tests/web/WebDriverTest.php
+++ b/tests/web/WebDriverTest.php
@@ -1039,13 +1039,13 @@ HTML
     public function testChangingCapabilities()
     {
         $this->notForPhantomJS();
-        $this->assertFalse($this->module->webDriver->getCapabilities()->getCapability('acceptInsecureCerts'));
+        $this->assertNotTrue($this->module->webDriver->getCapabilities()->getCapability('acceptInsecureCerts'));
         $this->module->_closeSession();
         $this->module->_capabilities(function($current) {
             $current['acceptInsecureCerts'] = true;
             return new DesiredCapabilities($current);
         });
-        $this->assertFalse($this->module->webDriver->getCapabilities()->getCapability('acceptInsecureCerts'));
+        $this->assertNotTrue($this->module->webDriver->getCapabilities()->getCapability('acceptInsecureCerts'));
         $this->module->_initializeSession();
         $this->assertTrue(true, $this->module->webDriver->getCapabilities()->getCapability('acceptInsecureCerts'));
     }

--- a/tests/web/WebDriverTest.php
+++ b/tests/web/WebDriverTest.php
@@ -2,6 +2,7 @@
 
 use Codeception\Step;
 use Codeception\Util\Stub;
+use Facebook\WebDriver\Remote\DesiredCapabilities;
 use Facebook\WebDriver\Remote\RemoteWebDriver;
 use Facebook\WebDriver\WebDriverBy;
 use Facebook\WebDriver\WebDriverKeys;
@@ -1038,11 +1039,14 @@ HTML
     public function testChangingCapabilities()
     {
         $this->notForPhantomJS();
+        $this->assertFalse($this->module->webDriver->getCapabilities()->getCapability('acceptInsecureCerts'));
         $this->module->_closeSession();
-        $this->module->_capabilities(['unexpectedAlertBehaviour' => 'accept']);
+        $this->module->_capabilities(function($current) {
+            $current['acceptInsecureCerts'] = true;
+            return new DesiredCapabilities($current);
+        });
+        $this->assertFalse($this->module->webDriver->getCapabilities()->getCapability('acceptInsecureCerts'));
         $this->module->_initializeSession();
-        $this->module->amOnPage('/form/popup');
-        $this->module->click('Alert');
-
+        $this->assertTrue(true, $this->module->webDriver->getCapabilities()->getCapability('acceptInsecureCerts'));
     }
 }


### PR DESCRIPTION
* added `start` option to disable autostart of a browser for tests. (can be useful for Cloud testing setups)
* added _capabilities method for setting desired capabilities in runtime
* `_initializeSession` and `_closeSession` added to public api of WebDriver
* added _closeSession null option to close the default session
* added few more environments to web.suite.yml