### PR TITLE
Lumen 5.5+ (5.3+ backward compatible) support for getRoutes method

### DIFF
--- a/src/Codeception/Module/Lumen.php
+++ b/src/Codeception/Module/Lumen.php
@@ -220,16 +220,18 @@ class Lumen extends Framework implements ActiveRecord, PartedModule
      */
     private function getRouteByName($routeName)
     {
-        foreach ($this->app->getRoutes() as $route) {
-            if ($route['method'] != 'GET') {
-                return;
-            }
-
+        if (isset($this->app->router) && $this->app->router instanceof \Laravel\Lumen\Routing\Router) {
+            $router = $this->app->router;
+        } else {
+            // backward compatibility with lumen 5.3
+            $router = $this->app;
+        }
+        foreach ($router->getRoutes() as $route) {
             if (isset($route['action']['as']) && $route['action']['as'] == $routeName) {
                 return $route;
             }
         }
-
+        $this->fail("Route with name '$routeName' does not exist");
         return null;
     }
 


### PR DESCRIPTION
Added Lumen 5.5+ (5.3+ backward compatible) support for getRoutes method in Lumen module.

On Lumen 5.5+ do a breaking change on commit https://github.com/laravel/lumen-framework/commit/7018d57d684e7e63bcef9576bc718e9ad75feb0c
This change generate a fatal error on method $this->amOnRoute('simple-route');

```bash
[Error] Call to undefined method Laravel\Lumen\Application::getRoutes()
```
