### PR TITLE
Manual app reset

### DIFF
--- a/src/Codeception/Lib/Connector/Yii2.php
+++ b/src/Codeception/Lib/Connector/Yii2.php
@@ -96,6 +96,8 @@ class Yii2 extends Client
             \yii\base\Event::offAll();
         }
         Yii::setLogger(null);
+        // This resolves an issue with database connections not closing properly.
+        gc_collect_cycles();
     }
 
     public function startApp()

--- a/src/Codeception/Lib/Connector/Yii2.php
+++ b/src/Codeception/Lib/Connector/Yii2.php
@@ -284,16 +284,6 @@ class Yii2 extends Client
         return $config;
     }
 
-    /**
-     * A new client is created for every test, it is destroyed after every test.
-     * @see InnerBrowser::_after()
-     *
-     */
-    public function __destruct()
-    {
-        $this->resetApplication();
-    }
-
     public function restart()
     {
         parent::restart();

--- a/src/Codeception/Module/Yii2.php
+++ b/src/Codeception/Module/Yii2.php
@@ -387,6 +387,8 @@ class Yii2 extends Framework implements ActiveRecord, PartedModule
              */
             if (isset($this->pdoCache[$key])) {
                 $connection->pdo = $this->pdoCache[$key];
+            } else {
+                $this->pdoCache[$key] = $connection->pdo;
             }
 
             if (isset($this->dsnCache[$connection->dsn])

--- a/src/Codeception/Module/Yii2.php
+++ b/src/Codeception/Module/Yii2.php
@@ -358,6 +358,8 @@ class Yii2 extends Framework implements ActiveRecord, PartedModule
         if ($this->client->getApplication()->has('session', true)) {
             $this->client->getApplication()->session->close();
         }
+
+        $this->client->resetApplication();
         parent::_after($test);
     }
 


### PR DESCRIPTION
Some modules keep references to the Yii2 Client object.
I wrongly assumed that the Yii2 Module was the only one, and thus I did application cleanup in upon client destruction.
Application destruction is now done in `_after()`.
An issue was fixed with the `$pdoCache` never getting filled.