### PR TITLE
[PhpBrowser] User-Agent can be set in config

### DIFF
--- a/src/Codeception/Module/PhpBrowser.php
+++ b/src/Codeception/Module/PhpBrowser.php
@@ -23,17 +23,15 @@ use GuzzleHttp\Client as GuzzleClient;
  * * Maintainer: **davert**
  * * Stability: **stable**
  * * Contact: codeception@codeception.com
- * * Works with [Guzzle](http://guzzlephp.org/)
  *
- * *Please review the code of non-stable modules and provide patches if you have issues.*
  *
  * ## Configuration
  *
  * * url *required* - start url of your app
+ * * headers - default headers are set before each test.
  * * handler (default: curl) -  Guzzle handler to use. By default curl is used, also possible to pass `stream`, or any valid class name as [Handler](http://docs.guzzlephp.org/en/latest/handlers-and-middleware.html#handlers).
  * * middleware - Guzzle middlewares to add. An array of valid callables is required.
  * * curl - curl options
- * * headers - ...
  * * cookies - ...
  * * auth - ...
  * * verify - ...
@@ -83,6 +81,7 @@ class PhpBrowser extends InnerBrowser implements Remote, MultiSession, RequiresP
     protected $requiredFields = ['url'];
 
     protected $config = [
+        'headers' => [],
         'verify' => false,
         'expect' => false,
         'timeout' => 30,
@@ -98,7 +97,6 @@ class PhpBrowser extends InnerBrowser implements Remote, MultiSession, RequiresP
     ];
 
     protected $guzzleConfigFields = [
-        'headers',
         'auth',
         'proxy',
         'verify',
@@ -244,6 +242,7 @@ class PhpBrowser extends InnerBrowser implements Remote, MultiSession, RequiresP
             }
         }
 
+        $this->headers = $this->config['headers'];
         $this->setCookiesFromOptions();
 
         if ($this->isGuzzlePsr7) {

--- a/tests/unit/Codeception/Module/PhpBrowserTest.php
+++ b/tests/unit/Codeception/Module/PhpBrowserTest.php
@@ -315,20 +315,6 @@ class PhpBrowserTest extends TestsForBrowsers
         $this->module->seeCurrentUrlEquals('/form/example3?validate=yes');
     }
 
-    public function testHeadersByConfig()
-    {
-        $this->module->_setConfig(['headers' => ['xxx' => 'yyyy']]);
-        $this->module->_initialize();
-        $this->module->amOnPage('/form1');
-
-        if (method_exists($this->module->guzzle, 'getConfig')) {
-            $headers = $this->module->guzzle->getConfig('headers');
-        } else {
-            $headers = $this->module->guzzle->getDefaultOption('headers');
-        }
-        $this->assertArrayHasKey('xxx', $headers);
-    }
-
     public function testHeadersBySetHeader()
     {
         $this->module->setHeader('xxx', 'yyyy');
@@ -686,5 +672,15 @@ HTML
         $this->module->see('Lots of valuable data here');
         $this->module->amOnUrl('http://localhost:8000');
         $this->module->dontSee('Lots of valuable data here');
+    }
+
+    public function testSetUserAgentUsingConfig()
+    {
+        $this->module->_setConfig(['headers' => ['User-Agent' => 'Codeception User Agent Test 1.0']]);
+        $this->module->_initialize();
+
+        $this->module->amOnPage('/user-agent');
+        $response = $this->module->grabPageSource();
+        $this->assertEquals('Codeception User Agent Test 1.0', $response, 'Incorrect user agent');
     }
 }


### PR DESCRIPTION
Headers option is processed by the module instead of passing it to constructor of Guzzle Client

Fixes #4576