### PR TITLE
[PhpBrowser] fixed second or later amOnUrl with empty path component

### DIFF
--- a/src/Codeception/Module/PhpBrowser.php
+++ b/src/Codeception/Module/PhpBrowser.php
@@ -176,6 +176,9 @@ class PhpBrowser extends InnerBrowser implements Remote, MultiSession, RequiresP
         $host = Uri::retrieveHost($url);
         $this->_reconfigure(['url' => $host]);
         $page = substr($url, strlen($host));
+        if ($page === '') {
+            $page = '/';
+        }
         $this->debugSection('Host', $host);
         $this->amOnPage($page);
     }

--- a/tests/unit/Codeception/Module/PhpBrowserTest.php
+++ b/tests/unit/Codeception/Module/PhpBrowserTest.php
@@ -676,4 +676,15 @@ HTML
         $sourceActual = $this->module->grabPageSource();
         $this->assertXmlStringEqualsXmlString($sourceExpected, $sourceActual);
     }
+
+    /**
+     * @issue https://github.com/Codeception/Codeception/issues/4383
+     */
+    public function testSecondAmOnUrlWithEmptyPath()
+    {
+        $this->module->amOnUrl('https://www.example.com/');
+        $this->module->see('Example Domain');
+        $this->module->amOnUrl('http://www.codeception.com');
+        $this->module->dontSee('Example Domain');
+    }
 }

--- a/tests/unit/Codeception/Module/PhpBrowserTest.php
+++ b/tests/unit/Codeception/Module/PhpBrowserTest.php
@@ -682,9 +682,9 @@ HTML
      */
     public function testSecondAmOnUrlWithEmptyPath()
     {
-        $this->module->amOnUrl('https://www.example.com/');
-        $this->module->see('Example Domain');
-        $this->module->amOnUrl('http://www.codeception.com');
-        $this->module->dontSee('Example Domain');
+        $this->module->amOnUrl('http://localhost:8000/info');
+        $this->module->see('Lots of valuable data here');
+        $this->module->amOnUrl('http://localhost:8000');
+        $this->module->dontSee('Lots of valuable data here');
     }
 }


### PR DESCRIPTION
If path component was empty, it used previous url

Fixes #4383