### PR TITLE
A fix for #4854 unnecessary escaping in operation arguments logging

### DIFF
--- a/src/Codeception/Step.php
+++ b/src/Codeception/Step.php
@@ -164,8 +164,9 @@ abstract class Step
                 $argument = $this->getClassName($argument);
             }
         }
-
-        return json_encode($argument, JSON_UNESCAPED_UNICODE);
+        $arg_str = json_encode($argument, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
+        $arg_str = str_replace('\"', '"', $arg_str);
+        return $arg_str;
     }
 
     protected function getClassName($argument)


### PR DESCRIPTION
A fix for #4854 unnecessary escaping in operation arguments logging. It's removing string escaping from the log:

before
[08:01:23.753] Wait for element visible {"xpath":"\\/\\/a[contains(text(),\\"Forgot your password?\\")]"} (13s 336ms)
17:01:03 I click {"xpath":"\\/\\/a[contains(text(),\\"Forgot your password?\\")]"}

after this fix
[08:01:23.753] Wait for element visible {"xpath":"//a[contains(text(),"Forgot your password?")]"} (13s 336ms)
17:01:03 I click {"xpath":"//a[contains(text(),"Forgot your password?")]"}
