### PR TITLE
adding new assert methods

### DIFF
--- a/src/Codeception/Module/Asserts.php
+++ b/src/Codeception/Module/Asserts.php
@@ -264,6 +264,17 @@ class Asserts extends CodeceptionModule
     }
 
     /**
+     * Checks that the condition is NOT true (everything but true)
+     *
+     * @param        $condition
+     * @param string $message
+     */
+    public function assertNotTrue($condition, $message = '')
+    {
+        parent::assertNotTrue($condition, $message);
+    }
+
+    /**
      * Checks that condition is negative.
      *
      * @param        $condition
@@ -272,6 +283,17 @@ class Asserts extends CodeceptionModule
     public function assertFalse($condition, $message = '')
     {
         parent::assertFalse($condition, $message);
+    }
+
+    /**
+     * Checks that the condition is NOT false (everything but false)
+     *
+     * @param        $condition
+     * @param string $message
+     */
+    public function assertNotFalse($condition, $message = '')
+    {
+        parent::assertNotFalse($condition, $message);
     }
 
     /**

--- a/src/Codeception/Util/Shared/Asserts.php
+++ b/src/Codeception/Util/Shared/Asserts.php
@@ -268,6 +268,17 @@ trait Asserts
     }
 
     /**
+     * Checks that the condition is NOT true (everything but true)
+     *
+     * @param        $condition
+     * @param string $message
+     */
+    protected function assertNotTrue($condition, $message = '')
+    {
+        \PHPUnit\Framework\Assert::assertNotTrue($condition, $message);
+    }
+
+    /**
      * Checks that condition is negative.
      *
      * @param        $condition
@@ -276,6 +287,17 @@ trait Asserts
     protected function assertFalse($condition, $message = '')
     {
         \PHPUnit\Framework\Assert::assertFalse($condition, $message);
+    }
+
+    /**
+     * Checks that the condition is NOT false (everything but false)
+     *
+     * @param        $condition
+     * @param string $message
+     */
+    protected function assertNotFalse($condition, $message = '')
+    {
+        \PHPUnit\Framework\Assert::assertNotFalse($condition, $message);
     }
 
     /**

--- a/tests/unit/Codeception/Module/AssertsTest.php
+++ b/tests/unit/Codeception/Module/AssertsTest.php
@@ -19,7 +19,13 @@ class AssertsTest extends \PHPUnit\Framework\TestCase
         $module->assertNotNull(false);
         $module->assertNotNull(0);
         $module->assertTrue(true);
+        $module->assertNotTrue(false);
+        $module->assertNotTrue(null);
+        $module->assertNotTrue('foo');
         $module->assertFalse(false);
+        $module->assertNotFalse(true);
+        $module->assertNotFalse(null);
+        $module->assertNotFalse('foo');
         $module->assertFileExists(__FILE__);
         $module->assertFileNotExists(__FILE__ . '.notExist');
         $module->assertInstanceOf('Exception', new Exception());


### PR DESCRIPTION
Adding new `assertXXX` methods..
The methods check for `NotTrue / NotFalse`, e.g., if you want to check, if a value is `not true`.. A simple `assertFalse()` may not suitable in this case, because the value also may be `null` or whatever..

The new `assert` methods from PHPUnit allow for the latter!

I also added Tests for the new assertions