### PR TITLE
[InnerBrowser] Make seeInField check options' texts

### DIFF
--- a/src/Codeception/Lib/InnerBrowser.php
+++ b/src/Codeception/Lib/InnerBrowser.php
@@ -634,7 +634,7 @@ class InnerBrowser extends Module implements Web, PageSourceSaver, ElementLocato
 
     protected function proceedSeeInField(Crawler $fields, $value)
     {
-        $testValues = $this->proceedGetValueFromField($fields);
+        $testValues = $this->proceedGetValueFromField($fields, true);
         if (!is_array($testValues)) {
             $testValues = [$testValues];
         }
@@ -1270,14 +1270,15 @@ class InnerBrowser extends Module implements Web, PageSourceSaver, ElementLocato
         if (!$nodes->count()) {
             throw new ElementNotFound($field, 'Field');
         }
-        return $this->proceedGetValueFromField($nodes);
+        return $this->proceedGetValueFromField($nodes, false);
     }
 
     /**
      * @param Crawler $nodes
+     * @param bool $getOptionTexts
      * @return array|mixed|string
      */
-    protected function proceedGetValueFromField(Crawler $nodes)
+    protected function proceedGetValueFromField(Crawler $nodes, $getOptionTexts)
     {
         $values = [];
         if ($nodes->filter('textarea')->count()) {
@@ -1301,10 +1302,17 @@ class InnerBrowser extends Module implements Web, PageSourceSaver, ElementLocato
             $options = $nodes->filter('option[selected]');
             foreach ($options as $option) {
                 $values[] = $option->getAttribute('value');
+
+                if ($getOptionTexts) {
+                    $values[] = $option->textContent;
+                    $values[] = trim($option->textContent);
+                }
             }
-            if (!$field->isMultiple()) {
+
+            if (!$getOptionTexts && !$field->isMultiple()) {
                 return reset($values);
             }
+
             return $values;
         }
 

--- a/tests/unit/Codeception/Module/TestsForWeb.php
+++ b/tests/unit/Codeception/Module/TestsForWeb.php
@@ -541,9 +541,11 @@ abstract class TestsForWeb extends \Codeception\TestCase\Test
     {
         $this->module->amOnPage('/form/field_values');
         $this->module->seeInField('select1', 'see test one');
+        $this->module->seeInField('select1', 'Selected');
         $this->module->dontSeeInField('select1', 'not seen one');
         $this->module->dontSeeInField('select1', 'not seen two');
         $this->module->dontSeeInField('select1', 'not seen three');
+        $this->module->dontSeeInField('select1', 'Not selected');
     }
 
     public function testSeeInFieldEmptyValueForUnselectedSelect()


### PR DESCRIPTION
Makes InnerBrowser's seeInField check for options' texts and trimmed texts on top of checking their values. This makes it behave the same as WebDriver as requested in #3905.

When an option's text is also its desired value, this avoids having to add a value anyway just to make `seeInFormFields` pass.

I did not add a test for the non trimmed text in TestsForWeb and left WebDriverTest::testSeeInFieldSelect as it is since it seems that the check for non trimmed values should be skipped with Selenium.