### PR TITLE
[Db] Database in DSN regex matching fix

### DIFF
--- a/src/Codeception/Lib/Driver/SqlSrv.php
+++ b/src/Codeception/Lib/Driver/SqlSrv.php
@@ -6,7 +6,7 @@ class SqlSrv extends Db
     public function getDb()
     {
         $matches = [];
-        $matched = preg_match('~Database=(.*);~s', $this->dsn, $matches);
+        $matched = preg_match('~Database=(.*);?~s', $this->dsn, $matches);
 
         if (!$matched) {
             return false;


### PR DESCRIPTION
If your DSN for MS SQL (sqlsrv) specifies the `Database` param as the last option then the regex for the Database name find it due to the semicolon not being optional.