### PR TITLE
Configurable output limit for data provider

### DIFF
--- a/docs/reference/Configuration.md
+++ b/docs/reference/Configuration.md
@@ -134,6 +134,7 @@ modules:
 
 ```
 
+* `data_provider_output_max`: maximum string size when printing data provider information when running cests. Default is 100.
 * `extends`: allows you to specify a file (relative to the `*.suite.yml` file) that holds some already pre-defined values. This can be used to always use the same configuration for modules or whatever.
 * `namespace`: default namespace of actor, support classes and tests.
 * `suite_namespace`: default namespace for new tests of this suite (ignores `namespace` option)

--- a/src/Codeception/Test/Cest.php
+++ b/src/Codeception/Test/Cest.php
@@ -26,8 +26,9 @@ class Cest extends Test implements
     protected $parser;
     protected $testClassInstance;
     protected $testMethod;
+    protected $settings;
 
-    public function __construct($testClass, $methodName, $fileName)
+    public function __construct($testClass, $methodName, $fileName, $settings = [])
     {
         $metadata = new Metadata();
         $metadata->setName($methodName);
@@ -35,6 +36,7 @@ class Cest extends Test implements
         $this->setMetadata($metadata);
         $this->testClassInstance = $testClass;
         $this->testMethod = $methodName;
+        $this->settings = $settings;
         $this->createScenario();
         $this->parser = new Parser($this->getScenario(), $this->getMetadata());
     }
@@ -50,7 +52,8 @@ class Cest extends Test implements
         // add example params to feature
         if ($this->getMetadata()->getCurrent('example')) {
             $step = new Comment('', $this->getMetadata()->getCurrent('example'));
-            $this->getScenario()->setFeature($this->getScenario()->getFeature() . ' | '. $step->getArgumentsAsString(100));
+            $outputMax = isset($this->settings['data_provider_output_max']) ? $this->settings['data_provider_output_max'] : 100;
+            $this->getScenario()->setFeature($this->getScenario()->getFeature() . ' | '. $step->getArgumentsAsString($outputMax));
         }
     }
 

--- a/src/Codeception/Test/Loader.php
+++ b/src/Codeception/Test/Loader.php
@@ -49,7 +49,7 @@ class Loader
         $this->path = $suiteSettings['path'];
         $this->formats = [
             new CeptLoader(),
-            new CestLoader(),
+            new CestLoader($suiteSettings),
             new UnitLoader(),
             new GherkinLoader($suiteSettings)
         ];

--- a/src/Codeception/Test/Loader/Cest.php
+++ b/src/Codeception/Test/Loader/Cest.php
@@ -1,6 +1,7 @@
 <?php
 namespace Codeception\Test\Loader;
 
+use Codeception\Configuration;
 use Codeception\Exception\TestParseException;
 use Codeception\Lib\Parser;
 use Codeception\Test\Cest as CestFormat;
@@ -9,7 +10,18 @@ use Codeception\Util\ReflectionHelper;
 
 class Cest implements LoaderInterface
 {
+    protected static $defaultSettings = [
+        'data_provider_output_max' => '100'
+    ];
+
     protected $tests = [];
+
+    protected $settings = [];
+
+    public function __construct($settings = [])
+    {
+        $this->settings = Configuration::mergeConfigs(self::$defaultSettings, $settings);
+    }
 
     public function getTests()
     {
@@ -86,7 +98,7 @@ class Cest implements LoaderInterface
                                 "Make sure this is a valid JSON (Hint: \"-char for strings) or a single-line annotation in Doctrine-style"
                             );
                         }
-                        $test = new CestFormat($unit, $method, $file);
+                        $test = new CestFormat($unit, $method, $file, $this->settings);
                         $test->getMetadata()->setCurrent(['example' => $example]);
                         $test->getMetadata()->setIndex($index);
                         $dataProvider->addTest($test);
@@ -95,7 +107,7 @@ class Cest implements LoaderInterface
                     $this->tests[] = $dataProvider;
                     continue;
                 }
-                $this->tests[] = new CestFormat($unit, $method, $file);
+                $this->tests[] = new CestFormat($unit, $method, $file, $this->settings);
             }
         }
     }


### PR DESCRIPTION
Closes https://github.com/Codeception/Codeception/issues/4994

Should not break anything - it will use the current default value if the new settings are not specified.

Any feedback will be appreciated. Thank you.