### PR TITLE
MySQL: readSql comment bug

### DIFF
--- a/tests/data/dumps/mysql.sql
+++ b/tests/data/dumps/mysql.sql
@@ -13,6 +13,8 @@ insert  into `groups`(`id`,`name`,`enabled`,`created_at`) values (1,'coders',1,'
 
 insert  into `groups`(`id`,`name`,`enabled`,`created_at`) values (2,'jazzman',0,'2012-02-01 21:18:40');
 
+insert  into `groups`(`id`,`name`,`enabled`,`created_at`) values (2,'A /* Z a \\|`~!\"£$%&/()=\'<>[]{}@#,.;:-_§*+ z',0,'2012-02-01 21:18:40');
+
 
 CREATE TABLE `users` (
   `id` int(11) NOT NULL AUTO_INCREMENT,


### PR DESCRIPTION
Source of the bug:

https://github.com/Codeception/Codeception/blob/c50789a9a62cc0eefc0252e88a5f04f8c47b55f4/src/Codeception/Module/Db.php#L269-L272

It shouldn't strip comment-like string that are real data.