### PR TITLE
Add Doctrine2 integration to ZendExpressive module

### DIFF
--- a/src/Codeception/Module/ZendExpressive.php
+++ b/src/Codeception/Module/ZendExpressive.php
@@ -5,6 +5,7 @@ use Codeception\Lib\Framework;
 use Codeception\TestInterface;
 use Codeception\Configuration;
 use Codeception\Lib\Connector\ZendExpressive as ZendExpressiveConnector;
+use Codeception\Lib\Interfaces\DoctrineProvider;
 
 /**
  * This module allows you to run tests inside Zend Expressive.
@@ -27,7 +28,7 @@ use Codeception\Lib\Connector\ZendExpressive as ZendExpressiveConnector;
  * * client - BrowserKit client
  *
  */
-class ZendExpressive extends Framework
+class ZendExpressive extends Framework implements DoctrineProvider
 {
     protected $config = [
         'container' => 'config/container.php',
@@ -101,5 +102,15 @@ class ZendExpressive extends Framework
 
         $this->responseCollector = new ZendExpressiveConnector\ResponseCollector;
         $emitterStack->unshift($this->responseCollector);
+    }
+
+    public function _getEntityManager()
+    {
+        $service = 'Doctrine\ORM\EntityManager';
+        if (!$this->container->has($service)) {
+            throw new \PHPUnit_Framework_AssertionFailedError("Service $service is not available in container");
+        }
+
+        return $this->container->get('Doctrine\ORM\EntityManager');
     }
 }


### PR DESCRIPTION
Previous PR #4464 was rejected because of missing tests. I've made two tests with single and multiple POST requests that creates entities in database. Now it is in this repository: https://github.com/artmnv/codeception-zend-expressive-tests/tree/doctrine-tests
I don't send PR in source repository because there is no 2.3 branch.

Feel free to ask additional help.