### PR TITLE
Fix test broken by php-code-coverage 5.2.4

### DIFF
--- a/tests/cli/IncludedCest.php
+++ b/tests/cli/IncludedCest.php
@@ -147,9 +147,9 @@ class IncludedCest
         $I->executeCommand('run --coverage-xml');
         $I->amInPath('_log');
         $I->seeFileFound('coverage.xml');
-        $I->seeInThisFile('<class name="BillEvans" namespace="Jazz\Pianist">');
-        $I->seeInThisFile('<class name="Musician" namespace="Jazz">');
-        $I->seeInThisFile('<class name="Hobbit" namespace="Shire">');
+        $I->seeInThisFile('BillEvans" namespace="Jazz\Pianist">');
+        $I->seeInThisFile('Musician" namespace="Jazz">');
+        $I->seeInThisFile('Hobbit" namespace="Shire">');
     }
 
     /**


### PR DESCRIPTION
The build was broken by PHP Code Coverage bugfix of  issue 455 in version 5.2.4: 

`Fail  No text '<class name="BillEvans" namespace="Jazz\Pianist">' in currently opened file`

Actual output: `<class name="Jazz\Pianist\BillEvans" namespace="Jazz\Pianist">\n`

https://github.com/Codeception/Codeception/pull/4648