### PR TITLE
[Laravel5] Don't duplicate associative array fields

### DIFF
--- a/src/Codeception/Lib/InnerBrowser.php
+++ b/src/Codeception/Lib/InnerBrowser.php
@@ -1634,6 +1634,13 @@ class InnerBrowser extends Module implements Web, PageSourceSaver, ElementLocato
         foreach ($requestParams as $name => $value) {
             $qs = http_build_query([$name => $value], '', '&');
             if (!empty($qs)) {
+                // If the field's name is of the form of "array[key]",
+                // we'll remove it from the request parameters
+                // and set the "array" key instead which will contain the actual array.
+                if (strpos($name, '[') && strpos($name, ']') > strpos($name, '[')) {
+                    unset($requestParams[$name]);
+                }
+
                 parse_str($qs, $expandedValue);
                 $varName = substr($name, 0, strlen(key($expandedValue)));
                 $requestParams = array_replace_recursive($requestParams, [$varName => current($expandedValue)]);

--- a/tests/unit/Codeception/Module/TestsForWeb.php
+++ b/tests/unit/Codeception/Module/TestsForWeb.php
@@ -1067,6 +1067,15 @@ abstract class TestsForWeb extends \Codeception\TestCase\Test
         $this->assertEquals('this & that', $form['test']);
     }
 
+    public function testSubmitFormWithArrayField()
+    {
+        $this->module->amOnPage('/form/example17');
+        $this->module->submitForm('form', []);
+        $data = data::get('form');
+        $this->assertSame('baz', $data['FooBar']['bar']);
+        $this->assertArrayNotHasKey('FooBar[bar]', $data);
+    }
+
     public function testSubmitFormMultiSelectWithArrayParameter()
     {
         $this->module->amOnPage('/form/submitform_multiple');


### PR DESCRIPTION
Using the Laravel5 module I have the issue that associative array inputs are duplicated, for example `<input name="foo[bar]">` results in both the `foo` and `foo[bar]` keys in the request. I added a check in `getFormPhpValues` to remove the spurious keys and leave the actual array only.

This issue doesn't occur in the framework modules which call `remapRequestParameters` (Phalcon, Universal, Yii, Yii2. Symfony and Zend may have the same issue) which then calls `http_build_query` on the request parameters and then `parse_str` on the query string. Same for PhpBrowser since Guzzle calls `http_build_query` on the `form_params` and `query` you pass to it. This has the side effect of leaving only the correct key since `"foo[bar]" = ''` and `'foo' = ['bar' => '']` have the same representation in a query string. However `http_build_query` removes parameters with a value of null (or an empty array) and with Laravel it's reasonable to submit null values directly since it has a middleware that converts empty string inputs to null.