### PR TITLE
WIP: Adding Ability To Specify More Than One Dump File For The Db Module

### DIFF
--- a/src/Codeception/Lib/DbPopulator.php
+++ b/src/Codeception/Lib/DbPopulator.php
@@ -8,13 +8,6 @@ namespace Codeception\Lib;
 class DbPopulator
 {
     /**
-     * The command to be executed.
-     *
-     * @var string
-     */
-    private $builtCommand;
-
-    /**
      * @var array
      */
     protected $config;
@@ -29,8 +22,6 @@ class DbPopulator
     public function __construct($config)
     {
         $this->config = $config;
-        $command = $this->config['populator'];
-        $this->builtCommand = $this->buildCommand((string) $command);
     }
 
     /**
@@ -52,7 +43,7 @@ class DbPopulator
      * @param array $config The configuration values used to replace any found $keys with values from this array.
      * @return string The resulting command string after evaluating any configuration's key
      */
-    protected function buildCommand($command)
+    protected function buildCommand($command, $dumpFile = null)
     {
         $dsn = isset($this->config['dsn']) ? $this->config['dsn'] : '';
         $dsnVars = [];
@@ -64,7 +55,12 @@ class DbPopulator
                 $dsnVars[$k] = $v;
             }
         }
+
         $vars = array_merge($dsnVars, $this->config);
+        if ($dumpFile !== null) {
+            $vars['dump'] = $dumpFile;
+        }
+
         foreach ($vars as $key => $value) {
             $vars['$'.$key] = $value;
             unset($vars[$key]);
@@ -81,7 +77,23 @@ class DbPopulator
      */
     public function run()
     {
-        $command = $this->getBuiltCommand();
+        if (!isset($this->config['dump'])) {
+            return $this->runCommand((string) $this->config['populator']);
+        } elseif (!is_array($this->config['dump'])) {
+            $this->config['dump'] = array($this->config['dump']);
+        }
+
+        foreach ($this->config['dump'] as $dumpFile) {
+            $this->runCommand($this->config['populator'], $dumpFile);
+        }
+
+        return true;
+    }
+
+    private function runCommand($command, $dumpFile = null)
+    {
+        $command = $this->buildCommand($command, $dumpFile);
+
         codecept_debug("[Db] Executing Populator: `$command`");
 
         exec($command, $output, $exitCode);

--- a/src/Codeception/Lib/DbPopulator.php
+++ b/src/Codeception/Lib/DbPopulator.php
@@ -77,7 +77,7 @@ class DbPopulator
      */
     public function run()
     {
-        if (!isset($this->config['dump'])) {
+        if (!isset($this->config['dump']) || $this->config['dump'] === false) {
             return $this->runCommand((string) $this->config['populator']);
         } elseif (!is_array($this->config['dump'])) {
             $this->config['dump'] = array($this->config['dump']);


### PR DESCRIPTION
I still need to update the testing on this. Posting for any comments. 

Currently the Db module only allows you to specify one file for the dump file. I personally was running across two issues with this. The first is that the software requires a base set of records to work. If These are put in the default dump file, then it has to be re added anytime someone updates the dump file. Very tedious. The second issue was that some of the base set of records have changes that need to be made to run additional checks/testing. With one dump file, this isn't possible without specifying a new copy of the entire db to change one row. This of course is overkill.

This PR adds the functionality to specify more than one file as the dump file:

```yaml
modules:
    enabled:
        - Db:
            dsn: '%DSN%'
            host: '%HOST%'
            dump:
                - ./tests/_data/schema.sql
                - ./tests/_data/dumps/base.sql
```

This change can also be used within environments:
```yaml
env:
    owner:
        modules:
            config:
                Db:
                    dump:
                        - ./tests/_data/schema.sql
                        - ./tests/_data/dumps/base.sql
                        - ./tests/_data/dumps/owner.sql
    employee:
        modules:
            config:
                Db:
                    dump:
                        - ./tests/_data/schema.sql
                        - ./tests/_data/dumps/base.sql
                        - ./tests/_data/dumps/employee.sql
```

I also updated the DbPopulator to be able to handle the multi dumping. If you have more than one dump file, it will call the popular command for each dump file. The idea of course being that you use the '$dump' syntax in the populator. 