### PR TITLE
Mongo haveInCollection fix

### DIFF
--- a/src/Codeception/Module/MongoDb.php
+++ b/src/Codeception/Module/MongoDb.php
@@ -267,7 +267,7 @@ class MongoDb extends CodeceptionModule implements RequiresPackage
             return $data['_id'];
         } else {
             $response = $collection->insertOne($data);
-            return $response->getInsertedId()->__toString();
+            return (string) $response->getInsertedId();
         }
     }
 


### PR DESCRIPTION
 Method `$response->getInsertedId()` already returns string. In case there is not a string `_toString()` will be called