### PR TITLE
Make wait() in Webdriver module accept fractional amount of seconds

### DIFF
--- a/src/Codeception/Module/WebDriver.php
+++ b/src/Codeception/Module/WebDriver.php
@@ -2162,7 +2162,7 @@ class WebDriver extends CodeceptionModule implements
     /**
      * Wait for $timeout seconds.
      *
-     * @param int $timeout secs
+     * @param int|float $timeout secs
      * @throws \Codeception\Exception\TestRuntimeException
      */
     public function wait($timeout)
@@ -2174,7 +2174,7 @@ class WebDriver extends CodeceptionModule implements
                 Please note that wait method accepts number of seconds as parameter."
             );
         }
-        sleep($timeout);
+        usleep($timeout * 1000000);
     }
 
     /**


### PR DESCRIPTION
Use case: sometimes we want to wait for less than a second.