### PR TITLE
use \Throwable instead \Exception

### DIFF
--- a/src/Codeception/Event/FailEvent.php
+++ b/src/Codeception/Event/FailEvent.php
@@ -4,7 +4,7 @@ namespace Codeception\Event;
 class FailEvent extends TestEvent
 {
     /**
-     * @var \Exception
+     * @var \Throwable
      */
     protected $fail;
 
@@ -13,7 +13,7 @@ class FailEvent extends TestEvent
      */
     protected $count;
 
-    public function __construct(\PHPUnit\Framework\Test $test, $time, \Exception $e, $count = 0)
+    public function __construct(\PHPUnit\Framework\Test $test, $time, \Throwable $e, $count = 0)
     {
         parent::__construct($test, $time);
         $this->fail = $e;

--- a/src/Codeception/Module.php
+++ b/src/Codeception/Module.php
@@ -258,7 +258,7 @@ abstract class Module
      * **HOOK** executed when test fails but before `_after`
      *
      * @param TestInterface $test
-     * @param \Exception $fail
+     * @param \Throwable $fail
      */
     public function _failed(TestInterface $test, $fail)
     {

--- a/src/Codeception/Subscriber/Console.php
+++ b/src/Codeception/Subscriber/Console.php
@@ -367,11 +367,16 @@ class Console implements EventSubscriberInterface
             return;
         }
 
-        $this->printException($fail);
-        $this->printExceptionTrace($fail);
+        $this->printThrowable($fail);
+        $this->printThrowableTrace($fail);
     }
 
     public function printException($e, $cause = null)
+    {
+        return $this->printThrowable($e, $cause);
+    }
+
+    public function printThrowable($e, $cause = null)
     {
         if ($e instanceof \PHPUnit\Framework\SkippedTestError or $e instanceof \PHPUnit\Framework_IncompleteTestError) {
             if ($e->getMessage()) {
@@ -426,22 +431,27 @@ class Console implements EventSubscriberInterface
             }
         }
 
-        $this->printException($fail, $failedStep);
+        $this->printThrowable($fail, $failedStep);
 
         $this->printScenarioTrace($failedTest);
         if ($this->output->getVerbosity() == OutputInterface::VERBOSITY_DEBUG) {
-            $this->printExceptionTrace($fail);
+            $this->printThrowableTrace($fail);
 
             return;
         }
         if (!$fail instanceof \PHPUnit\Framework\AssertionFailedError) {
-            $this->printExceptionTrace($fail);
+            $this->printThrowableTrace($fail);
 
             return;
         }
     }
 
     public function printExceptionTrace(\Exception $e)
+    {
+        return $this->printThrowableTrace($e);
+    }
+
+    public function printThrowableTrace(\Throwable $e)
     {
         static $limit = 10;
 
@@ -482,7 +492,7 @@ class Console implements EventSubscriberInterface
 
         $prev = $e->getPrevious();
         if ($prev) {
-            $this->printExceptionTrace($prev);
+            $this->printThrowableTrace($prev);
         }
     }
 


### PR DESCRIPTION
I try to migrate from 2.3 to 2.4 an I got a errors like 
```sh
An Error occurred while handling another error:
yii\web\HeadersAlreadySentException: Headers already sent in /repo/vendor/phpunit/phpunit/src/Util/Printer.php on line 109. in /var/www/html/vendor/yiisoft/yii2/web/Response.php:366
Stack trace:
#0 /var/www/html/vendor/yiisoft/yii2/web/Response.php(339): yii\web\Response->sendHeaders()
#1 /var/www/html/vendor/yiisoft/yii2/web/ErrorHandler.php(135): yii\web\Response->send()
#2 /var/www/html/vendor/yiisoft/yii2/base/ErrorHandler.php(111): yii\web\ErrorHandler->renderException(Object(TypeError))
#3 [internal function]: yii\base\ErrorHandler->handleException(Object(TypeError))
#4 {main}
Previous exception:
TypeError: Argument 3 passed to Codeception\Event\FailEvent::__construct() must be an instance of Exception, instance of Error given, called in /repo/vendor/codeception/phpunit-wrapper/src/ResultPrinter/UI.php on line 28 and defined in /repo/src/Codeception/Event/FailEvent.php:16
Stack trace:
#0 /repo/vendor/codeception/phpunit-wrapper/src/ResultPrinter/UI.php(28): Codeception\Event\FailEvent->__construct(Object(Codeception\Test\Cest), NULL, Object(Error), 1)
#1 /repo/vendor/phpunit/phpunit/src/TextUI/ResultPrinter.php(350): Codeception\PHPUnit\ResultPrinter\UI->printDefect(Object(PHPUnit\Framework\TestFailure), 1)
#2 /repo/vendor/phpunit/phpunit/src/TextUI/ResultPrinter.php(385): PHPUnit\TextUI\ResultPrinter->printDefects(Array, 'error')
#3 /repo/vendor/phpunit/phpunit/src/TextUI/ResultPrinter.php(182): PHPUnit\TextUI\ResultPrinter->printErrors(Object(PHPUnit\Framework\TestResult))
#4 /repo/src/Codeception/Codecept.php(204): PHPUnit\TextUI\ResultPrinter->printResult(Object(PHPUnit\Framework\TestResult))
#5 /repo/src/Codeception/Command/Run.php(376): Codeception\Codecept->printResult()
```

This is path to fix it. I will use it.

Important: this is require `php:^7.0`
http://php.net/manual/en/class.throwable.php


let's discuss!