### PR TITLE
Add Iteration Count for Dataprovider Examples to Cest Test Signatures

### DIFF
--- a/src/Codeception/Subscriber/Dependencies.php
+++ b/src/Codeception/Subscriber/Dependencies.php
@@ -28,7 +28,7 @@ class Dependencies implements EventSubscriberInterface
 
         $testSignatures = $test->getDependencies();
         foreach ($testSignatures as $signature) {
-            $matches = preg_grep('/'.addslashes($signature).'(?::\d+)?/', $this->successfulTests);
+            $matches = preg_grep('/' . preg_quote($signature) . '(?::\d+)?/', $this->successfulTests);
             if (empty($matches)) {
                 $test->getMetadata()->setSkip("This test depends on $signature to pass");
                 return;

--- a/src/Codeception/Subscriber/Dependencies.php
+++ b/src/Codeception/Subscriber/Dependencies.php
@@ -28,7 +28,8 @@ class Dependencies implements EventSubscriberInterface
 
         $testSignatures = $test->getDependencies();
         foreach ($testSignatures as $signature) {
-            if (!in_array($signature, $this->successfulTests)) {
+            $matches = preg_grep('/'.addslashes($signature).'(?::\d+)?/', $this->successfulTests);
+            if (empty($matches)) {
                 $test->getMetadata()->setSkip("This test depends on $signature to pass");
                 return;
             }

--- a/src/Codeception/Subscriber/Dependencies.php
+++ b/src/Codeception/Subscriber/Dependencies.php
@@ -28,7 +28,7 @@ class Dependencies implements EventSubscriberInterface
 
         $testSignatures = $test->getDependencies();
         foreach ($testSignatures as $signature) {
-            $matches = preg_grep('/' . preg_quote($signature) . '(?::\d+)?/', $this->successfulTests);
+            $matches = preg_grep('/' . preg_quote($signature) . '(?::.+)?/', $this->successfulTests);
             if (empty($matches)) {
                 $test->getMetadata()->setSkip("This test depends on $signature to pass");
                 return;

--- a/src/Codeception/Test/Cest.php
+++ b/src/Codeception/Test/Cest.php
@@ -155,11 +155,11 @@ class Cest extends Test implements
 
     public function getSignature()
     {
-        $signature = get_class($this->getTestClass()) . ":" . $this->getTestMethod();
-        if (!empty($this->getMetadata()->getCurrent('iteration'))) {
-            $signature .= ':' . $this->getMetadata()->getCurrent('iteration');
+        $iteration = $this->getMetadata()->getCurrent('iteration');
+        if ($iteration !== null) {
+            $iteration = ':' . $iteration;
         }
-        return $signature;
+        return get_class($this->getTestClass()) . ":" . $this->getTestMethod() . $iteration;
     }
 
     public function getTestClass()

--- a/src/Codeception/Test/Cest.php
+++ b/src/Codeception/Test/Cest.php
@@ -155,7 +155,11 @@ class Cest extends Test implements
 
     public function getSignature()
     {
-        return get_class($this->getTestClass()) . ":" . $this->getTestMethod();
+        $signature = get_class($this->getTestClass()) . ":" . $this->getTestMethod();
+        if (!empty($this->getMetadata()->getCurrent('iteration'))) {
+            $signature .= ':' . $this->getMetadata()->getCurrent('iteration');
+        }
+        return $signature;
     }
 
     public function getTestClass()

--- a/src/Codeception/Test/Loader/Cest.php
+++ b/src/Codeception/Test/Loader/Cest.php
@@ -87,7 +87,7 @@ class Cest implements LoaderInterface
                         }
                         $test = new CestFormat($unit, $method, $file);
                         $test->getMetadata()->setCurrent(['example' => $example]);
-                        $test->getMetadata()->setCurrent(['iteration' => ($k + 1)]);
+                        $test->getMetadata()->setCurrent(['iteration' => $k]);
                         $dataProvider->addTest($test);
                     }
                     $this->tests[] = $dataProvider;

--- a/src/Codeception/Test/Loader/Cest.php
+++ b/src/Codeception/Test/Loader/Cest.php
@@ -76,7 +76,6 @@ class Cest implements LoaderInterface
 
                 if (count($examples)) {
                     $dataProvider = new \PHPUnit_Framework_TestSuite_DataProvider();
-                    $iteration = 0;
                     foreach ($examples as $k => $example) {
                         if ($example === null) {
                             throw new TestParseException(
@@ -88,7 +87,7 @@ class Cest implements LoaderInterface
                         }
                         $test = new CestFormat($unit, $method, $file);
                         $test->getMetadata()->setCurrent(['example' => $example]);
-                        $test->getMetadata()->setCurrent(['iteration' => ++$iteration]);
+                        $test->getMetadata()->setCurrent(['iteration' => ($k + 1)]);
                         $dataProvider->addTest($test);
                     }
                     $this->tests[] = $dataProvider;

--- a/src/Codeception/Test/Loader/Cest.php
+++ b/src/Codeception/Test/Loader/Cest.php
@@ -76,6 +76,7 @@ class Cest implements LoaderInterface
 
                 if (count($examples)) {
                     $dataProvider = new \PHPUnit_Framework_TestSuite_DataProvider();
+                    $iteration = 0;
                     foreach ($examples as $k => $example) {
                         if ($example === null) {
                             throw new TestParseException(
@@ -87,6 +88,7 @@ class Cest implements LoaderInterface
                         }
                         $test = new CestFormat($unit, $method, $file);
                         $test->getMetadata()->setCurrent(['example' => $example]);
+                        $test->getMetadata()->setCurrent(['iteration' => ++$iteration]);
                         $dataProvider->addTest($test);
                     }
                     $this->tests[] = $dataProvider;

--- a/tests/cli/RunCest.php
+++ b/tests/cli/RunCest.php
@@ -466,8 +466,12 @@ EOF
 
     public function runTestWithAnnotationDataprovider(CliGuy $I)
     {
-        $I->executeCommand('run scenario -g dataprovider --steps');
-        $I->seeInShellOutput('OK (16 tests');
+        $I->executeCommand('run scenario -g dataprovider --steps', false);
+        $I->seeInShellOutput('Tests: 23, Assertions: 18, Failures: 2, Skipped: 1');
+        $I->seeInShellOutput('Step  See file found "i.do.not.exist.either.yml"');
+        $I->seeInShellOutput('Fail  File "i.do.not.exist.either.yml" not found at ""');
+        $I->seeInShellOutput('SKIPPED: This test depends on DataProviderCest:testDependsWithFailingDataProvider:1,');
+        $I->seeInShellOutput('DataProviderCest:testDependsWithFailingDataProvider:4 to pass');
     }
 
     public function runFailedTestAndCheckOutput(CliGuy $I)

--- a/tests/cli/RunCest.php
+++ b/tests/cli/RunCest.php
@@ -467,7 +467,8 @@ EOF
     public function runTestWithAnnotationDataprovider(CliGuy $I)
     {
         $I->executeCommand('run scenario -g dataprovider --steps', false);
-        $I->seeInShellOutput('Tests: 23, Assertions: 18, Failures: 2, Skipped: 1');
+        $I->seeInShellOutput('Tests: 23');
+        $I->seeInShellOutput('Failures: 2, Skipped: 1');
         $I->seeInShellOutput('Step  See file found "i.do.not.exist.either.yml"');
         $I->seeInShellOutput('Fail  File "i.do.not.exist.either.yml" not found at ""');
         $I->seeInShellOutput('SKIPPED: This test depends on DataProviderCest:testDependsWithFailingDataProvider:1,');

--- a/tests/cli/RunCest.php
+++ b/tests/cli/RunCest.php
@@ -467,7 +467,7 @@ EOF
     public function runTestWithAnnotationDataprovider(CliGuy $I)
     {
         $I->executeCommand('run scenario -g dataprovider --steps');
-        $I->seeInShellOutput('OK (15 tests');
+        $I->seeInShellOutput('OK (16 tests');
     }
 
     public function runFailedTestAndCheckOutput(CliGuy $I)

--- a/tests/cli/RunCest.php
+++ b/tests/cli/RunCest.php
@@ -470,9 +470,25 @@ EOF
         $I->seeInShellOutput('Tests: 23');
         $I->seeInShellOutput('Failures: 2, Skipped: 1');
         $I->seeInShellOutput('1) DataProviderCest: Test depends with failing data provider');
-        $I->seeInShellOutput('Test  tests/scenario/DataProviderCest.php:testDependsWithFailingDataProvider:1');
+        $testPath = implode(
+            DIRECTORY_SEPARATOR,
+            [
+                'tests',
+                'scenario',
+                'DataProviderCest.php:testDependsWithFailingDataProvider:1'
+            ]
+        );
+        $I->seeInShellOutput('Test  ' . $testPath);
         $I->seeInShellOutput('2) DataProviderCest: Test depends with failing data provider');
-        $I->seeInShellOutput('Test  tests/scenario/DataProviderCest.php:testDependsWithFailingDataProvider:4');
+        $testPath = implode(
+            DIRECTORY_SEPARATOR,
+            [
+                'tests',
+                'scenario',
+                'DataProviderCest.php:testDependsWithFailingDataProvider:4'
+            ]
+        );
+        $I->seeInShellOutput('Test  ' . $testPath);
         $I->seeInShellOutput(
             'SKIPPED: This test depends on DataProviderCest:testDependsWithFailingDataProvider:1, '
             . 'DataProviderCest:testDependsWithFailingDataProvider:4 to pass'

--- a/tests/cli/RunCest.php
+++ b/tests/cli/RunCest.php
@@ -469,10 +469,14 @@ EOF
         $I->executeCommand('run scenario -g dataprovider --steps', false);
         $I->seeInShellOutput('Tests: 23');
         $I->seeInShellOutput('Failures: 2, Skipped: 1');
-        $I->seeInShellOutput('Step  See file found "i.do.not.exist.either.yml"');
-        $I->seeInShellOutput('Fail  File "i.do.not.exist.either.yml" not found at ""');
-        $I->seeInShellOutput('SKIPPED: This test depends on DataProviderCest:testDependsWithFailingDataProvider:1,');
-        $I->seeInShellOutput('DataProviderCest:testDependsWithFailingDataProvider:4 to pass');
+        $I->seeInShellOutput('1) DataProviderCest: Test depends with failing data provider');
+        $I->seeInShellOutput('Test  tests/scenario/DataProviderCest.php:testDependsWithFailingDataProvider:1');
+        $I->seeInShellOutput('2) DataProviderCest: Test depends with failing data provider');
+        $I->seeInShellOutput('Test  tests/scenario/DataProviderCest.php:testDependsWithFailingDataProvider:4');
+        $I->seeInShellOutput(
+            'SKIPPED: This test depends on DataProviderCest:testDependsWithFailingDataProvider:1, '
+            . 'DataProviderCest:testDependsWithFailingDataProvider:4 to pass'
+        );
     }
 
     public function runFailedTestAndCheckOutput(CliGuy $I)

--- a/tests/cli/RunCest.php
+++ b/tests/cli/RunCest.php
@@ -467,8 +467,8 @@ EOF
     public function runTestWithAnnotationDataprovider(CliGuy $I)
     {
         $I->executeCommand('run scenario -g dataprovider --steps', false);
-        $I->seeInShellOutput('Tests: 23');
-        $I->seeInShellOutput('Failures: 2, Skipped: 1');
+        $I->seeInShellOutput('Tests: 24');
+        $I->seeInShellOutput('Failures: 2, Skipped: 2');
         $I->seeInShellOutput('1) DataProviderCest: Test depends with failing data provider');
         $testPath = implode(
             DIRECTORY_SEPARATOR,
@@ -493,6 +493,7 @@ EOF
             'SKIPPED: This test depends on DataProviderCest:testDependsWithFailingDataProvider:1, '
             . 'DataProviderCest:testDependsWithFailingDataProvider:4 to pass'
         );
+        $I->seeInShellOutput('SKIPPED: This test depends on DataProviderCest:testThatDoesNotExist to pass');
     }
 
     public function runFailedTestAndCheckOutput(CliGuy $I)

--- a/tests/data/claypit/tests/scenario/DataProviderCest.php
+++ b/tests/data/claypit/tests/scenario/DataProviderCest.php
@@ -47,7 +47,9 @@ class DataProviderCest
 
        /**
         * @group dataprovider
-        * @depends DataProviderCest:testDependsWithDataProvider
+        * @depends DataProviderCest:testDependsWithDataProvider:1
+        * @depends DataProviderCest:testDependsWithDataProvider:2
+        * @depends DataProviderCest:testDependsWithDataProvider:3
         */
        public function testDependsOnTestWithDataProvider()
        {

--- a/tests/data/claypit/tests/scenario/DataProviderCest.php
+++ b/tests/data/claypit/tests/scenario/DataProviderCest.php
@@ -63,6 +63,36 @@ class DataProviderCest
            return true;
        }
 
+       /**
+        * @group dataprovider
+        * @depends Codeception\Demo\Depends\DependencyForCest:forTestPurpose
+        * @dataprovider protectedFailingDataSource
+        */
+       public function testDependsWithFailingDataProvider(ScenarioGuy $I, Example $example)
+       {
+           $I->amInPath($example['path']);
+           $I->seeFileFound($example['file']);
+       }
+
+       /**
+        * @group dataprovider
+        * @depends DataProviderCest:testDependsWithFailingDataProvider
+        */
+       public function testDependsOnTestWithFailingDataProvider()
+       {
+           return true;
+       }
+
+       /**
+        * @group dataprovider
+        * @depends DataProviderCest:testDependsWithFailingDataProvider:2
+        */
+       public function testDependsOnTestWithDiscreteFailingDataProviderExample()
+       {
+           return true;
+       }
+
+
       /**
        * @return array
        */
@@ -84,6 +114,20 @@ class DataProviderCest
               ['path' => ".", 'file' => "scenario.suite.yml"],
               ['path' => ".",  'file' => "dummy.suite.yml"],
               ['path' => ".",  'file' => "unit.suite.yml"]
+          ];
+      }
+
+      /**
+       * @return array
+       */
+      protected function protectedFailingDataSource()
+      {
+          return[
+              ['path' => ".", 'file' => "scenario.suite.yml"],
+              ['path' => ".", 'file' => "i.do.not.exist.yml"],
+              ['path' => ".", 'file' => "dummy.suite.yml"],
+              ['path' => ".", 'file' => "unit.suite.yml"],
+              ['path' => ".", 'file' => "i.do.not.exist.either.yml"]
           ];
       }
 }

--- a/tests/data/claypit/tests/scenario/DataProviderCest.php
+++ b/tests/data/claypit/tests/scenario/DataProviderCest.php
@@ -86,6 +86,7 @@ class DataProviderCest
        /**
         * @group dataprovider
         * @depends DataProviderCest:testDependsWithFailingDataProvider:2
+        * @depends DataProviderCest:testDependsWithFailingDataProvider:3
         */
        public function testDependsOnTestWithDiscreteFailingDataProviderExample()
        {

--- a/tests/data/claypit/tests/scenario/DataProviderCest.php
+++ b/tests/data/claypit/tests/scenario/DataProviderCest.php
@@ -54,6 +54,15 @@ class DataProviderCest
            return true;
        }
 
+       /**
+        * @group dataprovider
+        * @depends DataProviderCest:testDependsWithDataProvider:1
+        */
+       public function testDependsOnTestWithDiscreteDataProviderExample()
+       {
+           return true;
+       }
+
       /**
        * @return array
        */

--- a/tests/data/claypit/tests/scenario/DataProviderCest.php
+++ b/tests/data/claypit/tests/scenario/DataProviderCest.php
@@ -93,6 +93,15 @@ class DataProviderCest
            return true;
        }
 
+       /**
+        * @group dataprovider
+        * @depends DataProviderCest:testDependsWithDataProvider
+        * @depends DataProviderCest:testThatDoesNotExist
+        */
+       public function testDependsOnTestWithDataProviderAndTestThatDoesNotExist()
+       {
+           return true;
+       }
 
       /**
        * @return array

--- a/tests/data/claypit/tests/scenario/DataProviderCest.php
+++ b/tests/data/claypit/tests/scenario/DataProviderCest.php
@@ -47,9 +47,7 @@ class DataProviderCest
 
        /**
         * @group dataprovider
-        * @depends DataProviderCest:testDependsWithDataProvider:1
-        * @depends DataProviderCest:testDependsWithDataProvider:2
-        * @depends DataProviderCest:testDependsWithDataProvider:3
+        * @depends DataProviderCest:testDependsWithDataProvider
         */
        public function testDependsOnTestWithDataProvider()
        {


### PR DESCRIPTION
## Issue
When iterating through dataprovider examples for a Cest method, the test signature remains the same for each example.

This causes any test failures picked up by `addFailure()` in `Codeception\PHPUnit\ResultPrinter\HTML` for all examples provided to the Cest method to accumulate in the same `$failures[Descriptor::getTestSignature($test)]` array.

The effect of this is the test results for each example in the generated HTML report also contain any failures from all previous examples provided by that dataprovider.

Fixes #4110

## Solution
An example iteration count is added to the test metadata in `Codeception\Test\Loader\Cest` which is then appended to the test signature in `Codeception\Test\Cest` so that each example gets its own key in the `$failures` array.