### PR TITLE
[InnerBrowser] Submit default values of checkboxes

### DIFF
--- a/src/Codeception/Lib/InnerBrowser.php
+++ b/src/Codeception/Lib/InnerBrowser.php
@@ -701,10 +701,10 @@ class InnerBrowser extends Module implements Web, PageSourceSaver, ElementLocato
             }
             $values = $params[$fieldName];
             if ($values === true) {
-                $params[$fieldName] = $box->getAttribute('value');
+                $params[$fieldName] = $box->hasAttribute('value') ? $box->getAttribute('value') : 'on';
                 $chFoundByName[$fieldName] = $pos + 1;
             } elseif ($values[$pos] === true) {
-                $params[$fieldName][$pos] = $box->getAttribute('value');
+                $params[$fieldName][$pos] = $box->hasAttribute('value') ? $box->getAttribute('value') : 'on';
                 $chFoundByName[$fieldName] = $pos + 1;
             } elseif (is_array($values)) {
                 array_splice($params[$fieldName], $pos, 1);

--- a/tests/data/app/view/form/checkbox_default_value.php
+++ b/tests/data/app/view/form/checkbox_default_value.php
@@ -1,0 +1,5 @@
+<!DOCTYPE html>
+
+<form>
+    <input type="checkbox" name="checkbox1">
+</form>

--- a/tests/unit/Codeception/Module/PhpBrowserTest.php
+++ b/tests/unit/Codeception/Module/PhpBrowserTest.php
@@ -629,6 +629,13 @@ class PhpBrowserTest extends TestsForBrowsers
         $this->module->dontSee('ERROR');
     }
 
+    public function testSubmitFormSubmitsDefaultCheckboxValues()
+    {
+        $this->module->amOnPage('/form/checkbox_default_value');
+        $this->module->submitForm('form', ['checkbox1' => true]);
+        $this->assertSame('on', data::get('query')['checkbox1']);
+    }
+
     /**
      * @issue https://github.com/Codeception/Codeception/issues/3953
      */

--- a/tests/unit/Codeception/Module/PhpBrowserTest.php
+++ b/tests/unit/Codeception/Module/PhpBrowserTest.php
@@ -629,13 +629,6 @@ class PhpBrowserTest extends TestsForBrowsers
         $this->module->dontSee('ERROR');
     }
 
-    public function testSubmitFormSubmitsDefaultCheckboxValues()
-    {
-        $this->module->amOnPage('/form/checkbox_default_value');
-        $this->module->submitForm('form', ['checkbox1' => true]);
-        $this->assertSame('on', data::get('query')['checkbox1']);
-    }
-
     /**
      * @issue https://github.com/Codeception/Codeception/issues/3953
      */

--- a/tests/unit/Codeception/Module/TestsForWeb.php
+++ b/tests/unit/Codeception/Module/TestsForWeb.php
@@ -1270,6 +1270,13 @@ abstract class TestsForWeb extends \Codeception\TestCase\Test
         $this->assertFalse(isset($form['checkbox1']), 'Checkbox value sent');
     }
 
+    public function testSubmitFormWithCheckboxesWithoutValue()
+    {
+        $this->module->amOnPage('/form/checkbox_default_value');
+        $this->module->submitForm('form', ['checkbox1' => true]);
+        $this->assertSame('on', data::get('query')['checkbox1']);
+    }
+
     public function testSubmitFormWithButtons()
     {
         $this->module->amOnPage('/form/form_with_buttons');


### PR DESCRIPTION
Currently if you use `submitForm` in functional tests passing a checkbox with the value of true and that checkbox doesn't have a value attribute in the HTML page, that field will have the value of an empty string in the resulting request because `setCheckboxBoolValues` just gets the value attribute of checkboxes. This pull request modifies it to check if the checkbox does have a value attribute, and if it doesn't it uses "on" as value.