### PR TITLE
Header Enhancements

### DIFF
--- a/src/Codeception/Lib/Connector/Guzzle.php
+++ b/src/Codeception/Lib/Connector/Guzzle.php
@@ -216,7 +216,7 @@ class Guzzle extends Client
 
         $contentHeaders = ['Content-Length' => true, 'Content-Md5' => true, 'Content-Type' => true];
         foreach ($server as $header => $val) {
-            $header = implode('-', array_map('ucfirst', explode('-', strtolower(str_replace('_', '-', $header)))));
+            $header = html_entity_decode(implode('-', array_map('ucfirst', explode('-', strtolower(str_replace('_', '-', $header))))), ENT_NOQUOTES);
             if (strpos($header, 'Http-') === 0) {
                 $headers[substr($header, 5)] = $val;
             } elseif (isset($contentHeaders[$header])) {

--- a/src/Codeception/Lib/Connector/Guzzle6.php
+++ b/src/Codeception/Lib/Connector/Guzzle6.php
@@ -214,7 +214,7 @@ class Guzzle6 extends Client
 
         $contentHeaders = ['Content-Length' => true, 'Content-Md5' => true, 'Content-Type' => true];
         foreach ($server as $header => $val) {
-            $header = implode('-', array_map('ucfirst', explode('-', strtolower(str_replace('_', '-', $header)))));
+            $header = html_entity_decode(implode('-', array_map('ucfirst', explode('-', strtolower(str_replace('_', '-', $header))))), ENT_NOQUOTES);
             if (strpos($header, 'Http-') === 0) {
                 $headers[substr($header, 5)] = $val;
             } elseif (isset($contentHeaders[$header])) {

--- a/src/Codeception/Lib/Connector/ZF1.php
+++ b/src/Codeception/Lib/Connector/ZF1.php
@@ -132,7 +132,7 @@ class ZF1 extends Client
 
         $contentHeaders = ['Content-Length' => true, 'Content-Md5' => true, 'Content-Type' => true];
         foreach ($server as $header => $val) {
-            $header = implode('-', array_map('ucfirst', explode('-', strtolower(str_replace('_', '-', $header)))));
+            $header = html_entity_decode(implode('-', array_map('ucfirst', explode('-', strtolower(str_replace('_', '-', $header))))), ENT_NOQUOTES);
 
             if (strpos($header, 'Http-') === 0) {
                 $headers[substr($header, 5)] = $val;

--- a/src/Codeception/Lib/Connector/ZF2.php
+++ b/src/Codeception/Lib/Connector/ZF2.php
@@ -124,7 +124,7 @@ class ZF2 extends Client
 
         $contentHeaders = ['Content-Length' => true, 'Content-Md5' => true, 'Content-Type' => true];
         foreach ($server as $header => $val) {
-            $header = implode('-', array_map('ucfirst', explode('-', strtolower(str_replace('_', '-', $header)))));
+            $header = html_entity_decode(implode('-', array_map('ucfirst', explode('-', strtolower(str_replace('_', '-', $header))))), ENT_NOQUOTES);
 
             if (strpos($header, 'Http-') === 0) {
                 $headers[substr($header, 5)] = $val;

--- a/src/Codeception/Lib/Connector/ZendExpressive.php
+++ b/src/Codeception/Lib/Connector/ZendExpressive.php
@@ -128,7 +128,7 @@ class ZendExpressive extends Client
 
         $contentHeaders = ['Content-Length' => true, 'Content-Md5' => true, 'Content-Type' => true];
         foreach ($server as $header => $val) {
-            $header = implode('-', array_map('ucfirst', explode('-', strtolower(str_replace('_', '-', $header)))));
+            $header = html_entity_decode(implode('-', array_map('ucfirst', explode('-', strtolower(str_replace('_', '-', $header))))), ENT_NOQUOTES);
 
             if (strpos($header, 'Http-') === 0) {
                 $headers[substr($header, 5)] = $val;

--- a/src/Codeception/Lib/InnerBrowser.php
+++ b/src/Codeception/Lib/InnerBrowser.php
@@ -295,6 +295,17 @@ class InnerBrowser extends Module implements Web, PageSourceSaver, ElementLocato
      * ?>
      * ```
      *
+     * To use special chars in Header Key use HTML Character Entities:
+     * Example:
+     * Header with underscore - 'Client_Id'
+     * should be represented as - 'Client&#x0005F;Id' or 'Client&#95;Id'
+     *
+     * ```php
+     * <?php
+     * $I->haveHttpHeader('Client&#95;Id', 'Codeception');
+     * ?>
+     * ```
+     *
      * @param string $name the name of the request header
      * @param string $value the value to set it to for subsequent
      *        requests


### PR DESCRIPTION
Updates to [Fix Underscore Bug in HTTP Headers #4520](https://github.com/Codeception/Codeception/pull/4520)

So this is an enhancement to accommodate special chars in the headers like underscore. 

I can now pass in a header with html encoded character example`client&#95;id` and later during header extraction decode the html character `client_id`.

The html decoding will only work if encoded chars are passed in else the functionality is unaffected.
