### PR TITLE
Implement command-line option for specifying shuffle seed value

### DIFF
--- a/docs/reference/Commands.md
+++ b/docs/reference/Commands.md
@@ -169,6 +169,7 @@ Options:
  --ansi                Force ANSI output.
  --no-ansi             Disable ANSI output.
  --no-interaction (-n) Do not ask any interactive question.
+ --seed                Use the given seed for shuffling tests
 ```
 
 

--- a/src/Codeception/Codecept.php
+++ b/src/Codeception/Codecept.php
@@ -185,7 +185,9 @@ class Codecept
     {
         $suiteManager = new SuiteManager($this->dispatcher, $suite, $settings);
         $suiteManager->initialize();
+        srand($this->options['seed']);
         $suiteManager->loadTests($test);
+        srand();
         $suiteManager->run($this->runner, $this->result, $this->options);
         return $this->result;
     }

--- a/src/Codeception/Command/Run.php
+++ b/src/Codeception/Command/Run.php
@@ -86,6 +86,7 @@ use Symfony\Component\Console\Output\OutputInterface;
  *  --ansi                Force ANSI output.
  *  --no-ansi             Disable ANSI output.
  *  --no-interaction (-n) Do not ask any interactive question.
+ *  --seed                Use the given seed for shuffling tests
  * ```
  *
  */
@@ -202,6 +203,13 @@ class Run extends Command
             ),
             new InputOption('fail-fast', 'f', InputOption::VALUE_NONE, 'Stop after first failure'),
             new InputOption('no-rebuild', '', InputOption::VALUE_NONE, 'Do not rebuild actor classes on start'),
+            new InputOption(
+                'seed',
+                '',
+                InputOption::VALUE_REQUIRED,
+                'Define random seed for shuffle setting'
+            ),
+
         ]);
 
         parent::configure();
@@ -241,10 +249,21 @@ class Run extends Command
         if (!$this->options['colors']) {
             $this->options['colors'] = $config['settings']['colors'];
         }
+
+        if (!$this->options['seed']) {
+            $this->options['seed'] = rand();
+        } else {
+            $this->options['seed'] = intval($this->options['seed']);
+        }
+
         if (!$this->options['silent']) {
             $this->output->writeln(
                 Codecept::versionString() . "\nPowered by " . \PHPUnit\Runner\Version::getVersionString()
             );
+            $this->output->writeln(
+                "Running with seed: " . $this->options['seed'] . "\n"
+            );
+
         }
         if ($this->options['debug']) {
             $this->output->setVerbosity(OutputInterface::VERBOSITY_VERY_VERBOSE);

--- a/src/Codeception/Command/Run.php
+++ b/src/Codeception/Command/Run.php
@@ -250,12 +250,6 @@ class Run extends Command
             $this->options['colors'] = $config['settings']['colors'];
         }
 
-        if (!$this->options['seed']) {
-            $this->options['seed'] = rand();
-        } else {
-            $this->options['seed'] = intval($this->options['seed']);
-        }
-
         if (!$this->options['silent']) {
             $this->output->writeln(
                 Codecept::versionString() . "\nPowered by " . \PHPUnit\Runner\Version::getVersionString()
@@ -288,6 +282,11 @@ class Run extends Command
         $userOptions['interactive'] = !$input->hasParameterOption(['--no-interaction', '-n']);
         $userOptions['ansi'] = (!$input->hasParameterOption('--no-ansi') xor $input->hasParameterOption('ansi'));
 
+        if (!$this->options['seed']) {
+            $userOptions['seed'] = rand();
+        } else {
+            $userOptions['seed'] = intval($this->options['seed']);
+        }
         if ($this->options['no-colors'] || !$userOptions['ansi']) {
             $userOptions['colors'] = false;
         }


### PR DESCRIPTION
This PR implements #4795, it is an alternative for #4907 .

The changes are:
- Always seed the random number generator.
- Print the seed to stdout, except when using `--silent`.
- Seed is only configurable via the commandline.
- Same seed is used for each suite.

@acorncom, @edno your feedback is welcome!

Usage is simple, assuming you have shuffle enabled:
```sh
$ codecept run 
Codeception PHP Testing Framework v2.4.5
Powered by PHPUnit 7.3.5 by Sebastian Bergmann and contributors.
Running with seed: 1870695360
...
...
$ codecept run 
Codeception PHP Testing Framework v2.4.5
Powered by PHPUnit 7.3.5 by Sebastian Bergmann and contributors.
Running with seed: 824399276
...
...
Your test failed.
$ codecept run --seed 824399276 --debug
Codeception PHP Testing Framework v2.4.5
Powered by PHPUnit 7.3.5 by Sebastian Bergmann and contributors.
Running with seed: 824399276
...
...
```
