### PR TITLE
fixed compat with phpunit 7.2

### DIFF
--- a/src/Codeception/Codecept.php
+++ b/src/Codeception/Codecept.php
@@ -7,7 +7,7 @@ use Symfony\Component\EventDispatcher\EventDispatcher;
 
 class Codecept
 {
-    const VERSION = "2.4.4";
+    const VERSION = "2.4.5";
 
     /**
      * @var \Codeception\PHPUnit\Runner

--- a/src/Codeception/Subscriber/Dependencies.php
+++ b/src/Codeception/Subscriber/Dependencies.php
@@ -26,7 +26,7 @@ class Dependencies implements EventSubscriberInterface
             return;
         }
 
-        $testSignatures = $test->getDependencies();
+        $testSignatures = $test->fetchDependencies();
         foreach ($testSignatures as $signature) {
             if (!in_array($signature, $this->successfulTests)) {
                 $test->getMetadata()->setSkip("This test depends on $signature to pass");

--- a/src/Codeception/Suite.php
+++ b/src/Codeception/Suite.php
@@ -34,7 +34,7 @@ class Suite extends \PHPUnit\Framework\TestSuite
             return [$test];
         }
         $tests = [];
-        foreach ($test->getDependencies() as $requiredTestName) {
+        foreach ($test->fetchDependencies() as $requiredTestName) {
             $required = $this->findMatchedTest($requiredTestName);
             if (!$required) {
                 continue;

--- a/src/Codeception/Test/Cept.php
+++ b/src/Codeception/Test/Cept.php
@@ -77,7 +77,7 @@ class Cept extends Test implements Interfaces\Plain, Interfaces\ScenarioDriven, 
         return $this->parser;
     }
 
-    public function getDependencies()
+    public function fetchDependencies()
     {
         return $this->getMetadata()->getDependencies();
     }

--- a/src/Codeception/Test/Cest.php
+++ b/src/Codeception/Test/Cest.php
@@ -188,7 +188,7 @@ class Cest extends Test implements
         return $this->parser;
     }
 
-    public function getDependencies()
+    public function fetchDependencies()
     {
         $names = [];
         foreach ($this->getMetadata()->getDependencies() as $required) {

--- a/src/Codeception/Test/Interfaces/Dependent.php
+++ b/src/Codeception/Test/Interfaces/Dependent.php
@@ -3,5 +3,5 @@ namespace Codeception\Test\Interfaces;
 
 interface Dependent
 {
-    public function getDependencies();
+    public function fetchDependencies();
 }

--- a/src/Codeception/Test/Unit.php
+++ b/src/Codeception/Test/Unit.php
@@ -130,7 +130,7 @@ class Unit extends \PHPUnit\Framework\TestCase implements
         ];
     }
 
-    public function getDependencies()
+    public function fetchDependencies()
     {
         $names = [];
         foreach ($this->getMetadata()->getDependencies() as $required) {
@@ -148,7 +148,7 @@ class Unit extends \PHPUnit\Framework\TestCase implements
      */
     public function handleDependencies()
     {
-        $dependencies = $this->getDependencies();
+        $dependencies = $this->fetchDependencies();
         if (empty($dependencies)) {
             return true;
         }

--- a/tests/data/claypit/composer.lock
+++ b/tests/data/claypit/composer.lock
@@ -14,12 +14,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/Codeception/c3.git",
-                "reference": "f7e31fce8a9abf1021990b4e31a7ed01689f4295"
+                "reference": "d841be32a6785e2f565b9f88f5ff36c905931a9a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Codeception/c3/zipball/f7e31fce8a9abf1021990b4e31a7ed01689f4295",
-                "reference": "f7e31fce8a9abf1021990b4e31a7ed01689f4295",
+                "url": "https://api.github.com/repos/Codeception/c3/zipball/d841be32a6785e2f565b9f88f5ff36c905931a9a",
+                "reference": "d841be32a6785e2f565b9f88f5ff36c905931a9a",
                 "shasum": ""
             },
             "require": {
@@ -56,7 +56,7 @@
                 "code coverage",
                 "codecoverage"
             ],
-            "time": "2018-05-26 21:53:33"
+            "time": "2018-05-26 22:34:28"
         }
     ],
     "aliases": [],


### PR DESCRIPTION
Replaces #5097 

We have our own methods for dependencies collection so it's easier to rename ours than maintain compatibility with constantly changing PHPUnit signatures. 