### PR TITLE
added app url option for laravel

### DIFF
--- a/src/Codeception/Lib/Connector/Laravel5.php
+++ b/src/Codeception/Lib/Connector/Laravel5.php
@@ -171,8 +171,7 @@ class Laravel5 extends Client
 
         // Set the request instance for the application,
         if (is_null($request)) {
-            $appConfig = require $this->module->config['project_dir'] . 'config/app.php';
-            $request = SymfonyRequest::create($appConfig['url']);
+            $request = SymfonyRequest::create($this->getUrl());
         }
         $this->app->instance('request', Request::createFromBase($request));
 
@@ -221,6 +220,28 @@ class Laravel5 extends Client
         }
 
         $this->module->setApplication($this->app);
+    }
+
+    /**
+     * Get the Laravel app url.
+     * @return string
+     * @throws ModuleConfig
+     */
+    private function getUrl()
+    {
+        return (isset($this->module->config['url'])) ? $this->module->config['url'] :  $this->getUrlFromApp();
+    }
+    
+    /**
+     * Get the Laravel app url from app config file.
+     * @return string
+     * @throws ModuleConfig
+     */
+    private function getUrlFromApp()
+    {
+        $appConfig = require $this->module->config['project_dir'] . 'config/app.php';
+        
+        return $appConfig['url'];
     }
 
     /**

--- a/src/Codeception/Lib/Connector/Laravel5.php
+++ b/src/Codeception/Lib/Connector/Laravel5.php
@@ -229,7 +229,7 @@ class Laravel5 extends Client
      */
     private function getUrl()
     {
-        return (isset($this->module->config['url'])) ? $this->module->config['url'] :  $this->getUrlFromApp();
+        return ($this->module->config['url']) ? $this->module->config['url'] :  $this->getUrlFromApp();
     }
     
     /**

--- a/src/Codeception/Module/Laravel5.php
+++ b/src/Codeception/Module/Laravel5.php
@@ -137,6 +137,7 @@ class Laravel5 extends Framework implements ActiveRecord, PartedModule
                 'disable_middleware' => false,
                 'disable_events' => false,
                 'disable_model_events' => false,
+                'url' => null
             ],
             (array)$config
         );


### PR DESCRIPTION
When the initialize method of Codeception\Lib\Connector\Laravel5 is called first .env has never been loaded. 

Lets say  you have the following on  
**config/app.php** 
```php
'url' => env('APP_URL', 'http://wrongurl'),
```
**.env.testing**
```
APP_URL=http://testing
```
**.env**

```
APP_URL=http://production
```

When initialize method is called for the first time even though http://testing has to be the value http://wrongurl is taken as the `url`.

here is the actual code and what happens when the method is run for the first time

```php

    private function initialize($request = null)
    {

        ........

        $this->app = $this->kernel = $this->loadApplication();

        // lets say request is null
        if (is_null($request)) {
            $appConfig = require $this->module->config['project_dir'] . 'config/app.php';
            // dump($_ENV['APP_URL']); returns undifined index, expected http://testing
            // so the value of $appConfig['url] is http://wrongurl
            // eventhough http://testing is expected
            $request = SymfonyRequest::create($appConfig['url']);
        }

        ........

       // dump($_ENV['APP_URL']); returns undifined index, expected http://testing
        $this->app->make('Illuminate\Contracts\Http\Kernel')->bootstrap();
       // dump($_ENV['APP_URL']); returns http://testing, expected http://testing

        .........
```

So what I did is to get url from module's config.

```YML
modules:
    enabled:
        - Asserts
        - REST:
            depends: Laravel
        - Laravel:
            environment_file: .env.testing
            url: http://testing
```

This fix will optimize by getting the already loaded config value from module instead of loading whole config/app.php file to just get the url. Additionally, the previous option is set as the fallback.