### PR TITLE
Reloading module on reconfigure to persist new configs

### DIFF
--- a/src/Codeception/Module/DataFactory.php
+++ b/src/Codeception/Module/DataFactory.php
@@ -198,6 +198,15 @@ EOF;
         return ['Codeception\Lib\Interfaces\ORM' => $this->dependencyMessage];
     }
 
+
+    /**
+     * @throws ModuleException
+     */
+    public function onReconfigure()
+    {
+        $this->_beforeSuite();
+    }
+
     /**
      * Creates a model definition. This can be used from a helper:.
      *

--- a/src/Codeception/Module/Doctrine2.php
+++ b/src/Codeception/Module/Doctrine2.php
@@ -115,6 +115,14 @@ EOF;
         }
     }
 
+    /**
+     * @throws ModuleConfigException
+     */
+    public function onReconfigure()
+    {
+        $this->retrieveEntityManager();
+    }
+
     protected function retrieveEntityManager()
     {
         if ($this->dependentModule) {

--- a/src/Codeception/Module/Symfony.php
+++ b/src/Codeception/Module/Symfony.php
@@ -221,6 +221,11 @@ class Symfony extends Framework implements DoctrineProvider, PartedModule
         parent::_after($test);
     }
 
+    public function onReconfigure()
+    {
+        $this->_beforeSuite();
+    }
+
     /**
      * Retrieve Entity Manager.
      *


### PR DESCRIPTION
I had a trouble when I was try to change by differents entity managers, e.g using DataFactory.
Always when I tried to change dinamicaly the entity manager by configs such as 
`$this->getModule('ModuleName')->_reconfigure(['field' => "value"]);`

It hadn't any effect then I figure out this solution. 