### PR TITLE
added support for dotenv version 1.1

### DIFF
--- a/src/Codeception/Lib/ParamsLoader.php
+++ b/src/Codeception/Lib/ParamsLoader.php
@@ -76,14 +76,20 @@ class ParamsLoader
 
     protected function loadDotEnvFile()
     {
-        if (!class_exists('Dotenv\Dotenv')) {
+        if (class_exists('Dotenv\Dotenv')) {
+            $dotEnv = new \Dotenv\Dotenv(codecept_root_dir(), $this->paramStorage);
+            $dotEnv->load();
+        } elseif (class_exists('Dotenv')) {
+            // dotenv version 1.1 does not have namespace
+            $dotEnv = new \Dotenv(codecept_root_dir(), $this->paramStorage);
+            $dotEnv->load(codecept_root_dir());
+        } else {
             throw new ConfigurationException(
                 "`vlucas/phpdotenv` library is required to parse .env files.\n" .
                 "Please install it via composer: composer require vlucas/phpdotenv"
             );
         }
-        $dotEnv = new \Dotenv\Dotenv(codecept_root_dir(), $this->paramStorage);
-        $dotEnv->load();
+        
         return $_SERVER;
     }
 


### PR DESCRIPTION
dotenv in [version 1.1](https://github.com/vlucas/phpdotenv/blob/1.1/src/Dotenv.php) doesn't have namespace, but dotenv 1.1 is still used in Laravel 5.1 (which is LTS with support until June 2018). 

This PR won't break backward compatibility.