### PR TITLE
Fix deprecated YAML syntax

### DIFF
--- a/tests/data/params/codeception_self.yml
+++ b/tests/data/params/codeception_self.yml
@@ -11,5 +11,5 @@ params:
 modules:
     enabled:
         - \Helper\Dummy:
-            vars: [%KEY1%, %KEY2%]
-            path: %PATH%
+            vars: ["%KEY1%", "%KEY2%"]
+            path: "%PATH%"

--- a/tests/data/params/tests/dummy.suite.yml
+++ b/tests/data/params/tests/dummy.suite.yml
@@ -2,5 +2,5 @@ class_name: DummyTester
 modules:
     enabled:
         - \Helper\Dummy:
-            vars: [%KEY1%, %KEY2%]
-            path: %PATH%
+            vars: ["%KEY1%", "%KEY2%"]
+            path: "%PATH%"


### PR DESCRIPTION
Deprecated usage of % at the beginning of an unquoted string since symfony/yaml:3.1, throw ParseError since symfony/yaml:4.0.0