### PR TITLE
fix remote coverage name with slash

### DIFF
--- a/src/Codeception/Coverage/Subscriber/RemoteServer.php
+++ b/src/Codeception/Coverage/Subscriber/RemoteServer.php
@@ -25,7 +25,7 @@ class RemoteServer extends LocalServer
             return;
         }
 
-        $suite = $e->getSuite()->getName();
+        $suite = strtr($e->getSuite()->getName(), ['\\' => '.']);
         if ($this->options['coverage-xml']) {
             $this->retrieveAndPrintXml($suite);
         }


### PR DESCRIPTION
Fixes #4610 

```yml
namespace: frontend\tests
```
produced something like `...frontend.tests...`
```sh
php-code/frontend/tests/_output/frontend.tests.acceptance.remote.coverage.xml
```