### PR TITLE
Yii2 rework, new PR same changes.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,20 +1,58 @@
 sudo: false
 
 language: php
-
+matrix:
+  fast_finish: true
+php:
+  - 5.6
+  - 7.0
+  - 7.1
+  - 7.2
+env:
+  global:
+    - XDEBUG=
+    - SUITES=
+    - FXP=
+    - PECL=
+    - TEST_PATH='framework-tests'
+    - SYMFONY_DEPRECATIONS_HELPER=weak
+  matrix:
+  - FRAMEWORK=Codeception SUITES=cli,unit TEST_PATH=. XDEBUG=1 PECL=mongodb
+  - FRAMEWORK=Yii2 TEST_REPO="https://github.com/Codeception/yii2-tests"
+  - FRAMEWORK=Symfony VERSION=2.8 TEST_REPO='-b 2.1 https://github.com/Codeception/symfony-demo.git' SUITES=functional TEST_PATH=framework-tests/src/AppBundle
+  - FRAMEWORK=Symfony VERSION=3.4 TEST_REPO='--recurse-submodules https://github.com/Naktibalda/codeception-symfony-tests'
+  - FRAMEWORK=Symfony VERSION=4 TEST_REPO='https://github.com/Codeception/symfony-demo.git' SUITES=functional,unit
+  - FRAMEWORK=Lumen TEST_REPO='-b codeception-2.2 https://github.com/codeception/codeception-lumen-sample.git'
+  - FRAMEWORK=Laravel TEST_REPO='-b codeception-2.3 https://github.com/codeception/codeception-laravel5-sample.git'
+  - FRAMEWORK=Phalcon TEST_REPO=https://github.com/Codeception/phalcon-demo.git
+  - FRAMEWORK=Zend1 TEST_REPO='-b 2.2 --recurse-submodules https://github.com/Naktibalda/codeception-zf1-tests'
+  - FRAMEWORK=Zend2 TEST_REPO='-b 2.2 --recurse-submodules https://github.com/Naktibalda/codeception-zf2-tests' SUITES=functional
+  - FRAMEWORK=ZendExpressive TEST_REPO='-b 2.2 --recurse-submodules https://github.com/Naktibalda/codeception-zend-expressive-tests' SUITES=functional
 matrix:
   include:
-    - php: 5.6
-      env: SYMFONY=2.8.12 SYMFONY_DEPRECATIONS_HELPER=weak # latest version of 2.8.*
-    - php: 7.0
-      env: SYMFONY=3.2.9 SYMFONY_DEPRECATIONS_HELPER=weak # latest version of 3.2.*
-    - php: 7.1
-      env: SYMFONY=3.3.2 SYMFONY_DEPRECATIONS_HELPER=weak # latest version of 3.3.*
-    - php: 7.1
-      env: SYMFONY=4.0.1 SYMFONY_DEPRECATIONS_HELPER=weak # latest version of 4.0.*
-    - php: 7.2
-      env: SYMFONY=4.0.1 SYMFONY_DEPRECATIONS_HELPER=weak # latest version of 4.0.*
-
+  - php: 7.1
+    env: FRAMEWORK=Codeception SUITES=cli,unit,coverage TEST_PATH=. XDEBUG=1 PECL=mongodb
+  exclude:
+  - php: 7.1
+    env: FRAMEWORK=Codeception SUITES=cli,unit TEST_PATH=. XDEBUG=1 PECL=mongodb
+  - php: 7.0
+    env: FRAMEWORK=Symfony VERSION=2.8 TEST_REPO='-b 2.1 https://github.com/Codeception/symfony-demo.git' SUITES=functional TEST_PATH=framework-tests/src/AppBundle
+  - php: 7.1
+    env: FRAMEWORK=Symfony VERSION=2.8 TEST_REPO='-b 2.1 https://github.com/Codeception/symfony-demo.git' SUITES=functional TEST_PATH=framework-tests/src/AppBundle
+  - php: 7.2
+    env: FRAMEWORK=Symfony VERSION=2.8 TEST_REPO='-b 2.1 https://github.com/Codeception/symfony-demo.git' SUITES=functional TEST_PATH=framework-tests/src/AppBundle
+  - php: 5.6
+    env: FRAMEWORK=Symfony VERSION=3.4 TEST_REPO='--recurse-submodules https://github.com/Naktibalda/codeception-symfony-tests'
+  - php: 7.0
+    env: FRAMEWORK=Symfony VERSION=3.4 TEST_REPO='--recurse-submodules https://github.com/Naktibalda/codeception-symfony-tests'
+  - php: 5.6
+    env: FRAMEWORK=Symfony VERSION=4 TEST_REPO='https://github.com/Codeception/symfony-demo.git' SUITES=functional,unit
+  - php: 7.0
+    env: FRAMEWORK=Symfony VERSION=4 TEST_REPO='https://github.com/Codeception/symfony-demo.git' SUITES=functional,unit
+#  - php: 7.1
+#    env: FRAMEWORK=ZendExpressive TEST_REPO='-b 2.2 --recurse-submodules https://github.com/Naktibalda/codeception-zend-expressive-tests' functional
+#  - php: 7.2
+#    env: FRAMEWORK=ZendExpressive TEST_REPO='-b 2.2 --recurse-submodules https://github.com/Naktibalda/codeception-zend-expressive-tests' functional
 addons:
   postgresql: "9.2"
 
