### PR TITLE
Add waitForElementClickable

### DIFF
--- a/src/Codeception/Module/WebDriver.php
+++ b/src/Codeception/Module/WebDriver.php
@@ -2342,6 +2342,27 @@ class WebDriver extends CodeceptionModule implements
     }
 
     /**
+     * Waits up to $timeout seconds for the given element to be clickable.
+     * If element doesn't become clickable, a timeout exception is thrown.
+     *
+     * ``` php
+     * <?php
+     * $I->waitForElementClickable('#agree_button', 30); // secs
+     * $I->click('#agree_button');
+     * ?>
+     * ```
+     *
+     * @param $element
+     * @param int $timeout seconds
+     * @throws \Exception
+     */
+    public function waitForElementClickable($element, $timeout = 10)
+    {
+        $condition = WebDriverExpectedCondition::elementToBeClickable($this->getLocator($element));
+        $this->webDriver->wait($timeout)->until($condition);
+    }
+
+    /**
      * Waits up to $timeout seconds for the given string to appear on the page.
      *
      * Can also be passed a selector to search in, be as specific as possible when using selectors.

--- a/tests/web/WebDriverTest.php
+++ b/tests/web/WebDriverTest.php
@@ -554,7 +554,7 @@ class WebDriverTest extends TestsForBrowsers
 
     public function testWebDriverWaits()
     {
-        $fakeWd = Stub::make(self::WEBDRIVER_CLASS, ['wait' => Stub::exactly(12, function () {
+        $fakeWd = Stub::make(self::WEBDRIVER_CLASS, ['wait' => Stub::exactly(16, function () {
             return new \Codeception\Util\Maybe();
         })]);
         $module = Stub::make(self::MODULE_CLASS, ['webDriver' => $fakeWd]);

--- a/tests/web/WebDriverTest.php
+++ b/tests/web/WebDriverTest.php
@@ -572,6 +572,11 @@ class WebDriverTest extends TestsForBrowsers
         $module->waitForElementNotVisible(['id' => 'user']);
         $module->waitForElementNotVisible(['css' => '.user']);
         $module->waitForElementNotVisible('//xpath');
+
+        $module->waitForElementClickable(WebDriverBy::partialLinkText('yeah'));
+        $module->waitForElementClickable(['id' => 'user']);
+        $module->waitForElementClickable(['css' => '.user']);
+        $module->waitForElementClickable('//xpath');
     }
 
     public function testWaitForElement()


### PR DESCRIPTION
I needed a way to wait on a button to become clickable, and noticed that WebDriver already has a `WebDriverExpectedCondition::elementToBeClickable()` method available. Pretty easy win!

Fixes #5216.

Note: I was unable to get the `web` suite working, so I was unable to actually test this through `WebDriverTest`, but I actually built this into my own app before submitting here. It looks like that suite isn't running in TravisCI? I was hoping I'd be able to at least let CI tell me if I got it right.

I tried running this through the `docker-compose` steps in [the readme](https://github.com/Codeception/Codeception/blob/2.5/tests/README.md), but I'm unsure if docker automatically spins up chromedriver and the rest of the necessary steps. When I tried running `docker-compose run --rm codecept run web --env chrome WebDriverTest:testWebDriverWaits` I would receive an error tat chrome couldn't connect to chromedriver. I ended up running chromedriver locally and I get this message:
```
E WebDriverTest: Web driver waits 
--------------------------------------------------------------------------------------
DEPRECATION: Stub::exactly is deprecated in favor of \Codeception\Stub\Expected::exactly


Time: 122 ms, Memory: 14.00MB

There was 1 error:

---------
1) WebDriverTest: Web driver waits
 Test  tests/web/WebDriverTest.php:testWebDriverWaits
                                                                                                                                                             
  [Facebook\WebDriver\Exception\WebDriverException] JSON decoding of remote response failed.
Error code: 4
The response: 'unknown command: wd/hub/session'
  
                                                                                                                                                             
#1  /home/james/dev/Codeception/vendor/facebook/webdriver/lib/Remote/HttpCommandExecutor.php:298
#2  /home/james/dev/Codeception/vendor/facebook/webdriver/lib/Remote/RemoteWebDriver.php:126
#3  /home/james/dev/Codeception/src/Codeception/Module/WebDriver.php:1441
#4  /home/james/dev/Codeception/src/Codeception/Module/WebDriver.php:426
#5  /home/james/dev/Codeception/vendor/symfony/event-dispatcher/EventDispatcher.php:212
#6  /home/james/dev/Codeception/vendor/symfony/event-dispatcher/EventDispatcher.php:44
#7  /home/james/dev/Codeception/codecept:43

ERRORS!
Tests: 1, Assertions: 0, Errors: 1.
```

I'd absolutely love to get this test working, just let me know what to do!