### PR TITLE
Fix memory leak when using Laravel factories inside Codeception

### DIFF
--- a/src/Codeception/Module/Laravel5.php
+++ b/src/Codeception/Module/Laravel5.php
@@ -217,6 +217,10 @@ class Laravel5 extends Framework implements ActiveRecord, PartedModule
                     $connection->disconnect();
                 }
             }
+
+            // Remove references to Faker in factories to prevent memory leak
+            unset($this->app[\Faker\Generator::class]);
+            unset($this->app[\Illuminate\Database\Eloquent\Factory::class]);
         }
     }
 


### PR DESCRIPTION
Hi,

Recently I started noticing out of memory problem during Codeception run in my Laravel 5 project. After some profiling & investigation, I found out that Faker library used in Laravel factories causing some of those problems.
For now Laravel module doesn't support factories yet, but if we plan to do that we'd probably need to take care of this memory leak. Here is a ticket for it - #3849 

I expect this PR to be low risk because I'm just removing something from Service Container that is initialized one more time in next request.

I made some manual tests in my project on 96 tests, most of them are using factories:

Before:
```
Time: 12.31 seconds, Memory: 404.00MB

OK (96 tests, 380 assertions)
```
After:
```
Time: 13.43 seconds, Memory: 134.00MB

OK (96 tests, 380 assertions)
```

