### PR TITLE
use param files .yaml like .yml

### DIFF
--- a/src/Codeception/Lib/ParamsLoader.php
+++ b/src/Codeception/Lib/ParamsLoader.php
@@ -28,7 +28,7 @@ class ParamsLoader
         }
 
         try {
-            if (preg_match('~\.yml$~', $paramStorage)) {
+            if (preg_match('~\.ya?ml$~', $paramStorage)) {
                 return $this->loadYamlFile();
             }
 


### PR DESCRIPTION
Since version 4, Symfony the default app skeleton uses .yaml files