### PR TITLE
Improve support of PHPUnit warning status

### DIFF
--- a/src/Codeception/Events.php
+++ b/src/Codeception/Events.php
@@ -93,6 +93,13 @@ final class Events
      */
     const TEST_SKIPPED = 'test.skipped';
 
+
+    /**
+     * The event listener method receives a {@link Codeception\Event\FailEvent} instance.
+     */
+    const TEST_WARNING = 'test.warning';
+
+
     /**
      * The event listener method receives a {@link Codeception\Event\TestEvent} instance.
      */

--- a/src/Codeception/Subscriber/Console.php
+++ b/src/Codeception/Subscriber/Console.php
@@ -40,6 +40,7 @@ class Console implements EventSubscriberInterface
         Events::TEST_ERROR         => 'testError',
         Events::TEST_INCOMPLETE    => 'testIncomplete',
         Events::TEST_SKIPPED       => 'testSkipped',
+        Events::TEST_WARNING       => 'testWarning',
         Events::TEST_FAIL_PRINT    => 'printFail',
         Events::RESULT_PRINT_AFTER => 'afterResult',
     ];
@@ -234,6 +235,16 @@ class Console implements EventSubscriberInterface
     {
         $this->metaStep = null;
         $this->printedTest = null;
+    }
+
+    public function testWarning(TestEvent $e)
+    {
+        if ($this->isDetailed($e->getTest())) {
+            $this->message('WARNING')->center(' ')->style('pending')->append("\n")->writeln();
+
+            return;
+        }
+        $this->writelnFinishedTest($e, $this->message('W')->style('pending'));
     }
 
     public function testFail(FailEvent $e)

--- a/tests/cli/RunCest.php
+++ b/tests/cli/RunCest.php
@@ -474,7 +474,7 @@ EOF
         $I->executeCommand('run powers PowerUpCest');
         $I->dontSeeInShellOutput('FAILURES');
     }
-    
+
     public function runCestWithTwoFailedTest(CliGuy $I)
     {
         $I->executeCommand('run scenario PartialFailedCest', false);
@@ -483,4 +483,15 @@ EOF
         $I->seeInShellOutput('Tests: 3,');
         $I->seeInShellOutput('Failures: 2.');
     }
+
+
+    public function runWarningTests(CliGuy $I)
+    {
+        $I->executeCommand('run unit WarningTest.php:testWarningInvalidDataProvider', false);
+        $I->seeInShellOutput('There was 1 warning');
+        $I->seeInShellOutput('WarningTest::testWarningInvalidDataProvider');
+        $I->seeInShellOutput('Tests: 1,');
+        $I->seeInShellOutput('Warnings: 1.');
+    }
+
 }

--- a/tests/data/claypit/tests/unit/WarningTest.php
+++ b/tests/data/claypit/tests/unit/WarningTest.php
@@ -1,0 +1,15 @@
+<?php
+class WarningTest extends \Codeception\Test\Unit
+{
+    /**
+     * @dataProvider dependentProvider
+     */
+    public function testWarningInvalidDataProvider($a)
+    {
+        $this->assertTrue(true);
+    }
+    public function dependentProvider()
+    {
+        throw new Exception;
+    }
+}


### PR DESCRIPTION
This PR requires following PRs for **phpunit-wrapper** :
- codeception/phpunit-wrapper#21
- codeception/phpunit-wrapper#22

Better support of PHPUnit warning status:
- add new event `test.warning`
- display 'W' instead of success for warning test cases