### PR TITLE
Adding Logic In Case Of Exit

### DIFF
--- a/tests/unit/Codeception/Subscriber/ErrorHandlerTest.php
+++ b/tests/unit/Codeception/Subscriber/ErrorHandlerTest.php
@@ -15,6 +15,9 @@ class ErrorHandlerTest extends \PHPUnit_Framework_TestCase
         $suiteEvent = new SuiteEvent(new Suite(), null, ['error_level' => 'E_ERROR']);
         $errorHandler->handle($suiteEvent);
 
+        //Satisfying The Premature Exit Handling
+        $errorHandler->onFinish($suiteEvent);
+
         Notification::all(); //clear the messages
         $errorHandler->errorHandler(E_USER_DEPRECATED, 'deprecated message', __FILE__, __LINE__, []);
 


### PR DESCRIPTION
I have been working on getting my testing setup within a CI. I was looking at the output of one such run when I realized that the test did not appear to be finishing, but was not giving any errors. After digging into it, I learned that one of my Junior Developers created a new class following some of the legacy code in the system. They put includes inside a class file (rather than relying on the PSR-4 Autoloader). One of these includes was a script to check a user's login/session and redirecting them to the homepage if they weren't logged in. Because a call to exit without params is equivalent to exit(0), my CI system thought that the test completed succesfully when it didn't actual do so.

This change is an attempt to catch such instances in the future. I use a shutdown function defined specifically for the execute to throw an exception in case the shutdown occurs.

Please note that I've not studied the Codeception Codebase so there may be a better way to detect this situation.