### PR TITLE
Adding Finally To Ensure Suite After Always Runs, Even If Exception

### DIFF
--- a/src/Codeception/SuiteManager.php
+++ b/src/Codeception/SuiteManager.php
@@ -154,8 +154,11 @@ class SuiteManager
     {
         $runner->prepareSuite($this->suite, $options);
         $this->dispatcher->dispatch(Events::SUITE_BEFORE, new Event\SuiteEvent($this->suite, $result, $this->settings));
-        $runner->doEnhancedRun($this->suite, $result, $options);
-        $this->dispatcher->dispatch(Events::SUITE_AFTER, new Event\SuiteEvent($this->suite, $result, $this->settings));
+        try {
+            $runner->doEnhancedRun($this->suite, $result, $options);
+        } finally {
+            $this->dispatcher->dispatch(Events::SUITE_AFTER, new Event\SuiteEvent($this->suite, $result, $this->settings));
+        }
     }
 
     /**


### PR DESCRIPTION
I noticed that the 'Command Did Not Finish Properly' feature I added previously was having adverse effects when an exception was thrown in the beforeSuite or afterSuite methods of a module. This was occurring even though the exception occurred. In my mind, an Exception should disable the Command Did Not Finish  Properly as it is to be handled by the normal error trapping. I've wrapped the Suite Event that fires the tests and the after-tests with a try/finally so that the after suite will still get called if an exception occurs. This will prevent the display of the original exception as well as the following 'Command Did Not Finish Properly'