### PR TITLE
Restore null check for client in Yii2 (fix #4929)

### DIFF
--- a/src/Codeception/Module/Yii2.php
+++ b/src/Codeception/Module/Yii2.php
@@ -355,7 +355,7 @@ class Yii2 extends Framework implements ActiveRecord, PartedModule
             $this->loadedFixtures = [];
         }
 
-        if ($this->client->getApplication()->has('session', true)) {
+        if ($this->client !== null && $this->client->getApplication()->has('session', true)) {
             $this->client->getApplication()->session->close();
         }
         parent::_after($test);


### PR DESCRIPTION
Restored the null check that was deleted in https://github.com/Codeception/Codeception/commit/08e487b0854bcc1f8a8478a5d5b7cf9713cbbc76#diff-938f756d763fc21aace78bb43ea26870L238