### PR TITLE
Clarify `grabFromDatabase` and `grabColumnFromDatabase`

### DIFF
--- a/docs/modules/Db.md
+++ b/docs/modules/Db.md
@@ -208,7 +208,7 @@ Supported operators: `<`, `>`, `>=`, `<=`, `!=`, `like`.
 
 ### grabColumnFromDatabase
  
-Fetches all values from the column in database.
+Fetches a single column value from a database.
 Provide table name, desired column and criteria.
 
 ``` php
@@ -225,7 +225,7 @@ $mails = $I->grabColumnFromDatabase('users', 'email', array('name' => 'RebOOter'
 
 ### grabFromDatabase
  
-Fetches all values from the column in database.
+Fetches a single column value from a database.
 Provide table name, desired column and criteria.
 
 ``` php

--- a/src/Codeception/Module/Db.php
+++ b/src/Codeception/Module/Db.php
@@ -575,7 +575,7 @@ class Db extends CodeceptionModule implements DbInterface
     }
 
     /**
-     * Fetches all values from the column in database.
+     * Fetches a single column value from a database.
      * Provide table name, desired column and criteria.
      *
      * @param string $table
@@ -598,7 +598,7 @@ class Db extends CodeceptionModule implements DbInterface
     }
 
     /**
-     * Fetches all values from the column in database.
+     * Fetches a single column value from a database.
      * Provide table name, desired column and criteria.
      *
      * ``` php
@@ -624,7 +624,7 @@ class Db extends CodeceptionModule implements DbInterface
     }
 
     /**
-     * Fetches all values from the column in database.
+     * Fetches a single column value from a database.
      * Provide table name, desired column and criteria.
      *
      * ``` php


### PR DESCRIPTION
The methods does not fetching "all values", but a single column.

It seems that `grabFromDatabase` and `grabColumnFromDatabase` doing the same:
I recomend to keep `grabFromDatabase` method but rename it to
`grabColumnFromDatabase` because it's more verbose.

I'm not sure that it's accepting comparison expressions or not, but if it
isn't, then the documentation about this should be affected in another PR (see
src/Codeception/Lib/Interfaces/Db.php:67).