### PR TITLE
check if entity manager has been retrieved

### DIFF
--- a/src/Codeception/Module/Doctrine2.php
+++ b/src/Codeception/Module/Doctrine2.php
@@ -531,6 +531,9 @@ EOF;
 
     public function _getEntityManager()
     {
+        if (is_null($this->em)) {
+            $this->retrieveEntityManager();
+        }
         return $this->em;
     }
 }


### PR DESCRIPTION
I use the following config:
```
modules:
    enabled:
      - DataFactory
          depends: Doctrine2
      - Doctrine2
```

which results in getting the following error:

` [League\FactoryMuffin\Exceptions\SaveMethodNotFoundException] The save method 'persist' was not found on the model: 'League\FactoryMuffin\Stores\RepositoryStore'.  `

The reason is the sequence of modules - `DataFactory::_before` executes sooner then `Doctrine2::_before` , so `DataFactory` has `null` as `$em`.

As a workaround you can change the sequence of modules.
This PR solves the issue.
