### PR TITLE
2.4 bug 4847

### DIFF
--- a/src/Codeception/Util/Uri.php
+++ b/src/Codeception/Util/Uri.php
@@ -20,6 +20,10 @@ class Uri
     {
         $base = new Psr7Uri($baseUri);
         $parts = parse_url($uri);
+
+        //If the relative URL does not parse, attempt to parse the entire URL.
+        //PHP Known bug ( https://bugs.php.net/bug.php?id=70942 )
+        $parts = ($parts === false)?parse_url($baseUri):$parts;
         if ($parts === false) {
             throw new \InvalidArgumentException("Invalid URI $uri");
         }

--- a/tests/unit/Codeception/Util/UriTest.php
+++ b/tests/unit/Codeception/Util/UriTest.php
@@ -50,6 +50,14 @@ class UriTest extends \Codeception\Test\Unit
         $this->assertEquals('/form/?param=1#anchor2', Uri::mergeUrls('/form/?param=1#anchor1', '#anchor2'));
         $this->assertEquals('/form/?param=2', Uri::mergeUrls('/form/?param=1#anchor', '?param=2'));
         $this->assertEquals('/page/', Uri::mergeUrls('/form/?param=1#anchor', '/page/'));
+    }   
+
+    /**
+     * @Issue https://github.com/Codeception/Codeception/pull/4847
+     */
+    public function testMergingNonParsingPath()
+    {
+        $this->assertEquals('/3.0/en/index/page:5', Uri::mergeUrls('https://cakephp.org/', '/3.0/en/index/page:5'));
     }
 
     /**


### PR DESCRIPTION
PHP's parse_url fails on specific relative URLs.
If the absolute URL is passed, it parses as expected.
PHP Known bug: https://bugs.php.net/bug.php?id=70942
Discussion thread: https://github.com/Codeception/Codeception/issues/4847

### Code example:
```php
$I->amOnPage('/units/view/1/page:2');
```

Behaviour before:
```bash
1) AdminDevicesCest: Check i can see a particular device and all its scans
 Test  tests/rServices/AdminDevicesCest.php:checkUnitScans

  [InvalidArgumentException] Invalid URI /units/view/1/page:2
```

Behavior after:
```bash
 I am on page "/units/view/1/page:2"
  [Request Headers] []
  [Page] /units/view/1/page:2
  [Response] 200
```

### Internal Testing
Before patch
```bash
Unit Tests (10) ----------------------------------------------------------------------------------------------------------------
✔ UriTest: Url merge (0.00s)
✔ UriTest: Append anchor (0.00s)
✔ UriTest: Merge urls when base uri ends with slash but uri path has no leading slash (0.00s)
✔ UriTest: Append path (0.00s)
✔ UriTest: Merge urls when base uri has no trailing slash and uri path has no leading slash (0.00s)
✔ UriTest: Merging path (0.00s)
✔ UriTest: Append path removes query string and anchor (0.00s)
E UriTest: Merging non parsing path (0.00s)
--------------------------------------------------------------------------------------------------------------------------------
```

After patch:
```bash
Unit Tests (10) ----------------------------------------------------------------------------------------------------------------
✔ UriTest: Merging scheme (0.00s)
✔ UriTest: Append anchor (0.00s)
✔ UriTest: Merge urls when base uri has no trailing slash and uri path has no leading slash (0.00s)
✔ UriTest: Append path (0.00s)
✔ UriTest: Merging path (0.00s)
✔ UriTest: Append empty path (0.00s)
✔ UriTest: Append path removes query string and anchor (0.00s)
✔ UriTest: Url merge (0.00s)
✔ UriTest: Merge urls when base uri ends with slash but uri path has no leading slash (0.00s)
✔ UriTest: Merging non parsing path (0.00s)
--------------------------------------------------------------------------------------------------------------------------------
```

Best efforts made to ensure the style matches the project - please accept my apologies if it doesn't.
