### PR TITLE
Fixed Cookies debug section for WebDriver

### DIFF
--- a/src/Codeception/Module/WebDriver.php
+++ b/src/Codeception/Module/WebDriver.php
@@ -774,7 +774,7 @@ class WebDriver extends CodeceptionModule implements
             },
             $cookies
         );
-        $this->debugSection('Cookies', json_encode($this->webDriver->manage()->getCookies()));
+        $this->debugSection('Cookies', json_encode($this->getCookiesAsArray($this->webDriver->manage()->getCookies())));
         $this->assertContains($cookie, $cookies);
     }
 
@@ -787,7 +787,7 @@ class WebDriver extends CodeceptionModule implements
             },
             $cookies
         );
-        $this->debugSection('Cookies', json_encode($this->webDriver->manage()->getCookies()));
+        $this->debugSection('Cookies', json_encode($this->getCookiesAsArray($this->webDriver->manage()->getCookies())));
         $this->assertNotContains($cookie, $cookies);
     }
 
@@ -805,13 +805,13 @@ class WebDriver extends CodeceptionModule implements
             }
         }
         $this->webDriver->manage()->addCookie($params);
-        $this->debugSection('Cookies', json_encode($this->webDriver->manage()->getCookies()));
+        $this->debugSection('Cookies', json_encode($this->getCookiesAsArray($this->webDriver->manage()->getCookies())));
     }
 
     public function resetCookie($cookie, array $params = [])
     {
         $this->webDriver->manage()->deleteCookieNamed($cookie);
-        $this->debugSection('Cookies', json_encode($this->webDriver->manage()->getCookies()));
+        $this->debugSection('Cookies', json_encode($this->getCookiesAsArray($this->webDriver->manage()->getCookies())));
     }
 
     public function grabCookie($cookie, array $params = [])
@@ -838,6 +838,23 @@ class WebDriver extends CodeceptionModule implements
         $this->_getCurrentUri();
 
         return $this->webDriver->getPageSource();
+    }
+
+    /**
+     * Maps an array of cookie objects into an array of cookie arrays.
+     * 
+     * @param array $cookies Array of cookie objects.
+     *
+     * @return array Array of cookies in array form.
+     */
+    protected function getCookiesAsArray(array $cookies)
+    {
+        return array_map(
+            function (Cookie $cookie) {
+                return $cookie->toArray();
+            },
+            $cookies
+        );
     }
 
     protected function filterCookies($cookies, $params = [])
@@ -1634,13 +1651,13 @@ class WebDriver extends CodeceptionModule implements
     * ```
     *
     * @param $field
-    */    
+    */
     public function clearField($field)
     {
         $el = $this->findField($field);
         $el->clear();
     }
-        
+
     public function attachFile($field, $filename)
     {
         $el = $this->findField($field);


### PR DESCRIPTION
When running Codeception in debug mode and setting cookies, the debug section shows an array of cookies with no data in them.  For example:

```
 [Cookies] [{}]
```

This is what I was seeing after setting a cookie.   Because the method `$this->webDriver->manage()->getCookies()` returns an array of `\Facebook\WebDriver\Cookie`s that have no public properties (or a `__toString()` method), `json_encode` will return an empty object for each cookie - not so ideal.

My suggestion is to perform an `array_map` on the aforementioned `getCookies()` method and call the `toArray()` method on each Cookie object.  Initially I had it as just `$cookie->getName();` but personally I found `$cookie->toArray();` to be more beneficial.  I now get the following when doing `setCookie` in my tests:

```
 [Cookies] [{"name":"PHPSESSID","value":"random123456","path":"/","domain":"localhost","expiry":1521004033,"secure":false,"httpOnly":false}]
```

:tada: much more useful!

**Codeception version:** 2.4.0 (also occurred in 2.3.8)
**WebDriver browser:** chrome