### PR TITLE
Fix `see` when source code contains `<=` JS operator

### DIFF
--- a/src/Codeception/Lib/InnerBrowser.php
+++ b/src/Codeception/Lib/InnerBrowser.php
@@ -1877,6 +1877,10 @@ class InnerBrowser extends Module implements Web, PageSourceSaver, ElementLocato
     protected function getNormalizedResponseContent()
     {
         $content = $this->_getResponseContent();
+        // Since strip_tags has problems with JS code that contains
+        // an <= operator the script tags have to be removed manually first.
+        $content = preg_replace('#<script(.*?)>(.*?)</script>#is', '', $content);
+        
         $content = strip_tags($content);
         $content = html_entity_decode($content, ENT_QUOTES);
         $content = str_replace("\n", ' ', $content);

--- a/tests/data/app/view/info.php
+++ b/tests/data/app/view/info.php
@@ -44,5 +44,14 @@
     <a id="third-link">Third</a>
 </div>
 
+<script>
+    var a = 2;
+    var b = 3;
+    if (a <= b) {
+        console.log('a is less than b!');
+    }
+</script>
+<p>Text behind JS comparision</p>
+
 </body>
 </html>

--- a/tests/unit/Codeception/Module/PhpBrowserTest.php
+++ b/tests/unit/Codeception/Module/PhpBrowserTest.php
@@ -71,6 +71,14 @@ class PhpBrowserTest extends TestsForBrowsers
         $this->module->click('Ссылочка');
     }
 
+    /**
+     * @see https://github.com/Codeception/Codeception/issues/4509
+     */
+    public function testSeeTextAfterJSComparisionOperator()
+    {
+        $this->module->amOnPage('/info');
+        $this->module->see('Text behind JS comparision');
+    }
 
     public function testSetMultipleCookies()
     {


### PR DESCRIPTION
This PR fixes https://github.com/Codeception/Codeception/issues/4509