@@ -33,107 +71,62 @@ services:
   - postgresql
   - redis
 
-
 before_install:
+  - '[[ !(-z "$XDEBUG") ]] || phpenv config-rm xdebug.ini'
   - export INI=~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
   - echo memory_limit = -1 >> $INI
-
 install:
-  - export SF_VERSION=$(echo $SYMFONY | head -c 1)
-  - 'pecl install -f mongodb'
-  - yes '' | pecl install imagick
-  #- echo "extension = mongodb.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini
-  - composer self-update && composer --version
-  - if [ -n "$CI_USER_TOKEN" ]; then composer config github-oauth.github.com ${CI_USER_TOKEN}; echo "Configured Github token"; fi;
-  - 'composer require mongodb/mongodb --no-update'
-  - '[[ "$TRAVIS_PHP_VERSION" == "7.2" ]] || composer global require "fxp/composer-asset-plugin:~1.3.1"'
-  - '[[ -z "$SYMFONY" ]] || composer require symfony/finder=~$SYMFONY --no-update --ignore-platform-reqs'
-  - '[[ -z "$SYMFONY" ]] || composer require symfony/yaml=~$SYMFONY --no-update --ignore-platform-reqs'
-  - '[[ -z "$SYMFONY" ]] || composer require symfony/console=~$SYMFONY --no-update --ignore-platform-reqs'
-  - '[[ -z "$SYMFONY" ]] || composer require symfony/event-dispatcher=~$SYMFONY --no-update --ignore-platform-reqs'
-  - '[[ -z "$SYMFONY" ]] || composer require symfony/css-selector=~$SYMFONY --no-update --ignore-platform-reqs'
-  - '[[ -z "$SYMFONY" ]] || composer require symfony/dom-crawler=~$SYMFONY --no-update --ignore-platform-reqs'
-  - '[[ -z "$SYMFONY" ]] || composer require symfony/browser-kit=~$SYMFONY --no-update --ignore-platform-reqs'
-  - composer_parameters="-n --prefer-dist" # this variable will be used in all composer install commands
-  - '[[ "$dependencies" != "lowest" ]] || composer_parameters="$composer_parameters --prefer-lowest"'
-  - composer update $composer_parameters
-  - composer_parameters="$composer_parameters --no-dev" # Codeception needs dev dependencies, but frameworks don't
-  # Yii2
-  - '[[ "$TRAVIS_PHP_VERSION" == "7.2" ]] || composer create-project "yiisoft/yii2-app-basic" frameworks-yii-basic --no-dev'
+  - '[[ -z "$CI_USER_TOKEN" ]] || composer config github-oauth.github.com ${CI_USER_TOKEN};'
+  # Add extensions
+  - '[[ -z "$PECL" ]] || (yes "" | pecl install $PECL)'
+  # Clone test repository
+  - '[[ "$FRAMEWORK" == "Codeception" ]] || git clone -q --depth=1 $TEST_REPO framework-tests'
+  - '[[ "$FRAMEWORK" == "Codeception" ]] || git --git-dir framework-tests/.git log -n 1'
+  - '[[ "$FRAMEWORK" != "Codeception" ]] || composer require mongodb/mongodb --no-update'
+  - '[[ -z "$FXP" ]] || composer global require "fxp/composer-asset-plugin:~1.3.1"'
+  - '[[ "$FRAMEWORK" != "Symfony" ]] || composer require symfony/finder=~$VERSION --no-update --ignore-platform-reqs'
+  - '[[ "$FRAMEWORK" != "Symfony" ]] || composer require symfony/yaml=~$VERSION --no-update --ignore-platform-reqs'
+  - '[[ "$FRAMEWORK" != "Symfony" ]] || composer require symfony/console=~$VERSION --no-update --ignore-platform-reqs'
+  - '[[ "$FRAMEWORK" != "Symfony" ]] || composer require symfony/event-dispatcher=~$VERSION --no-update --ignore-platform-reqs'
+  - '[[ "$FRAMEWORK" != "Symfony" ]] || composer require symfony/css-selector=~$VERSION --no-update --ignore-platform-reqs'
+  - '[[ "$FRAMEWORK" != "Symfony" ]] || composer require symfony/dom-crawler=~$VERSION --no-update --ignore-platform-reqs'
+  - '[[ "$FRAMEWORK" != "Symfony" ]] || composer require symfony/browser-kit=~$VERSION --no-update --ignore-platform-reqs'
+  - '[[ "$FRAMEWORK" != "Symfony" ]] || composer require symfony/browser-kit=~$VERSION --no-update --ignore-platform-reqs'
   # Phalcon
