### PR TITLE
Changing params loader to use $_SERVER global instead of $_ENV

### DIFF
--- a/src/Codeception/Lib/ParamsLoader.php
+++ b/src/Codeception/Lib/ParamsLoader.php
@@ -84,7 +84,7 @@ class ParamsLoader
         }
         $dotEnv = new \Dotenv\Dotenv(codecept_root_dir(), $this->paramStorage);
         $dotEnv->load();
-        return $_ENV;
+        return $_SERVER;
     }
 
     protected function loadEnvironmentVars()


### PR DESCRIPTION
This PR changes the params loader to use the `$_SERVER` global when loading from a `.env` file instead of `$_ENV`. The global `$_ENV` is [not populated by default](https://github.com/php/php-src/blob/master/php.ini-production#L618) on most installations of PHP, so users who try to use Codeception without any changes to their `php.ini` will not have params expanded into the corresponding values. I previously asked about this in [the PR which refactored the ParamsLoader to this state](https://github.com/Codeception/Codeception/pull/3786#discussion_r118803073) but didn't get a response, so decided to make a PR and fix some issues I've been having.

There is not much difference between `$_ENV` and `$_SERVER` in a CLI context, and `$_SERVER` is already being returned by `loadEnvironmentVars()`, so this just makes it consistent.