### PR TITLE
Fixed an issue with exit exceptions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -98,8 +98,8 @@ install:
   - '[[ "$FRAMEWORK" != "Phalcon" ]] || (cd cphalcon/build; bash ./install --phpize $(phpenv which phpize) --php-config $(phpenv which php-config) &>/dev/null && phpenv config-add ../tests/_ci/phalcon.ini &> /dev/null)'
   # Symfony
   #- '[[ "$FRAMEWORK$VERSION" != "Symfony3" ]] || composer require -d framework-tests symfony/symfony=~$VERSION --no-update'
-  - composer install
-  - '[[ "$FRAMEWORK" == "Codeception" ]] || composer update -d framework-tests --no-dev --prefer-dist'
+  - '[[ -z "$FRAMEWORK" ]] composer install'
+  - '[[ "$FRAMEWORK" == "Codeception" ]] || [[ -z "$FRAMEWORK" ]] || composer update -d framework-tests --no-dev --prefer-dist'
 before_script:
   - '[[ "$TRAVIS_PHP_VERSION" == 7.* ]] || echo "extension = mongo.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini'
   # preparing databases

--- a/.travis.yml
+++ b/.travis.yml
@@ -129,4 +129,5 @@ before_script:
   # Build
   - '[[ -z "$FRAMEWORK" ]] || php codecept build -c $TEST_PATH'
 script:
+  # Run tests if $FRAMEWORK is not empty
   - '[[ -z "$FRAMEWORK" ]] || php codecept run $SUITES -c $TEST_PATH'

--- a/.travis.yml
+++ b/.travis.yml
@@ -98,7 +98,7 @@ install:
   - '[[ "$FRAMEWORK" != "Phalcon" ]] || (cd cphalcon/build; bash ./install --phpize $(phpenv which phpize) --php-config $(phpenv which php-config) &>/dev/null && phpenv config-add ../tests/_ci/phalcon.ini &> /dev/null)'
   # Symfony
   #- '[[ "$FRAMEWORK$VERSION" != "Symfony3" ]] || composer require -d framework-tests symfony/symfony=~$VERSION --no-update'
-  - '[[ -z "$FRAMEWORK" ]] composer install'
+  - '[[ -z "$FRAMEWORK" ]] || composer install'
   - '[[ "$FRAMEWORK" == "Codeception" ]] || [[ -z "$FRAMEWORK" ]] || composer update -d framework-tests --no-dev --prefer-dist'
 before_script:
   - '[[ "$TRAVIS_PHP_VERSION" == 7.* ]] || echo "extension = mongo.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini'

--- a/src/Codeception/Lib/Connector/Yii2.php
+++ b/src/Codeception/Lib/Connector/Yii2.php
@@ -184,13 +184,12 @@ class Yii2 extends Client
                 // to expect error response codes in tests.
                 $app->errorHandler->discardExistingOutput = false;
                 $app->errorHandler->handleException($e);
-                $response = $app->response;
-
             } elseif (!$e instanceof ExitException) {
                 // for exceptions not related to Http, we pass them to Codeception
                 $this->resetApplication();
                 throw $e;
             }
+            $response = $app->response;
         }
 
         $this->encodeCookies($response, $yiiRequest, $app->security);


### PR DESCRIPTION
Certain kinds of exceptions (`ExitException`) lead to a code path where the response object was unset.
Test case was added to test repo.