-  - 'git clone -q --depth=1 https://github.com/phalcon/cphalcon.git'
-  - '(cd cphalcon/build; bash ./install --phpize $(phpenv which phpize) --php-config $(phpenv which php-config) &>/dev/null && phpenv config-add ../tests/_ci/phalcon.ini &> /dev/null)'
-  - 'git clone -q --depth=1 https://github.com/Codeception/phalcon-demo.git frameworks-phalcon'
-  - 'composer update -d frameworks-phalcon $composer_parameters'
-  # Laravel 5
-  - 'git clone -q --depth=1 -b codeception-2.3 https://github.com/codeception/codeception-laravel5-sample.git frameworks-l5'
-  - 'composer update -d frameworks-l5 $composer_parameters --no-dev'
-  # Lumen
-  - 'git clone -q --depth=1 -b codeception-2.2 https://github.com/codeception/codeception-lumen-sample.git frameworks-lumen'
-  - 'composer update -d frameworks-lumen $composer_parameters --no-dev'
+  - '[[ "$FRAMEWORK" != "Phalcon" ]] || git clone -q --depth=1 https://github.com/phalcon/cphalcon.git'
+  - '[[ "$FRAMEWORK" != "Phalcon" ]] || (cd cphalcon/build; bash ./install --phpize $(phpenv which phpize) --php-config $(phpenv which php-config) &>/dev/null && phpenv config-add ../tests/_ci/phalcon.ini &> /dev/null)'
   # Symfony
-  - '[[ "$SF_VERSION" != "2" ]] || (git clone -q --depth=1 -b 2.1 https://github.com/Codeception/symfony-demo.git frameworks-symfony && echo "Cloned Symfony 2 site")'
-  - '[[ "$SF_VERSION" != "3" ]] || (git clone -q --depth=1 -b master --recursive https://github.com/Naktibalda/codeception-symfony-tests frameworks-symfony && echo "Cloned Symfony 3 site")'
-  - '[[ "$SF_VERSION" != "4" ]] || (git clone -q --depth=1 -b master https://github.com/Codeception/symfony-demo.git frameworks-symfony && echo "Cloned Symfony 4 site")'
-  - '[[ "$SF_VERSION" == "4" ]] || composer require -d frameworks-symfony symfony/symfony=~$SYMFONY --no-update'
-  - "mysql -e 'create database symfony_test;'"
-  - 'composer update -d frameworks-symfony $composer_parameters --no-dev'
-  # ZF1
-  - git clone -q -b 2.2 --recursive https://github.com/Naktibalda/codeception-zf1-tests frameworks-zf1
-  - composer update -d frameworks-zf1 $composer_parameters --no-dev
-  # ZF2
-  - git clone -q -b 2.2 --recursive https://github.com/Naktibalda/codeception-zf2-tests frameworks-zf2
-  - composer update -d frameworks-zf2 $composer_parameters --no-dev
-  # Zend Expressive
-  - 'git clone -q -b 2.2 --recursive https://github.com/Naktibalda/codeception-zend-expressive-tests frameworks-zend-expressive'
-  - 'composer update -d frameworks-zend-expressive $composer_parameters'
-
+  #- '[[ "$FRAMEWORK$VERSION" != "Symfony3" ]] || composer require -d framework-tests symfony/symfony=~$VERSION --no-update'
+  - composer install
+  - '[[ "$FRAMEWORK" == "Codeception" ]] || composer update -d framework-tests --no-dev --prefer-dist'
 before_script:
   - '[[ "$TRAVIS_PHP_VERSION" == 7.* ]] || echo "extension = mongo.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini'
   # preparing databases
-  - "mysql -e 'create database codeception_test;'"
-  - psql -c 'create database codeception_test;' -U postgres
+  - '[[ "$FRAMEWORK" != "Codeception" ]] || mysql -e "create database codeception_test;"'
+  - '[[ "$FRAMEWORK" != "Codeception" ]] || psql -c "create database codeception_test;" -U postgres'
+  - '[[ "$FRAMEWORK" != "Symfony" ]] || mysql -e "create database symfony_test;"'
   # starting demo servers
-  - 'php -S 127.0.0.1:8000 -t tests/data/app >/dev/null 2>&1 &'
-  - 'php -S 127.0.0.1:8010 -t tests/data >/dev/null 2>&1 &'
+  - '[[ "$FRAMEWORK" != "Codeception" ]] || php -S 127.0.0.1:8000 -t tests/data/app >/dev/null 2>&1 &'
+  - '[[ "$FRAMEWORK" != "Codeception" ]] || php -S 127.0.0.1:8010 -t tests/data >/dev/null 2>&1 &'
   # Phalcon
-  - mysql -e 'CREATE DATABASE phalcon_demo CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;'
-  - 'cat frameworks-phalcon/schemas/phalcon_demo.sql | mysql phalcon_demo'
+  - '[[ "$FRAMEWORK" != "Phalcon" ]] || mysql -e "CREATE DATABASE phalcon_demo CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;"'
+  - '[[ "$FRAMEWORK" != "Phalcon" ]] || cat framework-tests/schemas/phalcon_demo.sql | mysql phalcon_demo'
   # Laravel 5
