### PR TITLE
Allow absolute paths in `extends` property of configs

### DIFF
--- a/CHANGELOG-2.4.md
+++ b/CHANGELOG-2.4.md
@@ -5,6 +5,7 @@
 * [Asserts] Added new methods `assertNotTrue` and `assertNotFalse` methods; by @johannesschobel
 * [REST][PhpBrowser][Frameworks] Added new methods to check for `Http Status Ranges` with nice "wrappers" (e.g., `seeHttpStatusCodeIsSuccessful()` checks the code between 200 and 299); by @johannesschobel
 * Improved the docs; by community
+* Recently added `extends` property in the `codeception.yml` and `*.suite.yml` files now support absolute paths; by @silverfire
 
 #### 2.4.2
 

--- a/CHANGELOG-2.4.md
+++ b/CHANGELOG-2.4.md
@@ -1,3 +1,8 @@
+#### 2.4.4
+
+* Recently added `extends` property in the `codeception.yml` and `*.suite.yml` files now support absolute paths; by @silverfire
+* Fixed absolute paths handling on Windows in ParamLoader; by @silverfire
+
 #### 2.4.3
 
 * [Create your own test formats](https://codeception.com/docs/07-AdvancedUsage#Formats) (e.g., Cept, Cest, ...); by @mlambley
@@ -5,7 +10,6 @@
 * [Asserts] Added new methods `assertNotTrue` and `assertNotFalse` methods; by @johannesschobel
 * [REST][PhpBrowser][Frameworks] Added new methods to check for `Http Status Ranges` with nice "wrappers" (e.g., `seeHttpStatusCodeIsSuccessful()` checks the code between 200 and 299); by @johannesschobel
 * Improved the docs; by community
-* Recently added `extends` property in the `codeception.yml` and `*.suite.yml` files now support absolute paths; by @silverfire
 
 #### 2.4.2
 

--- a/autoload.php
+++ b/autoload.php
@@ -113,6 +113,24 @@ if (!function_exists('codecept_absolute_path')) {
      */
     function codecept_absolute_path($path)
     {
-        return mb_substr($path, 0, 1) === DIRECTORY_SEPARATOR ? $path : codecept_root_dir($path);
+        return codecept_is_path_absolute($path) ? $path : codecept_root_dir($path);
+    }
+}
+
+if (!function_exists('codecept_is_path_absolute')) {
+    /**
+     * Check whether the given $path is absolute.
+     *
+     * @param string $path
+     * @return bool
+     * @since 2.4.4
+     */
+    function codecept_is_path_absolute($path)
+    {
+        if (DIRECTORY_SEPARATOR === '/') {
+            return mb_substr($path, 0, 1) === DIRECTORY_SEPARATOR;
+        }
+
+        return preg_match('#^[A-Z]:(?![^/\\])#i',$path) === 1;
     }
 }

--- a/autoload.php
+++ b/autoload.php
@@ -131,6 +131,6 @@ if (!function_exists('codecept_is_path_absolute')) {
             return mb_substr($path, 0, 1) === DIRECTORY_SEPARATOR;
         }
 
-        return preg_match('#^[A-Z]:(?![^/\\])#i',$path) === 1;
+        return preg_match('#^[A-Z]:(?![^/\\])#i', $path) === 1;
     }
 }

