### PR TITLE
Fixed compatibility with ZF2 ServiceManager

### DIFF
--- a/src/Codeception/Lib/Connector/ZF2/PersistentServiceManager.php
+++ b/src/Codeception/Lib/Connector/ZF2/PersistentServiceManager.php
@@ -17,17 +17,17 @@ class PersistentServiceManager extends ServiceManager implements ServiceLocatorI
         $this->serviceManager = $serviceManager;
     }
 
-    public function get($name)
+    public function get($name, $usePeeringServiceManagers = true)
     {
         if (parent::has($name)) {
-            return parent::get($name);
+            return parent::get($name, $usePeeringServiceManagers);
         }
         return $this->serviceManager->get($name);
     }
 
-    public function has($name)
+    public function has($name, $checkAbstractFactories = true, $usePeeringServiceManagers = true)
     {
-        if (parent::has($name)) {
+        if (parent::has($name, $checkAbstractFactories, $usePeeringServiceManagers)) {
             return true;
         }
         if (preg_match('/doctrine/i', $name)) {


### PR DESCRIPTION
Fixed compatibility for ZF2 ServiceManager. Without that, you got an error:

```
Codeception PHP Testing Framework v2.4.1
--
11-Apr-2018 20:17:17 | Powered by PHPUnit 5.7.14 by Sebastian Bergmann and contributors.
11-Apr-2018 20:17:20 | PHP Fatal error:  Declaration of Codeception\Lib\Connector\ZF2\PersistentServiceManager::get($name) must be compatible with Zend\ServiceManager\ServiceManager::get($name, $usePeeringServiceManagers = true) in /data/vendor/codeception/codeception/src/Codeception/Lib/Connector/ZF2/PersistentServiceManager.php on line 8
```