### PR TITLE
Appveyor.yml to specify php 7.1 and PhpBrowserTest fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ matrix:
     - php: 5.4 # lowest versions of all dependencies
       env: SYMFONY=2.7.19 SYMFONY_DEPRECATIONS_HELPER=weak # latest version of 2.7.*
     - php: 5.5
-      env: SYMFONY=2.7.5 dependencies=lowest SYMFONY_DEPRECATIONS_HELPER=weak #lowest version of 2.7
+      env: SYMFONY=2.7.19 SYMFONY_DEPRECATIONS_HELPER=weak #latest version of 2.7.*
     - php: 5.6
       env: SYMFONY=2.8.12 SYMFONY_DEPRECATIONS_HELPER=weak # latest version of 2.8.*
     - php: 7.0

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -33,7 +33,7 @@ install:
   - SET PATH=C:\Program Files\curl;%PATH%
   - sc config wuauserv start= auto
   - net start wuauserv
-  - IF %PHP%==1 cinst -y php
+  - IF %PHP%==1 cinst -y php --version 7.1.14
   - IF %PHP%==1 cd c:\tools\php71
   - IF %PHP%==1 cd ext
   - IF %PHP%==1 appveyor DownloadFile http://windows.php.net/downloads/pecl/releases/mongodb/1.2.0/php_mongodb-1.2.0-7.1-nts-vc14-x64.zip

--- a/tests/unit/Codeception/Module/PhpBrowserTest.php
+++ b/tests/unit/Codeception/Module/PhpBrowserTest.php
@@ -282,7 +282,7 @@ class PhpBrowserTest extends TestsForBrowsers
     {
         $this->module->amOnUrl('http://httpbin.org/redirect-to?url=//codeception.com/');
         $currentUrl = $this->module->client->getHistory()->current()->getUri();
-        $this->assertSame('http://codeception.com/', $currentUrl);
+        $this->assertSame('https://codeception.com/', $currentUrl);
     }
 
     public function testSetCookieByHeader()

--- a/tests/unit/Codeception/Module/PhpBrowserTest.php
+++ b/tests/unit/Codeception/Module/PhpBrowserTest.php
@@ -280,9 +280,9 @@ class PhpBrowserTest extends TestsForBrowsers
 
     public function testRedirectToAnotherDomainUsingSchemalessUrl()
     {
-        $this->module->amOnUrl('http://httpbin.org/redirect-to?url=//codeception.com/');
+        $this->module->amOnUrl('http://httpbin.org/redirect-to?url=//example.org/');
         $currentUrl = $this->module->client->getHistory()->current()->getUri();
-        $this->assertSame('https://codeception.com/', $currentUrl);
+        $this->assertSame('http://example.org/', $currentUrl);
     }
 
     public function testSetCookieByHeader()


### PR DESCRIPTION
Pull request #4799 fails due to AppVeyor and Chocolatey installing PHP 7.2 and not constrained to any version. This entire file assumes PHP 7.1, so I added what I believe is the constraint for Chocolatey/cist. 

Disclaimer: I am not familiar with Chocolatey or AppVeyor so I'm kind of taking a stab in the dark, well an educated guess have you.