### PR TITLE
Symfony/fix_profiler_loading 

### DIFF
--- a/src/Codeception/Lib/Connector/Symfony.php
+++ b/src/Codeception/Lib/Connector/Symfony.php
@@ -75,12 +75,12 @@ class Symfony extends \Symfony\Component\HttpKernel\Client
         $this->kernel->boot();
         $this->container = $this->kernel->getContainer();
 
-        if ($this->container->has('profiler')) {
-            $this->container->get('profiler')->enable();
-        }
-
         foreach ($this->persistentServices as $serviceName => $service) {
             $this->container->set($serviceName, $service);
+        }
+
+        if ($this->container->has('profiler')) {
+            $this->container->get('profiler')->enable();
         }
     }
 }


### PR DESCRIPTION
- Problem:
When I have several request within one test, my services have different _entity_managers_, which results in bugs.

- Problem cause:
When _profiler_ service is being loaded, dozens of services are instantiated. Some of them needs _entity_manager_, which has not been instantiated by that time, so it is null, and so container creates new one. Then we set _persistent_services_ (which include _entity_manager_), so all the other services will get _entity_manager_ from _persistent_services_, not the one created during _profiler_ enabled.

- Solution:
Set the persistent services and **then** enable the profiler.


