### PR TITLE
Print debug information for started/stopped transactions in tests

### DIFF
--- a/src/Codeception/Module/Doctrine2.php
+++ b/src/Codeception/Module/Doctrine2.php
@@ -111,7 +111,7 @@ EOF;
         $this->retrieveEntityManager();
         if ($this->config['cleanup']) {
             $this->em->getConnection()->beginTransaction();
-            $this->debugSection('Transaction', 'Started');
+            $this->debugSection('Database', 'Transaction started');
         }
     }
 
@@ -156,7 +156,7 @@ EOF;
         if ($this->config['cleanup'] && $this->em->getConnection()->isTransactionActive()) {
             try {
                 $this->em->getConnection()->rollback();
-                $this->debugSection('Transaction', 'Stopped. Changes reverted');
+                $this->debugSection('Database', 'Transaction cancelled; all changes reverted.');
             } catch (\PDOException $e) {
             }
         }

--- a/src/Codeception/Module/Doctrine2.php
+++ b/src/Codeception/Module/Doctrine2.php
@@ -111,6 +111,7 @@ EOF;
         $this->retrieveEntityManager();
         if ($this->config['cleanup']) {
             $this->em->getConnection()->beginTransaction();
+            $this->debugSection('Transaction', 'Started');
         }
     }
 
@@ -155,6 +156,7 @@ EOF;
         if ($this->config['cleanup'] && $this->em->getConnection()->isTransactionActive()) {
             try {
                 $this->em->getConnection()->rollback();
+                $this->debugSection('Transaction', 'Stopped. Changes reverted');
             } catch (\PDOException $e) {
             }
         }

--- a/src/Codeception/Module/Laravel5.php
+++ b/src/Codeception/Module/Laravel5.php
@@ -175,8 +175,7 @@ class Laravel5 extends Framework implements ActiveRecord, PartedModule
 
         if ($this->applicationUsesDatabase() && $this->config['cleanup']) {
             $this->app['db']->beginTransaction();
-            $this->debugSection('Transaction', 'Started');
-
+            $this->debugSection('Database', 'Transaction started');
         }
 
         if ($this->config['run_database_seeder']) {
@@ -197,7 +196,7 @@ class Laravel5 extends Framework implements ActiveRecord, PartedModule
             if ($db instanceof \Illuminate\Database\DatabaseManager) {
                 if ($this->config['cleanup']) {
                     $db->rollback();
-                    $this->debugSection('Transaction', 'Stopped. Changes reverted');
+                    $this->debugSection('Database', 'Transaction cancelled; all changes reverted.');
                 }
 
                 /**

--- a/src/Codeception/Module/Laravel5.php
+++ b/src/Codeception/Module/Laravel5.php
@@ -175,6 +175,8 @@ class Laravel5 extends Framework implements ActiveRecord, PartedModule
 
         if ($this->applicationUsesDatabase() && $this->config['cleanup']) {
             $this->app['db']->beginTransaction();
+            $this->debugSection('Transaction', 'Started');
+
         }
 
         if ($this->config['run_database_seeder']) {
@@ -195,6 +197,7 @@ class Laravel5 extends Framework implements ActiveRecord, PartedModule
             if ($db instanceof \Illuminate\Database\DatabaseManager) {
                 if ($this->config['cleanup']) {
                     $db->rollback();
+                    $this->debugSection('Transaction', 'Stopped. Changes reverted');
                 }
 
                 /**

--- a/src/Codeception/Module/Phalcon.php
+++ b/src/Codeception/Module/Phalcon.php
@@ -170,7 +170,7 @@ class Phalcon extends Framework implements ActiveRecord, PartedModule
                 $this->di['db']->setNestedTransactionsWithSavepoints(true);
             }
             $this->di['db']->begin();
-            $this->debugSection('Transaction', 'Started');
+            $this->debugSection('Database', 'Transaction started');
         }
 
         // localize
@@ -205,7 +205,7 @@ class Phalcon extends Framework implements ActiveRecord, PartedModule
                 $level = $this->di['db']->getTransactionLevel();
                 try {
                     $this->di['db']->rollback(true);
-                    $this->debugSection('Transaction', 'Stopped. Changes reverted');
+                    $this->debugSection('Database', 'Transaction cancelled; all changes reverted.');
                 } catch (PDOException $e) {
                 }
                 if ($level == $this->di['db']->getTransactionLevel()) {

--- a/src/Codeception/Module/Phalcon.php
+++ b/src/Codeception/Module/Phalcon.php
@@ -170,6 +170,7 @@ class Phalcon extends Framework implements ActiveRecord, PartedModule
                 $this->di['db']->setNestedTransactionsWithSavepoints(true);
             }
             $this->di['db']->begin();
+            $this->debugSection('Transaction', 'Started');
         }
 
         // localize
@@ -204,6 +205,7 @@ class Phalcon extends Framework implements ActiveRecord, PartedModule
                 $level = $this->di['db']->getTransactionLevel();
                 try {
                     $this->di['db']->rollback(true);
+                    $this->debugSection('Transaction', 'Stopped. Changes reverted');
                 } catch (PDOException $e) {
                 }
                 if ($level == $this->di['db']->getTransactionLevel()) {

--- a/src/Codeception/Module/Yii2.php
+++ b/src/Codeception/Module/Yii2.php
@@ -189,7 +189,7 @@ class Yii2 extends Framework implements ActiveRecord, PartedModule
             && $this->app->db instanceof \yii\db\Connection
         ) {
             $this->transaction = $this->app->db->beginTransaction();
-            $this->debugSection('Transaction', 'Started');
+            $this->debugSection('Database', 'Transaction started');
         }
     }
 
@@ -224,7 +224,7 @@ class Yii2 extends Framework implements ActiveRecord, PartedModule
 
             if ($this->transaction) {
                 $this->transaction->rollback();
-                $this->debugSection('Transaction', 'Stopped. Changes reverted');
+                $this->debugSection('Database', 'Transaction cancelled; all changes reverted.');
             }
         }
 

--- a/src/Codeception/Module/Yii2.php
+++ b/src/Codeception/Module/Yii2.php
@@ -189,6 +189,7 @@ class Yii2 extends Framework implements ActiveRecord, PartedModule
             && $this->app->db instanceof \yii\db\Connection
         ) {
             $this->transaction = $this->app->db->beginTransaction();
+            $this->debugSection('Transaction', 'Started');
         }
     }
 
@@ -223,6 +224,7 @@ class Yii2 extends Framework implements ActiveRecord, PartedModule
 
             if ($this->transaction) {
                 $this->transaction->rollback();
+                $this->debugSection('Transaction', 'Stopped. Changes reverted');
             }
         }
 


### PR DESCRIPTION
Following the proposal from @ThomasLandauer  https://github.com/Codeception/Codeception/issues/4326#issuecomment-309429330
I added debug notifications when transaction is started for tests.

Probably the message should be improved, so suggestions are welcome