### PR TITLE
Adding Ability To Translate Remote Paths To Local (IE: Docker)

### DIFF
--- a/docs/11-Codecoverage.md
+++ b/docs/11-Codecoverage.md
@@ -129,6 +129,24 @@ But in case of running tests on a remote server we are not sure of it.
 
 CodeCoverage results from remote server will be saved to `tests/_output` directory. Please note that remote codecoverage results won't be displayed in console by the reason mentioned above: local and remote results can't be merged, and console displays results for local codecoverage.
 
+### Working Directory (Docker/Shared Mounts)
+
+If your remote server is accessed through a shared mount, or a mounted folder (IE: Docker Volumes), you can still get merged coverage details.
+Use the `work_dir` option to specify the work directory. When CodeCoverage runs, Codeception will update any path that matches the `work_dir` option to match the local current project directory.
+
+Given a docker command similar to:
+```bash
+docker run -v $(pwd):/workdir -w /workdir...
+```
+
+Use the below configuration to allow coverage mergers.
+```yaml
+coverage:
+    remote: false
+    work_dir: /workdir
+
+``` 
+
 ### Remote Context Options
 
 HTML report generation can at times take a little more time than the default 30 second timeout. Or maybe you want to alter SSL settings (verify_peer, for example)

--- a/src/Codeception/Coverage/Subscriber/LocalServer.php
+++ b/src/Codeception/Coverage/Subscriber/LocalServer.php
@@ -9,6 +9,7 @@ use Codeception\Event\TestEvent;
 use Codeception\Events;
 use Codeception\Exception\ModuleException;
 use Codeception\Exception\RemoteException;
+use PHP_CodeCoverage;
 
 /**
  * When collecting code coverage data from local server HTTP requests are sent to c3.php file.
@@ -122,7 +123,41 @@ class LocalServer extends SuiteSubscriber
         if ($coverage === false) {
             return;
         }
-        $this->mergeToPrint($coverage);
+
+        $this->preProcessCoverage($coverage)
+             ->mergeToPrint($coverage);
+    }
+
+    /**
+     * Allows Translating Remote Paths To Local (IE: When Using Docker)
+     *
+     * @param \PHP_CodeCoverage $coverage
+     * @return $this
+     */
+    protected function preProcessCoverage($coverage)
+    {
+        //Only Process If Work Directory Set
+        if ($this->settings['work_dir'] === null) {
+            return $this;
+        }
+
+        $workDir    = rtrim($this->settings['work_dir'], '/\\') . DIRECTORY_SEPARATOR;
+        $projectDir = Configuration::projectDir();
+        $data       = $coverage->getData(true); //We only want covered files, not all whitelisted ones.
+
+        codecept_debug("Replacing All Instances Of {$workDir} with {$projectDir}");
+
+        foreach ($data as $path => $datum) {
+            unset($data[$path]);
+
+            $path = str_replace($workDir, $projectDir, $path);
+
+            $data[$path] = $datum;
+        }
+
+        $coverage->setData($data);
+
+        return $this;
     }
 
     protected function c3Request($action)

--- a/src/Codeception/Coverage/Subscriber/LocalServer.php
+++ b/src/Codeception/Coverage/Subscriber/LocalServer.php
@@ -9,7 +9,6 @@ use Codeception\Event\TestEvent;
 use Codeception\Events;
 use Codeception\Exception\ModuleException;
 use Codeception\Exception\RemoteException;
-use PHP_CodeCoverage;
 
 /**
  * When collecting code coverage data from local server HTTP requests are sent to c3.php file.
@@ -131,7 +130,7 @@ class LocalServer extends SuiteSubscriber
     /**
      * Allows Translating Remote Paths To Local (IE: When Using Docker)
      *
-     * @param \PHP_CodeCoverage $coverage
+     * @param \SebastianBergmann\CodeCoverage\CodeCoverage $coverage
      * @return $this
      */
     protected function preProcessCoverage($coverage)
@@ -145,7 +144,7 @@ class LocalServer extends SuiteSubscriber
         $projectDir = Configuration::projectDir();
         $data       = $coverage->getData(true); //We only want covered files, not all whitelisted ones.
 
-        codecept_debug("Replacing All Instances Of {$workDir} with {$projectDir}");
+        codecept_debug("Replacing all instances of {$workDir} with {$projectDir}");
 
         foreach ($data as $path => $datum) {
             unset($data[$path]);

--- a/src/Codeception/Coverage/SuiteSubscriber.php
+++ b/src/Codeception/Coverage/SuiteSubscriber.php
@@ -21,7 +21,8 @@ abstract class SuiteSubscriber implements EventSubscriberInterface
         'xdebug_session' => 'codeception',
         'remote_config'  => null,
         'show_uncovered' => false,
-        'c3_url'         => null
+        'c3_url'         => null,
+        'work_dir'       => null
     ];
 
     protected $settings = [];

