### PR TITLE
[WebDriver] Keep coverage cookies in LoadSessionSnapshot

### DIFF
--- a/src/Codeception/Module/WebDriver.php
+++ b/src/Codeception/Module/WebDriver.php
@@ -3066,7 +3066,14 @@ class WebDriver extends CodeceptionModule implements
         if (!isset($this->sessionSnapshots[$name])) {
             return false;
         }
-        $this->webDriver->manage()->deleteAllCookies();
+        
+        foreach ($this->webDriver->manage()->getCookies() as $cookie) {
+            if (in_array(trim($cookie['name']), [LocalServer::COVERAGE_COOKIE, LocalServer::COVERAGE_COOKIE_ERROR])) {
+                continue;
+            }
+            $this->webDriver->manage()->deleteCookieNamed($cookie['name']);
+        }
+        
         foreach ($this->sessionSnapshots[$name] as $cookie) {
             $this->webDriver->manage()->addCookie($cookie);
         }


### PR DESCRIPTION
As same in saveSessionSnapshot, at the moment of load the snapshot, I think we need to avoid the deletion of all cookies. we need to delete all of them except those related to COVERAGE.