### PR TITLE
Bugfix issue #5163

### DIFF
--- a/src/Codeception/Step.php
+++ b/src/Codeception/Step.php
@@ -174,7 +174,7 @@ abstract class Step
     {
         if ($argument instanceof \Closure) {
             return 'Closure';
-        } elseif (in_array(MockObject::class, class_implements(get_class($argument)))) {
+span class="pl-s1">         } elseif ($argument instanceof MockObject) {
             return $this->formatClassName($argument->__mocked);
         }
 

--- a/src/Codeception/Step.php
+++ b/src/Codeception/Step.php
@@ -5,6 +5,7 @@ use Codeception\Lib\ModuleContainer;
 use Codeception\Step\Argument\FormattedOutput;
 use Codeception\Step\Meta as MetaStep;
 use Codeception\Util\Locator;
+use PHPUnit\Framework\MockObject\MockObject;
 
 abstract class Step
 {
@@ -173,7 +174,7 @@ abstract class Step
     {
         if ($argument instanceof \Closure) {
             return 'Closure';
-        } elseif ((isset($argument->__mocked))) {
+        } elseif (in_array(MockObject::class, class_implements(get_class($argument)))) {
             return $this->formatClassName($argument->__mocked);
         }
 

--- a/src/Codeception/Step.php
+++ b/src/Codeception/Step.php
@@ -174,7 +174,7 @@ abstract class Step
     {
         if ($argument instanceof \Closure) {
             return 'Closure';
-span class="pl-s1">         } elseif ($argument instanceof MockObject) {
+        } elseif ($argument instanceof MockObject) {
             return $this->formatClassName($argument->__mocked);
         }
 

--- a/src/Codeception/Step.php
+++ b/src/Codeception/Step.php
@@ -174,7 +174,7 @@ abstract class Step
     {
         if ($argument instanceof \Closure) {
             return 'Closure';
-        } elseif ($argument instanceof MockObject) {
+        } elseif ($argument instanceof MockObject && isset($argument->__mocked)) {
             return $this->formatClassName($argument->__mocked);
         }
 

--- a/tests/unit/Codeception/StepTest.php
+++ b/tests/unit/Codeception/StepTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use Codeception\Util\Stub;
 use Facebook\WebDriver\WebDriverBy;
 use Codeception\Util\Locator;
 
@@ -32,6 +33,9 @@ class StepTest extends \PHPUnit\Framework\TestCase
 
         $step = $this->getStep([null, [['PDO', 'getAvailableDrivers']]]);
         $this->assertEquals('["PDO","getAvailableDrivers"]', $step->getArgumentsAsString());
+
+        $step = $this->getStep([null, [[Stub::make($this, []), 'testGetArguments']]]);
+        $this->assertEquals('["StepTest","testGetArguments"]', $step->getArgumentsAsString());
     }
 
     public function testGetHtml()

--- a/tests/unit/Codeception/StepTest.php
+++ b/tests/unit/Codeception/StepTest.php
@@ -36,6 +36,11 @@ class StepTest extends \PHPUnit\Framework\TestCase
 
         $step = $this->getStep([null, [[Stub::make($this, []), 'testGetArguments']]]);
         $this->assertEquals('["StepTest","testGetArguments"]', $step->getArgumentsAsString());
+
+        $mock = $this->createMock(get_class($this));
+        $step = $this->getStep([null, [[$mock, 'testGetArguments']]]);
+        $className = get_class($mock);
+        $this->assertEquals('["' . $className . '","testGetArguments"]', $step->getArgumentsAsString());
     }
 
     public function testGetHtml()


### PR DESCRIPTION
@DavertMik Are you able to have a look at this and review? I understand @SamMousa suggested removing `__mocked` property but not sure if that's would be an "easy fix", so just checking if class is implementing `PHPUnit\Framework\MockObject\MockObject` interface.

Closes #5163