### PR TITLE
Fix issue regarding 'The xxx service is already initialized, you cannot replace it'

### DIFF
--- a/src/Codeception/Lib/Connector/Symfony.php
+++ b/src/Codeception/Lib/Connector/Symfony.php
@@ -76,7 +76,9 @@ class Symfony extends \Symfony\Component\HttpKernel\Client
         $this->container = $this->kernel->getContainer();
 
         foreach ($this->persistentServices as $serviceName => $service) {
-            $this->container->set($serviceName, $service);
+            if (!$this->container->has($serviceName)) {
+                $this->container->set($serviceName, $service);
+            }
         }
 
         if ($this->container->has('profiler')) {


### PR DESCRIPTION
Every time I clean /test cache and run API suite the error appears for the first test. Otherwise, it's OK.

The issue was reported here: #4806 