### PR TITLE
Fixed setExpectedException() default value for PHPUnit 5.7.23

### DIFF
--- a/src/Codeception/Test/Unit.php
+++ b/src/Codeception/Test/Unit.php
@@ -79,14 +79,14 @@ class Unit extends \PHPUnit_Framework_TestCase implements
      * If the method exists (PHPUnit 5) forward the call to the parent class, otherwise
      * call `expectException` instead (PHPUnit 6)
      */
-    public function setExpectedException($exception, $message = '', $code = null)
+    public function setExpectedException($exception, $message = null, $code = null)
     {
         if (is_callable('parent::setExpectedException')) {
             parent::setExpectedException($exception, $message, $code);
         } else {
             Notification::deprecate('PHPUnit\Framework\TestCase::setExpectedException deprecated in favor of expectException, expectExceptionMessage, and expectExceptionCode');
             $this->expectException($exception);
-            if ($message !== '') {
+            if ($message !== null) {
                 $this->expectExceptionMessage($message);
             }
             if ($code !== null) {


### PR DESCRIPTION
There has some update on [PHPUnit 5.7.23][]. It's solve the exception with empty message but adjust default behavior, so that we should fix default value on `setExpectedException()` method for this update.

[PHPUnit 5.7.23]: https://github.com/sebastianbergmann/phpunit/blob/master/ChangeLog-5.7.md#5723---2017-10-15