### PR TITLE
WebDriverTest: fixed incorrect assertion

### DIFF
--- a/tests/web/WebDriverTest.php
+++ b/tests/web/WebDriverTest.php
@@ -1116,6 +1116,6 @@ HTML
         });
         $this->assertNotTrue($this->module->webDriver->getCapabilities()->getCapability('acceptInsecureCerts'));
         $this->module->_initializeSession();
-        $this->assertTrue(true, $this->module->webDriver->getCapabilities()->getCapability('acceptInsecureCerts'));
+        $this->assertTrue($this->module->webDriver->getCapabilities()->getCapability('acceptInsecureCerts'));
     }
 }


### PR DESCRIPTION
`$this->assertTrue(true, expression`); looks wrong, especially if it doesn't return string.

Reported in #4956