### PR TITLE
Makes generators consistent

### DIFF
--- a/src/Codeception/Lib/Generator/Cest.php
+++ b/src/Codeception/Lib/Generator/Cest.php
@@ -11,7 +11,8 @@ class Cest
     use Namespaces;
 
     protected $template = <<<EOF
-<?php {{namespace}}
+<?php
+{{namespace}}
 
 class {{name}}Cest
 {

--- a/src/Codeception/Lib/Generator/Test.php
+++ b/src/Codeception/Lib/Generator/Test.php
@@ -11,7 +11,9 @@ class Test
     use Shared\Classname;
 
     protected $template = <<<EOF
-<?php {{namespace}}
+<?php
+{{namespace}}
+
 class {{name}}Test extends \Codeception\Test\Unit
 {
 {{tester}}


### PR DESCRIPTION
Most generators use consistent styles with regard to namespaces, except two. This PR fixes that by putting the namespace on a new line for all generators, along with a blank line before the class declaration