### PR TITLE
Unbind specific event handler instead of all class level events when …

### DIFF
--- a/src/Codeception/Lib/Connector/Yii2/ConnectionWatcher.php
+++ b/src/Codeception/Lib/Connector/Yii2/ConnectionWatcher.php
@@ -20,7 +20,7 @@ class ConnectionWatcher
 
     public function __construct()
     {
-        $this->handler = function(Event $event) {
+        $this->handler = function (Event $event) {
             if ($event->sender instanceof Connection) {
                 $this->connectionOpened($event->sender);
             }
@@ -51,7 +51,7 @@ class ConnectionWatcher
     {
         $count = count($this->connections);
         $this->debug("closing all ($count) connections");
-        foreach($this->connections as $connection) {
+        foreach ($this->connections as $connection) {
             $connection->close();
         }
     }

--- a/src/Codeception/Lib/Connector/Yii2/ConnectionWatcher.php
+++ b/src/Codeception/Lib/Connector/Yii2/ConnectionWatcher.php
@@ -1,0 +1,67 @@
+<?php
+
+
+namespace Codeception\Lib\Connector\Yii2;
+
+use yii\base\Event;
+use yii\db\Connection;
+
+/**
+ * Class ConnectionWatcher
+ * This class will watch for new database connection and store a reference to the connection object.
+ * @package Codeception\Lib\Connector\Yii2
+ */
+class ConnectionWatcher
+{
+    private $handler;
+
+    /** @var Connection[] */
+    private $connections = [];
+
+    public function __construct()
+    {
+        $this->handler = function(Event $event) {
+            if ($event->sender instanceof Connection) {
+                $this->connectionOpened($event->sender);
+            }
+        };
+    }
+
+    protected function connectionOpened(Connection $connection)
+    {
+        $this->debug('Connection opened!');
+        if ($connection instanceof Connection) {
+            $this->connections[] = $connection;
+        }
+    }
+
+    public function start()
+    {
+        Event::on(Connection::class, Connection::EVENT_AFTER_OPEN, $this->handler);
+        $this->debug('watching new connections');
+    }
+
+    public function stop()
+    {
+        Event::off(Connection::class, Connection::EVENT_AFTER_OPEN, $this->handler);
+        $this->debug('no longer watching new connections');
+    }
+
+    public function closeAll()
+    {
+        $count = count($this->connections);
+        $this->debug("closing all ($count) connections");
+        foreach($this->connections as $connection) {
+            $connection->close();
+        }
+    }
+
+    protected function debug($message)
+    {
+        $title = (new \ReflectionClass($this))->getShortName();
+        if (is_array($message) or is_object($message)) {
+            $message = stripslashes(json_encode($message));
+        }
+        codecept_debug("[$title] $message");
+    }
+}

--- a/src/Codeception/Lib/Connector/Yii2/TransactionForcer.php
+++ b/src/Codeception/Lib/Connector/Yii2/TransactionForcer.php
@@ -5,6 +5,7 @@ namespace Codeception\Lib\Connector\Yii2;
 
 use yii\base\Event;
 use yii\db\Connection;
+use yii\db\Transaction;
 
 /**
  * Class TransactionForcer
@@ -83,8 +84,10 @@ TEXT
     {
         /** @var Transaction $transaction */
         foreach ($this->transactions as $transaction) {
-            $transaction->rollBack();
-            $this->debug('Transaction cancelled; all changes reverted.');
+            if ($transaction->db->isActive) {
+                $transaction->rollBack();
+                $this->debug('Transaction cancelled; all changes reverted.');
+            }
         }
 
         $this->transactions = [];

--- a/src/Codeception/Lib/Connector/Yii2/TransactionForcer.php
+++ b/src/Codeception/Lib/Connector/Yii2/TransactionForcer.php
@@ -3,7 +3,6 @@
 
 namespace Codeception\Lib\Connector\Yii2;
 
-
 use yii\base\Event;
 use yii\db\Connection;
 

--- a/src/Codeception/Lib/Connector/Yii2/TransactionForcer.php
+++ b/src/Codeception/Lib/Connector/Yii2/TransactionForcer.php
@@ -1,0 +1,95 @@
+<?php
+
+
+namespace Codeception\Lib\Connector\Yii2;
+
+
+use yii\base\Event;
+use yii\db\Connection;
+
+/**
+ * Class TransactionForcer
+ * This class adds support for forcing transactions as well as reusing PDO objects.
+ * @package Codeception\Lib\Connector\Yii2
+ */
+class TransactionForcer extends ConnectionWatcher
+{
+    private $ignoreCollidingDSN;
+
+    private $pdoCache = [];
+
+    private $dsnCache;
+
+    private $transactions = [];
+
+    public function __construct(
+        $ignoreCollidingDSN
+    ) {
+        parent::__construct();
+        $this->ignoreCollidingDSN = $ignoreCollidingDSN;
+    }
+
+
+    protected function connectionOpened(Connection $connection)
+    {
+        parent::connectionOpened($connection);
+        /**
+         * We should check if the known PDO objects are the same, in which case we should reuse the PDO
+         * object so only 1 transaction is started and multiple connections to the same database see the
+         * same data (due to writes inside a transaction not being visible from the outside).
+         *
+         */
+        $key = md5(json_encode([
+            'dsn' => $connection->dsn,
+            'user' => $connection->username,
+            'pass' => $connection->password,
+            'attributes' => $connection->attributes,
+            'emulatePrepare' => $connection->emulatePrepare,
+            'charset' => $connection->charset
+        ]));
+
+        /*
+         * If keys match we assume connections are "similar enough".
+         */
+        if (isset($this->pdoCache[$key])) {
+            $connection->pdo = $this->pdoCache[$key];
+        } else {
+            $this->pdoCache[$key] = $connection->pdo;
+        }
+
+        if (isset($this->dsnCache[$connection->dsn])
+            && $this->dsnCache[$connection->dsn] !== $key
+            && !$this->ignoreCollidingDSN
+        ) {
+            $this->debug(<<<TEXT
+You use multiple connections to the same DSN ({$connection->dsn}) with different configuration.
+These connections will not see the same database state since we cannot share a transaction between different PDO
+instances.
+You can remove this message by adding 'ignoreCollidingDSN = true' in the module configuration.
+TEXT
+            );
+            Debug::pause();
+        }
+
+        if (isset($this->transactions[$key])) {
+            $this->debug('Reusing PDO, so no need for a new transaction');
+            return;
+        }
+
+        $this->debug('Transaction started for: ' . $connection->dsn);
+        $this->transactions[$key] = $connection->beginTransaction();
+    }
+
+    public function rollbackAll()
+    {
+        /** @var Transaction $transaction */
+        foreach ($this->transactions as $transaction) {
+            $transaction->rollBack();
+            $this->debug('Transaction cancelled; all changes reverted.');
+        }
+
+        $this->transactions = [];
+        $this->pdoCache = [];
+        $this->dsnCache = [];
+    }
+}

--- a/src/Codeception/Module/Yii2.php
+++ b/src/Codeception/Module/Yii2.php
@@ -317,24 +317,28 @@ class Yii2 extends Framework implements ActiveRecord, PartedModule
     private function loadFixtures($test)
     {
         $this->debugSection('Fixtures', 'Loading fixtures');
-        /** @var Connection[] $connections */
-        $connections = [];
-        // Register event handler.
-        Event::on(Connection::class, Connection::EVENT_AFTER_OPEN, function (Event $event) use (&$connections) {
-            $this->debugSection('Fixtures', 'Opened database connection: ' . $event->sender->dsn);
-            $connections[] = $event->sender;
-        });
         if (empty($this->loadedFixtures)
             && method_exists($test, $this->_getConfig('fixturesMethod'))
         ) {
-            $this->haveFixtures(call_user_func([$test, $this->_getConfig('fixturesMethod')]));
-        }
+            /** @var Connection[] $connections */
+            $connections = [];
+            // Register event handler.
+            $handler = function (Event $event) use (&$connections) {
+                $this->debugSection('Fixtures', 'Opened database connection: ' . $event->sender->dsn);
+                $connections[] = $event->sender;
+            };
 
-        Event::offAll();
-        // Close all connections so they get properly reopened after the transaction handler has been attached.
-        foreach ($connections as $connection) {
-            $this->debugSection('Fixtures', 'Closing database connection: ' . $connection->dsn);
-            $connection->close();
+            Event::on(Connection::class, Connection::EVENT_AFTER_OPEN, $handler);
+
+            $this->haveFixtures(call_user_func([$test, $this->_getConfig('fixturesMethod')]));
+
+            Event::off(Connection::class, Connection::EVENT_AFTER_OPEN, $handler);
+
+            // Close all connections so they get properly reopened after the transaction handler has been attached.
+            foreach ($connections as $connection) {
+                $this->debugSection('Fixtures', 'Closing database connection: ' . $connection->dsn);
+                $connection->close();
+            }
         }
         $this->debugSection('Fixtures', 'Done');
     }


### PR DESCRIPTION
This PR refactors database connection handling for the Yii2 module.

It is fully backwards compatible with the exception of broken stuff that is now fixed.

Database connections should now always be closed after tests no matter how you have opened them or who is holding references to them.