### PR TITLE
Accounting For Null Content In Phalcon Response Object (IE: Redirect)

### DIFF
--- a/src/Codeception/Lib/Connector/Phalcon.php
+++ b/src/Codeception/Lib/Connector/Phalcon.php
@@ -151,7 +151,7 @@ class Phalcon extends Client
         }
 
         return new Response(
-            $response->getContent(),
+            $response->getContent() ?: '',
             $status ? $status : 200,
             $headers
         );


### PR DESCRIPTION
The Phalcon Response class's content is null by default. If you use $response->redirect, the content stays null. When using functional testing, the null causes an error due to typehint requirements. This fixes that issue.