### PR TITLE
corrected regular expression in codecept_is_path_absolute

### DIFF
--- a/autoload.php
+++ b/autoload.php
@@ -131,6 +131,6 @@ if (!function_exists('codecept_is_path_absolute')) {
             return mb_substr($path, 0, 1) === DIRECTORY_SEPARATOR;
         }
 
-        return preg_match('#^[A-Z]:(?![^/\\])#i', $path) === 1;
+        return preg_match('#^[A-Z]:(?![^/\\\\])#i', $path) === 1;
     }
 }


### PR DESCRIPTION
Fixes a warning on Windows:

PHP Warning:  preg_match(): Compilation failed: missing terminating ] for character class at offset 16 in C:\[...]\vendor\codeception\codeception\autoload.php on line 134