### PR TITLE
Fix aliasing issue with Codeception/Verify.

### DIFF
--- a/shim.php
+++ b/shim.php
@@ -13,8 +13,10 @@ if (!class_exists('Symfony\Component\CssSelector\CssSelectorConverter')) {
 // Add aliases for PHPUnit 6
 
 namespace {
-    if (!class_exists('PHPUnit_Framework_TestCase') && class_exists('PHPUnit\Framework\TestCase')) {
+    if (!class_exists('PHPUnit_Framework_Assert') && class_exists('PHPUnit\Framework\Assert')) {
         class_alias('PHPUnit\Framework\Assert', 'PHPUnit_Framework_Assert');
+    }
+    if (!class_exists('PHPUnit_Framework_TestCase') && class_exists('PHPUnit\Framework\TestCase')) {
         class_alias('PHPUnit\Framework\AssertionFailedError', 'PHPUnit_Framework_AssertionFailedError');
         class_alias('PHPUnit\Framework\Constraint\Constraint', 'PHPUnit_Framework_Constraint');
         class_alias('PHPUnit\Framework\Constraint\LogicalNot', 'PHPUnit_Framework_Constraint_Not');


### PR DESCRIPTION
Adds an extra shim check before aliasing all PHPUnit classes. Maybe we should consider adding a check for every class to avoid similar problems?

Fixes #4479 

The problem is caused by https://github.com/Codeception/Verify/pull/31 and additionally, it is reported in https://github.com/Codeception/Verify/issues/32

