### PR TITLE
Create the _generated folder before writing a .gitignore file there

### DIFF
--- a/src/Codeception/Template/Acceptance.php
+++ b/src/Codeception/Template/Acceptance.php
@@ -88,6 +88,7 @@ EOF;
         $this->createEmptyDirectory($outputDir = $dir . DIRECTORY_SEPARATOR . '_output');
         $this->createEmptyDirectory($dir . DIRECTORY_SEPARATOR . '_data');
         $this->createDirectoryFor($supportDir = $dir . DIRECTORY_SEPARATOR . '_support');
+        $this->createDirectoryFor($supportDir . DIRECTORY_SEPARATOR . '_generated');
         $this->gitIgnore($outputDir);
         $this->gitIgnore($supportDir . DIRECTORY_SEPARATOR . '_generated');
         $this->sayInfo("Created test directories inside at $dir");

--- a/src/Codeception/Template/Api.php
+++ b/src/Codeception/Template/Api.php
@@ -58,6 +58,7 @@ EOF;
         $this->createEmptyDirectory($outputDir = $dir . DIRECTORY_SEPARATOR . '_output');
         $this->createEmptyDirectory($dir . DIRECTORY_SEPARATOR . '_data');
         $this->createDirectoryFor($supportDir = $dir . DIRECTORY_SEPARATOR . '_support');
+        $this->createDirectoryFor($supportDir . DIRECTORY_SEPARATOR . '_generated');
         $this->gitIgnore($outputDir);
         $this->gitIgnore($supportDir . DIRECTORY_SEPARATOR . '_generated');
         $this->sayInfo("Created test directories inside at $dir");


### PR DESCRIPTION
Hi there 👋 

After following the setup guide on a fresh project I got hit with a warning:
```
$ ./vendor/bin/codecept init api
Let's prepare Codeception for REST API testing

? Where tests will be stored? (tests) 
? Start url for tests (http://localhost/api) 
PHP Warning:  file_put_contents(tests/_support/_generated/.gitignore): failed to open stream: No such file or directory in /home/nico/Projects/myawesomeproject/vendor/codeception/codeception/src/Codeception/InitTemplate.php on line 204
> Created test directories inside at tests
> Api helper has been created in tests/_support/Helper
> ApiTester actor has been created in tests/_support
> Actions have been loaded
> Created global config codeception.yml inside the root directory
> Created a demo test ApiCest.php

 INSTALLATION COMPLETE 

Next steps:
1. Edit tests/ApiCest.php to write first API tests
2. Run tests using: codecept run

Happy testing!
```

To prevent this error, I came up with two solutions:
1. Create the directory before it exists
2. Patch the`gitIgnore()` method so it checks if the path exists before writing the file.

Approach 2 seemed more ideal but might break other logic since I don't know why the statement in https://github.com/Codeception/Codeception/blob/2.3/src/Codeception/InitTemplate.php#L203 exists. Why is it testing if we have a .gitignore in our project root? To prevent confusion I've picked solution 1. 

I'd love to know if you have any feedback on the PR. Thanks for Codeception 🚀 