### PR TITLE
[WebDriver] Fixed fatal error in _before on PHP 5.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "phpunit/phpunit": ">4.8.20 <7.0",
         "phpunit/php-code-coverage": ">=2.2.4 <6.0",
         "phpunit/phpunit-mock-objects": ">2.3 <5.0",
-        "facebook/webdriver": ">=1.0.1 <2.0",
+        "facebook/webdriver": ">=1.1.3 <2.0",
         "guzzlehttp/guzzle": ">=4.1.4 <7.0",
         "guzzlehttp/psr7": "~1.0",
         "symfony/finder": ">=2.7 <4.0",

--- a/src/Codeception/Module/WebDriver.php
+++ b/src/Codeception/Module/WebDriver.php
@@ -412,9 +412,17 @@ class WebDriver extends CodeceptionModule implements
         }
         $this->setBaseElement();
 
+        if (method_exists($this->webDriver, 'getCapabilities')) {
+            $browser = $this->webDriver->getCapabilities()->getBrowserName();
+            $capabilities = $this->webDriver->getCapabilities()->toArray();
+        } else {
+            //Used with facebook/php-webdriver <1.3.0 (usually on PHP 5.4)
+            $browser = $this->config['browser'];
+            $capabilities = $this->config['capabilities'];
+        }
         $test->getMetadata()->setCurrent([
-            'browser' => $this->webDriver->getCapabilities()->getBrowserName(),
-            'capabilities' => $this->webDriver->getCapabilities()->toArray()
+            'browser' => $browser,
+            'capabilities' => $capabilities,
         ]);
     }
 


### PR DESCRIPTION
webDriver->getCapabilities() is available in facebook/php-webdriver >=1.3.0 which requires PHP 5.5

closes #4435