### PR TITLE
Perform Yii2 application reset before performing request in functional tests

### DIFF
--- a/src/Codeception/Lib/Connector/Yii2.php
+++ b/src/Codeception/Lib/Connector/Yii2.php
@@ -121,6 +121,7 @@ class Yii2 extends Client
             $_GET[$k] = $v;
         }
 
+        $this->resetApplication();
         $app = $this->getApplication();
 
         $app->getResponse()->on(YiiResponse::EVENT_AFTER_PREPARE, [$this, 'processResponse']);
@@ -159,7 +160,6 @@ class Yii2 extends Client
                 $app->errorHandler->handleException($e);
             } elseif (!$e instanceof ExitException) {
                 // for exceptions not related to Http, we pass them to Codeception
-                $this->resetApplication();
                 throw $e;
             }
         }
@@ -171,8 +171,6 @@ class Yii2 extends Client
         if (isset($this->headers['location'])) {
             Debug::debug("[Headers] " . json_encode($this->headers));
         }
-
-        $this->resetApplication();
 
         return new Response($content, $this->statusCode, $this->headers);
     }

--- a/src/Codeception/Lib/Connector/Yii2.php
+++ b/src/Codeception/Lib/Connector/Yii2.php
@@ -10,7 +10,6 @@ use Symfony\Component\BrowserKit\Response;
 use Yii;
 use yii\base\ExitException;
 use yii\web\HttpException;
-use yii\web\Request as YiiRequest;
 use yii\web\Response as YiiResponse;
 
 class Yii2 extends Client
@@ -136,7 +135,9 @@ class Yii2 extends Client
 
         ob_start();
 
-        $yiiRequest = new YiiRequest();
+        // recreating request object to reset headers and cookies collections
+        $app->set('request', $app->getComponents()['request']);
+        $yiiRequest = $app->getRequest();
         if ($request->getContent() !== null) {
             $yiiRequest->setRawBody($request->getContent());
             $yiiRequest->setBodyParams(null);

--- a/src/Codeception/Lib/Connector/Yii2.php
+++ b/src/Codeception/Lib/Connector/Yii2.php
@@ -10,6 +10,7 @@ use Symfony\Component\BrowserKit\Response;
 use Yii;
 use yii\base\ExitException;
 use yii\web\HttpException;
+use yii\web\Request as YiiRequest;
 use yii\web\Response as YiiResponse;
 
 class Yii2 extends Client
@@ -121,7 +122,6 @@ class Yii2 extends Client
             $_GET[$k] = $v;
         }
 
-        $this->resetApplication();
         $app = $this->getApplication();
 
         $app->getResponse()->on(YiiResponse::EVENT_AFTER_PREPARE, [$this, 'processResponse']);
@@ -136,7 +136,7 @@ class Yii2 extends Client
 
         ob_start();
 
-        $yiiRequest = $app->getRequest();
+        $yiiRequest = new YiiRequest();
         if ($request->getContent() !== null) {
             $yiiRequest->setRawBody($request->getContent());
             $yiiRequest->setBodyParams(null);
@@ -160,6 +160,7 @@ class Yii2 extends Client
                 $app->errorHandler->handleException($e);
             } elseif (!$e instanceof ExitException) {
                 // for exceptions not related to Http, we pass them to Codeception
+                $this->resetApplication();
                 throw $e;
             }
         }
@@ -171,6 +172,8 @@ class Yii2 extends Client
         if (isset($this->headers['location'])) {
             Debug::debug("[Headers] " . json_encode($this->headers));
         }
+
+        $this->resetApplication();
 
         return new Response($content, $this->statusCode, $this->headers);
     }


### PR DESCRIPTION
## The problem

https://github.com/Codeception/Codeception/issues/4587

Before performing any request via REST module, I must obtain JWT token, that will allow me to perform request. Component, that generate JWT tokens use `Yii::$app->request->getUserIP()` and `Yii::$app->request->getHostInfo()`,  implementation of which [was changed in 2.0.13 release](https://github.com/yiisoft/yii2/pull/13780). Now it call `Yii::$app->request->getHeaders()`. `getHeaders()` method is create `HeaderCollection`, that will be cached inside private field.

For example I have such code:

```php
$token = Yii::$app->jwtProvider->getToken();
$I->amBearerAuthenticated($token);
$I->sendPost('/api/secure/resource', ['key' => 'value']);
$I->canSeeResponseCodeIs(200);
```

But you can simulate this problem more easier:

```php
Yii::$app->request->getHeaders();
$I->amBearerAuthenticated('123');
$I->sendPost('/api/secure/resource', ['key' => 'value']);
$I->canSeeResponseCodeIs(200);
```

If you try to debug, you will find such result:

![](http://erickskrauch.ely.by/monosnap-27-11-2017-at-02-54-38.png)

It's because request performed with last exists YIi2 application instance, where `Request` contains already read `headers` field.

### Solution

Simple call `resetApplication()` **before** performing request, because we want to execute request on clean app, without any external modifications.

I also remove calls of `resetApplication()` **after** request, because it can be useful to assert some application state with `Assert` module enabled.