### PR TITLE
Invalid Actor Hash Generation if dependencies are used

### DIFF
--- a/src/Codeception/Lib/Generator/Actions.php
+++ b/src/Codeception/Lib/Generator/Actions.php
@@ -58,8 +58,9 @@ EOF;
         $modules = Configuration::modules($this->settings);
         $this->moduleContainer = new ModuleContainer($this->di, $settings);
         foreach ($modules as $moduleName) {
-            $this->modules[$moduleName] = $this->moduleContainer->create($moduleName);
+            $this->moduleContainer->create($moduleName);
         }
+        $this->modules = $this->moduleContainer->all();
         $this->actions = $this->moduleContainer->getActions();
     }
 


### PR DESCRIPTION
If a module uses dependencies (like PhpBrowser for Facebook), these methods are not included for the hash calculation of the newly created actor trait (Actions::produce()).
During the hash check in AutoRebuild::updateActor() the hash is calculated with the included values. Therefore the Actor trait will be generated every time.

The difference between the two calculations is, that in SuiteManager:createSuite ModuleContainer::all() is called to populate the modules in the SUITE_INIT event, while the Actions class is relying on ModuleContainer::create(), which returns just the currently created module, but injects the dependencies to the internal modules array (Which id accessible by ModuleContainer::all()).

Creating the Actor on every run causes errors during parallel test execution. While process A has already created the Actor Trait, process B is may still creating it. Process B has deleted the trait because the hashes do not match, process A (a step ahead) is trying to load the Actor class, but is unable to find the used trait (because it's deleted). 

