### PR TITLE
Symfony test email count

### DIFF
--- a/src/Codeception/Module/Symfony.php
+++ b/src/Codeception/Module/Symfony.php
@@ -446,7 +446,13 @@ class Symfony extends Framework implements DoctrineProvider, PartedModule
 
     /**
      * Checks if the desired number of emails was sent.
-     * If the number is not provided then at least one email must be sent to satisfy the check.
+     * If no argument is provided then at least one email must be sent to satisfy the check.
+     *
+     * ``` php
+     * <?php
+     * $I->seeEmailIsSent(2);
+     * ?>
+     * ```
      *
      * @param null|int $expectedCount
      */

--- a/src/Codeception/Module/Symfony.php
+++ b/src/Codeception/Module/Symfony.php
@@ -448,9 +448,9 @@ class Symfony extends Framework implements DoctrineProvider, PartedModule
      * Checks if the desired number of emails was sent.
      * If the number is not provided then at least one email must be sent to satisfy the check.
      *
-     * @param null $emailCount
+     * @param null|int $expectedCount
      */
-    public function seeEmailIsSent($emailCount = null)
+    public function seeEmailIsSent($expectedCount = null)
     {
         $profile = $this->getProfile();
         if (!$profile) {
@@ -460,18 +460,27 @@ class Symfony extends Framework implements DoctrineProvider, PartedModule
             $this->fail('Emails can\'t be tested without SwiftMailer connector');
         }
 
-        if (!is_int($emailCount) && !is_null($emailCount)) {
+        if (!is_int($expectedCount) && !is_null($expectedCount)) {
             $this->fail(sprintf(
-                'The required number of emails must be either an integer or null. %s was provided.',
-                $emailCount
+                'The required number of emails must be either an integer or null. "%s" was provided.',
+                print_r($expectedCount, true)
             ));
         }
 
-        $messageCount = $profile->getCollector('swiftmailer')->getMessageCount();
-        if ($emailCount === null) {
-            $this->assertGreaterThan(0, $messageCount);
+        $realCount = $profile->getCollector('swiftmailer')->getMessageCount();
+        if ($expectedCount === null) {
+            $this->assertGreaterThan(0, $realCount);
         } else {
-            $this->assertEquals($emailCount, $messageCount);
+            $this->assertEquals(
+                $expectedCount,
+                $realCount,
+                sprintf(
+                    'Expected number of sent emails was %d, but in reality %d %s sent.',
+                    $expectedCount,
+                    $realCount,
+                    $realCount === 2 ? 'was' : 'were'
+                )
+            );
         }
     }
 

--- a/src/Codeception/Module/Symfony.php
+++ b/src/Codeception/Module/Symfony.php
@@ -445,11 +445,12 @@ class Symfony extends Framework implements DoctrineProvider, PartedModule
     }
 
     /**
-     * Checks if any email were sent by last request
+     * Checks if the desired number of emails was sent.
+     * If the number is not provided then at least one email must be sent to satisfy the check.
      *
-     * @throws \LogicException
+     * @param null $emailCount
      */
-    public function seeEmailIsSent()
+    public function seeEmailIsSent($emailCount = null)
     {
         $profile = $this->getProfile();
         if (!$profile) {
@@ -459,7 +460,29 @@ class Symfony extends Framework implements DoctrineProvider, PartedModule
             $this->fail('Emails can\'t be tested without SwiftMailer connector');
         }
 
-        $this->assertGreaterThan(0, $profile->getCollector('swiftmailer')->getMessageCount());
+        if (!is_int($emailCount) && !is_null($emailCount)) {
+            $this->fail(sprintf(
+                'The required number of emails must be either an integer or null. %s was provided.',
+                $emailCount
+            ));
+        }
+
+        $messageCount = $profile->getCollector('swiftmailer')->getMessageCount();
+        if ($emailCount === null) {
+            $this->assertGreaterThan(0, $messageCount);
+        } else {
+            $this->assertEquals($emailCount, $messageCount);
+        }
+    }
+
+    /**
+     * Checks that no email was sent. This is an alias for seeEmailIsSent(0).
+     *
+     * @part email
+     */
+    public function dontSeeEmailIsSent()
+    {
+        $this->seeEmailIsSent(0);
     }
 
     /**


### PR DESCRIPTION
This should resolve #5058.

I did not modify nor test nor docs.
The test for this I could not find. The [contributing page](https://github.com/Codeception/Codeception/blob/2.4/CONTRIBUTING.md) says that docs are autogenerated from dockblocks.
