### PR TITLE
Refactoring tests

### DIFF
--- a/tests/data/no_actor_suites/tests/BasicTest.php
+++ b/tests/data/no_actor_suites/tests/BasicTest.php
@@ -3,7 +3,7 @@ class BasicTest extends \Codeception\Test\Unit
 {
     public function testMe()
     {
-        $this->assertFalse(isset($this->tester));
+        $this->assertObjectNotHasAttribute('tester', $this);
         $this->assertTrue(true);
     }
 }

--- a/tests/unit/Codeception/Module/MongoDbLegacyTest.php
+++ b/tests/unit/Codeception/Module/MongoDbLegacyTest.php
@@ -72,7 +72,7 @@ class MongoDbLegacyTest extends \PHPUnit_Framework_TestCase
     public function testGrabFromCollection()
     {
         $user = $this->module->grabFromCollection('users', array('id' => 1));
-        $this->assertTrue(isset($user['email']));
+        $this->assertArrayHasKey('email', $user);
         $this->assertEquals('miles@davis.com', $user['email']);
     }
 

--- a/tests/unit/Codeception/Module/MongoDbTest.php
+++ b/tests/unit/Codeception/Module/MongoDbTest.php
@@ -77,7 +77,7 @@ class MongoDbTest extends Unit
     public function testGrabFromCollection()
     {
         $user = $this->module->grabFromCollection('users', array('id' => 1));
-        $this->assertTrue(isset($user['email']));
+        $this->assertArrayHasKey('email', $user);
         $this->assertEquals('miles@davis.com', $user['email']);
     }
 

--- a/tests/unit/Codeception/TestLoaderTest.php
+++ b/tests/unit/Codeception/TestLoaderTest.php
@@ -22,25 +22,25 @@ class TestLoaderTest extends \PHPUnit_Framework_TestCase
     public function testAddCept()
     {
         $this->testLoader->loadTest('SimpleCept.php');
-        $this->assertEquals(1, count($this->testLoader->getTests()));
+        $this->assertCount(1, $this->testLoader->getTests());
     }
 
     public function testAddTest()
     {
         $this->testLoader->loadTest('SimpleTest.php');
-        $this->assertEquals(1, count($this->testLoader->getTests()));
+        $this->assertCount(1, $this->testLoader->getTests());
     }
 
     public function testAddCeptAbsolutePath()
     {
         $this->testLoader->loadTest(codecept_data_dir('SimpleCept.php'));
-        $this->assertEquals(1, count($this->testLoader->getTests()));
+        $this->assertCount(1, $this->testLoader->getTests());
     }
 
     public function testAddCeptWithoutExtension()
     {
         $this->testLoader->loadTest('SimpleCept');
-        $this->assertEquals(1, count($this->testLoader->getTests()));
+        $this->assertCount(1, $this->testLoader->getTests());
     }
 
     /**
@@ -49,7 +49,7 @@ class TestLoaderTest extends \PHPUnit_Framework_TestCase
     public function testLoadFileWithFewCases()
     {
         $this->testLoader->loadTest('SimpleNamespacedTest.php');
-        $this->assertEquals(3, count($this->testLoader->getTests()));
+        $this->assertCount(3, $this->testLoader->getTests());
     }
 
     /**
@@ -87,6 +87,6 @@ class TestLoaderTest extends \PHPUnit_Framework_TestCase
 
     protected function assertContainsTestName($name, $testNames)
     {
-        $this->assertNotSame(false, array_search($name, $testNames), "$name not found in tests");
+        $this->assertContains($name, $testNames, "$name not found in tests");
     }
 }

--- a/tests/unit/Codeception/Util/StubTest.php
+++ b/tests/unit/Codeception/Util/StubTest.php
@@ -164,42 +164,42 @@ class StubTest extends \PHPUnit_Framework_TestCase
             $dummy
         );
         $dummy = Stub::make(new \DummyOverloadableClass());
-        $this->assertTrue(isset($dummy->__mocked));
+        $this->assertObjectHasAttribute('__mocked', $dummy);
         $dummy = Stub::makeEmpty(new \DummyClass());
         $this->assertInstanceOf(
             '\PHPUnit_Framework_MockObject_MockObject',
             $dummy
         );
         $dummy = Stub::makeEmpty(new \DummyOverloadableClass());
-        $this->assertTrue(isset($dummy->__mocked));
+        $this->assertObjectHasAttribute('__mocked', $dummy);
         $dummy = Stub::makeEmptyExcept(new \DummyClass(), 'helloWorld');
         $this->assertInstanceOf(
             '\PHPUnit_Framework_MockObject_MockObject',
             $dummy
         );
         $dummy = Stub::makeEmptyExcept(new \DummyOverloadableClass(), 'helloWorld');
-        $this->assertTrue(isset($dummy->__mocked));
+        $this->assertObjectHasAttribute('__mocked', $dummy);
         $dummy = Stub::construct(new \DummyClass());
         $this->assertInstanceOf(
             '\PHPUnit_Framework_MockObject_MockObject',
             $dummy
         );
         $dummy = Stub::construct(new \DummyOverloadableClass());
-        $this->assertTrue(isset($dummy->__mocked));
+        $this->assertObjectHasAttribute('__mocked', $dummy);
         $dummy = Stub::constructEmpty(new \DummyClass());
         $this->assertInstanceOf(
             '\PHPUnit_Framework_MockObject_MockObject',
             $dummy
         );
         $dummy = Stub::constructEmpty(new \DummyOverloadableClass());
-        $this->assertTrue(isset($dummy->__mocked));
+        $this->assertObjectHasAttribute('__mocked', $dummy);
         $dummy = Stub::constructEmptyExcept(new \DummyClass(), 'helloWorld');
         $this->assertInstanceOf(
             '\PHPUnit_Framework_MockObject_MockObject',
             $dummy
         );
         $dummy = Stub::constructEmptyExcept(new \DummyOverloadableClass(), 'helloWorld');
-        $this->assertTrue(isset($dummy->__mocked));
+        $this->assertObjectHasAttribute('__mocked', $dummy);
     }
 
     protected function assertMethodReplaced($dummy)
@@ -392,7 +392,7 @@ class StubTest extends \PHPUnit_Framework_TestCase
         // Expected null value when no more values
         $this->assertNull($dummy->helloWorld());
     }
-    
+
     public function testStubPrivateProperties()
     {
         $tester = Stub::construct(
@@ -410,7 +410,7 @@ class StubTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('randomstuff', $tester->getRandomName());
         $this->assertEquals('ticky2', $tester->getT());
     }
-    
+
     public function testStubMakeEmptyInterface()
     {
         $stub = Stub::makeEmpty('\Countable', ['count' => 5]);

--- a/tests/web/WebDriverTest.php
+++ b/tests/web/WebDriverTest.php
@@ -877,7 +877,7 @@ class WebDriverTest extends TestsForBrowsers
         // assert
         /* @var $steps Step[]  */
         $steps = $cept->getScenario()->getSteps();
-        $this->assertEquals(0, count($steps));
+        $this->assertCount(0, $steps);
     }
 
     public function testMoveMouseOver()


### PR DESCRIPTION
I've refactored some tests, using:
- `assertCount` instead of `count` function;
- `assertObjectNotHasAttribute`, `assertObjectHasAttribute` and `assertArrayHasKey` instead of `isset` function;
- `assertContains` instead of `array_search` function.