### PR TITLE
Typo fix in phpdoc

### DIFF
--- a/ext/Recorder.php
+++ b/ext/Recorder.php
@@ -39,7 +39,7 @@ use Codeception\Util\Template;
  * ``` yaml
  * extensions:
  *     enabled:
- *         Codeception\Extension\Recorder:
+ *         - Codeception\Extension\Recorder:
  *             module: AngularJS # enable for Angular
  *             delete_successful: false # keep screenshots of successful tests
  * ```


### PR DESCRIPTION
Wasn't work as-is.

+ May be add snippet 
  ``` yaml
  extensions:
      enabled:
          - Codeception\Extension\Recorder:
              module: AngularJS # enable for Angular
              delete_successful: false # keep screenshots of successful tests
  ```

to some file in /docs/ ?