### PR TITLE
Add your own test format classes to the loader

### DIFF
--- a/docs/07-AdvancedUsage.md
+++ b/docs/07-AdvancedUsage.md
@@ -661,6 +661,50 @@ groups:
 
 This will load all found `p*` files in `tests/_data` as groups. Group names will be as follows p1,p2,...,pN.
 
+## Formats
+
+In addition to the standard test formats (Cept, Cest, Unit, Gherkin) you can implement your own format classes to customise your test execution.
+Specify these in your suite configuration:
+
+```yaml
+formats:
+  - \My\Namespace\MyFormat
+```
+
+Then define a class which implements the LoaderInterface
+
+```php
+namespace My\Namespace;
+
+class MyFormat implements \Codeception\Test\Loader\LoaderInterface
+{
+    protected $tests;
+    
+    protected $settings;
+    
+    public function __construct($settings = [])
+    {
+        //These are the suite settings
+        $this->settings = $settings;
+    }
+    
+    public function loadTests($filename)
+    {
+        //Load file and create tests
+    }
+
+    public function getTests()
+    {
+        return $this->tests;
+    }
+
+    public function getPattern()
+    {
+        return '~Myformat\.php$~';
+    }
+}
+```
+
 ## Shell autocompletion
 
 For bash and zsh shells, you can use autocompletion for your Codeception projects by executing the following in your shell (or add it to your .bashrc/.zshrc):

--- a/docs/reference/Configuration.md
+++ b/docs/reference/Configuration.md
@@ -139,6 +139,7 @@ modules:
 * `suite_namespace`: default namespace for new tests of this suite (ignores `namespace` option)
 * `env`: override any configuration per [environment](http://codeception.com/docs/07-AdvancedUsage#Environments).
 * `groups`: [groups](http://codeception.com/docs/07-AdvancedUsage#Groups) with the list of tests of for corresponding group.
+* `formats`: [formats](http://codeception.com/docs/07-AdvancedUsage#Formats) with the list of extra test format classes.
 * `coverage`: pre suite [CodeCoverage](http://codeception.com/docs/11-Codecoverage#Configuration) settings.
 * `gherkin`: per suite [BDD Gherkin](http://codeception.com/docs/07-BDD#Configuration) settings.
 * `error_level`: [error level](http://codeception.com/docs/04-FunctionalTests#Error-Reporting) for runner in current suite. Should be specified for unit, integration, functional tests. Passes value to `error_reporting` function.

--- a/src/Codeception/Configuration.php
+++ b/src/Codeception/Configuration.php
@@ -113,6 +113,7 @@ class Configuration
         'extends'     => null,
         'namespace'   => null,
         'groups'      => [],
+        'formats'     => [],
         'shuffle'     => false,
         'extensions'  => [ // suite extensions
             'enabled' => [],

--- a/src/Codeception/Test/Loader.php
+++ b/src/Codeception/Test/Loader.php
@@ -53,6 +53,11 @@ class Loader
             new UnitLoader(),
             new GherkinLoader($suiteSettings)
         ];
+        if (isset($suiteSettings['formats'])) {
+            foreach ($suiteSettings['formats'] as $format) {
+                $this->formats[] = new $format($suiteSettings);
+            }
+        }
     }
 
     public function getTests()


### PR DESCRIPTION
Closes https://github.com/Codeception/Codeception/issues/5008

In addition to the standard test format classes (Cept, Cest, Unit, Gherkin), allow the user to specify their own test format classes, and configure the system to load these as well.