### PR TITLE
Support associative arrays in seeInFormFields

### DIFF
--- a/tests/unit/Codeception/Module/TestsForWeb.php
+++ b/tests/unit/Codeception/Module/TestsForWeb.php
@@ -661,6 +661,15 @@ abstract class TestsForWeb extends \Codeception\TestCase\Test
         $this->module->dontSeeInFormFields('form', $params);
     }
 
+    public function testSeeInFormFieldsWithAssociativeArrays()
+    {
+        $this->module->amOnPage('/form/example17');
+        $this->module->seeInFormFields('form', [
+            'FooBar' => ['bar' => 'baz'],
+            'Food'   => ['beer' => ['yum' => ['yeah' => 'mmhm']]],
+        ]);
+    }
+
     public function testSeeInFieldWithNonLatin()
     {
         $this->module->amOnPage('/info');


### PR DESCRIPTION
Adds support for associative arrays in seeInFormFields for both functional and acceptance tests.

`$I->seeInFormFields('form', ['foo' => ['bar' => 'baz']);`

Small issue: if a user does `$I->seeInFormFields('form', ['missing' => ['foo', 'bar']])` the error message will now be "Form element with '//*[@name='missing[0]']' was not found." But there's no way to know if the user was actually looking for a field with the name of "missing[0]".