### PR TITLE
[Yii2] make logger replaceable and allow enabled log targets

### DIFF
--- a/src/Codeception/Lib/Connector/Yii2.php
+++ b/src/Codeception/Lib/Connector/Yii2.php
@@ -48,7 +48,11 @@ class Yii2 extends Client
      */
     const CLEAN_MANUAL = 'manual';
 
-
+    /**
+     * @var bool keep log targets enabled or force disable. Set 'false' to force disable
+     */
+    public $logTargetsEnabled = false;
+    
     /**
      * @var string application config file
      */
@@ -157,12 +161,11 @@ class Yii2 extends Client
         $app = $this->getApplication();
 
         // disabling logging. Logs are slowing test execution down
-        foreach ($app->log->targets as $target) {
-            $target->enabled = false;
+        if (!$this->logTargetsEnabled) {
+            foreach ($app->log->targets as $target) {
+                $target->enabled = false;
+            }
         }
-
-
-
 
         $yiiRequest = $app->getRequest();
         if ($request->getContent() !== null) {

--- a/src/Codeception/Lib/Connector/Yii2.php
+++ b/src/Codeception/Lib/Connector/Yii2.php
@@ -118,8 +118,6 @@ class Yii2 extends Client
         $config = $this->mockMailer($config);
         /** @var \yii\web\Application $app */
         Yii::$app = Yii::createObject($config);
-
-        Yii::setLogger(Yii::createObject('yii\log\Logger'));
     }
 
     /**

--- a/src/Codeception/Lib/Connector/Yii2.php
+++ b/src/Codeception/Lib/Connector/Yii2.php
@@ -112,7 +112,7 @@ class Yii2 extends Client
         /** @var \yii\web\Application $app */
         Yii::$app = Yii::createObject($config);
 
-        Yii::setLogger(new Logger());
+        Yii::setLogger(Yii::createObject('yii\log\Logger'));
     }
 
     /**

--- a/src/Codeception/Lib/Connector/Yii2.php
+++ b/src/Codeception/Lib/Connector/Yii2.php
@@ -107,7 +107,10 @@ class Yii2 extends Client
         if (!isset($config['class'])) {
             $config['class'] = 'yii\web\Application';
         }
-
+        if (!isset($config['container']['definitions']['yii\log\Logger']['class'])) {
+            $config['container']['definitions']['yii\log\Logger']['class'] = 'Codeception\Lib\Connector\Yii2\Logger';
+        }
+        
         $config = $this->mockMailer($config);
         /** @var \yii\web\Application $app */
         Yii::$app = Yii::createObject($config);

--- a/src/Codeception/Module/Yii2.php
+++ b/src/Codeception/Module/Yii2.php
@@ -34,6 +34,7 @@ use yii\db\Transaction;
  * * `configFile` *required* - the path to the application config file. File should be configured for test environment and return configuration array.
  * * `entryUrl` - initial application url (default: http://localhost/index-test.php).
  * * `entryScript` - front script title (like: index-test.php). If not set - taken from entryUrl.
+ * * `logTargetsEnabled` - keep log targets enabled or set 'false' to force disable. Default is 'false'
  * * `transaction` - (default: true) wrap all database connection inside a transaction and roll it back after the test. Should be disabled for acceptance testing..
  * * `cleanup` - (default: true) cleanup fixtures after the test
  * * `ignoreCollidingDSN` - (default: false) When 2 database connections use the same DSN but different settings an exception will be thrown, set this to true to disable this behavior.
@@ -158,6 +159,7 @@ class Yii2 extends Framework implements ActiveRecord, PartedModule
         'transaction' => null,
         'entryScript' => '',
         'entryUrl'    => 'http://localhost/index-test.php',
+        'logTargetsEnabled' => false,
         'responseCleanMethod' => Yii2Connector::CLEAN_CLEAR,
         'requestCleanMethod' => Yii2Connector::CLEAN_RECREATE,
         'recreateComponents' => [],
@@ -280,7 +282,7 @@ class Yii2 extends Framework implements ActiveRecord, PartedModule
         $entryUrl = $this->config['entryUrl'];
         $entryFile = $this->config['entryScript'] ?: basename($entryUrl);
         $entryScript = $this->config['entryScript'] ?: parse_url($entryUrl, PHP_URL_PATH);
-
+        
         $this->client = new Yii2Connector([
             'SCRIPT_FILENAME' => $entryFile,
             'SCRIPT_NAME' => $entryScript,


### PR DESCRIPTION
make logger replaceable and allow enabled log targets

my use case: I currently use logger for logging activity, data change etc via target and I found out that it is impossible to test logger at all.

similar issues
#1342 