### PR TITLE
Improvements to Config Templates section in docs

### DIFF
--- a/docs/reference/Configuration.md
+++ b/docs/reference/Configuration.md
@@ -146,10 +146,9 @@ modules:
 
 ## Config Templates (dist)
 
-To provide same configuration templates for development team you can creare `codeception.dist.yml` config which will be loaded before `codeception.yml`. Dist config will provide shared options whil local `codeception.yml` will override them per user basis. This way `codeception.yml` should be ignored by VCS system.
+To provide the same configuration template for your development team, you can create a `codeception.dist.yml` config file, which will be loaded before `codeception.yml`. The dist config provides shared options, while local `codeception.yml` files override them on a per-installation basis. Therefore, `codeception.yml` should be ignored by your VCS system.
 
-For suite configuration template configs are also availble. Rename `suitename.suite.yml` to `suitename.dist.yml` to make a dist config.
-
+Config templates can also be used for suite configuration, by creating a `suitename.suite.dist.yml` file.
 
 Configuration loading order:
 


### PR DESCRIPTION
Thought I'd have a stab at improving the text here, mainly from a spelling/grammar/style point of view.  Also corrected the example name format for suite config dist files, from `suitename.dist.yml` to `suitename.suite.dist.yml`.