### PR TITLE
Сleaned up autoload.php

### DIFF
--- a/autoload.php
+++ b/autoload.php
@@ -13,7 +13,7 @@ if (file_exists('./vendor/autoload.php') && file_exists($autoloadFile) && __FILE
     die;
 } elseif (file_exists(__DIR__ . '/vendor/autoload.php')) {
     // for phar
-    require_once(__DIR__ . '/vendor/autoload.php');
+    require_once __DIR__ . '/vendor/autoload.php';
 } elseif (file_exists(__DIR__ . '/../../autoload.php')) {
     //for composer
     require_once __DIR__ . '/../../autoload.php';


### PR DESCRIPTION
The `require_once` is a statement, not a function. Parentheses are unnecessary.