### PR TITLE
[Db] improved getQuotedName in SqlSrv driver

### DIFF
--- a/src/Codeception/Lib/Driver/PostgreSql.php
+++ b/src/Codeception/Lib/Driver/PostgreSql.php
@@ -147,22 +147,6 @@ class PostgreSql extends Db
     }
 
     /**
-     * Gets a quoted name of a variable.
-     */
-    public function getQuotedName($name)
-    {
-        $name = explode('.', $name);
-        $name = array_map(
-            function ($data) {
-                return '"' . $data . '"';
-            },
-            $name
-        );
-
-        return implode('.', $name);
-    }
-
-    /**
      * Returns the primary key(s) of the table, based on:
      * https://wiki.postgresql.org/wiki/Retrieve_primary_key_columns.
      *

--- a/src/Codeception/Lib/Driver/SqlSrv.php
+++ b/src/Codeception/Lib/Driver/SqlSrv.php
@@ -69,7 +69,7 @@ class SqlSrv extends Db
 
     public function getQuotedName($name)
     {
-        return '[' . $name . ']';
+        return '[' . str_replace('.', '].[', $name) . ']';
     }
 
     /**


### PR DESCRIPTION
* SqlSrv driver wraps each part of identifier with []
* Removed getQuotedName method from PostgreSql driver, because it was functionally identical to method in parent class (" quotes are used by PostgreSql, but they are also used by parent Db class)


Fixes #4542 