### PR TITLE
make coverage 'show_only_summary' configurable

### DIFF
--- a/docs/11-Codecoverage.md
+++ b/docs/11-Codecoverage.md
@@ -63,7 +63,7 @@ coverage:
     show_only_summary: false
 ```
 
-For further information please refer to the [PHPUnit configuration docs](https://phpunit.readthedocs.io/en/7.3/configuration.html)
+For further information please refer to the [PHPUnit configuration docs](https://phpunit.readthedocs.io/en/latest/configuration.html)
 
 ## Local CodeCoverage
 

--- a/docs/11-Codecoverage.md
+++ b/docs/11-Codecoverage.md
@@ -47,6 +47,24 @@ coverage:
     high_limit: 60
 ```
 
+By default, show all whitelisted files in `--coverage-text` output not just the ones with coverage information is set to false, config option:
+
+```yaml
+coverage:
+    enabled: true
+    show_uncovered: false
+```
+
+By default, show only the coverage report summary in `--coverage-text` output is set to false, config option:
+
+```yaml
+coverage:
+    enabled: true
+    show_only_summary: false
+```
+
+For further information please refer to the [PHPUnit configuration docs](https://phpunit.readthedocs.io/en/7.3/configuration.html)
+
 ## Local CodeCoverage
 
 The basic codecoverage can be collected for functional and unit tests.

--- a/src/Codeception/Coverage/Subscriber/Printer.php
+++ b/src/Codeception/Coverage/Subscriber/Printer.php
@@ -17,10 +17,11 @@ class Printer implements EventSubscriberInterface
     ];
 
     protected $settings = [
-        'enabled'        => true,
-        'low_limit'      => '35',
-        'high_limit'     => '70',
-        'show_uncovered' => false
+        'enabled'           => true,
+        'low_limit'         => '35',
+        'high_limit'        => '70',
+        'show_uncovered'    => false,
+        'show_only_summary' => false
     ];
 
     public static $coverage;
@@ -92,7 +93,7 @@ class Printer implements EventSubscriberInterface
             $this->settings['low_limit'],
             $this->settings['high_limit'],
             $this->settings['show_uncovered'],
-            false
+            $this->settings['show_only_summary']
         );
         $printer->write($writer->process(self::$coverage, $this->options['colors']));
     }
@@ -129,7 +130,7 @@ class Printer implements EventSubscriberInterface
             $this->settings['low_limit'],
             $this->settings['high_limit'],
             $this->settings['show_uncovered'],
-            false
+            $this->settings['show_only_summary']
         );
         file_put_contents(
             $this->absolutePath($this->options['coverage-text']),


### PR DESCRIPTION
on init of 

`\SebastianBergmann\CodeCoverage\Report\Text` 

in 

`Codeception\Coverage\Subscriber\Printer`

Result is full BC and would result in a new coverage config option. So we can have for large projects a compact console output on CI/CD pipelines.

```
coverage:
    enabled: true
    low_limit: 30
    high_limit: 60
    show_uncovered: false
    show_only_summary: true
```
