### PR TITLE
Don't skip last test if some test has missing dependency

### DIFF
--- a/src/Codeception/Suite.php
+++ b/src/Codeception/Suite.php
@@ -27,6 +27,7 @@ class Suite extends \PHPUnit_Framework_TestSuite
         }
         $this->tests = $queue;
     }
+
     protected function getDependencies($test)
     {
         if (!$test instanceof Dependent) {
@@ -43,6 +44,7 @@ class Suite extends \PHPUnit_Framework_TestSuite
         $tests[] = $test;
         return $tests;
     }
+
     protected function findMatchedTest($testSignature)
     {
         foreach ($this->tests as $test) {
@@ -50,9 +52,6 @@ class Suite extends \PHPUnit_Framework_TestSuite
             if ($signature === $testSignature) {
                 return $test;
             }
-        }
-        if ($test instanceof TestInterface) {
-            $test->getMetadata()->setSkip("Dependent test for $testSignature not found");
         }
     }
 


### PR DESCRIPTION
Fixes #4598 

Skipping the last test was completely unnecessary.

The test with missing dependency is marked as skipped later on anyway.
```
DebugIssueCest: Test1
Signature: DebugIssueCest:test1
Test: tests/functional/DebugIssueCest.php:test1
Scenario --
 SKIPPED: This test depends on test5 to pass
DebugIssueCest: Test2
Signature: DebugIssueCest:test2
Test: tests/functional/DebugIssueCest.php:test2
Scenario --
 PASSED

DebugIssueCest: Test3
Signature: DebugIssueCest:test3
Test: tests/functional/DebugIssueCest.php:test3
Scenario --
 PASSED

------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------


Time: 2.15 seconds, Memory: 15.75MB

There was 1 skipped test:

---------
1) DebugIssueCest: Test1
 Test  tests/functional/DebugIssueCest.php:test1
This test depends on test5 to pass
```