### PR TITLE
seeLink: fix partial href matching

### DIFF
--- a/src/Codeception/Lib/InnerBrowser.php
+++ b/src/Codeception/Lib/InnerBrowser.php
@@ -504,7 +504,7 @@ class InnerBrowser extends Module implements Web, PageSourceSaver, ElementLocato
             $this->fail("No links containing text '$text' were found in page " . $this->_getCurrentUri());
         }
         if ($url) {
-            $crawler = $crawler->filterXPath(sprintf('.//a[contains(@href, %s)]', Crawler::xpathLiteral($url)));
+            $crawler = $crawler->filterXPath(sprintf('.//a[@href=%s]', Crawler::xpathLiteral($url)));
             if ($crawler->count() === 0) {
                 $this->fail("No links containing text '$text' and URL '$url' were found in page " . $this->_getCurrentUri());
             }
@@ -520,7 +520,7 @@ class InnerBrowser extends Module implements Web, PageSourceSaver, ElementLocato
                 $this->fail("Link containing text '$text' was found in page " . $this->_getCurrentUri());
             }
         }
-        $crawler = $crawler->filterXPath(sprintf('.//a[contains(@href, %s)]', Crawler::xpathLiteral($url)));
+        $crawler = $crawler->filterXPath(sprintf('.//a[@href=%s]', Crawler::xpathLiteral($url)));
         if ($crawler->count() > 0) {
             $this->fail("Link containing text '$text' and URL '$url' was found in page " . $this->_getCurrentUri());
         }

--- a/src/Codeception/Lib/InnerBrowser.php
+++ b/src/Codeception/Lib/InnerBrowser.php
@@ -504,7 +504,7 @@ class InnerBrowser extends Module implements Web, PageSourceSaver, ElementLocato
             $this->fail("No links containing text '$text' were found in page " . $this->_getCurrentUri());
         }
         if ($url) {
-            $crawler = $crawler->filterXPath(sprintf('.//a[@href=%s]', Crawler::xpathLiteral($url)));
+            $crawler = $crawler->filterXPath(sprintf('.//a[substring(@href, string-length(@href) - string-length(%1$s) + 1)=%1$s]', Crawler::xpathLiteral($url)));
             if ($crawler->count() === 0) {
                 $this->fail("No links containing text '$text' and URL '$url' were found in page " . $this->_getCurrentUri());
             }
@@ -520,7 +520,7 @@ class InnerBrowser extends Module implements Web, PageSourceSaver, ElementLocato
                 $this->fail("Link containing text '$text' was found in page " . $this->_getCurrentUri());
             }
         }
-        $crawler = $crawler->filterXPath(sprintf('.//a[@href=%s]', Crawler::xpathLiteral($url)));
+        $crawler = $crawler->filterXPath(sprintf('.//a[substring(@href, string-length(@href) - string-length(%1$s) + 1)=%1$s]', Crawler::xpathLiteral($url)));
         if ($crawler->count() > 0) {
             $this->fail("Link containing text '$text' and URL '$url' was found in page " . $this->_getCurrentUri());
         }

--- a/tests/unit/Codeception/Module/TestsForWeb.php
+++ b/tests/unit/Codeception/Module/TestsForWeb.php
@@ -147,6 +147,16 @@ abstract class TestsForWeb extends \Codeception\Test\Unit
         $this->module->seeLink('Next', '/fsdfsdf/');
     }
 
+    public function testSeeLinkFailsIfHrefDoesNotMatchExactly()
+    {
+        $this->setExpectedException(
+            'PHPUnit\Framework\AssertionFailedError',
+            "No links containing text 'Next' and URL 'http://codeception' were found in page /external_url"
+        );
+        $this->module->amOnPage('/external_url');
+        $this->module->seeLink('Next', 'http://codeception');
+    }
+
     public function testDontSeeLinkFailsIfTextMatches()
     {
         $this->setExpectedException(

--- a/tests/unit/Codeception/Module/TestsForWeb.php
+++ b/tests/unit/Codeception/Module/TestsForWeb.php
@@ -116,6 +116,8 @@ abstract class TestsForWeb extends \Codeception\Test\Unit
         $this->module->amOnPage('/external_url');
         $this->module->seeLink('Next');
         $this->module->seeLink('Next', 'http://codeception.com/');
+        // Without TLD and trailing slash
+        $this->module->dontSeeLink('Next', 'http://codeception');
     }
 
     public function testDontSeeLink()
@@ -169,6 +171,7 @@ abstract class TestsForWeb extends \Codeception\Test\Unit
     {
         $this->module->amOnPage('/info');
         $this->module->seeLink('Sign in!', '/login');
+        $this->module->dontSeeLink('Sign in!', '/log');
     }
 
     public function testDontSeeLinkMatchesRelativeLink()


### PR DESCRIPTION
The `contains` keyword in xpath matches also partial content.

The documentation states:
```php
$I->seeLink('Logout','/logout'); // matches <a href="/logout">Logout</a>
```
But now it also matches `<a href="/logout/foobar">Logout</a>`