### PR TITLE
Skip cleanup when ORM specifies no cleanup

### DIFF
--- a/src/Codeception/Module/DataFactory.php
+++ b/src/Codeception/Module/DataFactory.php
@@ -187,7 +187,7 @@ EOF;
     public function _after(TestInterface $test)
     {
         $skipCleanup = array_key_exists('cleanup', $this->config) && $this->config['cleanup'] === false;
-        if ($skipCleanup || $this->ormModule->_getConfig('cleanup')) {
+        if ($skipCleanup || $this->ormModule->_getConfig('cleanup') === false) {
             return;
         }
         $this->factoryMuffin->deleteSaved();


### PR DESCRIPTION
If you don't specify `cleanup: false` on the `DataFactory` module configuration and instead rely on the `cleanup` value for the ORM module (e.g. `Doctrine2`) then the `DataFactory` should correctly follow that value.

Correct me if I'm wrong but the `DataFactory` module should skip the cleanup if the `ORM` module (of which it depends on) has `cleanup: false`, right?  