### PR TITLE
Issue-4663 fixed signature in DummyCodeCoverage::stop

### DIFF
--- a/src/Codeception/Coverage/DummyCodeCoverage.php
+++ b/src/Codeception/Coverage/DummyCodeCoverage.php
@@ -7,7 +7,7 @@ class DummyCodeCoverage extends \PHP_CodeCoverage
     {
     }
 
-    public function stop($append = true, $linesToBeCovered = [], array $linesToBeUsed = [])
+    public function stop($append = true, $linesToBeCovered = [], array $linesToBeUsed = [], $ignoreForceCoversAnnotation = false)
     {
     }
 }


### PR DESCRIPTION
Need to add 4th parameter "$ignoreForceCoversAnnotation = false" in DummyCodeCoverage::stop method for keeping signature from "SebastianBergmann\CodeCoverage\CodeCoverage"

Fixed error:
" Declaration of Codeception\Coverage\DummyCodeCoverage::stop($append = true,  
   $linesToBeCovered = Array, array $linesToBeUsed = Array) should be compati  
  ble with SebastianBergmann\CodeCoverage\CodeCoverage::stop($append = true,   
  $linesToBeCovered = Array, array $linesToBeUsed = Array, $ignoreForceCovers  
  Annotation = false)"