### PR TITLE
Fixes PHPStan issue

### DIFF
--- a/src/Codeception/Module/Db.php
+++ b/src/Codeception/Module/Db.php
@@ -374,7 +374,7 @@ class Db extends CodeceptionModule implements DbInterface
      * exception on failure.
      *
      * @param $databaseKey
-     * @param actions $actions
+     * @param \Codeception\Util\ActionSequence|callable|array $actions
      * @throws ModuleConfigException
      */
     public function performInDatabase($databaseKey, $actions)

--- a/src/Codeception/Module/Db.php
+++ b/src/Codeception/Module/Db.php
@@ -374,7 +374,7 @@ class Db extends CodeceptionModule implements DbInterface
      * exception on failure.
      *
      * @param $databaseKey
-     * @param \Codeception\Util\ActionSequence|callable|array $actions
+     * @param \Codeception\Util\ActionSequence|array|callable $actions
      * @throws ModuleConfigException
      */
     public function performInDatabase($databaseKey, $actions)

--- a/src/Codeception/Module/WebDriver.php
+++ b/src/Codeception/Module/WebDriver.php
@@ -531,7 +531,7 @@ class WebDriver extends CodeceptionModule implements
     /**
      * Print out latest Selenium Logs in debug mode
      *
-     * @param TestInterface $test
+     * @param \Codeception\TestInterface $test
      */
     public function debugWebDriverLogs(TestInterface $test = null)
     {


### PR DESCRIPTION
When using namespaces in tests, and building the `*TesterActions` classes, PHPStan throws an error that it cannot find `<MyNamespace>\TestInterface` as well as `<MyNamespace>\actions`.

This fixes those issues.