### PR TITLE
ResultPrinter\HTML: Reset failures when test ends (fix #4110)

### DIFF
--- a/src/Codeception/PHPUnit/ResultPrinter/HTML.php
+++ b/src/Codeception/PHPUnit/ResultPrinter/HTML.php
@@ -132,6 +132,7 @@ class HTML extends CodeceptionResultPrinter
                 $failTemplate->setVar(['fail' => nl2br($failure)]);
                 $failures .= $failTemplate->render() . PHP_EOL;
             }
+            $this->failures[$name] = [];
         }
 
         $png = '';


### PR DESCRIPTION
Fixes #4110 

Reset failures when the test ends.
Prevents tests with the same signature inheriting the failures from previous runs.