### PR TITLE
Fix broken HTML report #3819

### DIFF
--- a/src/Codeception/PHPUnit/ResultPrinter/HTML.php
+++ b/src/Codeception/PHPUnit/ResultPrinter/HTML.php
@@ -271,7 +271,7 @@ class HTML extends CodeceptionResultPrinter
     protected function renderSubsteps(Meta $metaStep, $substepsBuffer)
     {
         $metaTemplate = new \Text_Template($this->templatePath . 'substeps.html');
-        $metaTemplate->setVar(['metaStep' => $metaStep, 'error' => $metaStep->hasFailed() ? 'failedStep' : '', 'steps' => $substepsBuffer, 'id' => uniqid()]);
+        $metaTemplate->setVar(['metaStep' => $metaStep->getHtml(), 'error' => $metaStep->hasFailed() ? 'failedStep' : '', 'steps' => $substepsBuffer, 'id' => uniqid()]);
         return $metaTemplate->render();
     }
 


### PR DESCRIPTION
Fixes broken HTML report: When arguments of function contains html content, it should get encoded properly.

Fixes #3819