--- a/tests/coverage/LocalWithWorkDirCept.php
+++ b/tests/coverage/LocalWithWorkDirCept.php
@@ -3,4 +3,4 @@ $I = new CoverGuy($scenario);
 $I->wantTo('try generate local codecoverage with work directory');
 $I->amInPath('tests/data/sandbox');
 $I->executeCommand('run remote_server --env=work --coverage --debug');
-$I->seeInShellOutput('Replacing All Instances Of /tmp/test/ with ' . realpath(__DIR__ . '/../..') . '/');
+$I->seeInShellOutput('Replacing all instances of /tmp/test/ with ' . realpath(__DIR__ . '/../..') . '/data/sandbox/');

--- a/tests/coverage/LocalWithWorkDirCept.php
+++ b/tests/coverage/LocalWithWorkDirCept.php
@@ -3,4 +3,4 @@ $I = new CoverGuy($scenario);
 $I->wantTo('try generate local codecoverage with work directory');
 $I->amInPath('tests/data/sandbox');
 $I->executeCommand('run remote_server --env=work --coverage --debug');
-$I->seeInShellOutput('Replacing all instances of /tmp/test/ with ' . realpath(__DIR__ . '/../..') . '/data/sandbox/');
+$I->seeInShellOutput('Replacing all instances of /tmp/test/ with ' . realpath(__DIR__ . '/../..') . '/tests/data/sandbox/');

--- a/tests/coverage/LocalWithWorkDirCept.php
+++ b/tests/coverage/LocalWithWorkDirCept.php
@@ -1,0 +1,6 @@
+<?php
+$I = new CoverGuy($scenario);
+$I->wantTo('try generate local codecoverage with work directory');
+$I->amInPath('tests/data/sandbox');
+$I->executeCommand('run remote_server --env=work --coverage --debug');
+$I->seeInShellOutput('Replacing All Instances Of /tmp/test/ with ' . realpath(__DIR__ . '/../..') . '/');

--- a/tests/data/claypit/tests/remote_server.suite.yml
+++ b/tests/data/claypit/tests/remote_server.suite.yml
@@ -15,7 +15,10 @@ env:
                 WebDriver:
                     url: http://127.0.0.1:8000
                     browser: firefox
-
+    work:
+        coverage:
+            remote: false
+            work_dir: /tmp/test
 
 coverage:
     enabled: true

--- a/tests/support/CliHelper.php
+++ b/tests/support/CliHelper.php
@@ -24,9 +24,9 @@ class CliHelper extends \Codeception\Module
         chdir(\Codeception\Configuration::projectDir());
     }
 
-    public function executeCommand($command, $fail = true)
+    public function executeCommand($command, $fail = true, $phpOptions = '')
     {
-        $this->getModule('Cli')->runShellCommand('php ' . \Codeception\Configuration::projectDir() . 'codecept ' . $command . ' -n', $fail);
+        $this->getModule('Cli')->runShellCommand('php ' . $phpOptions . ' ' . \Codeception\Configuration::projectDir() . 'codecept ' . $command . ' -n', $fail);
     }
 
     public function executeFailCommand($command)


### PR DESCRIPTION
This PR adds the ability to use coverage locally when utilizing docker or other forms of mounted/shared directories. It otherwise gives you the ability to run coverage without having to resort to remote coverage, provided you can use some form of shared mount when testing.

I use docker for most of my stuff. This includes both on my local computer and for my GitLab Pipelines (CI). When running coverage, if you are using docker, you have no choice but to set coverage up as a remote server. This of course means you will not get merged coverage. The only way you can use local coverage with a docker setup is to either run codeception through a docker container (And map everything to be the same paths) or to update the working directories of docker to be the same locally and within the container. Personally, I found both of these to be overkill. 

While trying to debug why I was getting no coverage on my acceptance testing, I found that the only reason was that the PHP_Codecoverage system is storing the absolute path to the file. As a proof of concept in my project, I just replaced the absolute path from the docker container with the absolute path in my actual computer. This worked perfectly, so I threw this together.

Adding the `work_dir` setting to the coverage will update the path of all covered files to match the project root. 

I haven't gotten any testing in yet and am open to suggestions on how to add testing for this, outside of just doing a unit test with reflection.

```yaml
coverage:
  enabled: true
  work_dir: /var/www
```