### PR TITLE
Fixed making for $settings['path'] in Configuration::suiteSettings() on Windows

### DIFF
--- a/src/Codeception/Configuration.php
+++ b/src/Codeception/Configuration.php
@@ -320,6 +320,8 @@ class Configuration
             $settings['path'] = $suite;
         }
 
+        $config['paths']['tests'] = str_replace('/', DIRECTORY_SEPARATOR, $config['paths']['tests']);
+
         $settings['path'] = self::$dir . DIRECTORY_SEPARATOR . $config['paths']['tests']
             . DIRECTORY_SEPARATOR . $settings['path'] . DIRECTORY_SEPARATOR;
 


### PR DESCRIPTION
codeception.dist.yml:

```
paths:
    tests: tests/codeception
    output: tests/codeception/_output
    data: tests/codeception/_data
    support: tests/codeception/_support
    envs: tests/codeception/_envs
actor_suffix: Tester
namespace: tests\codeception
groups:
    api: [tests/codeception/acceptance/Module/Api]
```

Tests:

```
C:\site.ru\tests\codeception\acceptance\Module\Api\User\CheckEmailAvailabilityCest.php
```

Run tests:

```
$ codecept run acceptance -g api --no-ansi --no-interaction 

Testing started at 13:53 ...
Codeception PHP Testing Framework v2.3.8
Powered by PHPUnit 6.5.6 by Sebastian Bergmann and contributors.
[Groups] api 

Time: 445 ms, Memory: 8.00MB

No tests executed!

Process finished with exit code 0
```

Tests not found, but they are.

During debugging, I found that in `\Codeception\Lib\GroupManager::groupsForTest` `$test->getReportFields()`:

```
Array
(
    [file] => C:\site.ru\tests/codeception\acceptance\Module\Api\User\CheckEmailAvailabilityCest.php
    [name] => tryToTest
    [class] => tests\codeception\Module\Api\User\CheckEmailAvailabilityCest
    [feature] => try to test
)
```

Problem in this `tests/codeception` string.

My fix in `\Codeception\Configuration::suiteSettings` solves the problem.

Os: Windows 10
PHP: 7.0.14
Codeception: 2.3.8