### PR TITLE
Fixes https://github.com/Codeception/Codeception/issues/4913

### DIFF
--- a/src/Codeception/Test/Descriptor.php
+++ b/src/Codeception/Test/Descriptor.php
@@ -34,7 +34,7 @@ class Descriptor
     {
         $example = null;
 
-        if ($testCase instanceof TestInterface
+        if (method_exists($testCase, 'getMetaData')
             && $example = $testCase->getMetadata()->getCurrent('example')
         ) {
             $example = ':' . substr(sha1(json_encode($example)), 0, 7);

--- a/src/Codeception/Test/Descriptor.php
+++ b/src/Codeception/Test/Descriptor.php
@@ -34,7 +34,7 @@ class Descriptor
     {
         $example = null;
 
-        if (is_callable([$testCase, 'getMetadata'])
+        if ($testCase instanceof TestInterface
             && $example = $testCase->getMetadata()->getCurrent('example')
         ) {
             $example = ':' . substr(sha1(json_encode($example)), 0, 7);


### PR DESCRIPTION
is_callable() cannot be used if $testCase implements __call().
instanceof TestInterface should be the correct check,