### PR TITLE
Descriptor: getTestSignatureUnique

### DIFF
--- a/src/Codeception/Lib/InnerBrowser.php
+++ b/src/Codeception/Lib/InnerBrowser.php
@@ -61,7 +61,7 @@ class InnerBrowser extends Module implements Web, PageSourceSaver, ElementLocato
         if (!$this->client || !$this->client->getInternalResponse()) {
             return;
         }
-        $filename = preg_replace('~\W~', '.', Descriptor::getTestSignature($test));
+        $filename = preg_replace('~\W~', '.', Descriptor::getTestSignatureUnique($test));
         $filename = mb_strcut($filename, 0, 244, 'utf-8') . '.fail.html';
         $this->_savePageSource($report = codecept_output_dir() . $filename);
         $test->getMetadata()->addReport('html', $report);
@@ -1343,7 +1343,7 @@ class InnerBrowser extends Module implements Web, PageSourceSaver, ElementLocato
     {
         $result = [];
         $nodes = $this->match($cssOrXpath);
-        
+
         foreach ($nodes as $node) {
             if ($attribute !== null) {
                 $result[] = $node->getAttribute($attribute);
@@ -1891,7 +1891,7 @@ class InnerBrowser extends Module implements Web, PageSourceSaver, ElementLocato
         // Since strip_tags has problems with JS code that contains
         // an <= operator the script tags have to be removed manually first.
         $content = preg_replace('#<script(.*?)>(.*?)</script>#is', '', $content);
-        
+
         $content = strip_tags($content);
         $content = html_entity_decode($content, ENT_QUOTES);
         $content = str_replace("\n", ' ', $content);

--- a/src/Codeception/Module/WebDriver.php
+++ b/src/Codeception/Module/WebDriver.php
@@ -499,7 +499,7 @@ class WebDriver extends CodeceptionModule implements
     public function _failed(TestInterface $test, $fail)
     {
         $this->debugWebDriverLogs($test);
-        $filename = preg_replace('~\W~', '.', Descriptor::getTestSignature($test));
+        $filename = preg_replace('~\W~', '.', Descriptor::getTestSignatureUnique($test));
         $outputDir = codecept_output_dir();
         $this->_saveScreenshot($report = $outputDir . mb_strcut($filename, 0, 245, 'utf-8') . '.fail.png');
         $test->getMetadata()->addReport('png', $report);

--- a/src/Codeception/Test/Descriptor.php
+++ b/src/Codeception/Test/Descriptor.php
@@ -24,6 +24,25 @@ class Descriptor
         return $testCase->toString();
     }
 
+    /**
+     * Provides a test name which is unique for individual iterations of tests using examples
+     *
+     * @param \PHPUnit_Framework_SelfDescribing $testCase
+     * @return string
+     */
+    public static function getTestSignatureUnique(\PHPUnit_Framework_SelfDescribing $testCase)
+    {
+        $example = null;
+
+        if (is_callable([$testCase, 'getMetadata'])
+            && $example = $testCase->getMetadata()->getCurrent('example')
+        ) {
+            $example = ':' . substr(sha1(json_encode($example)), 0, 7);
+        }
+
+        return self::getTestSignature($testCase) . $example;
+    }
+
     public static function getTestAsString(\PHPUnit_Framework_SelfDescribing $testCase)
     {
         if ($testCase instanceof \PHPUnit_Framework_TestCase) {


### PR DESCRIPTION
Add `Descriptor::getTestSignatureUnique()`, to create unique names for tests using examples where `Descriptor::getTestSignature()` is not unique.

Add use of the new unique descriptor to implementations of `PageSourceSaver` and `ScreenshotSaver` where filenames are being created to provide a unique filename for each failure.

Fixes #4672