### PR TITLE
Fix "already initialized service", "reboot kernel issue"

### DIFF
--- a/src/Codeception/Lib/Connector/Symfony.php
+++ b/src/Codeception/Lib/Connector/Symfony.php
@@ -77,7 +77,7 @@ class Symfony extends \Symfony\Component\HttpKernel\Client
         $this->container = $this->kernel->getContainer();
 
         foreach ($this->persistentServices as $serviceName => $service) {
-            if(!$this->container->initialized($serviceName)) {
+            if (!$this->container->initialized($serviceName)) {
                 $this->container->set($serviceName, $service);
             }
         }

--- a/src/Codeception/Lib/Connector/Symfony.php
+++ b/src/Codeception/Lib/Connector/Symfony.php
@@ -36,6 +36,7 @@ class Symfony extends \Symfony\Component\HttpKernel\Client
         $this->followRedirects(true);
         $this->rebootable = (boolean)$rebootable;
         $this->persistentServices = $services;
+        $this->container = $this->kernel->getContainer();
         $this->rebootKernel();
     }
 
@@ -76,7 +77,9 @@ class Symfony extends \Symfony\Component\HttpKernel\Client
         $this->container = $this->kernel->getContainer();
 
         foreach ($this->persistentServices as $serviceName => $service) {
-            $this->container->set($serviceName, $service);
+            if(!$this->container->initialized($serviceName)) {
+                $this->container->set($serviceName, $service);
+            }
         }
 
         if ($this->container->has('profiler')) {


### PR DESCRIPTION
I have an issue. When i work with DataFactory and Doctrine2 modules, and when my testing services uses EntityManager - the instances of entity managers are different. Therefore DataFactory EntityManager knows about created entities through have() method. But my EntityManager is not. Also Doctrine2 cleanup service is not working, because all of them (DataFactory, Doctrine2, my service) use different connections and transactions. Because of this i have alot of bugs during testing.
I have investigated the issue. The reason is - codeception Symfony module rebooted the kernel and on first request services that was in kernel's container are lost. But this kernel's container still uses for App services.
There is code for persistent services, but, this is not works for first request. Because of Symfony module $this->container is empty, and kernel's container services are not saving. I'm suggest initialize $this->container variable from kernel first, and then perform rebootKernel method. Thus all persistent services from initial kernel can be saved and re-seted. This patch works and all bugs are gone. I spend a lot of time on these bugs. Now works DataFactory and Doctrine2 "cleanup" options together perfect.
Also i had another one bug. This is described in https://github.com/Codeception/Codeception/issues/4806. I'm suggest check that service is already initialized by perform "initialize" method. It works perfect. 
Also can i know why need reboot kernel on first request in Symfony module contructor?