### PR TITLE
[Yii2] Reset global event handlers

### DIFF
--- a/src/Codeception/Lib/Connector/Yii2.php
+++ b/src/Codeception/Lib/Connector/Yii2.php
@@ -83,6 +83,9 @@ class Yii2 extends Client
         static::$db = null;
         static::$mailer = null;
         \yii\web\UploadedFile::reset();
+        if (method_exists(yii\base\Event::className(), 'offAll')) {
+            \yii\base\Event::offAll();
+        }
     }
 
     /**


### PR DESCRIPTION
Global event handlers should not persist between tests.
The `if` statement is needed since the `offAll()` function exists only since 2.0.10 of the framework.

Ping @samdark 