### PR TITLE
match title in input fields

### DIFF
--- a/src/Codeception/Module/WebDriver.php
+++ b/src/Codeception/Module/WebDriver.php
@@ -989,7 +989,7 @@ class WebDriver extends CodeceptionModule implements
      *
      * ```
      * @api
-     * @param $page WebDriver instance or an element to search within
+     * @param RemoteWebDriver $page WebDriver instance or an element to search within
      * @param $link a link text or locator to click
      * @return WebDriverElement
      */
@@ -1025,7 +1025,7 @@ class WebDriver extends CodeceptionModule implements
             ".//input[./@type = 'submit' or ./@type = 'image' or ./@type = 'button'][contains(./@value, $locator)]",
             ".//input[./@type = 'image'][contains(./@alt, $locator)]",
             ".//button[contains(normalize-space(string(.)), $locator)]",
-            ".//input[./@type = 'submit' or ./@type = 'image' or ./@type = 'button'][./@name = $locator]",
+            ".//input[./@type = 'submit' or ./@type = 'image' or ./@type = 'button'][./@name = $locator or ./@title = $locator]",
             ".//button[./@name = $locator or ./@title = $locator]"
         );
 

--- a/tests/data/app/view/form/anchor.php
+++ b/tests/data/app/view/form/anchor.php
@@ -6,7 +6,7 @@
 
 <form action="#a" method="post">
     <input name="field1" />
-    <input type="submit" value="Hash Form" />
+    <input type="submit" value="Hash Form" title="Hash Form Title" />
     <button type="submit" title="Hash Button Form"></button>
 </form>
 

--- a/tests/web/WebDriverTest.php
+++ b/tests/web/WebDriverTest.php
@@ -857,6 +857,13 @@ class WebDriverTest extends TestsForBrowsers
         $this->module->seeCurrentUrlEquals('/form/anchor#a');
     }
 
+    public function testSubmitHashFormTitle()
+    {
+        $this->module->amOnPage('/form/anchor');
+        $this->module->click('Hash Form Title');
+        $this->module->seeCurrentUrlEquals('/form/anchor#a');
+    }
+
     public function testSubmitHashButtonForm()
     {
         $this->module->amOnPage('/form/anchor');


### PR DESCRIPTION
Make it possible to click on a input by title. For example when you have a form input with only a font icon.

```
<input type="submit" class="btn btn-success" value="&#xf011;" title="Login" />
```

<a class="jsbin-embed" href="http://jsbin.com/bevotayuga/1/embed?html,css,output">JS Bin on jsbin.com</a>