### PR TITLE
Added safety check for runtimes emulating php 7.1+ but not supporting pcntl_async_signals()

### DIFF
--- a/src/Codeception/Subscriber/GracefulTermination.php
+++ b/src/Codeception/Subscriber/GracefulTermination.php
@@ -9,6 +9,7 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 class GracefulTermination implements EventSubscriberInterface
 {
     const SIGNAL_FUNC = 'pcntl_signal';
+    const ASYNC_SIGNAL_HANDLING_FUNC = 'pcntl_async_signals';
 
     /**
      * @var SuiteEvent
@@ -17,10 +18,11 @@ class GracefulTermination implements EventSubscriberInterface
 
     public function handleSuite(SuiteEvent $event)
     {
-        if (PHP_MAJOR_VERSION === 7) {
-            if (PHP_MINOR_VERSION === 0) {
-                return; // skip for PHP 7.0: https://github.com/Codeception/Codeception/issues/3607
-            }
+        if (PHP_MAJOR_VERSION === 7 && PHP_MINOR_VERSION === 0) {
+            // skip for PHP 7.0: https://github.com/Codeception/Codeception/issues/3607
+            return;
+        }
+        if (function_exists(self::ASYNC_SIGNAL_HANDLING_FUNC)) {
             pcntl_async_signals(true);
         }
         if (function_exists(self::SIGNAL_FUNC)) {


### PR DESCRIPTION
Hi!

Latest available HHVM doesn't have `pcntl_async_signals()` on board, but mimics PHP 7.1, which was assumed to have. I added basic function_exists() check to prevent function-does-not-exist errors. This probably should be ported to older minor releases.