--- a/src/Codeception/Configuration.php
+++ b/src/Codeception/Configuration.php
@@ -690,7 +690,10 @@ class Configuration
 
         // now we check the suite config file, if a extends key is defined
         if (isset($suiteConf['extends'])) {
-            $presetFilePath = realpath($suiteDir . DIRECTORY_SEPARATOR . $suiteConf['extends']);
+            $presetFilePath = mb_substr($suiteConf['extends'], 0, 1) === DIRECTORY_SEPARATOR
+                ? $suiteConf['extends'] // If path is absolute – use it
+                : realpath($suiteDir . DIRECTORY_SEPARATOR . $suiteConf['extends']); // Otherwise try to locate it in the suite dir
+
             if (file_exists($presetFilePath)) {
                 $settings = self::mergeConfigs(self::getConfFromFile($presetFilePath), $settings);
             }

--- a/src/Codeception/Configuration.php
+++ b/src/Codeception/Configuration.php
@@ -186,7 +186,7 @@ class Configuration
         // we check for the "extends" key in the yml file
         if (isset($config['extends'])) {
             // and now we search for the file
-            $presetFilePath = realpath(self::$dir . DIRECTORY_SEPARATOR . $config['extends']);
+            $presetFilePath = codecept_absolute_path($config['extends']);
             if (file_exists($presetFilePath)) {
                 // and merge it with our configuration file
                 $config = self::mergeConfigs(self::getConfFromFile($presetFilePath), $config);

--- a/src/Codeception/Configuration.php
+++ b/src/Codeception/Configuration.php
@@ -690,7 +690,7 @@ class Configuration
 
         // now we check the suite config file, if a extends key is defined
         if (isset($suiteConf['extends'])) {
-            $presetFilePath = mb_substr($suiteConf['extends'], 0, 1) === DIRECTORY_SEPARATOR
+            $presetFilePath = codecept_is_path_absolute($suiteConf['extends'])
                 ? $suiteConf['extends'] // If path is absolute – use it
                 : realpath($suiteDir . DIRECTORY_SEPARATOR . $suiteConf['extends']); // Otherwise try to locate it in the suite dir
 

--- a/tests/cli/ConfigExtendsCest.php
+++ b/tests/cli/ConfigExtendsCest.php
@@ -10,8 +10,8 @@ class ConfigExtendsCest
         $I->amInPath('tests/data/config_extends');
         $I->executeCommand('run');
 
-        $I->seeInShellOutput('✔');
         $I->seeInShellOutput('UnitCest');
+        $I->seeInShellOutput('OK (1 test, 1 assertion)');
         $I->dontSeeInShellOutput('Exception');
     }
 }

--- a/tests/cli/ConfigExtendsCest.php
+++ b/tests/cli/ConfigExtendsCest.php
@@ -1,0 +1,17 @@
+<?php
+
+class ConfigExtendsCest
+{
+    /**
+     * @param CliGuy $I
+     */
+    public function runIncludedSuites(\CliGuy $I)
+    {
+        $I->amInPath('tests/data/config_extends');
+        $I->executeCommand('run');
+
+        $I->seeInShellOutput('✔');
+        $I->seeInShellOutput('UnitCest');
+        $I->dontSeeInShellOutput('Exception');
+    }
+}

--- a/tests/data/config_extends/codeception.common.yml
+++ b/tests/data/config_extends/codeception.common.yml
@@ -1,0 +1,13 @@
+paths:
+    tests: tests
+    log: tests/_output
+    data: tests/_data
+    support: tests/_support
+    envs: tests/_envs
+settings:
+    bootstrap: _bootstrap.php
+    colors: true
+    memory_limit: 2048M
+extensions:
+    enabled:
+        - Codeception\Extension\RunFailed

--- a/tests/data/config_extends/codeception.yml
+++ b/tests/data/config_extends/codeception.yml
@@ -1,0 +1,2 @@
+actor: Tester
+extends: codeception.common.yml

--- a/tests/data/config_extends/tests/_output/.gitignore
+++ b/tests/data/config_extends/tests/_output/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/tests/data/config_extends/tests/_support/UnitTester.php
+++ b/tests/data/config_extends/tests/_support/UnitTester.php
@@ -1,0 +1,26 @@
+<?php
+
+
+/**
+ * Inherited Methods
+ * @method void wantToTest($text)
+ * @method void wantTo($text)
+ * @method void execute($callable)
+ * @method void expectTo($prediction)
+ * @method void expect($prediction)
+ * @method void amGoingTo($argumentation)
+ * @method void am($role)
+ * @method void lookForwardTo($achieveValue)
+ * @method void comment($description)
+ * @method \Codeception\Lib\Friend haveFriend($name, $actorClass = NULL)
+ *
+ * @SuppressWarnings(PHPMD)
+*/
+class UnitTester extends \Codeception\Actor
+{
+    use _generated\UnitTesterActions;
+
+   /**
+    * Define custom actions here
+    */
+}

--- a/tests/data/config_extends/tests/_support/_generated/.gitignore
+++ b/tests/data/config_extends/tests/_support/_generated/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/tests/data/config_extends/tests/unit.suite.common.yml
+++ b/tests/data/config_extends/tests/unit.suite.common.yml
@@ -1,0 +1,3 @@
+modules:
+    enabled:
+        - Asserts

--- a/tests/data/config_extends/tests/unit.suite.yml
+++ b/tests/data/config_extends/tests/unit.suite.yml
@@ -1,0 +1,6 @@
+# Codeception Test Suite Configuration
+#
+# Suite for unit (internal) tests.
+
+class_name: UnitTester
+extends: unit.suite.common.yml

--- a/tests/data/config_extends/tests/unit/UnitCest.php
+++ b/tests/data/config_extends/tests/unit/UnitCest.php
@@ -1,0 +1,9 @@
+<?php
+
+class UnitCest
+{
+    public function successful(UnitTester $I)
+    {
+        $I->assertTrue(true);
+    }
+}

--- a/tests/unit/Codeception/ConfigurationTest.php
+++ b/tests/unit/Codeception/ConfigurationTest.php
@@ -69,17 +69,4 @@ class ConfigurationTest extends \PHPUnit\Framework\TestCase
         $this->assertArrayHasKey('extends', $defaultConfig);
         $this->assertNull($defaultConfig['extends']);
     }
-
-    public function testConfigExtension()
-    {
-        $pathToConfig = dirname(__DIR__, 2) . DIRECTORY_SEPARATOR . 'data/config_extends/codeception.yml';
-        $config = \Codeception\Configuration::config($pathToConfig);
-
-        $this->assertSame('2048M', $config['settings']['memory_limit']);
-
-        $suites = \Codeception\Configuration::suites();
-        $unitSuiteSettings = \Codeception\Configuration::suiteSettings('unit', \Codeception\Configuration::config());
-
-//        $this->assertArrayHasKey('')
-    }
 }

--- a/tests/unit/Codeception/ConfigurationTest.php
+++ b/tests/unit/Codeception/ConfigurationTest.php
@@ -65,5 +65,21 @@ class ConfigurationTest extends \PHPUnit\Framework\TestCase
 
         $commandsConfig = $defaultConfig['extensions'];
         $this->assertArrayHasKey('commands', $commandsConfig);
+
+        $this->assertArrayHasKey('extends', $defaultConfig);
+        $this->assertNull($defaultConfig['extends']);
+    }
+
+    public function testConfigExtension()
+    {
+        $pathToConfig = dirname(__DIR__, 2) . DIRECTORY_SEPARATOR . 'data/config_extends/codeception.yml';
+        $config = \Codeception\Configuration::config($pathToConfig);
+
+        $this->assertSame('2048M', $config['settings']['memory_limit']);
+
+        $suites = \Codeception\Configuration::suites();
+        $unitSuiteSettings = \Codeception\Configuration::suiteSettings('unit', \Codeception\Configuration::config());
+
+//        $this->assertArrayHasKey('')
     }
 }


### PR DESCRIPTION
This pull requests adds support of absolute paths in `extends` property on configs and adds tests that the new feature works.