### PR TITLE
Fixes a missing _ for _getResponseContent() in seeXmlResponseEquals

### DIFF
--- a/src/Codeception/Module/REST.php
+++ b/src/Codeception/Module/REST.php
@@ -1295,7 +1295,7 @@ EOF;
      */
     public function seeXmlResponseEquals($xml)
     {
-        \PHPUnit\Framework\Assert::assertXmlStringEqualsXmlString($this->connectionModule->getResponseContent(), $xml);
+        \PHPUnit\Framework\Assert::assertXmlStringEqualsXmlString($this->connectionModule->_getResponseContent(), $xml);
     }
 
 

--- a/tests/unit/Codeception/Module/RestTest.php
+++ b/tests/unit/Codeception/Module/RestTest.php
@@ -122,6 +122,13 @@ class RestTest extends Unit
         $this->module->seeResponseEquals('<xml><name>John</name></xml>');
     }
 
+    public function testXmlResponseEquals()
+    {
+        $this->setStubResponse('<xml></xml>');
+        $this->module->seeResponseIsXml();
+        $this->module->seeXmlResponseEquals('<xml></xml>');
+    }
+
     public function testInvalidXml()
     {
         $this->setExpectedException('PHPUnit\Framework\ExpectationFailedException');


### PR DESCRIPTION
Simple fix I think. I'm 99.9% sure this was a typo when the phpunit wrapper was added.