### PR TITLE
Prevent NPE in Yii2 module

### DIFF
--- a/src/Codeception/Module/Yii2.php
+++ b/src/Codeception/Module/Yii2.php
@@ -343,9 +343,11 @@ class Yii2 extends Framework implements ActiveRecord, PartedModule
 
         $this->rollbackTransactions();
 
-        $this->connectionWatcher->stop();
-        $this->connectionWatcher->closeAll();
-        unset($this->connectionWatcher);
+        if (isset($this->connectionWatcher)) {
+            $this->connectionWatcher->stop();
+            $this->connectionWatcher->closeAll();
+            unset($this->connectionWatcher);
+        }
 
         if ($this->config['cleanup']) {
             foreach ($this->loadedFixtures as $fixture) {


### PR DESCRIPTION
There are some cases when `_after` method can be called without calling `_before`, that leads to null-pointer exception. For example, `_after` can be called from error handler during unhandled exception proceeding.