### PR TITLE
New Extension for a "sticky" failed Group

### DIFF
--- a/ext/RunFailedStickyExtension
+++ b/ext/RunFailedStickyExtension
@@ -1,0 +1,89 @@
+<?php
+namespace Codeception\Extension;
+
+use Codeception\Event\PrintResultEvent;
+use Codeception\Events;
+use Codeception\Extension;
+use Codeception\Test\Descriptor;
+
+/**
+ * Saves failed tests into tests/log/failed-sticky in order to rerun failed tests.
+ * Tests will stay logged in this file until the tests passes.
+ * This makes it possible to "collect" all failed tests in a Suite and fix them
+ * one by one with --fail-fast
+ *
+ * To rerun failed tests just run the `failed-sticky` group:
+ *
+ * ```
+ * php codecept run -g failed-sticky
+ * ```
+ *
+ * To change failed group name add:
+ * ```
+ * --override "extensions: config: Codeception\Extension\RunFailedSticky: fail-group: another_group1"
+ * ```
+ * Remember: if you run tests and they generated custom-named fail group, to run this group, you should add override too
+ *
+ * Starting from Codeception 2.1 **this extension is enabled by default**.
+ *
+ * ``` yaml
+ * extensions:
+ *     enabled: [Codeception\Extension\RunStickyFailed]
+ * ```
+ *
+ * On each execution failed tests are logged and saved into `tests/_output/failed` file.
+ */
+class RunFailedStickyExtension extends Extension
+{
+    public static $events = [
+        Events::RESULT_PRINT_AFTER => 'saveFailed',
+    ];
+
+    /** @var string filename/groupname for failed tests */
+    protected $group = 'failed-sticky';
+
+    public function _initialize()
+    {
+        if (array_key_exists('fail-group', $this->config) && $this->config['fail-group']) {
+            $this->group = $this->config['fail-group'];
+        }
+        $logPath = str_replace($this->getRootDir(), '', $this->getLogDir()); // get local path to logs
+        $this->_reconfigure(['groups' => [$this->group => $logPath . $this->group]]);
+    }
+
+    public function saveFailed(PrintResultEvent $e)
+    {
+        $file = $this->getLogDir() . $this->group;
+        $result = $e->getResult();
+
+        $output = [];
+        if (file_exists($file)) {
+            $output = explode("\n", file_get_contents($file));
+        }
+        foreach ($result->failures() as $fail) {
+            $output[] = $this->localizePath(Descriptor::getTestFullName($fail->failedTest()));
+        }
+        foreach ($result->errors() as $fail) {
+            $output[] = $this->localizePath(Descriptor::getTestFullName($fail->failedTest()));
+        }
+        foreach ($result->passed() as $passed) {
+            $testName = $this->localizePath(Descriptor::getTestFullName($passed->failedTest()));
+            if (in_array($testName, $output)) {
+                unset($output[array_search($testName, $output)]);
+            }
+        }
+        $output = array_unique($output);
+
+        file_put_contents($file, implode("\n", $output));
+    }
+
+    protected function localizePath($path)
+    {
+        $root = realpath($this->getRootDir()) . DIRECTORY_SEPARATOR;
+        if (substr($path, 0, strlen($root)) == $root) {
+            return substr($path, strlen($root));
+        }
+
+        return $path;
+    }
+}


### PR DESCRIPTION
Saves failed tests into tests/log/failed-sticky in order to rerun failed tests.
Tests will stay logged in this file until the tests passes.
This makes it possible to "collect" all failed tests in a Suite and fix them one by one with --fail-fast