### PR TITLE
Cest generator: suite namespaces

### DIFF
--- a/src/Codeception/Lib/Generator/Cest.php
+++ b/src/Codeception/Lib/Generator/Cest.php
@@ -50,14 +50,18 @@ EOF;
 
         $namespace = rtrim($this->settings['namespace'], '\\');
         $ns = $this->getNamespaceHeader($namespace.'\\'.$this->name);
-        if ($ns) {
+
+        $actorHasNamespace = strpos($actor, '\\') !== false;
+		if ($actorHasNamespace) {
+			$ns .= "use ".ltrim($actor, '\\').";";
+		} elseif ($ns) {
             $ns .= "use ".$this->settings['namespace'].'\\'.$actor.";";
         }
 
         return (new Template($this->template))
             ->place('name', $this->getShortClassName($this->name))
             ->place('namespace', $ns)
-            ->place('actor', $actor)
+            ->place('actor', $this->getShortClassName($actor))
             ->produce();
     }
 }

--- a/src/Codeception/Lib/Generator/Cest.php
+++ b/src/Codeception/Lib/Generator/Cest.php
@@ -48,20 +48,22 @@ EOF;
             throw new ConfigurationException("Cept can't be created for suite without an actor. Add `actor: SomeTester` to suite config");
         }
 
-        $namespace = rtrim($this->settings['namespace'], '\\');
+        if (array_key_exists('suite_namespace', $this->settings)) {
+            $namespace = rtrim($this->settings['suite_namespace'], '\\');
+        } else {
+            $namespace = rtrim($this->settings['namespace'], '\\');
+        }
+
         $ns = $this->getNamespaceHeader($namespace.'\\'.$this->name);
 
-        $actorHasNamespace = strpos($actor, '\\') !== false;
-		if ($actorHasNamespace) {
-			$ns .= "use ".ltrim($actor, '\\').";";
-		} elseif ($ns) {
+        if ($namespace) {
             $ns .= "use ".$this->settings['namespace'].'\\'.$actor.";";
         }
 
         return (new Template($this->template))
             ->place('name', $this->getShortClassName($this->name))
             ->place('namespace', $ns)
-            ->place('actor', $this->getShortClassName($actor))
+            ->place('actor', $actor)
             ->produce();
     }
 }

--- a/tests/unit/Codeception/Command/GenerateCestTest.php
+++ b/tests/unit/Codeception/Command/GenerateCestTest.php
@@ -78,4 +78,17 @@ class GenerateCestTest extends BaseCommandRunner
         $this->assertContains('class HallUnderTheHillCest', $this->content);
         $this->assertContains('Test was created in tests/shire/MiddleEarth/HallUnderTheHillCest.php', $this->output);
     }
+
+    public function testGenerateWithDifferentNamedspacedActor()
+	{
+		$this->config['namespace'] = 'MiddleEarth';
+		$this->config['actor'] = '\\Mordor\\Bosses\\SauronGuy';
+		$this->execute(array('suite' => 'shire', 'class' => 'HallUnderTheHillCest'));
+		$this->assertEquals($this->filename, 'tests/shire/HallUnderTheHillCest.php');
+		$this->assertContains('namespace MiddleEarth;', $this->content);
+		$this->assertContains('use Mordor\\Bosses\\SauronGuy', $this->content);
+		$this->assertNotContains('use MiddleEarth\\HobbitGuy;', $this->content);
+		$this->assertContains('public function tryToTest(SauronGuy $I)', $this->content);
+		$this->assertIsValidPhp($this->content);
+	}
 }

--- a/tests/unit/Codeception/Command/GenerateCestTest.php
+++ b/tests/unit/Codeception/Command/GenerateCestTest.php
@@ -79,7 +79,7 @@ class GenerateCestTest extends BaseCommandRunner
         $this->assertContains('Test was created in tests/shire/MiddleEarth/HallUnderTheHillCest.php', $this->output);
     }
 
