### PR TITLE
Clarified docblock of `seeInField`

### DIFF
--- a/src/Codeception/Lib/Interfaces/Web.php
+++ b/src/Codeception/Lib/Interfaces/Web.php
@@ -480,8 +480,8 @@ interface Web
     public function dontSeeCheckboxIsChecked($checkbox);
 
     /**
-     * Checks that the given input field or textarea contains the given value.
-     * For fuzzy locators, fields are matched by label text, the "name" attribute, CSS, and XPath.
+     * Checks that the given input field or textarea *equals* (i.e. not just contains) the given value.
+     * Fields are matched by label text, the "name" attribute, CSS, or XPath.
      *
      * ``` php
      * <?php


### PR DESCRIPTION
Please double-check if this is true! And what does `dontSeeInField` do?: `!==` or `does not contain`?