-  - 'touch frameworks-l5/storage/testing.sqlite'
-  - 'php frameworks-l5/artisan migrate --env=testing --database=sqlite_testing --force'
+  - '[[ "$FRAMEWORK" != "Laravel" ]] || touch framework-tests/storage/testing.sqlite'
+  - '[[ "$FRAMEWORK" != "Laravel" ]] || php framework-tests/artisan migrate --env=testing --database=sqlite_testing --force'
   # Lumen
-  - 'cp frameworks-lumen/.env.testing frameworks-lumen/.env'
-  - 'touch frameworks-lumen/storage/testing.sqlite'
-  - 'php frameworks-lumen/artisan migrate --database=testing --force'
+  - '[[ "$FRAMEWORK" != "Lumen" ]] || cp framework-tests/.env.testing framework-tests/.env'
+  - '[[ "$FRAMEWORK" != "Lumen" ]] || touch framework-tests/storage/testing.sqlite'
+  - '[[ "$FRAMEWORK" != "Lumen" ]] || php framework-tests/artisan migrate --database=testing --force'
   # Symfony
-  - '[[ "$SF_VERSION" != "2" ]] || php frameworks-symfony/app/console doctrine:schema:create -n --env test'
-  - '[[ "$SF_VERSION" != "2" ]] || php frameworks-symfony/app/console doctrine:fixtures:load -n --env test'
-  - '[[ "$SF_VERSION" != "3" ]] || php frameworks-symfony/bin/console doctrine:schema:update --force -n'
+  - '[[ "$FRAMEWORK$VERSION" != "Symfony2.8" ]] || php framework-tests/app/console doctrine:schema:create -n --env test'
+  - '[[ "$FRAMEWORK$VERSION" != "Symfony2.8" ]] || php framework-tests/app/console doctrine:fixtures:load -n --env test'
+  - '[[ "$FRAMEWORK$VERSION" != "Symfony3.4" ]] || php framework-tests/bin/console doctrine:schema:update --force -n'
   # ZF2
-  - "mysql -e 'create database zf2_test;'"
-  - php frameworks-zf2/vendor/bin/doctrine-module orm:schema-tool:create
+  - '[[ "$FRAMEWORK" != "Zend2" ]] || mysql -e "create database zf2_test;"'
+  - '[[ "$FRAMEWORK" != "Zend2" ]] || php framework-tests/vendor/bin/doctrine-module orm:schema-tool:create'
   # Build
-  - '[[ "$TRAVIS_PHP_VERSION" == "7.2" ]] || php codecept build -c frameworks-yii-basic'
-  - 'php codecept build -c frameworks-phalcon'
-  - '[[ "$SF_VERSION" != "2" ]] || php codecept build -c frameworks-symfony/src/AppBundle'
-  - '[[ "$SF_VERSION" == "2" ]] || php codecept build -c frameworks-symfony'
-  - 'php codecept build -c frameworks-l5'
-  - 'php codecept build -c frameworks-lumen'
-  - php codecept build -c frameworks-zf1
-  - php codecept build -c frameworks-zf2
-  - 'php codecept build -c frameworks-zend-expressive'
-
+  - php codecept build -c $TEST_PATH
 script:
-  - php codecept run cli,unit # self tests
-  - '[[ "$TRAVIS_PHP_VERSION" == "7.0" ]] || php codecept run coverage'  # run coverage tests on php only
-  - '[[ "$TRAVIS_PHP_VERSION" == "7.2" ]] || php codecept run functional -c frameworks-yii-basic' # Yii2 tests
-  - 'php codecept run -c frameworks-l5 --skip=seeder' # Laravel5 Tests
-  - 'php codecept run -c frameworks-lumen' # Lumen Tests
-  - 'php codecept run functional -c frameworks-phalcon' # Phalcon Tests
-  - '[[ "$SF_VERSION" != "2" ]] || php codecept run functional -c frameworks-symfony/src/AppBundle' # Symfony 2 Tests
-  - '[[ "$SF_VERSION" != "3" ]] || php codecept run -c frameworks-symfony' # Symfony 3 Tests
-  - '[[ "$SF_VERSION" != "4" ]] || php codecept run -c frameworks-symfony functional,unit' # Symfony 4 Tests
-  - php codecept run functional -c frameworks-zf1 # ZF1 Tests
-  - 'php codecept run -c frameworks-zf2 functional'
-  - 'php codecept run functional -c frameworks-zend-expressive' # Zend Expressive Tests
+  #- '[[ !("$FRAMEWORK" == "Codeception" && "$TRAVIS_PHP_VERSION" == "7.1") ]] || php codecept run coverage'  # run coverage tests on php only
+  - php codecept run $SUITES -c $TEST_PATH

--- a/CHANGELOG-2.4.md
+++ b/CHANGELOG-2.4.md
@@ -15,6 +15,7 @@
   * More reliable application state before and during test execution
   * Fixtures method is now configurable
   * Subset of misconfigurations are now detected and create informative messages
