### PR TITLE
add config option for session lock wait setting

### DIFF
--- a/docs/modules/Db.md
+++ b/docs/modules/Db.md
@@ -35,6 +35,7 @@ if you run into problems loading dumps and cleaning databases.
 * populate: false - whether the the dump should be loaded before the test suite is started
 * cleanup: false - whether the dump should be reloaded before each test
 * reconnect: false - whether the module should reconnect to the database before each test
+* waitlock: 0 - wait lock (in seconds) that the database session should use for DDL statements
 * ssl_key - path to the SSL key (MySQL specific, @see http://php.net/manual/de/ref.pdo-mysql.php#pdo.constants.mysql-attr-key)
 * ssl_cert - path to the SSL certificate (MySQL specific, @see http://php.net/manual/de/ref.pdo-mysql.php#pdo.constants.mysql-attr-ssl-cert)
 * ssl_ca - path to the SSL certificate authority (MySQL specific, @see http://php.net/manual/de/ref.pdo-mysql.php#pdo.constants.mysql-attr-ssl-ca)
@@ -51,6 +52,7 @@ if you run into problems loading dumps and cleaning databases.
              populate: true
              cleanup: true
              reconnect: true
+             waitlock: 10
              ssl_key: '/path/to/client-key.pem'
              ssl_cert: '/path/to/client-cert.pem'
              ssl_ca: '/path/to/ca-cert.pem'

--- a/src/Codeception/Lib/Driver/Db.php
+++ b/src/Codeception/Lib/Driver/Db.php
@@ -121,6 +121,15 @@ class Db
     {
     }
 
+    /**
+     * Set the lock waiting interval for the database session
+     * @param int $seconds
+     * @return void
+     */
+    public function setWaitLock($seconds)
+    {
+    }
+
     public function load($sql)
     {
         $query = '';
@@ -224,7 +233,7 @@ class Db
 
         return 'WHERE ' . implode('AND ', $params);
     }
-    
+
     /**
      * @deprecated use deleteQueryByCriteria instead
      */

--- a/src/Codeception/Lib/Driver/Oci.php
+++ b/src/Codeception/Lib/Driver/Oci.php
@@ -3,6 +3,10 @@ namespace Codeception\Lib\Driver;
 
 class Oci extends Db
 {
+    public function setWaitLock($seconds)
+    {
+        $this->dbh->exec('ALTER SESSION SET ddl_lock_timeout = ' . (int) $seconds);
+    }
 
     public function cleanup()
     {


### PR DESCRIPTION
(and Oracle implementation)

The point here is to avoid false negative test error-failures that might occur due to database object locks.  In particular, I'm seeing occasional `ORA-00054: resource busy and acquire with NOWAIT specified or timeout expired` occurrences during the before-test dump-populate step, when running a `--group failed` follow-up execution after a previous execution recorded errors.

In my case, I'm hoping having a 10-30sec lock wait (rather than the default no-wait of 0) might avoid these `ORA-00054`s.