-    public function testGenerateWithDifferentNamedspacedActor()
+    public function testGenerateWithSuiteNamespace()
 	{
         $this->config['suite_namespace'] = 'MiddleEarth\\Bosses\\';
         $this->config['namespace'] = 'MiddleEarth';

--- a/tests/unit/Codeception/Command/GenerateCestTest.php
+++ b/tests/unit/Codeception/Command/GenerateCestTest.php
@@ -81,14 +81,14 @@ class GenerateCestTest extends BaseCommandRunner
 
     public function testGenerateWithDifferentNamedspacedActor()
 	{
-		$this->config['namespace'] = 'MiddleEarth';
-		$this->config['actor'] = '\\Mordor\\Bosses\\SauronGuy';
-		$this->execute(array('suite' => 'shire', 'class' => 'HallUnderTheHillCest'));
-		$this->assertEquals($this->filename, 'tests/shire/HallUnderTheHillCest.php');
-		$this->assertContains('namespace MiddleEarth;', $this->content);
-		$this->assertContains('use Mordor\\Bosses\\SauronGuy', $this->content);
-		$this->assertNotContains('use MiddleEarth\\HobbitGuy;', $this->content);
-		$this->assertContains('public function tryToTest(SauronGuy $I)', $this->content);
-		$this->assertIsValidPhp($this->content);
+        $this->config['namespace'] = 'MiddleEarth';
+        $this->config['actor'] = '\\Mordor\\Bosses\\SauronGuy';
+        $this->execute(array('suite' => 'shire', 'class' => 'HallUnderTheHillCest'));
+        $this->assertEquals($this->filename, 'tests/shire/HallUnderTheHillCest.php');
+        $this->assertContains('namespace MiddleEarth;', $this->content);
+        $this->assertContains('use Mordor\\Bosses\\SauronGuy', $this->content);
+        $this->assertNotContains('use MiddleEarth\\HobbitGuy;', $this->content);
+        $this->assertContains('public function tryToTest(SauronGuy $I)', $this->content);
+        $this->assertIsValidPhp($this->content);
 	}
 }

--- a/tests/unit/Codeception/Command/GenerateCestTest.php
+++ b/tests/unit/Codeception/Command/GenerateCestTest.php
@@ -81,14 +81,14 @@ class GenerateCestTest extends BaseCommandRunner
 
     public function testGenerateWithDifferentNamedspacedActor()
 	{
+        $this->config['suite_namespace'] = 'MiddleEarth\\Bosses\\';
         $this->config['namespace'] = 'MiddleEarth';
-        $this->config['actor'] = '\\Mordor\\Bosses\\SauronGuy';
+        $this->config['actor'] = 'HobbitGuy';
         $this->execute(array('suite' => 'shire', 'class' => 'HallUnderTheHillCest'));
         $this->assertEquals($this->filename, 'tests/shire/HallUnderTheHillCest.php');
-        $this->assertContains('namespace MiddleEarth;', $this->content);
-        $this->assertContains('use Mordor\\Bosses\\SauronGuy', $this->content);
-        $this->assertNotContains('use MiddleEarth\\HobbitGuy;', $this->content);
-        $this->assertContains('public function tryToTest(SauronGuy $I)', $this->content);
+        $this->assertContains('namespace MiddleEarth\\Bosses;', $this->content);
+        $this->assertContains('use MiddleEarth\\HobbitGuy', $this->content);
+        $this->assertContains('public function tryToTest(HobbitGuy $I)', $this->content);
         $this->assertIsValidPhp($this->content);
 	}
 }


### PR DESCRIPTION
Hi I've added support to allow for suites to have different namespaces from the main configuration namespace, while the actors still use the main namespace.

The specific use case for me was that I wanted to have a different namespace for each of my test suites, but still have the Actors be in the /tests/_support folder.

Sample suite configuration:
```
suite_namespace: 'tests\unit'
class_name: 'UnitTester'
```
Sample global configuration:
```
namespace: 'tests'
```

This pull request solves that by adding a new suite_namespace setting in the suite. This should not cause any breaking changes.