### PR TITLE
Fixed issue with empty response stream in Yii2

### DIFF
--- a/src/Codeception/Lib/Connector/Yii2.php
+++ b/src/Codeception/Lib/Connector/Yii2.php
@@ -341,7 +341,7 @@ class Yii2 extends Client
         }
 
         $content = ob_get_clean();
-        if (empty($content) && !empty($response->content)) {
+        if (empty($content) && !empty($response->content) && !isset($response->stream)) {
             throw new \Exception('No content was sent from Yii application');
         }
 


### PR DESCRIPTION
This fixes an issue when using a response with nonempty `$content` and an empty `$stream`.
This could be the cause of #5131 .