### PR TITLE
Fixes #4432

### DIFF
--- a/src/Codeception/Command/Run.php
+++ b/src/Codeception/Command/Run.php
@@ -323,6 +323,12 @@ class Run extends Command
                     $config = Configuration::config($projectDir);
                 }
             } elseif (!empty($suite)) {
+                // Workaround when codeception.yml is inside tests directory and tests path is set to "."
+                // @see https://github.com/Codeception/Codeception/issues/4432
+                if ($config['paths']['tests'] === '.' && !preg_match('~^\.[/\\\]~', $suite)) {
+                    $suite = './' . $suite;
+                }
+                
                 // Run single test without included tests
                 if (! Configuration::isEmpty() && strpos($suite, $config['paths']['tests']) === 0) {
                     list(, $suite, $test) = $this->matchTestFromFilename($suite, $config['paths']['tests']);

--- a/tests/cli/CodeceptionYmlInTestsDirCest.php
+++ b/tests/cli/CodeceptionYmlInTestsDirCest.php
@@ -1,0 +1,16 @@
+<?php
+class CodeceptionYmlInTestsDirCest
+{
+    /**
+     * @param CliGuy $I
+     */
+    public function runTestPath(\CliGuy $I)
+    {
+        $I->amInPath('tests/data/codeception_yml_in_tests_dir');
+        $I->executeCommand('run unit/ExampleCest.php');
+        
+        $I->seeResultCodeIs(0);
+        $I->dontSeeInShellOutput('RuntimeException');
+        $I->dontSeeInShellOutput('could not be found');
+    }
+}

--- a/tests/data/codeception_yml_in_tests_dir/_bootstrap.php
+++ b/tests/data/codeception_yml_in_tests_dir/_bootstrap.php
@@ -1,0 +1,2 @@
+<?php
+// This is global bootstrap for autoloading

--- a/tests/data/codeception_yml_in_tests_dir/_output/.gitignore
+++ b/tests/data/codeception_yml_in_tests_dir/_output/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/tests/data/codeception_yml_in_tests_dir/_support/UnitTester.php
+++ b/tests/data/codeception_yml_in_tests_dir/_support/UnitTester.php
@@ -1,0 +1,26 @@
+<?php
+
+
+/**
+ * Inherited Methods
+ * @method void wantToTest($text)
+ * @method void wantTo($text)
+ * @method void execute($callable)
+ * @method void expectTo($prediction)
+ * @method void expect($prediction)
+ * @method void amGoingTo($argumentation)
+ * @method void am($role)
+ * @method void lookForwardTo($achieveValue)
+ * @method void comment($description)
+ * @method \Codeception\Lib\Friend haveFriend($name, $actorClass = NULL)
+ *
+ * @SuppressWarnings(PHPMD)
+*/
+class UnitTester extends \Codeception\Actor
+{
+    use _generated\UnitTesterActions;
+
+   /**
+    * Define custom actions here
+    */
+}

--- a/tests/data/codeception_yml_in_tests_dir/_support/_generated/.gitignore
+++ b/tests/data/codeception_yml_in_tests_dir/_support/_generated/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/tests/data/codeception_yml_in_tests_dir/codeception.yml
+++ b/tests/data/codeception_yml_in_tests_dir/codeception.yml
@@ -1,0 +1,8 @@
+actor: Tester
+paths:
+    tests: .
+    log: _output
+    data: _data
+    support: _support
+settings:
+    bootstrap: _bootstrap.php

--- a/tests/data/codeception_yml_in_tests_dir/unit.suite.yml
+++ b/tests/data/codeception_yml_in_tests_dir/unit.suite.yml
@@ -1,0 +1,8 @@
+# Codeception Test Suite Configuration
+#
+# Suite for unit (internal) tests.
+
+class_name: UnitTester
+modules:
+    enabled:
+        - Asserts

--- a/tests/data/codeception_yml_in_tests_dir/unit/ExampleCest.php
+++ b/tests/data/codeception_yml_in_tests_dir/unit/ExampleCest.php
@@ -1,0 +1,9 @@
+<?php
+
+class ExampleCest
+{
+    public function successful(UnitTester $I)
+    {
+        $I->assertTrue(true);
+    }
+}

--- a/tests/data/codeception_yml_in_tests_dir/unit/_bootstrap.php
+++ b/tests/data/codeception_yml_in_tests_dir/unit/_bootstrap.php
@@ -1,0 +1,2 @@
+<?php
+// Here you can initialize variables that will be available to your tests


### PR DESCRIPTION
Apply a workaround to fix #4432.

This allows having codeception.yml inside the tests directory by setting `paths`: `tests: .`

Fixing this issue properly requires a lot more work. The current CodeCeption implementation uses only basic string matching and does not expect "empty" tests path in multiple places. See for example Run->matchTestFromFilename() and Configuration::isEmpty()