### PR TITLE
Db: don't clear database for empty dump

### DIFF
--- a/src/Codeception/Module/Db.php
+++ b/src/Codeception/Module/Db.php
@@ -629,7 +629,7 @@ class Db extends CodeceptionModule implements DbInterface
         }
         try {
             // don't clear database for empty dump
-            if (isset($this->databasesSql[$databaseKey]) && !count($this->databasesSql[$databaseKey])) {
+            if (!isset($this->databasesSql[$databaseKey]) || !count($this->databasesSql[$databaseKey])) {
                 return;
             }
             $this->drivers[$databaseKey]->cleanup();


### PR DESCRIPTION
Previously only the presence of SQL counted:

https://github.com/Codeception/Codeception/blob/5fee32d5c82791548931cbc34806b4de6aa1abfc/src/Codeception/Module/Db.php#L405-L408

The code edited in https://github.com/Codeception/Codeception/pull/5140 forgot that SQL can also be completely absent