### PR TITLE
[Autoload] Removed json_last_error_msg declaration

### DIFF
--- a/autoload.php
+++ b/autoload.php
@@ -34,27 +34,6 @@ if (PHP_MAJOR_VERSION < 7) {
 }
 // @codingStandardsIgnoreEnd
 
-if (!function_exists('json_last_error_msg')) {
-    /**
-     * Copied from http://php.net/manual/en/function.json-last-error-msg.php#117393
-     * @return string
-     */
-    function json_last_error_msg()
-    {
-        static $errors = array(
-            JSON_ERROR_NONE => 'No error',
-            JSON_ERROR_DEPTH => 'Maximum stack depth exceeded',
-            JSON_ERROR_STATE_MISMATCH => 'State mismatch (invalid or malformed JSON)',
-            JSON_ERROR_CTRL_CHAR => 'Control character error, possibly incorrectly encoded',
-            JSON_ERROR_SYNTAX => 'Syntax error',
-            JSON_ERROR_UTF8 => 'Malformed UTF-8 characters, possibly incorrectly encoded'
-        );
-
-        $error = json_last_error();
-        return isset($errors[$error]) ? $errors[$error] : 'Unknown error';
-    }
-}
-
 // function not autoloaded in PHP, thus its a good place for them
 if (!function_exists('codecept_debug')) {
     function codecept_debug($data)


### PR DESCRIPTION
because PHP 5.4 is no longer supported.
PHP 5.5 and newer versions have native implementation.