+  * Application no longer available via the `$module->app`, now you must use `\Yii::$app` everywhere
 **Upgrade Notice**: If you face issues with underscore PHPUnit class names (like PHPUnit_Framework_Assert) you have two options:
 
 * Lock version for PHPUnit in composer.json: "phpunit/phpunit":"^5.0.0"

--- a/CHANGELOG-2.4.md
+++ b/CHANGELOG-2.4.md
@@ -15,7 +15,7 @@
   * More reliable application state before and during test execution
   * Fixtures method is now configurable
   * Subset of misconfigurations are now detected and create informative messages
-  * Application no longer available via the `$module->app`, now you must use `\Yii::$app` everywhere
+  * Application is no longer available via the `$module->app`, now you must use `\Yii::$app` everywhere
 **Upgrade Notice**: If you face issues with underscore PHPUnit class names (like PHPUnit_Framework_Assert) you have two options:
 
 * Lock version for PHPUnit in composer.json: "phpunit/phpunit":"^5.0.0"

--- a/CHANGELOG-2.4.md
+++ b/CHANGELOG-2.4.md
@@ -10,8 +10,13 @@
   * `_failed` called when test fails
   * `_passed` called when tests is successful
   * `_after` is called for failing and successful tests   
-
+* Yii2 Module request flow and database transactions refactored (by @sammousa):
+  * Multiple databases are now supported
+  * More reliable application state before and during test execution
+  * Fixtures method is now configurable
+  * Subset of misconfigurations are now detected and create informative messages
 **Upgrade Notice**: If you face issues with underscore PHPUnit class names (like PHPUnit_Framework_Assert) you have two options:
 
 * Lock version for PHPUnit in composer.json: "phpunit/phpunit":"^5.0.0"
-* Update your codebase and replace underscore PHPUnit class names to namespaced (PHPUnit 6+ API) 
+* Update your codebase and replace underscore PHPUnit class names to namespaced (PHPUnit 6+ API)
+

--- a/src/Codeception/Module/Yii2.php
+++ b/src/Codeception/Module/Yii2.php
@@ -10,8 +10,13 @@ use Codeception\Lib\Interfaces\ActiveRecord;
 use Codeception\Lib\Interfaces\PartedModule;
 use Codeception\Lib\Notification;
 use Codeception\TestInterface;
+use Codeception\Util\Debug;
 use Yii;
+use yii\base\Event;
 use yii\db\ActiveRecordInterface;
