### PR TITLE
[Doctrine2] Making cleanup property work after on reconfigure

### DIFF
--- a/src/Codeception/Module/Doctrine2.php
+++ b/src/Codeception/Module/Doctrine2.php
@@ -108,6 +108,11 @@ EOF;
 
     public function _before(TestInterface $test)
     {
+        $this->init();
+    }
+
+    private function init()
+    {
         $this->retrieveEntityManager();
         if ($this->config['cleanup']) {
             $this->em->getConnection()->beginTransaction();
@@ -120,7 +125,8 @@ EOF;
      */
     public function onReconfigure()
     {
-        $this->retrieveEntityManager();
+        $this->finish();
+        $this->init();
     }
 
     protected function retrieveEntityManager()
@@ -156,7 +162,7 @@ EOF;
         $this->em->getConnection()->connect();
     }
 
-    public function _after(TestInterface $test)
+    private function finish()
     {
         if (!$this->em instanceof \Doctrine\ORM\EntityManagerInterface) {
             return;
@@ -172,6 +178,11 @@ EOF;
         }
         $this->clean();
         $this->em->getConnection()->close();
+    }
+
+    public function _after(TestInterface $test)
+    {
+        $this->finish();
     }
 
     protected function clean()


### PR DESCRIPTION
After last release the cleanup property on Doctrine2 module is not working when you try to reconfigure the module. 