### PR TITLE
Added RunProcess extension

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -49,7 +49,7 @@
         "predis/predis": "^1.0",
         "squizlabs/php_codesniffer": "~2.0",
         "vlucas/phpdotenv": "^2.4.0",
-        "symfony/process": "^3.3"
+        "symfony/process": ">=2.7 <4.0"
     },
     "suggest": {
         "codeception/specify": "BDD-style code blocks",

--- a/composer.json
+++ b/composer.json
@@ -48,7 +48,8 @@
         "mongodb/mongodb": "^1.0",
         "predis/predis": "^1.0",
         "squizlabs/php_codesniffer": "~2.0",
-        "vlucas/phpdotenv": "^2.4.0"
+        "vlucas/phpdotenv": "^2.4.0",
+        "symfony/process": "^3.3"
     },
     "suggest": {
         "codeception/specify": "BDD-style code blocks",

--- a/ext/RunProcess.php
+++ b/ext/RunProcess.php
@@ -1,0 +1,104 @@
+<?php
+
+namespace Codeception\Extension;
+
+use Codeception\Exception\ExtensionException;
+use Codeception\Extension;
+use Symfony\Component\Process\Process;
+
+/**
+ * Extension to start and stop processes per suite.
+ * Can be used to start/stop selenium server, chromedriver, phantomjs, mailcatcher, etc.
+ *
+ * Can be configured in suite config:
+ *
+ * ```yaml
+ * # acceptance.suite.yml
+ * extensions:
+ *     enabled:
+ *         - Codeception\Extension\RunProcess:
+ *             - chromedriver
+ * ```
+ *
+ * Multiple parameters can be passed as array:
+ *
+ * ```yaml
+ * # acceptance.suite.yml
+ *
+ * extensions:
+ *     enabled:
+ *         - Codeception\Extension\RunProcess:
+ *             - php -S 127.0.0.1:8000 -t tests/data/app
+ *             - java -jar ~/selenium-server.jar
+ * ```
+ *
+ * In the end of a suite all launched processes will be stopped.
+ *
+ * To wait for the process to be launched use `sleep` option.
+ * In this case you need configuration to be specified as object:
+ *
+ * ```yaml
+ * extensions:
+ *     enabled:
+ *         - Codeception\Extension\RunProcess:
+ *             0: java -jar ~/selenium-server.jar
+ *             1: mailcatcher
+ *             sleep: 5 # wait 5 seconds for processes to boot
+ * ```
+ *
+ * HINT: you can use different configurations per environment.
+ */
+class RunProcess extends Extension
+{
+    public $config = ['sleep' => 0];
+    
+    static $events = [
+        'suite.before' => 'runProcess',
+        'suite.after' => 'stopProcess'
+    ];
+
+    protected $processes = [];
+    
+    public function _initialize()
+    {
+        if (!class_exists('Symfony\Component\Process\Process')) {
+            throw new ExtensionException($this, 'symfony/process package is required');
+        }
+    }
+
+    public function runProcess()
+    {
+        $this->processes = [];
+        foreach ($this->config as $key => $command) {
+            if (!$command) {
+                continue;
+            }
+            if (!is_int($key)) {
+                continue; // configuration options
+            }
+            $process = new Process($command, $this->getRootDir(), null, null, null);
+            $process->start();
+            $this->processes[] = $process;
+            $this->output->debug('[RunProcess] Starting '.$command);
+        }
+        sleep($this->config['sleep']);
+    }
+
+    public function __destruct()
+    {
+        $this->stopProcess();
+    }
+
+    public function stopProcess()
+    {
+        foreach (array_reverse($this->processes) as $process) {
+            /** @var $process Process  **/
+            if (!$process->isRunning()) {
+                continue;
+            }
+            $this->output->debug('[RunProcess] Stopping ' . $process->getCommandLine());
+            $process->stop();
+        }
+        $this->processes = [];
+    }
+}

--- a/ext/RunProcess.php
+++ b/ext/RunProcess.php
@@ -2,6 +2,7 @@
 
 namespace Codeception\Extension;
 
+use Codeception\Events;
 use Codeception\Exception\ExtensionException;
 use Codeception\Extension;
 use Symfony\Component\Process\Process;
@@ -53,8 +54,8 @@ class RunProcess extends Extension
     public $config = ['sleep' => 0];
     
     static $events = [
-        'suite.before' => 'runProcess',
-        'suite.after' => 'stopProcess'
+        Events::SUITE_BEFORE => 'runProcess',
+        Events::SUITE_AFTER => 'stopProcess'
     ];
 
     protected $processes = [];


### PR DESCRIPTION
This extension allows in a simple way to start and stop background processes. 
It is useful for launching Selenium, PhantomJS, etc.