### PR TITLE
Bug fix with multiple kernels

### DIFF
--- a/src/Codeception/Module/Symfony.php
+++ b/src/Codeception/Module/Symfony.php
@@ -286,21 +286,23 @@ class Symfony extends Framework implements DoctrineProvider, PartedModule
                 . "Specify directory where file with Kernel class for your application is located with `app_path` parameter."
             );
         }
-        $file = current($results);
 
         if (file_exists(codecept_root_dir() . 'vendor' . DIRECTORY_SEPARATOR . 'autoload.php')) {
             // ensure autoloader from this dir is loaded
             require_once codecept_root_dir() . 'vendor' . DIRECTORY_SEPARATOR . 'autoload.php';
         }
 
-        require_once $file;
+        $filesRealPath = array_map(function ($file){
+            require_once $file;
+            return $file->getRealPath();
+        }, $results);
 
         $possibleKernelClasses = $this->getPossibleKernelClasses();
 
         foreach ($possibleKernelClasses as $class) {
             if (class_exists($class)) {
                 $refClass = new \ReflectionClass($class);
-                if ($refClass->getFileName() === $file->getRealpath()) {
+                if ($file = array_search($refClass->getFileName(), $filesRealPath)) {
                     return $class;
                 }
             }

--- a/src/Codeception/Module/Symfony.php
+++ b/src/Codeception/Module/Symfony.php
@@ -292,7 +292,7 @@ class Symfony extends Framework implements DoctrineProvider, PartedModule
             require_once codecept_root_dir() . 'vendor' . DIRECTORY_SEPARATOR . 'autoload.php';
         }
 
-        $filesRealPath = array_map(function ($file){
+        $filesRealPath = array_map(function ($file) {
             require_once $file;
             return $file->getRealPath();
         }, $results);


### PR DESCRIPTION
It's not possible to set a Kernel different of the AppKernel, and I have
two kernels an Admin and an Api, and I need use ApiKernel to run tests.

This commit makes a checking if kernel defined exists in the path.
Because the previous version it gets the first kernel in my case it gets
AdminKernel and always returns Kernel not found, because the Kernel defined is different of the loaded kernel 

http://symfony.com/doc/3.4/configuration/multiple_kernels.html