### PR TITLE
[Db] hide isPopulated method

### DIFF
--- a/src/Codeception/Module/Db.php
+++ b/src/Codeception/Module/Db.php
@@ -639,7 +639,7 @@ class Db extends CodeceptionModule implements DbInterface
         }
     }
 
-    public function isPopulated()
+    public function _isPopulated()
     {
         return $this->databasesPopulated[$this->currentDatabase];
     }

--- a/tests/data/snapshots/tests/_support/_generated/DataTesterActions.php
+++ b/tests/data/snapshots/tests/_support/_generated/DataTesterActions.php
@@ -670,18 +670,7 @@ trait DataTesterActions
         return $this->getScenario()->runStep(new \Codeception\Step\Action('performInDatabase', func_get_args()));
     }
 
- 
-    /**
-     * [!] Method is generated. Documentation taken from corresponding module.
-     *
-     *
-     * @see \Codeception\Module\Db::isPopulated()
-     */
-    public function isPopulated() {
-        return $this->getScenario()->runStep(new \Codeception\Step\Action('isPopulated', func_get_args()));
-    }
 
- 
     /**
      * [!] Method is generated. Documentation taken from corresponding module.
      *

--- a/tests/unit/Codeception/Module/Db/TestsForDb.php
+++ b/tests/unit/Codeception/Module/Db/TestsForDb.php
@@ -20,7 +20,7 @@ abstract class TestsForDb extends \Codeception\Test\Unit
         $this->module = new \Codeception\Module\Db(make_container(), $config);
         $this->module->_beforeSuite();
         $this->module->_before(\Codeception\Util\Stub::makeEmpty('\Codeception\TestInterface'));
-        $this->assertTrue($this->module->isPopulated());
+        $this->assertTrue($this->module->_isPopulated());
     }
 
     protected function tearDown()
@@ -159,7 +159,7 @@ abstract class TestsForDb extends \Codeception\Test\Unit
     public function testLoadWithPopulator()
     {
         $this->module->_cleanup();
-        $this->assertFalse($this->module->isPopulated());
+        $this->assertFalse($this->module->_isPopulated());
         try {
             $this->module->seeInDatabase('users', ['name' => 'davert']);
         } catch (\PDOException $noTable) {
@@ -174,7 +174,7 @@ abstract class TestsForDb extends \Codeception\Test\Unit
             ]
         );
         $this->module->_loadDump();
-        $this->assertTrue($this->module->isPopulated());
+        $this->assertTrue($this->module->_isPopulated());
         $this->module->seeInDatabase('users', ['name' => 'davert']);
     }
     


### PR DESCRIPTION
I noticed that undocumented method `isPopulated` appears in [documentation](https://codeception.com/docs/modules/Db#isPopulated), but the only reason why it is public is that it is used in Codeception tests.

So I'm hiding it by renaming it to `_isPopulated`.