### PR TITLE
[WebDriver] Smart wait for elements.

### DIFF
--- a/src/Codeception/Module/WebDriver.php
+++ b/src/Codeception/Module/WebDriver.php
@@ -866,9 +866,9 @@ class WebDriver extends CodeceptionModule implements
         if (!$selector) {
             return $this->assertPageContains($text);
         }
-        $this->enableImplicitWait(true);
+        $this->enableImplicitWait();
         $nodes = $this->matchVisible($selector);
-        $this->enableImplicitWait(false);
+        $this->disableImplicitWait();
         $this->assertNodesContain($text, $nodes, $selector);
     }
 
@@ -1073,9 +1073,9 @@ class WebDriver extends CodeceptionModule implements
 
     public function seeLink($text, $url = null)
     {
-        $this->enableImplicitWait(true);
+        $this->enableImplicitWait();
         $nodes = $this->baseElement->findElements(WebDriverBy::partialLinkText($text));
-        $this->enableImplicitWait(false);
+        $this->disableImplicitWait();
         $currentUri = $this->_getCurrentUri();
 
         if (empty($nodes)) {
@@ -1681,9 +1681,9 @@ class WebDriver extends CodeceptionModule implements
 
     public function seeElement($selector, $attributes = [])
     {
-        $this->enableImplicitWait(true);
+        $this->enableImplicitWait();
         $els = $this->matchVisible($selector);
-        $this->enableImplicitWait(false);
+        $this->disableImplicitWait();
         $els = $this->filterByAttributes($els, $attributes);
         $this->assertNotEmpty($els);
     }
@@ -1709,10 +1709,10 @@ class WebDriver extends CodeceptionModule implements
      */
     public function seeElementInDOM($selector, $attributes = [])
     {
-        $this->enableImplicitWait(true);
+        $this->enableImplicitWait();
         $els = $this->match($this->baseElement, $selector);
         $els = $this->filterByAttributes($els, $attributes);
-        $this->enableImplicitWait(false);
+        $this->disableImplicitWait();
         $this->assertNotEmpty($els);
     }
 
@@ -2316,8 +2316,7 @@ class WebDriver extends CodeceptionModule implements
      */
     public function executeInSelenium(\Closure $function)
     {
-        $result = $function($this->webDriver);
-        return $result;
+        return $function($this->webDriver);
     }
 
     /**
@@ -2680,9 +2679,9 @@ class WebDriver extends CodeceptionModule implements
      */
     protected function matchFirstOrFail($page, $selector)
     {
-        $this->enableImplicitWait(true);
+        $this->enableImplicitWait();
         $els = $this->match($page, $selector);
-        $this->enableImplicitWait(false);
+        $this->disableImplicitWait();
         if (!count($els)) {
             throw new ElementNotFound($selector, "CSS or XPath");
         }
@@ -3159,15 +3158,20 @@ class WebDriver extends CodeceptionModule implements
         $this->baseElement = $this->matchFirstOrFail($this->webDriver, $element);
     }
 
-    protected function enableImplicitWait($enable)
+    protected function enableImplicitWait()
     {
         if (!$this->config['wait']) {
             return;
         }
-        if ($enable) {
-            $this->webDriver->manage()->timeouts()->implicitlyWait($this->config['wait']);
+        $this->webDriver->manage()->timeouts()->implicitlyWait($this->config['wait']);
+    }
+
+    protected function disableImplicitWait()
+    {
+        if (!$this->config['wait']) {
             return;
         }
         $this->webDriver->manage()->timeouts()->implicitlyWait(0);
+
     }
 }

--- a/src/Codeception/Module/WebDriver.php
+++ b/src/Codeception/Module/WebDriver.php
@@ -931,7 +931,7 @@ class WebDriver extends CodeceptionModule implements
             $page = $this->matchFirstOrFail($this->webDriver, $context);
         }
         $el = $this->_findClickable($page, $link);
-        if (!$el) {
+        if (!$el) { // check one more time if this was a CSS selector we didn't match
             try {
                 $els = $this->match($page, $link);
             } catch (MalformedLocatorException $e) {
@@ -974,14 +974,9 @@ class WebDriver extends CodeceptionModule implements
             return $this->matchFirstOrFail($page, $link);
         }
 
-        // try to match by CSS or XPath
-        try {
-            $els = $this->match($page, $link, false);
-            if (!empty($els)) {
-                return reset($els);
-            }
-        } catch (MalformedLocatorException $e) {
-            //ignore exception, link could still match on of the things below
+        // try to match by strict locators, CSS Ids or XPath
+        if (Locator::isPrecise($link)) {
+            return $this->matchFirstOrFail($page, $link);
         }
 
         $locator = Crawler::xpathLiteral(trim($link));

--- a/src/Codeception/Util/Locator.php
+++ b/src/Codeception/Util/Locator.php
@@ -214,6 +214,23 @@ class Locator
         return @$xpath->evaluate($locator, $document) !== false;
     }
 
+    public static function isPrecise($locator)
+    {
+        if (is_array($locator)) {
+            return true;
+        }
+        if ($locator instanceof WebDriverBy) {
+            return true;
+        }
+        if (Locator::isID($locator)) {
+            return true;
+        }
+        if (strpos($locator, '//') === 0) {
+            return true; // simple xpath check
+        }
+        return false;
+    }
+
     /**
      * Checks that a string is valid CSS ID
      *

--- a/tests/data/app/view/form/timeout.php
+++ b/tests/data/app/view/form/timeout.php
@@ -1,0 +1,23 @@
+<html>
+<body>
+
+<p>Wait for button!</p>
+
+<div id="el">
+
+</div>
+
+<div id="text"></div>
+
+<script>
+    function writeText() {
+        document.getElementById('text').innerHTML = 'Hello!';
+    }
+
+  setTimeout(function () {
+    document.getElementById('el').innerHTML = '<button id="btn" onclick="writeText()">Click</button>';
+  }, 3000);
+</script>
+</body>
+</html>
+<?php

--- a/tests/web.suite.yml
+++ b/tests/web.suite.yml
@@ -38,6 +38,7 @@ env:
     modules:
       config:
         WebDriver:
+          wait: 10
           browser: chrome
           port: 9515 # ChromeDriver port
           window_size: false

--- a/tests/web.suite.yml
+++ b/tests/web.suite.yml
@@ -38,7 +38,6 @@ env:
     modules:
       config:
         WebDriver:
-          wait: 10
           browser: chrome
           port: 9515 # ChromeDriver port
           window_size: false

--- a/tests/web/WebDriverTest.php
+++ b/tests/web/WebDriverTest.php
@@ -552,6 +552,23 @@ class WebDriverTest extends TestsForBrowsers
         $module->waitForElementNotVisible('//xpath');
     }
 
+    public function testWaitForElement()
+    {
+        $this->module->amOnPage('/form/timeout');
+        $this->module->waitForElement('#btn');
+        $this->module->click('Click');
+        $this->module->see('Hello');
+    }
+
+    public function testImplicitWait()
+    {
+        $this->module->_reconfigure(['wait' => 5]);
+        $this->module->amOnPage('/form/timeout');
+        $this->module->click('#btn');
+        $this->module->see('Hello');
+    }
+
+
     public function testBug1467()
     {
         $this->module->amOnPage('/form/bug1467');


### PR DESCRIPTION
This should dramatically improve the stability for tests.

Whenever an element is required and is not on a page, setting `wait: 5` will make Codeception wait for 5 seconds to find it. 

This should simplify tests, and reduce a number of waiters:

```php
$I->waitForElement('#click-me', 5);
$I->click('#click-me');
```
can be simplified to

```php
$I->click('#click-me');
```
with `wait: 5` in config.

*(use CSS ids or strict locators to make this work with click)*

In the same way `$I->seeElement()` will wait for an element to appear before failing.
This should not affect the performance as implicit waits are added only when element is requried to continue a test.

---

Technical note:
Currently `wait` option corresponds to turning on Selenium [Implicit waits](http://www.seleniumhq.org/docs/04_webdriver_advanced.jsp#implicit-waits).
This was not working great as it was waiting for elements everywhere, especially when guessing locators, or checking the absence of an element. It slowed down tests. Current patch also uses implicit waits but only for cases when exactly one element is required.