### PR TITLE
fix Step::addMetaStep by dereferencing stack arguments that may have …

### DIFF
--- a/src/Codeception/Step.php
+++ b/src/Codeception/Step.php
@@ -297,7 +297,11 @@ abstract class Step
 
             // in case arguments were passed by reference, copy args array to ensure dereference.  array_values() does not dereference values
             $args=[];
-            if(is_array($step['args'])) foreach($step['args'] as $a) $args[]=$a;
+            if (is_array($step['args'])) {
+                foreach($step['args'] as $a) {
+                    $args[]=$a;
+                }
+            }
 
             $this->metaStep = new Step\Meta($step['function'], $args);
             $this->metaStep->setTraceInfo($step['file'], $step['line']);

--- a/src/Codeception/Step.php
+++ b/src/Codeception/Step.php
@@ -295,7 +295,11 @@ abstract class Step
                 continue;
             }
 
-            $this->metaStep = new Step\Meta($step['function'], array_values($step['args']));
+            // in case arguments were passed by reference, copy args array to ensure dereference.  array_values() does not dereference values
+            $args=[];
+            if(is_array($step['args'])) foreach($step['args'] as $a) $args[]=$a;
+
+            $this->metaStep = new Step\Meta($step['function'], $args);
             $this->metaStep->setTraceInfo($step['file'], $step['line']);
 
             // pageobjects or other classes should not be included with "I"

--- a/src/Codeception/Step.php
+++ b/src/Codeception/Step.php
@@ -298,7 +298,7 @@ abstract class Step
             // in case arguments were passed by reference, copy args array to ensure dereference.  array_values() does not dereference values
             $args=[];
             if (is_array($step['args'])) {
-                foreach($step['args'] as $a) {
+                foreach ($step['args'] as $a) {
                     $args[]=$a;
                 }
             }

--- a/src/Codeception/Step.php
+++ b/src/Codeception/Step.php
@@ -296,14 +296,9 @@ abstract class Step
             }
 
             // in case arguments were passed by reference, copy args array to ensure dereference.  array_values() does not dereference values
-            $args=[];
-            if (is_array($step['args'])) {
-                foreach ($step['args'] as $a) {
-                    $args[]=$a;
-                }
-            }
-
-            $this->metaStep = new Step\Meta($step['function'], $args);
+            $this->metaStep = new Step\Meta($step['function'], array_map(function ($i) {
+                return $i;
+            }, array_values($step['args'])));
             $this->metaStep->setTraceInfo($step['file'], $step['line']);
 
             // pageobjects or other classes should not be included with "I"


### PR DESCRIPTION
…been passed-by-reference, so that later modules like console do not clobber original referenced value by accident

Quick fix for issue #4402 