### PR TITLE
Updating Phalcon Module To Be Able To Override MemorySession Class

### DIFF
--- a/docs/modules/Phalcon.md
+++ b/docs/modules/Phalcon.md
@@ -22,6 +22,7 @@ The following configurations are required for this module:
 * cleanup: `boolean`, default `true` - all database queries will be run in a transaction,
   which will be rolled back at the end of each test
 * savepoints: `boolean`, default `true` - use savepoints to emulate nested transactions
+* session: `string`, default `\Codeception\Lib\Connector\Phalcon\MemorySession` - set the class to load for simulating the session. You can also override this using `$di->set(MemorySession::class, MyAwesomeFakeSession::class)`
 
 The application bootstrap file must return Application object but not call its handle() method.
 

--- a/src/Codeception/Module/Phalcon.php
+++ b/src/Codeception/Module/Phalcon.php
@@ -91,6 +91,7 @@ class Phalcon extends Framework implements ActiveRecord, PartedModule
         'bootstrap'  => 'app/config/bootstrap.php',
         'cleanup'    => true,
         'savepoints' => true,
+        'session'    => PhalconConnector\MemorySession::class
     ];
 
     /**
@@ -158,7 +159,7 @@ class Phalcon extends Framework implements ActiveRecord, PartedModule
 
         if ($this->di->has('session')) {
             // Destroy existing sessions of previous tests
-            $this->di['session'] = new PhalconConnector\MemorySession();
+            $this->di['session'] = $this->di->get($this->config['session']);
         }
 
         if ($this->di->has('cookies')) {


### PR DESCRIPTION
The Phalcon Module uses the supplied MemorySession class for the session object. The problem I've found with this is that I tend to extend session and add helper methods to the extensions. These end up breaking in testing because the methods aren't there. To get around this, I have to add extra module code to override the session after init.

This PR adds a new config to the module to allow setting the class name to use for the session. It also updates it so that Phalcon users can use the built in service override of Phalcon's DIC.