### PR TITLE
PageConstraint:uriMessage always returns Message

### DIFF
--- a/src/Codeception/PHPUnit/Constraint/Page.php
+++ b/src/Codeception/PHPUnit/Constraint/Page.php
@@ -71,7 +71,7 @@ class Page extends \PHPUnit_Framework_Constraint
     protected function uriMessage($onPage = "")
     {
         if (!$this->uri) {
-            return "";
+            return new Message('');
         }
         $message = new Message($this->uri);
         $message->prepend(" $onPage ");


### PR DESCRIPTION
It used to return empty string which could cause an error
`[Error] Call to a member function append() on string`