### PR TITLE
Move manual app reset into null check

### DIFF
--- a/src/Codeception/Module/Yii2.php
+++ b/src/Codeception/Module/Yii2.php
@@ -357,11 +357,13 @@ class Yii2 extends Framework implements ActiveRecord, PartedModule
             $this->loadedFixtures = [];
         }
 
-        if ($this->client !== null && $this->client->getApplication()->has('session', true)) {
-            $this->client->getApplication()->session->close();
+        if ($this->client !== null) {
+            if ($this->client->getApplication()->has('session', true)) {
+                $this->client->getApplication()->session->close();
+            }
+            $this->client->resetApplication();
         }
 
-        $this->client->resetApplication();
         parent::_after($test);
     }
 


### PR DESCRIPTION
The call to `resetApplication()` was added in #4928 but I think this should also happen in the null check.

Without this change, I run into this error:

```
Codeception PHP Testing Framework v2.4.2
Powered by PHPUnit 7.1.5 by Sebastian Bergmann and contributors.

Fatal error: Uncaught Error: Call to a member function resetApplication() on null in C:\project\vendor\codeception\codeception\src\Codeception\Module\Yii2.php:364
Stack trace:
#0 C:\project\vendor\codeception\codeception\src\Codeception\Subscriber\Module.php(66): Codeception\Module\Yii2->_after(Object(Codeception\Test\Cest))
#1 C:\project\vendor\symfony\event-dispatcher\EventDispatcher.php(212): Codeception\Subscriber\Module->after(Object(Codeception\Event\TestEvent), 'test.after', Object(Symfony\Component\EventDispatcher\EventDispatcher))
#2 C:\project\vendor\symfony\event-dispatcher\EventDispatcher.php(44): Symfony\Component\EventDispatcher\EventDispatcher->doDispatch(Array, 'test.after', Object(Codeception\Event\TestEvent))
#3 C:\project\vendor\codeception\phpunit-wrapper\src\Listener.php(133): Symfony\Component\EventDispatcher\EventDispatcher->dispatch('test.after', Object(Codeception\Event\TestEvent))
#4 C:\project\vendor\ in C:\project\vendor\codeception\codeception\src\Codeception\Module\Yii2.php on line 364
```