### PR TITLE
coverage: removed unexpected page load

### DIFF
--- a/src/Codeception/Coverage/Subscriber/LocalServer.php
+++ b/src/Codeception/Coverage/Subscriber/LocalServer.php
@@ -156,7 +156,11 @@ class LocalServer extends SuiteSubscriber
         ];
         $value = json_encode($value);
 
-        $this->module->setCookie(self::COVERAGE_COOKIE, $value);
+        $c3Url = parse_url($this->settings['c3_url'] ? $this->settings['c3_url'] : $this->module->_getUrl());
+        $c3Host = isset($c3Url['host']) ? $c3Url['host'] : 'localhost';
+        $c3Host .= isset($c3Url['port']) ? ':' . $c3Url['port'] : '';
+
+        $this->module->setCookie(self::COVERAGE_COOKIE, $value, array('domain' => $c3Host));
 
         // putting in configuration ensures the cookie is used for all sessions of a MultiSession test
 

--- a/src/Codeception/Coverage/Subscriber/LocalServer.php
+++ b/src/Codeception/Coverage/Subscriber/LocalServer.php
@@ -156,7 +156,6 @@ class LocalServer extends SuiteSubscriber
         ];
         $value = json_encode($value);
 
-        $this->module->amOnPage('/');
         $this->module->setCookie(self::COVERAGE_COOKIE, $value);
 
         // putting in configuration ensures the cookie is used for all sessions of a MultiSession test


### PR DESCRIPTION
The line `$this->module->amOnPage('/');` in `LocalServer::startCoverageCollection()` is not needed but introduces an unexpected page load.

This is not only for performance reasons but my tests fail with coverage enables as I'm using an own written module to break if something happens to a specific error log and I don't have a route for `/` so I get an error log entry with message `ERR (3): error-router-no-match` on each test if coverage is enabled and my tests will fail :(