### PR TITLE
Added symfony xml support for parameter files.

### DIFF
--- a/src/Codeception/Lib/ParamsLoader.php
+++ b/src/Codeception/Lib/ParamsLoader.php
@@ -92,10 +92,17 @@ class ParamsLoader
                     case 'int':
                     case 'integer':
                     case 'float':
-                    case 'double'    : $a[$key] = settype($value, $type); break;
-                    case 'collection': $a[$key] = $paramsToArray($param);       break;
-                    case 'constant'  : $a[$key] = constant($value);             break;
-                    default          : $a[$key] = (string) $param;
+                    case 'double':
+                        $a[$key] = settype($value, $type);
+                        break;
+                    case 'constant':
+                        $a[$key] = constant($value);
+                        break;
+                    case 'collection':
+                        $a[$key] = $paramsToArray($param);
+                        break;
+                    default:
+                        $a[$key] = (string) $param;
                 }
             }
 

--- a/src/Codeception/Lib/ParamsLoader.php
+++ b/src/Codeception/Lib/ParamsLoader.php
@@ -43,6 +43,10 @@ class ParamsLoader
             if (preg_match('~(\.env(\.|$))~', $paramStorage)) {
                 return $this->loadDotEnvFile();
             }
+
+            if (preg_match('~\.xml$~', $paramStorage)) {
+                return $this->loadXmlFile();
+            }
         } catch (\Exception $e) {
             throw new ConfigurationException("Failed loading params from $paramStorage\n" . $e->getMessage());
         }
@@ -72,6 +76,33 @@ class ParamsLoader
             $params = $params['parameters'];
         }
         return $params;
+    }
+
+    protected function loadXmlFile()
+    {
+        $paramsToArray = function (\SimpleXMLElement $params) use (&$paramsToArray) {
+            $a = [];
+            foreach ($params as $param) {
+                $key = isset($param['key']) ? (string) $param['key'] : $param->getName();
+                $type = isset($param['type']) ? (string) $param['type'] : 'string';
+                $value = (string) $param;
+                switch ($type) {
+                    case 'bool':
+                    case 'boolean':
+                    case 'int':
+                    case 'integer':
+                    case 'float':
+                    case 'double'    : $a[$key] = settype($value, $type); break;
+                    case 'collection': $a[$key] = $paramsToArray($param);       break;
+                    case 'constant'  : $a[$key] = constant($value);             break;
+                    default          : $a[$key] = (string) $param;
+                }
+            }
+
+            return $a;
+        };
+
+        return $paramsToArray(simplexml_load_file($this->paramsFile));
     }
 
     protected function loadDotEnvFile()

--- a/tests/cli/ConfigParamsCest.php
+++ b/tests/cli/ConfigParamsCest.php
@@ -37,4 +37,11 @@ class ConfigParamsCest
         $I->executeCommand('run -c codeception_self.yml');
         $I->seeInShellOutput('OK (1 test');
     }
+
+    public function checkXmlParamsPassed(CliGuy $I)
+    {
+        $I->amInPath('tests/data/params');
+        $I->executeCommand('run -c codeception_xml.yml');
+        $I->seeInShellOutput('OK (1 test');
+    }
 }

--- a/tests/data/params/codeception_xml.yml
+++ b/tests/data/params/codeception_xml.yml
@@ -1,0 +1,9 @@
+actor: Tester
+paths:
+    tests: tests
+    log: .
+    data: .
+    support: tests/_support
+params:
+    - env
+    - params.xml

--- a/tests/data/params/params.xml
+++ b/tests/data/params/params.xml
@@ -1,0 +1,4 @@
+<parameters>
+    <parameter key="KEY1" type="string">val1</parameter>
+    <parameter key="KEY2">val2</parameter>
+</parameters>


### PR DESCRIPTION
Added Symfony XML like parameter file support.

Example XML file:
```xml
<parameters>
    <parameter key="KEY1" type="string">val1</parameter>
    <parameter key="KEY2">val2</parameter>
    <parameter key="KEY3" type="collection">
        <parameter key="KEY4" type="string">false</parameter>
        <parameter key="KEY5" type="bool">true</parameter>
        <parameter key="KEY6" type="constant">PHP_VERSION</parameter>
    </parameter>
</parameters>
```
