### PR TITLE
[WebDriver] Add deleteAllCookies before loadSessionSnapshot

### DIFF
--- a/src/Codeception/Module/WebDriver.php
+++ b/src/Codeception/Module/WebDriver.php
@@ -2977,6 +2977,7 @@ class WebDriver extends CodeceptionModule implements
         if (!isset($this->sessionSnapshots[$name])) {
             return false;
         }
+        $this->deleteAllCookies();
         foreach ($this->sessionSnapshots[$name] as $cookie) {
             $this->webDriver->manage()->addCookie($cookie);
         }

--- a/src/Codeception/Module/WebDriver.php
+++ b/src/Codeception/Module/WebDriver.php
@@ -2977,7 +2977,7 @@ class WebDriver extends CodeceptionModule implements
         if (!isset($this->sessionSnapshots[$name])) {
             return false;
         }
-        $this->deleteAllCookies();
+        $this->webDriver->manage()->deleteAllCookies();
         foreach ($this->sessionSnapshots[$name] as $cookie) {
             $this->webDriver->manage()->addCookie($cookie);
         }


### PR DESCRIPTION
Hello,

Sometimes when I load session snapshot it seems not working (user is log in but with very strange behaviour). I can't reproduce this every times but in my project I found this fix that work better.

I think when we need to load the cookies we need to delete all cookies before to be sure to not have a mix of different cookie in the same browser.

First browser
> cookieA
> cookieB
> => saveSessionSnapshot

Second browser
> cookie1
> cookie2
> => loadSessionSnapshot 

Actual result:
cookie1, cookie2, cookieA, cookieB

Expected result:
cookieA, cookieB

