### PR TITLE
Fix clean command bug when output dir is not exist

### DIFF
--- a/src/Codeception/Command/Clean.php
+++ b/src/Codeception/Command/Clean.php
@@ -31,12 +31,11 @@ class Clean extends Command
 
     private function cleanProjectsRecursively(OutputInterface $output, $projectDir)
     {
-        $config = Configuration::config($projectDir);
-
-        $logDir = $projectDir . DIRECTORY_SEPARATOR . $config['paths']['output'];
+        $logDir = Configuration::logDir();
         $output->writeln("<info>Cleaning up output " . $logDir . "...</info>");
         FileSystem::doEmptyDir($logDir);
 
+        $config = Configuration::config($projectDir);
         $subProjects = $config['include'];
         foreach ($subProjects as $subProject) {
             $subProjectDir = $projectDir . $subProject;


### PR DESCRIPTION
Fix the bug when output dir is not exist and run Clean command.

The follow messages is error output:

```
$ php vendor/bin/codecept clean -vvv
Cleaning up output /Users/miles/GitHub/104corp/104isgd-common-php//build...

In FileSystem.php line 17:
                                                                                                                                                 
  [UnexpectedValueException]                                                                                                                     
  RecursiveDirectoryIterator::__construct(/Users/miles/GitHub/104corp/104isgd-common-php//build): failed to open dir: No such file or directory  
                                                                                                                                                 

Exception trace:
 RecursiveDirectoryIterator->__construct() at /Users/miles/GitHub/104corp/104isgd-common-php/vendor/codeception/codeception/src/Codeception/Util/FileSystem.php:17
 Codeception\Util\FileSystem::doEmptyDir() at /Users/miles/GitHub/104corp/104isgd-common-php/vendor/codeception/codeception/src/Codeception/Command/Clean.php:38
 Codeception\Command\Clean->cleanProjectsRecursively() at /Users/miles/GitHub/104corp/104isgd-common-php/vendor/codeception/codeception/src/Codeception/Command/Clean.php:28
 Codeception\Command\Clean->execute() at /Users/miles/GitHub/104corp/104isgd-common-php/vendor/symfony/console/Command/Command.php:252
 Symfony\Component\Console\Command\Command->run() at /Users/miles/GitHub/104corp/104isgd-common-php/vendor/symfony/console/Application.php:946
 Symfony\Component\Console\Application->doRunCommand() at /Users/miles/GitHub/104corp/104isgd-common-php/vendor/symfony/console/Application.php:248
 Symfony\Component\Console\Application->doRun() at /Users/miles/GitHub/104corp/104isgd-common-php/vendor/symfony/console/Application.php:148
 Symfony\Component\Console\Application->run() at /Users/miles/GitHub/104corp/104isgd-common-php/vendor/codeception/codeception/src/Codeception/Application.php:108
 Codeception\Application->run() at /Users/miles/GitHub/104corp/104isgd-common-php/vendor/codeception/codeception/codecept:42

clean
```