### PR TITLE
Added support for namespace option for Symfony module

### DIFF
--- a/src/Codeception/Module/Symfony.php
+++ b/src/Codeception/Module/Symfony.php
@@ -299,7 +299,7 @@ class Symfony extends Framework implements DoctrineProvider, PartedModule
         // mixing default kernel classes and class with changed namespace
 
         if ($this->config['app_kernel']) {
-            $this->kernelClasses = array_merge($this->kernelClasses, [$this->config['app_kernel']]);
+            $this->kernelClasses = [$this->config['app_kernel']];
         }
 
         foreach ($this->kernelClasses as $class) {


### PR DESCRIPTION
With this fix one can add `app_kernel` option to Symfony module config to specify full qualified Application Kernel Class Name (with all namespace chaining) of Symfony 4 Kernel. 