### PR TITLE
New REST / InnerBrowser Helper

### DIFF
--- a/src/Codeception/Module/REST.php
+++ b/src/Codeception/Module/REST.php
@@ -1467,4 +1467,19 @@ EOF;
     {
         $this->client->followRedirects(true);
     }
+
+    /**
+     * Loads a File from the DATA directory and replaces specific placeholders
+     *
+     * @param string $fileName the stub file to be loaded (relative to the DATA directory)
+     * @param array  $vars key/value for replacements
+     * @param string $startPattern
+     * @param string $endPattern
+     *
+     * @return mixed|string
+     */
+    public function loadAndPrepareStub($fileName, array $vars = [], $startPattern = '{{', $endPattern = '}}')
+    {
+        return $this->connectionModule->loadAndPrepareStub($fileName, $vars, $startPattern, $endPattern);
+    }
 }

--- a/tests/data/rest/stub.json
+++ b/tests/data/rest/stub.json
@@ -1,0 +1,7 @@
+{
+  "data" : {
+    "title" : "{{book-title}}",
+    "author" : "{{book-author}}",
+    "year" : "{{book-year}}"
+  }
+}

--- a/tests/data/rest/stub2.json
+++ b/tests/data/rest/stub2.json
@@ -1,0 +1,7 @@
+{
+  "data" : {
+    "title" : "##book-title++",
+    "author" : "##book-author++",
+    "year" : "##book-year++"
+  }
+}

--- a/tests/unit/Codeception/Module/PhpBrowserRestTest.php
+++ b/tests/unit/Codeception/Module/PhpBrowserRestTest.php
@@ -323,4 +323,68 @@ class PhpBrowserRestTest extends Unit
         $this->module->sendGET('/rest/http-host/');
         $this->assertEquals('/rest/http-host/', $this->phpBrowser->grabFromCurrentUrl());
     }
+
+    public function test_if_stub_can_be_loaded()
+    {
+        $replacements = [];
+
+        $stub = $this->module->loadAndPrepareStub('rest/stub.json', $replacements);
+
+        $this->assertNotEmpty($stub);
+        $this->assertJson($stub);
+
+        $this->assertContains('{{book-title}}', $stub);
+        $this->assertContains('{{book-author}}', $stub);
+        $this->assertContains('{{book-year}}', $stub);
+    }
+
+    public function test_if_stub_can_be_loaded_and_placeholders_are_replaced()
+    {
+        $replacements = [
+            'book-author' => 'JRR Tolkien',
+            'book-title' => 'Lord of the Rings',
+            'book-year' => 1954,
+        ];
+
+        $stub = $this->module->loadAndPrepareStub('rest/stub.json', $replacements);
+
+        $this->assertNotEmpty($stub);
+        $this->assertJson($stub);
+
+        $this->assertNotContains('{{book-title}}', $stub);
+        $this->assertNotContains('{{book-author}}', $stub);
+        $this->assertNotContains('{{book-year}}', $stub);
+
+        $this->assertContains('JRR Tolkien', $stub);
+        $this->assertContains('Lord of the Rings', $stub);
+        $this->assertContains('1954', $stub);
+    }
+
+    public function test_if_stub_can_be_loaded_and_placeholders_are_replaced_with_custom_patterns()
+    {
+        $replacements = [
+            'book-author' => 'JRR Tolkien',
+            'book-title' => 'Lord of the Rings',
+            'book-year' => 1954,
+        ];
+
+        $stub = $this->module->loadAndPrepareStub('rest/stub2.json', $replacements, '##', '++');
+
+        $this->assertNotEmpty($stub);
+        $this->assertJson($stub);
+
+        $this->assertNotContains('{{book-title}}', $stub);
+        $this->assertNotContains('{{book-author}}', $stub);
+        $this->assertNotContains('{{book-year}}', $stub);
+
+        $this->assertContains('JRR Tolkien', $stub);
+        $this->assertContains('Lord of the Rings', $stub);
+        $this->assertContains('1954', $stub);
+    }
+
+    public function test_if_exception_is_thrown_when_missing_stub_is_loaded()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $stub = $this->module->loadAndPrepareStub('rest/missing.stub', []);
+    }
 }


### PR DESCRIPTION
Hi @DavertMik ,

This PR adds a new "helper" that allows loading custom `Stub`s from the `_data` directory of the current suite. This may be useful in the context of RESTful API testing (e.g., you can define the JSON documents to be sent to the API).

Further, you can define "placeholders" in the stub files and automatically replace them..

Consider the following example:
**STUB FILE:**
``` json 
{
  "data" : {
    "title" : "{{book-title}}",
    "author" : "{{book-author}}",
    "year" : "{{book-year}}"
  }
}
```

In the `REST` module you can call it like so:
``` php
$replacements = [
    'book-author' => 'JRR Tolkien',
    'book-title' => 'Lord of the Rings',
    'book-year' => 1954,
];

// $I is an Instance of an Tester that includes the REST module!
$stub = $I->loadAndPrepareStub('path/to/stub.json', $replacements);
```

The content of `$stub`, in turn, will then be:
``` json
{
  "data" : {
    "title" : "Lord of the Rings",
    "author" : "JRR Tolkien",
    "year" : "1954"
  }
}
```

I think, this will help to further improve API testing by separating.. Can you give me feedback on this?!
Will love to contribute again, if you agree :laughing: 

All the best