### PR TITLE
Add seed to suite configuration

### DIFF
--- a/src/Codeception/Codecept.php
+++ b/src/Codeception/Codecept.php
@@ -148,6 +148,7 @@ class Codecept
         );
 
         $config = $config ?: Configuration::config();
+        $config['seed'] = $this->options['seed'];
 
         $settings = Configuration::suiteSettings($suite, $config);
 
@@ -166,6 +167,7 @@ class Codecept
                 if (isset($environments[$env])) {
                     $currentEnvironment = isset($config['current_environment']) ? [$config['current_environment']] : [];
                     $config = Configuration::mergeConfigs($config, $environments[$env]);
+                    $config['seed'] = $this->options['seed'];
                     $currentEnvironment[] = $config['current_environment'];
                     $config['current_environment'] = implode(',', $currentEnvironment);
                 }

--- a/src/Codeception/Configuration.php
+++ b/src/Codeception/Configuration.php
@@ -309,7 +309,7 @@ class Configuration
 
         // load global config
         $globalConf = $config['settings'];
-        foreach (['modules', 'coverage', 'namespace', 'groups', 'env', 'gherkin', 'extensions'] as $key) {
+        foreach (['modules', 'coverage', 'namespace', 'groups', 'env', 'gherkin', 'extensions', 'seed'] as $key) {
             if (isset($config[$key])) {
                 $globalConf[$key] = $config[$key];
             }


### PR DESCRIPTION
Adds the current seed to the suite configuration so it can be used in modules. This for example allows for a Faker module to generate reproducible data when a seed is given, much like is done with shuffle.

Example:
```php
<?php

class ApiHelper extends \Codeception\Module
{
    protected $seed = null;

    public function _beforeSuite($settings = [])
    {
        $this->seed = $settings['seed'];
    }

    // ...
```