### PR TITLE
Correct Windows entrypoint (codecept.bat)

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,7 +4,7 @@ platform: 'x86'
 branches:
   except:
     - gh-pages
-    
+
 cache:
   - c:\tools\php71 -> appveyor.yml
 
@@ -27,15 +27,15 @@ install:
   - SET PATH=C:\Program Files\PostgreSQL\9.3\bin\;%PATH%
   # php setup
   - IF EXIST c:\tools\php71 (SET PHP=0)
+  - ps: Set-Service wuauserv -StartupType Manual
   - IF %PHP%==1 cinst -y OpenSSL.Light
   - SET PATH=C:\Program Files\OpenSSL;%PATH%
   - cinst -y curl
   - SET PATH=C:\Program Files\curl;%PATH%
   - sc config wuauserv start= auto
-  - net start wuauserv
   - IF %PHP%==1 cinst -y php --version 7.1.14
   - IF %PHP%==1 cd c:\tools\php71
-  - IF %PHP%==1 copy php.ini-production php.ini  
+  - IF %PHP%==1 copy php.ini-production php.ini
   - IF %PHP%==1 echo extension_dir=ext >> php.ini
   - IF %PHP%==1 echo extension=php_openssl.dll >> php.ini
   - IF %PHP%==1 echo date.timezone="UTC" >> php.ini
@@ -55,5 +55,5 @@ before_test:
   - mysql -uroot -pPassword12! -e "CREATE DATABASE codeception_test"
 
 test_script:
-  - php codecept run cli --no-colors -n --skip-group coverage
-  - php codecept run unit -g core -g appveyor --no-colors -n
+  - codecept run cli --no-colors -n --skip-group coverage
+  - codecept run unit -g core -g appveyor --no-colors -n

--- a/codecept.bat
+++ b/codecept.bat
@@ -1,11 +1,7 @@
 @echo off
-if "%PHPBIN%" == "" set PHPBIN=@php_bin@
-if exist "codecept" goto INTERNAL
-if not exist "%PHPBIN%" if "%PHP_PEAR_PHP_BIN%" neq "" goto USE_PEAR_PATH
-GOTO RUN
-:USE_PEAR_PATH
-set PHPBIN=%PHP_PEAR_PHP_BIN%
-:RUN
-"%PHPBIN%" "@bin_dir@\codecept" %*
-:INTERNAL
+
+if "%PHP_PEAR_PHP_BIN%" neq "" (
+	set PHPBIN=%PHP_PEAR_PHP_BIN%
+) else set PHPBIN=php
+
 "%PHPBIN%" "codecept" %*


### PR DESCRIPTION
I simplified the `codecept.bat` file and removed `@var_name@` variables. The `@var_name@` vars should be replaced during a PHAR build. I think that `@var_name@` vars are not universal, and I am also not sure that they make sense (or even used) right now.

It's using `%PHP_PEAR_PHP_BIN%` because that's a global variable which may be set by PEAR. I just figure, if it's available anyway, why not use it; and in the other case, it will just try php, assuming most Windows users will have added that to their `PATH`.

These changes should be covered by ` appveyor.yml:test_script` (I hope).