### PR TITLE
new REST / InnerBrowser Asserts

### DIFF
--- a/src/Codeception/Lib/InnerBrowser.php
+++ b/src/Codeception/Lib/InnerBrowser.php
@@ -1577,6 +1577,24 @@ class InnerBrowser extends Module implements Web, PageSourceSaver, ElementLocato
     }
 
     /**
+     * Checks that response code is between a certain range. Between actually means [from <= CODE <= to]
+     *
+     * @param $from
+     * @param $to
+     */
+    public function seeResponseCodeIsBetween($from, $to)
+    {
+        $failureMessage = sprintf(
+            'Expected HTTP Status Code between %s and %s. Actual Status Code: %s',
+            HttpCode::getDescription($from),
+            HttpCode::getDescription($to),
+            HttpCode::getDescription($this->getResponseStatusCode())
+        );
+        $this->assertGreaterThanOrEqual($from, $this->getResponseStatusCode(), $failureMessage);
+        $this->assertLessThanOrEqual($to, $this->getResponseStatusCode(), $failureMessage);
+    }
+
+    /**
      * Checks that response code is equal to value provided.
      *
      * ```php
@@ -1595,6 +1613,38 @@ class InnerBrowser extends Module implements Web, PageSourceSaver, ElementLocato
             HttpCode::getDescription($code)
         );
         $this->assertNotEquals($code, $this->getResponseStatusCode(), $failureMessage);
+    }
+
+    /**
+     * Checks that the response code 2xx
+     */
+    public function seeResponseCodeIsSuccessful()
+    {
+        $this->seeResponseCodeIsBetween(200, 299);
+    }
+
+    /**
+     * Checks that the response code 3xx
+     */
+    public function seeResponseCodeIsRedirection()
+    {
+        $this->seeResponseCodeIsBetween(300, 399);
+    }
+
+    /**
+     * Checks that the response code is 4xx
+     */
+    public function seeResponseCodeIsClientError()
+    {
+        $this->seeResponseCodeIsBetween(400, 499);
+    }
+
+    /**
+     * Checks that the response code is 5xx
+     */
+    public function seeResponseCodeIsServerError()
+    {
+        $this->seeResponseCodeIsBetween(500, 599);
     }
 
     public function seeInTitle($title)

--- a/src/Codeception/Module/REST.php
+++ b/src/Codeception/Module/REST.php
@@ -1162,6 +1162,39 @@ EOF;
     }
 
     /**
+     * Checks that the response code is 2xx
+     */
+    public function seeResponseCodeIsSuccessful()
+    {
+        $this->connectionModule->seeResponseCodeIsSuccessful();
+    }
+
+    /**
+     * Checks that the response code 3xx
+     */
+    public function seeResponseCodeIsRedirection()
+    {
+        $this->connectionModule->seeResponseCodeIsRedirection();
+    }
+
+    /**
+     * Checks that the response code is 4xx
+     */
+    public function seeResponseCodeIsClientError()
+    {
+        $this->connectionModule->seeResponseCodeIsClientError();
+    }
+
+    /**
+     * Checks that the response code is 5xx
+     */
+    public function seeResponseCodeIsServerError()
+    {
+        $this->connectionModule->seeResponseCodeIsServerError();
+    }
+
+
+    /**
      * Checks whether last response was valid XML.
      * This is done with libxml_get_last_error function.
      *

--- a/tests/unit/Codeception/Module/PhpBrowserTest.php
+++ b/tests/unit/Codeception/Module/PhpBrowserTest.php
@@ -691,4 +691,40 @@ HTML
         $response = $this->module->grabPageSource();
         $this->assertEquals('Codeception User Agent Test 1.0', $response, 'Incorrect user agent');
     }
+
+    public function testIfStatusCodeIsWithin2xxRange()
+    {
+        $this->module->amOnPage('https://httpstat.us/200');
+        $this->module->seeResponseCodeIsSuccessful();
+
+        $this->module->amOnPage('https://httpstat.us/299');
+        $this->module->seeResponseCodeIsSuccessful();
+    }
+
+    public function testIfStatusCodeIsWithin3xxRange()
+    {
+        $this->module->amOnPage('https://httpstat.us/300');
+        $this->module->seeResponseCodeIsRedirection();
+
+        $this->module->amOnPage('https://httpstat.us/399');
+        $this->module->seeResponseCodeIsRedirection();
+    }
+
+    public function testIfStatusCodeIsWithin4xxRange()
+    {
+        $this->module->amOnPage('https://httpstat.us/400');
+        $this->module->seeResponseCodeIsClientError();
+
+        $this->module->amOnPage('https://httpstat.us/499');
+        $this->module->seeResponseCodeIsClientError();
+    }
+
+    public function testIfStatusCodeIsWithin5xxRange()
+    {
+        $this->module->amOnPage('https://httpstat.us/500');
+        $this->module->seeResponseCodeIsServerError();
+
+        $this->module->amOnPage('https://httpstat.us/599');
+        $this->module->seeResponseCodeIsServerError();
+    }
 }


### PR DESCRIPTION
This PR adds new assertions to check, if a `HttpStatusCode` is between a certain range (e.g., `4xx`) and provides "wrappers" for common blocks..

For example:
- `seeStatusCodeIsSuccessful()` checks for `2xx`
- `seeStatusCodeIsClientError()` checks for `4xx`
and so on.. 