+use yii\db\QueryInterface;
+use yii\db\Transaction;
+use yii\db\Connection;
 
 /**
  * This module provides integration with [Yii framework](http://www.yiiframework.com/) (2.0).
@@ -122,49 +127,105 @@ use yii\db\ActiveRecordInterface;
  * Maintainer: **samdark**
  * Stability: **stable**
  *
+ * @property \Codeception\Lib\Connector\Yii2 $client
  */
 class Yii2 extends Framework implements ActiveRecord, PartedModule
 {
-    const TEST_FIXTURES_METHOD = '_fixtures';
-
     /**
      * Application config file must be set.
      * @var array
      */
     protected $config = [
+        'fixturesMethod' => '_fixtures',
         'cleanup'     => true,
+        'ignoreCollidingDSN' => false,
         'transaction' => null,
         'entryScript' => '',
         'entryUrl'    => 'http://localhost/index-test.php',
     ];
 
     protected $requiredFields = ['configFile'];
-    protected $transaction;
 
     /**
-     * @var \yii\base\Application
+     * @var array Array of Transaction objects indexed by a string key
      */
-    public $app;
+    private $transactions = [];
+    /**
+     * @var \PDO[] Array of PDO objects indexed by a string key
+     */
+    private $pdoCache = [];
+    /**
+     * @var string[] Array of cache keys indexes by their DSN
+     */
+    private $dsnCache = [];
 
     /**
      * @var Yii2Connector\FixturesStore[]
      */
     public $loadedFixtures = [];
 
+    /**
+     * @var array The contents of $_SERVER upon initialization of this object.
+     * This is only used to restore it upon object destruction.
+     * It MUST not be used anywhere else.
+     */
+    private $server;
     public function _initialize()
     {
         if ($this->config['transaction'] === null) {
             $this->config['transaction'] = $this->backupConfig['transaction'] = $this->config['cleanup'];
         }
 
+        $this->defineConstants();
+        $this->server = $_SERVER;
+        $this->initServerGlobal();
+    }
+
+
+    /**
+     * Module configuration changed inside a test.
+     * We might need to re-create the application.
+     */
+    protected function onReconfigure()
+    {
+        parent::onReconfigure();
+        if (isset(\Yii::$app)) {
+            $this->client->restart();
+        }
+    }
+
+
+    /**
+     * Adds the required server params.
+     * Note this is done separately from the request cycle since someone might call
+     * `Url::to` before doing a request, which would instantiate the request component with incorrect server params.
+     */
+    private function initServerGlobal()
+    {
+
+        $entryUrl = $this->config['entryUrl'];
+        $entryFile = $this->config['entryScript'] ?: basename($entryUrl);
+        $entryScript = $this->config['entryScript'] ?: parse_url($entryUrl, PHP_URL_PATH);
+        $_SERVER = array_merge($_SERVER, [
+            'SCRIPT_FILENAME' => $entryFile,
+            'SCRIPT_NAME' => $entryScript,
+            'SERVER_NAME' => parse_url($entryUrl, PHP_URL_HOST),
+            'SERVER_PORT' => parse_url($entryUrl, PHP_URL_PORT) ?: '80',
+            'HTTPS' => parse_url($entryUrl, PHP_URL_SCHEME) === 'https'
+        ]);
+    }
+
+    protected function validateConfig()
+    {
+        parent::validateConfig();
         if (!is_file(Configuration::projectDir() . $this->config['configFile'])) {
             throw new ModuleConfigException(
                 __CLASS__,
                 "The application config file does not exist: " . Configuration::projectDir() . $this->config['configFile']
             );
         }
-        $this->defineConstants();
     }
+
 
     public function _before(TestInterface $test)
     {
@@ -172,17 +233,18 @@ class Yii2 extends Framework implements ActiveRecord, PartedModule
         $entryFile = $this->config['entryScript'] ?: basename($entryUrl);
         $entryScript = $this->config['entryScript'] ?: parse_url($entryUrl, PHP_URL_PATH);
 
-        $this->client = new Yii2Connector();
-        $this->client->defaultServerVars = [
+        $this->client = new Yii2Connector([
             'SCRIPT_FILENAME' => $entryFile,
-            'SCRIPT_NAME'     => $entryScript,
-            'SERVER_NAME'     => parse_url($entryUrl, PHP_URL_HOST),
-            'SERVER_PORT'     => parse_url($entryUrl, PHP_URL_PORT) ?: '80',
-        ];
-        $this->client->defaultServerVars['HTTPS'] = parse_url($entryUrl, PHP_URL_SCHEME) === 'https';
-        $this->client->restoreServerVars();
+            'SCRIPT_NAME' => $entryScript,
+            'SERVER_NAME' => parse_url($entryUrl, PHP_URL_HOST),
+            'SERVER_PORT' => parse_url($entryUrl, PHP_URL_PORT) ?: '80',
+            'HTTPS' => parse_url($entryUrl, PHP_URL_SCHEME) === 'https'
+        ]);
+
         $this->client->configFile = Configuration::projectDir() . $this->config['configFile'];
-        $this->app = $this->client->getApplication();
+
+        $this->client->resetApplication();
+        $app = $this->client->getApplication();
 
         // load fixtures before db transaction
         if ($test instanceof \Codeception\Test\Cest) {
@@ -191,13 +253,7 @@ class Yii2 extends Framework implements ActiveRecord, PartedModule
             $this->loadFixtures($test);
         }
 
-        if ($this->config['transaction']
-            && $this->app->has('db')
-            && $this->app->db instanceof \yii\db\Connection
-        ) {
-            $this->transaction = $this->app->db->beginTransaction();
-            $this->debugSection('Database', 'Transaction started');
-        }
+        $this->startTransactions();
     }
 
     /**
@@ -207,11 +263,27 @@ class Yii2 extends Framework implements ActiveRecord, PartedModule
      */
     private function loadFixtures($test)
     {
+        $this->debugSection('Fixtures', 'Loading fixtures');
+        /** @var Connection[] $connections */
+        $connections = [];
+        // Register event handler.
+        Event::on(Connection::class, Connection::EVENT_AFTER_OPEN, function (Event $event) use (&$connections) {
+            $this->debugSection('Fixtures', 'Opened database connection: ' . $event->sender->dsn);
+            $connections[] = $event->sender;
+        });
         if (empty($this->loadedFixtures)
-            && method_exists($test, self::TEST_FIXTURES_METHOD)
+            && method_exists($test, $this->_getConfig('fixturesMethod'))
         ) {
-            $this->haveFixtures(call_user_func([$test, self::TEST_FIXTURES_METHOD]));
+            $this->haveFixtures(call_user_func([$test, $this->_getConfig('fixturesMethod')]));
         }
+
+        Event::offAll();
+        // Close all connections so they get properly reopened after the transaction handler has been attached.
+        foreach ($connections as $connection) {
+            $this->debugSection('Fixtures', 'Closing database connection: ' . $connection->dsn);
+            $connection->close();
+        }
+        $this->debugSection('Fixtures', 'Done');
     }
 
     public function _after(TestInterface $test)
@@ -223,10 +295,7 @@ class Yii2 extends Framework implements ActiveRecord, PartedModule
         $_COOKIE = [];
         $_REQUEST = [];
 
-        if ($this->config['transaction'] && $this->transaction) {
-            $this->transaction->rollBack();
-            $this->debugSection('Database', 'Transaction cancelled; all changes reverted.');
-        }
+        $this->rollbackTransactions();
 
         if ($this->config['cleanup']) {
             foreach ($this->loadedFixtures as $fixture) {
@@ -235,20 +304,78 @@ class Yii2 extends Framework implements ActiveRecord, PartedModule
             $this->loadedFixtures = [];
         }
 
-        if ($this->client) {
-            $this->client->resetPersistentVars();
-        }
-
-        if (isset(\Yii::$app) && \Yii::$app->has('session', true)) {
-            \Yii::$app->session->close();
-        }
-
-        // Close connections if exists
-        if (isset(\Yii::$app) && \Yii::$app->has('db', true)) {
-            \Yii::$app->db->close();
+        if ($this->client->getApplication()->has('session', true)) {
+            $this->client->getApplication()->session->close();
         }
 
         parent::_after($test);
+    }
+
+    protected function startTransactions()
+    {
+        if ($this->config['transaction']) {
+            // This should register handlers that start a transaction whenever a connection opens and add it to the transactions array.
+            Event::on(Connection::class, Connection::EVENT_AFTER_OPEN, function (Event $event) {
+                if ($event->sender instanceof Connection) {
+                    $connection = $event->sender;
+                    /*
+                     * We should check if the known PDO objects are the same, in which case we should reuse the PDO
+                     * object so only 1 transaction is started and multiple connections to the same database see the
+                     * same data (due to writes inside a transaction not being visible from the outside).
+                     *
+                     */
+                    $key = md5(json_encode([
+                        'dsn' => $connection->dsn,
+                        'user' => $connection->username,
+                        'pass' => $connection->password,
+                        'attributes' => $connection->attributes,
+                        'emulatePrepare' => $connection->emulatePrepare,
+                        'charset' => $connection->charset
+                    ]));
+
+                    /*
+                     * If keys match we assume connections are "similar enough".
+                     */
+                    if (isset($this->pdoCache[$key])) {
+                        $connection->pdo = $this->pdoCache[$key];
+                    }
+
+                    if (isset($this->dsnCache[$connection->dsn])
+                        && $this->dsnCache[$connection->dsn] !== $key
+                        && !$this->config['ignoreCollidingDSN']
+                    ) {
+                        $this->debugSection('WARNING', <<<TEXT
+You use multiple connections to the same DSN ({$connection->dsn}) with different configuration.
+These connections will not see the same database state since we cannot share a transaction between different PDO
+instances.
+You can remove this message by adding 'ignoreCollidingDSN = true' in the module configuration.
+TEXT
+                        );
+                        Debug::pause();
+                    }
+
+                    if (isset($this->transactions[$key])) {
+                        $this->debugSection('Database', 'Reusing PDO, so no need for a new transaction');
+                        return;
+                    }
+
+                    $this->debugSection('Database', 'Transaction started for: ' . $connection->dsn);
+                    $this->transactions[$key] = $connection->beginTransaction();
+                }
+            });
+        }
+    }
+
+    protected function rollbackTransactions()
+    {
+        /** @var Transaction $transaction */
+        foreach ($this->transactions as $transaction) {
+            $transaction->rollBack();
+            $this->debugSection('Database', 'Transaction cancelled; all changes reverted.');
+        }
+        $this->transactions = [];
+        $this->pdoCache = [];
+        $this->dsnCache = [];
     }
 
     public function _parts()
@@ -276,17 +403,17 @@ class Yii2 extends Framework implements ActiveRecord, PartedModule
      */
     public function amLoggedInAs($user)
     {
-        if (!Yii::$app->has('user')) {
+        if (!$this->client->getApplication()->has('user')) {
             throw new ModuleException($this, 'User component is not loaded');
         }
         if ($user instanceof \yii\web\IdentityInterface) {
             $identity = $user;
         } else {
             // class name implementing IdentityInterface
-            $identityClass = Yii::$app->user->identityClass;
+            $identityClass = $this->client->getApplication()->user->identityClass;
             $identity = call_user_func([$identityClass, 'findIdentity'], $user);
         }
-        Yii::$app->user->login($identity);
+        $this->client->getApplication()->user->login($identity);
     }
 
     /**
@@ -473,24 +600,32 @@ class Yii2 extends Framework implements ActiveRecord, PartedModule
         return $this->findRecord($model, $attributes);
     }
 
+    /**
+     * @param string $model Class name
+     * @param array $attributes
+     * @return mixed
+     */
     protected function findRecord($model, $attributes = [])
     {
-        $this->getModelRecord($model);
-        return call_user_func([$model, 'find'])
-            ->andWhere($attributes)
-            ->one();
-    }
-
-    protected function getModelRecord($model)
-    {
         if (!class_exists($model)) {
-            throw new \RuntimeException("Model $model does not exist");
+            throw new \RuntimeException("Class $model does not exist");
         }
-        $record = Yii::createObject($model);
-        if (!$record instanceof ActiveRecordInterface) {
-            throw new \RuntimeException("Model $model is not implement interface \\yii\\db\\ActiveRecordInterface");
+        $rc = new \ReflectionClass($model);
+        if ($rc->hasMethod('find')
+            && ($findMethod = $rc->getMethod('find'))
+            && $findMethod->isStatic()
+            && $findMethod->isPublic()
+            && $findMethod->getNumberOfRequiredParameters() === 0
+        ) {
+            $activeQuery = $findMethod->invoke(null);
+            if ($activeQuery instanceof QueryInterface) {
+                return $activeQuery->andWhere($attributes)->one();
+            }
+
+            throw new \RuntimeException("$model::find() must return an instance of yii\db\QueryInterface");
+
         }
-        return $record;
+        throw new \RuntimeException("Class $model does not have a public static find() method without required parameters");
     }
 
     /**
@@ -522,7 +657,7 @@ class Yii2 extends Framework implements ActiveRecord, PartedModule
     protected function clientRequest($method, $uri, array $parameters = [], array $files = [], array $server = [], $content = null, $changeHistory = true)
     {
         if (is_array($uri)) {
-            $uri = Yii::$app->getUrlManager()->createUrl($uri);
+            $uri = $this->client->getApplication()->getUrlManager()->createUrl($uri);
         }
         return parent::clientRequest($method, $uri, $parameters, $files, $server, $content, $changeHistory);
     }
@@ -541,10 +676,10 @@ class Yii2 extends Framework implements ActiveRecord, PartedModule
      */
     public function grabComponent($component)
     {
-        if (!Yii::$app->has($component)) {
+        if (!$this->client->getApplication()->has($component)) {
             throw new ModuleException($this, "Component $component is not available in current application");
         }
-        return Yii::$app->get($component);
+        return $this->client->getApplication()->get($component);
     }
 
     /**
@@ -660,10 +795,10 @@ class Yii2 extends Framework implements ActiveRecord, PartedModule
      */
     public function getInternalDomains()
     {
-        $domains = [$this->getDomainRegex(Yii::$app->urlManager->hostInfo)];
+        $domains = [$this->getDomainRegex($this->client->getApplication()->urlManager->hostInfo)];
 
-        if (Yii::$app->urlManager->enablePrettyUrl) {
-            foreach (Yii::$app->urlManager->rules as $rule) {
+        if ($this->client->getApplication()->urlManager->enablePrettyUrl) {
+            foreach ($this->client->getApplication()->urlManager->rules as $rule) {
                 /** @var \yii\web\UrlRule $rule */
                 if (isset($rule->host)) {
                     $domains[] = $this->getDomainRegex($rule->host);
@@ -689,8 +824,8 @@ class Yii2 extends Framework implements ActiveRecord, PartedModule
     public function setCookie($name, $val, array $params = [])
     {
         // Sign the cookie.
-        if ($this->app->request->enableCookieValidation) {
-            $val = $this->app->security->hashData(serialize([$name, $val]), $this->app->request->cookieValidationKey);
+        if ($this->client->getApplication()->request->enableCookieValidation) {
+            $val = $this->client->getApplication()->security->hashData(serialize([$name, $val]), $this->client->getApplication()->request->cookieValidationKey);
         }
         parent::setCookie($name, $val, $params);
     }
@@ -702,9 +837,18 @@ class Yii2 extends Framework implements ActiveRecord, PartedModule
      */
     public function createAndSetCsrfCookie($val)
     {
-        $masked = $this->app->security->maskToken($val);
-        $name = $this->app->request->csrfParam;
+        $masked = $this->client->getApplication()->security->maskToken($val);
+        $name = $this->client->getApplication()->request->csrfParam;
         $this->setCookie($name, $val);
         return [$name, $masked];
     }
+
+    public function _afterSuite()
+    {
+        parent::_afterSuite();
+        codecept_debug('Suite done, restoring $_SERVER to original');
+
+        $_SERVER = $this->server;
+    }
+
 }


### PR DESCRIPTION
- No more static variables
- No more database connection caching (that didn't actually work)
- Support for multiple database connections / database services with names other than 'db'

This needs more testing; I've tested it in a few of my production apps.

Also somewhere in the docs we should update the "contract" about application state:

1. When a test starts you get a fresh application.
2. Just before a request is executed the `Request` and `Response` component are reloaded.
3. Application state is persisted after the request and reused for the next request (as long as it is not in the `Request` or `Response` component.
4. All PDO based connections are supported as long as they are subclasses of `yii\db\Connection` and fire the `AFTER_OPEN` event.


Database handling (for transactions)

1. All caches are cleared at the end of a test.
2. At the start of a test we register an event handler for `AFTER_OPEN`.
3. When the event is fired we generate a cache key based on connection settings.
4. We store the PDO object in the cache.
5. We store an entry in the dsn cache, this is used to identify unsupported cases (think connecting to the same database with different credentials, in which case the transaction creates 2 world views which could cause issues).
6. If we detect a duplicate PDO object we replace the new PDO with the existing one, this causes the new connection to be closed immediately and guarantees us that the new `Connection` object uses the same PDO object and thus has the same world view.
