### PR TITLE
Compatibility with phpunit-mock-objects 5.*

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "ext-mbstring": "*",
         "phpunit/phpunit": ">=4.8.28 <5.0.0 || >=5.6.3 <7.0",
         "phpunit/php-code-coverage": ">=2.2.4 <6.0",
-        "phpunit/phpunit-mock-objects": ">2.3 <5.0",
+        "phpunit/phpunit-mock-objects": ">2.3 <6.0",
         "facebook/webdriver": ">=1.1.3 <2.0",
         "guzzlehttp/guzzle": ">=4.1.4 <7.0",
         "guzzlehttp/psr7": "~1.0",

--- a/shim.php
+++ b/shim.php
@@ -80,6 +80,7 @@ namespace Codeception\Platform {
     {
     }
 }
+
 namespace {
     class_alias('Codeception\TestInterface', 'Codeception\TestCase');
 
@@ -92,6 +93,45 @@ namespace {
         class_alias('SebastianBergmann\CodeCoverage\Report\Crap4j', 'PHP_CodeCoverage_Report_Crap4j');
         class_alias('SebastianBergmann\CodeCoverage\Report\Html\Facade', 'PHP_CodeCoverage_Report_HTML');
         class_alias('SebastianBergmann\CodeCoverage\Exception', 'PHP_CodeCoverage_Exception');
+    }
+
+    // phpunit-mock-objects 5+
+    if (class_exists('PHPUnit\Framework\MockObject\Generator')) {
+        class_alias('PHPUnit\Framework\MockObject\Generator', 'PHPUnit_Framework_MockObject_Generator');
+        class_alias('PHPUnit\Framework\MockObject\InvocationMocker', 'PHPUnit_Framework_MockObject_InvocationMocker');
+        class_alias('PHPUnit\Framework\MockObject\Invokable', 'PHPUnit_Framework_MockObject_Invokable');
+        class_alias('PHPUnit\Framework\MockObject\Matcher', 'PHPUnit_Framework_MockObject_Matcher');
+        class_alias('PHPUnit\Framework\MockObject\MockBuilder', 'PHPUnit_Framework_MockObject_MockBuilder');
+        if (!interface_exists('PHPUnit_Framework_MockObject_MockObject')){
+            /*
+             * old name still exists in https://github.com/sebastianbergmann/phpunit-mock-objects/blob/master/src/MockObject.php
+             * but namespaced alias is provided by https://github.com/sebastianbergmann/phpunit-mock-objects/blob/master/src/ForwardCompatibility/MockObject.php
+             */
+            class_alias('PHPUnit\Framework\MockObject\MockObject', 'PHPUnit_Framework_MockObject_MockObject');
+        }
+        class_alias('PHPUnit\Framework\MockObject\Stub', 'PHPUnit_Framework_MockObject_Stub');
+        class_alias('PHPUnit\Framework\MockObject\Verifiable', 'PHPUnit_Framework_MockObject_Verifiable');
+        class_alias('PHPUnit\Framework\MockObject\Matcher\AnyInvokedCount', 'PHPUnit_Framework_MockObject_Matcher_AnyInvokedCount');
+        class_alias('PHPUnit\Framework\MockObject\Matcher\ConsecutiveParameters', 'PHPUnit_Framework_MockObject_Matcher_ConsecutiveParameters');
+        class_alias('PHPUnit\Framework\MockObject\Matcher\Invocation', 'PHPUnit_Framework_MockObject_Matcher_Invocation');
+        class_alias('PHPUnit\Framework\MockObject\Matcher\InvokedAtIndex', 'PHPUnit_Framework_MockObject_Matcher_InvokedAtIndex');
+        class_alias('PHPUnit\Framework\MockObject\Matcher\InvokedAtLeastCount', 'PHPUnit_Framework_MockObject_Matcher_InvokedAtLeastCount');
+        class_alias('PHPUnit\Framework\MockObject\Matcher\InvokedAtLeastOnce', 'PHPUnit_Framework_MockObject_Matcher_InvokedAtLeastOnce');
+        class_alias('PHPUnit\Framework\MockObject\Matcher\InvokedAtMostCount', 'PHPUnit_Framework_MockObject_Matcher_InvokedAtMostCount');
+        class_alias('PHPUnit\Framework\MockObject\Matcher\InvokedCount', 'PHPUnit_Framework_MockObject_Matcher_InvokedCount');
+        class_alias('PHPUnit\Framework\MockObject\Matcher\InvokedRecorder', 'PHPUnit_Framework_MockObject_Matcher_InvokedRecorder');
+        class_alias('PHPUnit\Framework\MockObject\Matcher\MethodName', 'PHPUnit_Framework_MockObject_Matcher_MethodName');
+        class_alias('PHPUnit\Framework\MockObject\Matcher\Parameters', 'PHPUnit_Framework_MockObject_Matcher_Parameters');
+        class_alias('PHPUnit\Framework\MockObject\Matcher\StatelessInvocation', 'PHPUnit_Framework_MockObject_Matcher_StatelessInvocation');
+        class_alias('PHPUnit\Framework\MockObject\Stub\ConsecutiveCalls', 'PHPUnit_Framework_MockObject_Stub_ConsecutiveCalls');
+        class_alias('PHPUnit\Framework\MockObject\Stub\Exception', 'PHPUnit_Framework_MockObject_Stub_Exception');
+        class_alias('PHPUnit\Framework\MockObject\Stub\MatcherCollection', 'PHPUnit_Framework_MockObject_Stub_MatcherCollection');
+        class_alias('PHPUnit\Framework\MockObject\Stub\ReturnArgument', 'PHPUnit_Framework_MockObject_Stub_ReturnArgument');
+        class_alias('PHPUnit\Framework\MockObject\Stub\ReturnCallback', 'PHPUnit_Framework_MockObject_Stub_ReturnCallback');
+        class_alias('PHPUnit\Framework\MockObject\Stub\ReturnReference', 'PHPUnit_Framework_MockObject_Stub_ReturnReference');
+        class_alias('PHPUnit\Framework\MockObject\Stub\ReturnSelf', 'PHPUnit_Framework_MockObject_Stub_ReturnSelf');
+        class_alias('PHPUnit\Framework\MockObject\Stub\ReturnStub', 'PHPUnit_Framework_MockObject_Stub_Return');
+        class_alias('PHPUnit\Framework\MockObject\Stub\ReturnValueMap', 'PHPUnit_Framework_MockObject_Stub_ReturnValueMap');
     }
 }
 


### PR DESCRIPTION
Add class aliases used by Codeception\Util\Stub

Allows to install PHPUnit 6.5
Fixes #4715 