### PR TITLE
Minor formating

### DIFF
--- a/src/Codeception/Lib/Interfaces/Web.php
+++ b/src/Codeception/Lib/Interfaces/Web.php
@@ -700,7 +700,7 @@ interface Web
     public function fillField($field, $value);
 
     /**
-     * Attaches a file relative to the Codeception data directory to the given file upload field.
+     * Attaches a file relative to the Codeception `_data` directory to the given file upload field.
      *
      * ``` php
      * <?php

--- a/src/Codeception/Module/WebDriver.php
+++ b/src/Codeception/Module/WebDriver.php
@@ -1831,7 +1831,7 @@ class WebDriver extends CodeceptionModule implements
     }
 
     /**
-     * Dismisses the active JavaScript popup, as created by `window.alert`|`window.confirm`|`window.prompt`.
+     * Dismisses the active JavaScript popup, as created by `window.alert`, `window.confirm`, or `window.prompt`.
      */
     public function cancelPopup()
     {


### PR DESCRIPTION
The `|` letters were rendered as a table