### PR TITLE
[REST] Fixed JsonType crash when key 0 is not an array

### DIFF
--- a/src/Codeception/Util/JsonType.php
+++ b/src/Codeception/Util/JsonType.php
@@ -96,8 +96,8 @@ class JsonType
      */
     public function matches(array $jsonType)
     {
-        if (array_key_exists(0, $this->jsonArray)) {
-            // sequential array
+        if (array_key_exists(0, $this->jsonArray) && is_array($this->jsonArray[0])) {
+            // a list of items
             $msg = '';
             foreach ($this->jsonArray as $array) {
                 $res = $this->typeComparison($array, $jsonType);

--- a/tests/unit/Codeception/Util/JsonTypeTest.php
+++ b/tests/unit/Codeception/Util/JsonTypeTest.php
@@ -186,4 +186,22 @@ class JsonTypeTest extends \Codeception\Test\Unit
         $this->assertContains('3` is of type `integer:<3', $res);
         $this->assertContains('5` is of type `integer:<3', $res);
     }
+
+    /**
+     * @issue https://github.com/Codeception/Codeception/issues/4517
+     */
+    public function testMatchesArrayReturnedByFetchBoth()
+    {
+        $jsonType = new JsonType([
+            '0' => 10,
+            'a' => 10,
+            '1' => 11,
+            'b' => 11,
+        ]);
+
+        $this->assertTrue($jsonType->matches([
+            'a' => 'integer',
+            'b' => 'integer',
+        ]));
+    }
 }


### PR DESCRIPTION
Fixes #4517 