### PR TITLE
Wrong failed step

### DIFF
--- a/src/Codeception/Subscriber/Console.php
+++ b/src/Codeception/Subscriber/Console.php
@@ -68,7 +68,7 @@ class Console implements EventSubscriberInterface
      */
     protected $output;
     protected $conditionalFails = [];
-    protected $failedStep;
+    protected $failedStep = [];
     protected $reports = [];
     protected $namespace = '';
     protected $chars = ['success' => '+', 'fail' => 'x', 'of' => ':'];
@@ -194,7 +194,7 @@ class Console implements EventSubscriberInterface
             $this->conditionalFails[] = $step;
             return;
         }
-        $this->failedStep = $step;
+        $this->failedStep[] = $step;
     }
 
     /**
@@ -411,7 +411,7 @@ class Console implements EventSubscriberInterface
         } else {
             $failedStep = (string) $failedTest->getScenario()->getMetaStep();
             if ($failedStep === '') {
-                $failedStep = (string)$this->failedStep;
+                $failedStep = (string) array_shift($this->failedStep);
             }
         }
 

--- a/tests/cli/RunCest.php
+++ b/tests/cli/RunCest.php
@@ -491,6 +491,7 @@ EOF
         $I->executeCommand('run scenario PartialFailedCest', false);
         $I->seeInShellOutput('See file found "testcasetwo.txt"');
         $I->seeInShellOutput('See file found "testcasethree.txt"');
-        $I->seeInShellOutput('Tests: 3, Assertions: 3, Failures: 2.');
+        $I->seeInShellOutput('Tests: 3,');
+        $I->seeInShellOutput('Failures: 2.');
     }
 }

--- a/tests/cli/RunCest.php
+++ b/tests/cli/RunCest.php
@@ -485,4 +485,12 @@ EOF
         $I->executeCommand('run powers PowerUpCest');
         $I->dontSeeInShellOutput('FAILURES');
     }
+    
+    public function runCestWithTwoFailedTest(CliGuy $I)
+    {
+        $I->executeCommand('run scenario PartialFailedCest', false);
+        $I->seeInShellOutput('See file found "testcasetwo.txt"');
+        $I->seeInShellOutput('See file found "testcasethree.txt"');
+        $I->seeInShellOutput('Tests: 3, Assertions: 3, Failures: 2.');
+    }
 }

--- a/tests/data/claypit/tests/scenario/PartialFailedCest.php
+++ b/tests/data/claypit/tests/scenario/PartialFailedCest.php
@@ -1,0 +1,23 @@
+<?php
+
+class PartialFailedCest
+{
+    public function testCaseOne(ScenarioGuy $I)
+    {
+        $I->amInPath('.');
+        $I->seeFileFound('scenario.suite.yml');
+    }
+
+    public function testCaseTwo(ScenarioGuy $I)
+    {
+        $I->amInPath('.');
+        $I->seeFileFound('testcasetwo.txt');
+    }
+
+    public function testCaseThree(ScenarioGuy $I)
+    {
+        $I->amInPath('.');
+        $I->seeFileFound('testcasethree.txt');
+    }
+
+}


### PR DESCRIPTION
Hello,

Context: In one cest file with three tests (1 success and 2 failed)

Actual result: 
```
There were 2 failures:

  ---------
  1) PartialFailedCest: Test case two
   Test  tests/scenario/PartialFailedCest.php:testCaseTwo
   Step  See file found "testcasethree.txt"                  <==== bug here
   Fail  File "testcasetwo.txt" not found at ""

  Scenario Steps:

   2. $I->seeFileFound("testcasetwo.txt") at tests/scenario/PartialFailedCest.php:14
   1. $I->amInPath(".") at tests/scenario/PartialFailedCest.php:13


  ---------
  2) PartialFailedCest: Test case three
   Test  tests/scenario/PartialFailedCest.php:testCaseThree
   Step  See file found "testcasethree.txt"
   Fail  File "testcasethree.txt" not found at ""

  Scenario Steps:

   2. $I->seeFileFound("testcasethree.txt") at tests/scenario/PartialFailedCest.php:20
   1. $I->amInPath(".") at tests/scenario/PartialFailedCest.php:19


  FAILURES!
  Tests: 3, Assertions: 3, Failures: 2.
```

Expected result: 
```
There were 2 failures:

  ---------
  1) PartialFailedCest: Test case two
   Test  tests/scenario/PartialFailedCest.php:testCaseTwo
   Step  See file found "testcasetwo.txt"
   Fail  File "testcasetwo.txt" not found at ""

  Scenario Steps:

   2. $I->seeFileFound("testcasetwo.txt") at tests/scenario/PartialFailedCest.php:14
   1. $I->amInPath(".") at tests/scenario/PartialFailedCest.php:13


  ---------
  2) PartialFailedCest: Test case three
   Test  tests/scenario/PartialFailedCest.php:testCaseThree
   Step  See file found "testcasethree.txt"
   Fail  File "testcasethree.txt" not found at ""

  Scenario Steps:

   2. $I->seeFileFound("testcasethree.txt") at tests/scenario/PartialFailedCest.php:20
   1. $I->amInPath(".") at tests/scenario/PartialFailedCest.php:19


  FAILURES!
  Tests: 3, Assertions: 3, Failures: 2.
```

Fix this previous PR #4607