### PR TITLE
Fix Underscore Bug in HTTP Headers

### DIFF
--- a/src/Codeception/Lib/Connector/Guzzle6.php
+++ b/src/Codeception/Lib/Connector/Guzzle6.php
@@ -216,7 +216,7 @@ class Guzzle6 extends Client
         foreach ($server as $header => $val) {
             $header = implode('-', array_map('ucfirst', explode('-', strtolower(str_replace('_', '-', $header)))));
             if (strpos($header, 'Http-') === 0) {
-                $headers[substr($header, 5)] = $val;
+                $headers[str_replace('-', '_', substr($header, 5))] = $val;
             } elseif (isset($contentHeaders[$header])) {
                 $headers[$header] = $val;
             }


### PR DESCRIPTION
Codeception was converting all the underscores in the headers to Hyphen causing the headers to be malformed. 

We utilize custom headers in our development with underscores - example - "Client_id"
When the header is appended with HTTP and later removed in the guzzle utility the underscores are converted to hyphens leading to a malformed header. 

I am just resetting the header to original status once the http tag is stripped.