### PR TITLE
Update autoload.php

### DIFF
--- a/autoload.php
+++ b/autoload.php
@@ -131,6 +131,6 @@ if (!function_exists('codecept_is_path_absolute')) {
             return mb_substr($path, 0, 1) === DIRECTORY_SEPARATOR;
         }
 
-        return preg_match('#^[A-Z]:(?![^/\\])#i', $path) === 1;
+        return preg_match('#^[A-Z]:(?![^/\\\])#i', $path) === 1;
     }
 }


### PR DESCRIPTION
Fixes Compilation error:

>Warning: preg_match(): Compilation failed: missing terminating ] for character class at offset 16 in C:\xampp-7\htdocs\www\vendor\codeception\codeception\autoload.php on line 134