### PR TITLE
Changed Wercker builds to run only RunCest tests

### DIFF
--- a/wercker.yml
+++ b/wercker.yml
@@ -45,6 +45,11 @@ build:
     # A custom script step, name value is used in the UI
     # and the code value contains the command that get executed
     - script:
-        name: codeception tests
+        name: codeception CLI tests
         code: |
-          php codecept run cli,unit
+          php codecept run cli RunCest
+
+    - script:
+        name: codeception unit tests
+        code: |
+          php codecept run unit


### PR DESCRIPTION
Wercker builds are often terminated by timeout.
I removed some of CLI tests so now they should work faster
