### PR TITLE
_capabilities documentation fix

### DIFF
--- a/src/Codeception/Module/WebDriver.php
+++ b/src/Codeception/Module/WebDriver.php
@@ -388,7 +388,7 @@ class WebDriver extends CodeceptionModule implements
      *      $name = \Codeception\Test\Descriptor::getTestAsString($test->toString());
      *      $this->getModule('WebDriver')->_capabilities(function($currentCapabilities) use ($name) {
      *          $currentCapabilities['name'] = $name;
-     *          return new DesiredCapabilities($currentCapabilities);
+     *          return $currentCapabilities;
      *      });
      * }
      * ```


### PR DESCRIPTION
$capabilityFunction should return array, otherwise on second test run you got:
```
[PHPUnit_Framework_Exception] Argument 1 passed to Facebook\WebDriver\Remote\DesiredCapabilities::__construct() must be of the type array, object given
```