### PR TITLE
Yii2: Move implementations to connector

### DIFF
--- a/src/Codeception/Lib/Connector/Guzzle6.php
+++ b/src/Codeception/Lib/Connector/Guzzle6.php
@@ -333,13 +333,16 @@ class Guzzle6 extends Client
 
     public static function createHandler($handler)
     {
+        if ($handler instanceof HandlerStack) {
+            return $handler;
+        }
         if ($handler === 'curl') {
             return HandlerStack::create(new CurlHandler());
         }
         if ($handler === 'stream') {
             return HandlerStack::create(new StreamHandler());
         }
-        if (class_exists($handler)) {
+        if (is_string($handler) && class_exists($handler)) {
             return HandlerStack::create(new $handler);
         }
         if (is_callable($handler)) {

--- a/src/Codeception/Lib/Connector/Yii2.php
+++ b/src/Codeception/Lib/Connector/Yii2.php
@@ -159,7 +159,7 @@ class Yii2 extends Client
         $urlManager = $this->getApplication()->urlManager;
         $domains = [$this->getDomainRegex($urlManager->hostInfo)];
         if ($urlManager->enablePrettyUrl) {
-            foreach($urlManager->rules as $rule) {
+            foreach ($urlManager->rules as $rule) {
                 /** @var \yii\web\UrlRule $rule */
                 if (isset($rule->host)) {
                     $domains[] = $this->getDomainRegex($rule->host);

--- a/src/Codeception/Lib/Connector/Yii2.php
+++ b/src/Codeception/Lib/Connector/Yii2.php
@@ -1,7 +1,9 @@
 <?php
 namespace Codeception\Lib\Connector;
 
+use Codeception\Exception\ConfigurationException;
 use Codeception\Lib\Connector\Yii2\Logger;
+use Codeception\Lib\Connector\Yii2\TestMailer;
 use Codeception\Lib\InnerBrowser;
 use Codeception\Util\Debug;
 use Symfony\Component\BrowserKit\Client;
@@ -79,7 +81,7 @@ class Yii2 extends Client
     /**
      * @return \yii\web\Application
      */
-    public function getApplication()
+    protected function getApplication()
     {
         if (!isset(Yii::$app)) {
             $this->startApp();
@@ -90,6 +92,7 @@ class Yii2 extends Client
     public function resetApplication()
     {
         codecept_debug('Destroying application');
+        $this->closeSession();
         Yii::$app = null;
         \yii\web\UploadedFile::reset();
         if (method_exists(\yii\base\Event::className(), 'offAll')) {
@@ -98,6 +101,144 @@ class Yii2 extends Client
         Yii::setLogger(null);
         // This resolves an issue with database connections not closing properly.
         gc_collect_cycles();
+    }
+
+    /**
+     * Finds and logs in a user
+     * @param $user
+     * @throws ConfigurationException
+     */
+    public function findAndLoginUser($user)
+    {
+        $app = $this->getApplication();
+        if (!$app->has('user')) {
+            throw new ConfigurationException('The user component is not configured');
+        }
+
+        if ($user instanceof \yii\web\IdentityInterface) {
+            $identity = $user;
+        } else {
+            // class name implementing IdentityInterface
+            $identityClass = $app->user->identityClass;
+            $identity = call_user_func([$identityClass, 'findIdentity'], $user);
+        }
+        $app->user->login($identity);
+    }
+
+    /**
+     * Masks a value
+     * @param string $val
+     * @return string
+     * @see \yii\base\Security::maskToken
+     */
+    public function maskToken($val)
+    {
+        return $this->getApplication()->security->maskToken($val);
+    }
+
+    /**
+     * @param string $name The name of the cookie
+     * @param string $value The value of the cookie
+     * @return string The value to send to the browser
+     */
+    public function hashCookieData($name, $value)
+    {
+        $app = $this->getApplication();
+        if (!$app->request->enableCookieValidation) {
+            return $value;
+        }
+        return $app->security->hashData(serialize([$name, $value]), $app->request->cookieValidationKey);
+    }
+
+    /**
+     * @return array List of regex patterns for recognized domain names
+     */
+    public function getInternalDomains()
+    {
+        /** @var \yii\web\UrlManager $urlManager */
+        $urlManager = $this->getApplication()->urlManager;
+        $domains = [$this->getDomainRegex($urlManager->hostInfo)];
+        if ($urlManager->enablePrettyUrl) {
+            foreach($urlManager->rules as $rule) {
+                /** @var \yii\web\UrlRule $rule */
+                if (isset($rule->host)) {
+                    $domains[] = $this->getDomainRegex($rule->host);
+                }
+            }
+        }
+        return array_unique($domains);
+    }
+
+    /**
+     * @return array List of sent emails
+     */
+    public function getEmails()
+    {
+        $app = $this->getApplication();
+        if ($app->has('mailer', true)) {
+            $mailer = $app->get('mailer');
+            if ($mailer instanceof TestMailer) {
+                return $app->get('mailer')->getSentMessages();
+            } else {
+                throw new ConfigurationException("Mailer module is not mocked, can't test emails");
+            }
+        }
+        return [];
+    }
+
+    public function getComponent($name)
+    {
+        $app = $this->getApplication();
+        if (!$app->has($name)) {
+            throw new ConfigurationException("Component $name is not available in current application");
+        }
+        return $app->get($name);
+    }
+
+    /**
+     * Getting domain regex from rule host template
+     *
+     * @param string $template
+     * @return string
+     */
+    private function getDomainRegex($template)
+    {
+        if (preg_match('#https?://(.*)#', $template, $matches)) {
+            $template = $matches[1];
+        }
+        $parameters = [];
+        if (strpos($template, '<') !== false) {
+            $template = preg_replace_callback(
+                '/<(?:\w+):?([^>]+)?>/u',
+                function ($matches) use (&$parameters) {
+                    $key = '#' . count($parameters) . '#';
+                    $parameters[$key] = isset($matches[1]) ? $matches[1] : '\w+';
+                    return $key;
+                },
+                $template
+            );
+        }
+        $template = preg_quote($template);
+        $template = strtr($template, $parameters);
+        return '/^' . $template . '$/u';
+    }
+
+    /**
+     * Gets the name of the CSRF param.
+     * @return string
+     */
+    public function getCsrfParamName()
+    {
+        return $this->getApplication()->request->csrfParam;
+    }
+
+    /**
+     * @param $params
+     * @return mixed
+     */
+    public function createUrl($params)
+    {
+        return is_array($params) ?$this->getApplication()->getUrlManager()->createUrl($params) : $params;
     }
 
     public function startApp()
@@ -290,6 +431,16 @@ class Yii2 extends Client
     {
         parent::restart();
         $this->resetApplication();
+    }
+
+    /**
+     * This functions closes the session of the application, if the application exists and has a session.
+     */
+    public function closeSession()
+    {
+        if (isset(\Yii::$app) && \Yii::$app->has('session', true)) {
+            \Yii::$app->session->close();
+        }
     }
 
     /**

--- a/src/Codeception/Module/PhpBrowser.php
+++ b/src/Codeception/Module/PhpBrowser.php
@@ -172,7 +172,9 @@ class PhpBrowser extends InnerBrowser implements Remote, MultiSession, RequiresP
     public function amOnUrl($url)
     {
         $host = Uri::retrieveHost($url);
-        $this->_reconfigure(['url' => $host]);
+        $config = $this->config;
+        $config['url'] = $host;
+        $this->_reconfigure($config);
         $page = substr($url, strlen($host));
         if ($page === '') {
             $page = '/';
@@ -186,7 +188,9 @@ class PhpBrowser extends InnerBrowser implements Remote, MultiSession, RequiresP
         $url = $this->config['url'];
         $url = preg_replace('~(https?:\/\/)(.*\.)(.*\.)~', "$1$3", $url); // removing current subdomain
         $url = preg_replace('~(https?:\/\/)(.*)~', "$1$subdomain.$2", $url); // inserting new
-        $this->_reconfigure(['url' => $url]);
+        $config = $this->config;
+        $config['url'] = $url;
+        $this->_reconfigure($config);
     }
 
     protected function onReconfigure()

--- a/src/Codeception/Module/Yii2.php
+++ b/src/Codeception/Module/Yii2.php
@@ -2,6 +2,7 @@
 namespace Codeception\Module;
 
 use Codeception\Configuration;
+use Codeception\Exception\ConfigurationException;
 use Codeception\Exception\ModuleConfigException;
 use Codeception\Exception\ModuleException;
 use Codeception\Lib\Connector\Yii2 as Yii2Connector;
@@ -356,10 +357,6 @@ class Yii2 extends Framework implements ActiveRecord, PartedModule
             $this->loadedFixtures = [];
         }
 
-        if ($this->client !== null && $this->client->getApplication()->has('session', true)) {
-            $this->client->getApplication()->session->close();
-        }
-
         $this->client->resetApplication();
         parent::_after($test);
     }
@@ -406,17 +403,11 @@ class Yii2 extends Framework implements ActiveRecord, PartedModule
      */
     public function amLoggedInAs($user)
     {
-        if (!$this->client->getApplication()->has('user')) {
-            throw new ModuleException($this, 'User component is not loaded');
+        try {
+            $this->client->findAndLoginUser($user);
+        } catch (ConfigurationException $e) {
+            throw new ModuleException($this, $e->getMessage());
         }
-        if ($user instanceof \yii\web\IdentityInterface) {
-            $identity = $user;
-        } else {
-            // class name implementing IdentityInterface
-            $identityClass = $this->client->getApplication()->user->identityClass;
-            $identity = call_user_func([$identityClass, 'findIdentity'], $user);
-        }
-        $this->client->getApplication()->user->login($identity);
     }
 
     /**
@@ -659,10 +650,7 @@ class Yii2 extends Framework implements ActiveRecord, PartedModule
      */
     protected function clientRequest($method, $uri, array $parameters = [], array $files = [], array $server = [], $content = null, $changeHistory = true)
     {
-        if (is_array($uri)) {
-            $uri = $this->client->getApplication()->getUrlManager()->createUrl($uri);
-        }
-        return parent::clientRequest($method, $uri, $parameters, $files, $server, $content, $changeHistory);
+        return parent::clientRequest($method, $this->client->createUrl($uri), $parameters, $files, $server, $content, $changeHistory);
     }
 
     /**
@@ -676,13 +664,15 @@ class Yii2 extends Framework implements ActiveRecord, PartedModule
      * @param $component
      * @return mixed
      * @throws ModuleException
+     * @deprecated in your tests you can use \Yii::$app directly.
      */
     public function grabComponent($component)
     {
-        if (!$this->client->getApplication()->has($component)) {
-            throw new ModuleException($this, "Component $component is not available in current application");
+        try {
+            return $this->client->getComponent($component);
+        } catch (ConfigurationException $e) {
+            throw new ModuleException($this, $e->getMessage());
         }
-        return $this->client->getApplication()->get($component);
     }
 
     /**
@@ -738,11 +728,11 @@ class Yii2 extends Framework implements ActiveRecord, PartedModule
      */
     public function grabSentEmails()
     {
-        $mailer = $this->grabComponent('mailer');
-        if (!$mailer instanceof Yii2Connector\TestMailer) {
-            throw new ModuleException($this, "Mailer module is not mocked, can't test emails");
+        try {
+            return $this->client->getEmails();
+        } catch (ConfigurationException $e) {
+            throw new ModuleException($this, $e->getMessage());
         }
-        return $mailer->getSentMessages();
     }
 
     /**
@@ -763,33 +753,7 @@ class Yii2 extends Framework implements ActiveRecord, PartedModule
         return end($messages);
     }
 
-    /**
-     * Getting domain regex from rule host template
-     *
-     * @param string $template
-     * @return string
-     */
-    private function getDomainRegex($template)
-    {
-        if (preg_match('#https?://(.*)#', $template, $matches)) {
-            $template = $matches[1];
-        }
-        $parameters = [];
-        if (strpos($template, '<') !== false) {
-            $template = preg_replace_callback(
-                '/<(?:\w+):?([^>]+)?>/u',
-                function ($matches) use (&$parameters) {
-                    $key = '#' . count($parameters) . '#';
-                    $parameters[$key] = isset($matches[1]) ? $matches[1] : '\w+';
-                    return $key;
-                },
-                $template
-            );
-        }
-        $template = preg_quote($template);
-        $template = strtr($template, $parameters);
-        return '/^' . $template . '$/u';
-    }
+
 
     /**
      * Returns a list of regex patterns for recognized domain names
@@ -798,17 +762,7 @@ class Yii2 extends Framework implements ActiveRecord, PartedModule
      */
     public function getInternalDomains()
     {
-        $domains = [$this->getDomainRegex($this->client->getApplication()->urlManager->hostInfo)];
-
-        if ($this->client->getApplication()->urlManager->enablePrettyUrl) {
-            foreach ($this->client->getApplication()->urlManager->rules as $rule) {
-                /** @var \yii\web\UrlRule $rule */
-                if (isset($rule->host)) {
-                    $domains[] = $this->getDomainRegex($rule->host);
-                }
-            }
-        }
-        return array_unique($domains);
+        return $this->client->getInternalDomains();
     }
 
     private function defineConstants()
@@ -826,11 +780,7 @@ class Yii2 extends Framework implements ActiveRecord, PartedModule
      */
     public function setCookie($name, $val, array $params = [])
     {
-        // Sign the cookie.
-        if ($this->client->getApplication()->request->enableCookieValidation) {
-            $val = $this->client->getApplication()->security->hashData(serialize([$name, $val]), $this->client->getApplication()->request->cookieValidationKey);
-        }
-        parent::setCookie($name, $val, $params);
+        parent::setCookie($name, $this->client->hashCookieData($name, $val), $params);
     }
 
     /**
@@ -840,8 +790,8 @@ class Yii2 extends Framework implements ActiveRecord, PartedModule
      */
     public function createAndSetCsrfCookie($val)
     {
-        $masked = $this->client->getApplication()->security->maskToken($val);
-        $name = $this->client->getApplication()->request->csrfParam;
+        $masked = $this->client->maskToken($val);
+        $name = $this->client->getCsrfParamName();
         $this->setCookie($name, $val);
         return [$name, $masked];
     }

--- a/tests/unit/Codeception/Module/PhpBrowserTest.php
+++ b/tests/unit/Codeception/Module/PhpBrowserTest.php
@@ -4,6 +4,8 @@ use Codeception\Util\Stub;
 
 require_once 'tests/data/app/data.php';
 require_once __DIR__ . '/TestsForBrowsers.php';
+
+use GuzzleHttp\Handler\MockHandler;
 use GuzzleHttp\Psr7\Response;
 
 class PhpBrowserTest extends TestsForBrowsers
@@ -19,7 +21,7 @@ class PhpBrowserTest extends TestsForBrowsers
     {
         $this->module = new \Codeception\Module\PhpBrowser(make_container());
         $url = 'http://localhost:8000';
-        $this->module->_setConfig(array('url' => $url));
+        $this->module->_setConfig(['url' => $url]);
         $this->module->_initialize();
         $this->module->_before($this->makeTest());
         if (class_exists('GuzzleHttp\Url')) {
@@ -280,7 +282,15 @@ class PhpBrowserTest extends TestsForBrowsers
 
     public function testRedirectToAnotherDomainUsingSchemalessUrl()
     {
-        $this->module->amOnUrl('http://httpbin.org/redirect-to?url=//example.org/');
+        $this->module->_reconfigure([
+            'handler' => function() {
+                return new MockHandler([
+                    new Response(302, ['Location' => '//example.org/']),
+                    new Response(200, [], 'Cool stuff')
+                ]);
+            }
+        ]);
+        $this->module->amOnUrl('http://fictional.redirector/redirect-to?url=//example.org/');
         $currentUrl = $this->module->client->getHistory()->current()->getUri();
         $this->assertSame('http://example.org/', $currentUrl);
     }
@@ -481,7 +491,7 @@ class PhpBrowserTest extends TestsForBrowsers
     {
         $this->skipForOldGuzzle();
 
-        $mock = new \GuzzleHttp\Handler\MockHandler([
+        $mock = new MockHandler([
             new Response(200, ['X-Foo' => 'Bar']),
         ]);
         $handler = \GuzzleHttp\HandlerStack::create($mock);

--- a/tests/unit/Codeception/Module/PhpBrowserTest.php
+++ b/tests/unit/Codeception/Module/PhpBrowserTest.php
@@ -282,14 +282,14 @@ class PhpBrowserTest extends TestsForBrowsers
 
     public function testRedirectToAnotherDomainUsingSchemalessUrl()
     {
+
         $this->module->_reconfigure([
-            'handler' => function() {
-                return new MockHandler([
-                    new Response(302, ['Location' => '//example.org/']),
-                    new Response(200, [], 'Cool stuff')
-                ]);
-            }
+            'handler' => new MockHandler([
+                new Response(302, ['Location' => '//example.org/']),
+                new Response(200, [], 'Cool stuff')
+            ])
         ]);
+        /** @var \GuzzleHttp\HandlerStack $handlerStack */
         $this->module->amOnUrl('http://fictional.redirector/redirect-to?url=//example.org/');
         $currentUrl = $this->module->client->getHistory()->current()->getUri();
         $this->assertSame('http://example.org/', $currentUrl);


### PR DESCRIPTION
This PR moves some of the implementations from the module to the connector.
The public interface of the module remains unchanged but internally more is handled by the connector.

This prevents unneeded loading of the application.