### PR TITLE
Changed domain name used in redirect test

### DIFF
--- a/tests/unit/Codeception/Module/PhpBrowserTest.php
+++ b/tests/unit/Codeception/Module/PhpBrowserTest.php
@@ -280,9 +280,9 @@ class PhpBrowserTest extends TestsForBrowsers
 
     public function testRedirectToAnotherDomainUsingSchemalessUrl()
     {
-        $this->module->amOnUrl('http://httpbin.org/redirect-to?url=//codeception.com/');
+        $this->module->amOnUrl('http://httpbin.org/redirect-to?url=//example.org/');
         $currentUrl = $this->module->client->getHistory()->current()->getUri();
-        $this->assertSame('http://codeception.com/', $currentUrl);
+        $this->assertSame('http://example.org/', $currentUrl);
     }
 
     public function testSetCookieByHeader()


### PR DESCRIPTION
Because tests failed on Travis with:
[GuzzleHttp\Exception\ConnectException] cURL error 35: gnutls_handshake() failed: Handshake failed