### PR TITLE
Added error_level to the global configuration

### DIFF
--- a/src/Codeception/Configuration.php
+++ b/src/Codeception/Configuration.php
@@ -309,7 +309,7 @@ class Configuration
 
         // load global config
         $globalConf = $config['settings'];
-        foreach (['modules', 'coverage', 'namespace', 'groups', 'env', 'gherkin', 'extensions'] as $key) {
+        foreach (['modules', 'coverage', 'namespace', 'groups', 'env', 'gherkin', 'extensions', 'error_level'] as $key) {
             if (isset($config[$key])) {
                 $globalConf[$key] = $config[$key];
             }


### PR DESCRIPTION
According to the documentation (https://codeception.com/docs/04-FunctionalTests#Error-Reporting), it should be possible to configure the error_level globally in the `codeception.yml`. But the config was not passed to the suite configurations.

> error_level can also be set globally in codeception.yml file