### PR TITLE
Add clear field method

### DIFF
--- a/src/Codeception/Lib/Interfaces/Web.php
+++ b/src/Codeception/Lib/Interfaces/Web.php
@@ -698,34 +698,20 @@ interface Web
      * @param $value
      */
     public function fillField($field, $value);
-
+    
     /**
-     * Fills field with the given value.
+     * Attaches a file relative to the Codeception `_data` directory to the given file upload field.
      *
      * ``` php
      * <?php
-     * $I->fillField('#username', 'username');
+     * // file is stored in 'tests/_data/prices.xls'
+     * $I->attachFile('input[@type="file"]', 'prices.xls');
      * ?>
      * ```
      *
      * @param $field
-     * @param $value
+     * @param $filename
      */
-    
-    public function clearField($field);
-
-    /**
-     * Clears given field which isn't empty.
-     *
-     * ``` php
-     * <?php
-     * $I->clearField('#username');
-     * ?>
-     * ```
-     *
-     * @param $field
-     */
-    
     public function attachFile($field, $filename);
 
     /**

--- a/src/Codeception/Lib/Interfaces/Web.php
+++ b/src/Codeception/Lib/Interfaces/Web.php
@@ -700,18 +700,32 @@ interface Web
     public function fillField($field, $value);
 
     /**
-     * Attaches a file relative to the Codeception `_data` directory to the given file upload field.
+     * Fills field with the given value.
      *
      * ``` php
      * <?php
-     * // file is stored in 'tests/_data/prices.xls'
-     * $I->attachFile('input[@type="file"]', 'prices.xls');
+     * $I->fillField('#username', 'username');
      * ?>
      * ```
      *
      * @param $field
-     * @param $filename
+     * @param $value
      */
+    
+    public function clearField($field);
+
+    /**
+     * Clears given field which isn't empty.
+     *
+     * ``` php
+     * <?php
+     * $I->clearField('#username');
+     * ?>
+     * ```
+     *
+     * @param $field
+     */
+    
     public function attachFile($field, $filename);
 
     /**

--- a/src/Codeception/Module/WebDriver.php
+++ b/src/Codeception/Module/WebDriver.php
@@ -1624,6 +1624,17 @@ class WebDriver extends CodeceptionModule implements
         $el->sendKeys($value);
     }
 
+    /**
+    * Clears given field which isn't empty.
+    *
+    * ``` php
+    * <?php
+    * $I->clearField('#username');
+    * ?>
+    * ```
+    *
+    * @param $field
+    */    
     public function clearField($field)
     {
         $el = $this->findField($field);

--- a/src/Codeception/Module/WebDriver.php
+++ b/src/Codeception/Module/WebDriver.php
@@ -1624,6 +1624,12 @@ class WebDriver extends CodeceptionModule implements
         $el->sendKeys($value);
     }
 
+    public function clearField($field)
+    {
+        $el = $this->findField($field);
+        $el->clear();
+    }
+        
     public function attachFile($field, $filename)
     {
         $el = $this->findField($field);

--- a/tests/web/WebDriverTest.php
+++ b/tests/web/WebDriverTest.php
@@ -810,7 +810,7 @@ class WebDriverTest extends TestsForBrowsers
     {
         $this->module->fillField('#username', 'username');
         $this->module->clearField('#username');
-        $this->module->dontSee('username');        
+        $this->module->dontSeeInField('#username', 'username');        
     } 
 
     public function testClickHashLink()

--- a/tests/web/WebDriverTest.php
+++ b/tests/web/WebDriverTest.php
@@ -808,9 +808,10 @@ class WebDriverTest extends TestsForBrowsers
     */
     public function testClearField()
     {
-        $this->module->fillField('#username', 'username');
-        $this->module->clearField('#username');
-        $this->module->dontSeeInField('#username', 'username');        
+        $this->module->amOnPage('/form/textarea');
+        $this->module->fillField('#description', 'description');
+        $this->module->clearField('#description');
+        $this->module->dontSeeInField('#description', 'description');        
     } 
 
     public function testClickHashLink()

--- a/tests/web/WebDriverTest.php
+++ b/tests/web/WebDriverTest.php
@@ -802,6 +802,16 @@ class WebDriverTest extends TestsForBrowsers
         $this->module->amOnPage('/form/bug2921');
         $this->module->seeInField('foo', 'bar baz');
     }
+    
+    /**
+    * @Issue 4726
+    */
+    public function testClearField()
+    {
+        $this->module->fillField('#username', 'username');
+        $this->module->clearField('#username');
+        $this->module->dontSee('username');        
+    } 
 
     public function testClickHashLink()
     {


### PR DESCRIPTION
Is it right, that Codeception automatically generate this method in the AcceptanceTesterAction.php with the codecept build command?
```
  /**
     * [!] Method is generated. Documentation taken from corresponding module.
     *
     *
     * @see \Codeception\Module\WebDriver::clearField()
     */
    public function clearField($field) {
        return $this->getScenario()->runStep(new \Codeception\Step\Action('clearField', func_get_args()));
    }
```

Closes  #4726