### PR TITLE
Phalcon find null support

### DIFF
--- a/src/Codeception/Module/Phalcon.php
+++ b/src/Codeception/Module/Phalcon.php
@@ -564,8 +564,12 @@ class Phalcon extends Framework implements ActiveRecord, PartedModule
         $conditions = [];
         $bind       = [];
         foreach ($attributes as $key => $value) {
-            $conditions[] = "$key = :$key:";
-            $bind[$key]   = $value;
+            if ($value === null) {
+                $conditions[] = "$key IS NULL";
+            } else {
+                $conditions[] = "$key = :$key:";
+                $bind[$key] = $value;
+            }
         }
         $query = implode(' AND ', $conditions);
         $this->debugSection('Query', $query);

--- a/src/Codeception/Module/Phalcon.php
+++ b/src/Codeception/Module/Phalcon.php
@@ -573,10 +573,10 @@ class Phalcon extends Framework implements ActiveRecord, PartedModule
         }
         $query = implode(' AND ', $conditions);
         $this->debugSection('Query', $query);
-        return call_user_func_array([$model, 'findFirst'], [
+        return call_user_func_array([$model, 'findFirst'], [[
             'conditions' => $query,
             'bind'       => $bind,
-        ]);
+        ]]);
     }
 
     /**

--- a/src/Codeception/Module/Phalcon.php
+++ b/src/Codeception/Module/Phalcon.php
@@ -573,10 +573,12 @@ class Phalcon extends Framework implements ActiveRecord, PartedModule
         }
         $query = implode(' AND ', $conditions);
         $this->debugSection('Query', $query);
-        return call_user_func_array([$model, 'findFirst'], [[
-            'conditions' => $query,
-            'bind'       => $bind,
-        ]]);
+        return call_user_func_array([$model, 'findFirst'], [
+            [
+                'conditions' => $query,
+                'bind'       => $bind,
+            ]
+        ]);
     }
 
     /**


### PR DESCRIPTION
This PR introduces support for finding null fields when using `findRecord`. When you currently want to search for a record where a certain field has a null value it will fail.

Another things this PR fixes is the usage of bind parameters (introduced in #5158). This was giving a `Wrong number of parameters` exception because the properties were not wrapped in an array, so only the 'conditions' were passed into the `findFirst()` instead of an array containing both conditions and parameters.