### PR TITLE
Make @dataProvider work with yield/generators

### DIFF
--- a/src/Codeception/Test/Loader/Cest.php
+++ b/src/Codeception/Test/Loader/Cest.php
@@ -63,6 +63,10 @@ class Cest implements LoaderInterface
                 if (!empty($dataMethod)) {
                     try {
                         $data = ReflectionHelper::invokePrivateMethod($unit, $dataMethod);
+                        if ($data instanceof \Traversable) {
+                            $data = iterator_to_array($data, false);
+                        }
+
                         // allow to mix example and dataprovider annotations
                         $examples = array_merge($examples, $data);
                     } catch (\ReflectionException $e) {

--- a/src/Codeception/Test/Loader/Cest.php
+++ b/src/Codeception/Test/Loader/Cest.php
@@ -63,12 +63,9 @@ class Cest implements LoaderInterface
                 if (!empty($dataMethod)) {
                     try {
                         $data = ReflectionHelper::invokePrivateMethod($unit, $dataMethod);
-                        if ($data instanceof \Traversable) {
-                            $data = iterator_to_array($data, false);
+                        foreach ($data as $example) {
+                            $examples[] = $example;
                         }
-
-                        // allow to mix example and dataprovider annotations
-                        $examples = array_merge($examples, $data);
                     } catch (\ReflectionException $e) {
                         throw new TestParseException(
                             $file,

--- a/tests/data/SimpleWithDataProviderArrayCest.php
+++ b/tests/data/SimpleWithDataProviderArrayCest.php
@@ -1,0 +1,26 @@
+<?php
+
+class SimpleWithDataProviderArrayCest
+{
+    /**
+     * @dataProvider getTestData
+     */
+    public function helloWorld(\CodeGuy $I, \Codeception\Example $example) {
+        $I->execute(function($example) {
+            if (!is_array($example)) {
+                return false;
+            }
+
+            return count($example);
+        })->seeResultEquals(2);
+    }
+
+    protected function getTestData()
+    {
+        return [
+            ['foo', 'bar'],
+            [1, 2],
+            [true, false],
+        ];
+    }
+}

--- a/tests/data/SimpleWithDataProviderArrayCest.php
+++ b/tests/data/SimpleWithDataProviderArrayCest.php
@@ -4,6 +4,9 @@ class SimpleWithDataProviderArrayCest
 {
     /**
      * @dataProvider getTestData
+     *
+     * @example ["fizz", "buzz"]
+     * @example [null, "test"]
      */
     public function helloWorld(\CodeGuy $I, \Codeception\Example $example) {
         $I->execute(function($example) {

--- a/tests/data/SimpleWithDataProviderYieldGeneratorCest.php
+++ b/tests/data/SimpleWithDataProviderYieldGeneratorCest.php
@@ -1,0 +1,27 @@
+<?php
+
+class SimpleWithDataProviderYieldGeneratorCest
+{
+    /**
+     * @dataProvider getTestData
+     */
+    public function helloWorld(\CodeGuy $I, \Codeception\Example $example) {
+        $I->execute(function($example) {
+            if (!is_array($example)) {
+                return false;
+            }
+
+            return count($example);
+        })->seeResultEquals(2);
+    }
+
+    /**
+     * @return Generator
+     */
+    protected function getTestData()
+    {
+        yield ['foo', 'bar'];
+        yield [1, 2];
+        yield [true, false];
+    }
+}

--- a/tests/data/SimpleWithDataProviderYieldGeneratorCest.php
+++ b/tests/data/SimpleWithDataProviderYieldGeneratorCest.php
@@ -4,6 +4,9 @@ class SimpleWithDataProviderYieldGeneratorCest
 {
     /**
      * @dataProvider getTestData
+     *
+     * @example ["fizz", "buzz"]
+     * @example [null, "test"]
      */
     public function helloWorld(\CodeGuy $I, \Codeception\Example $example) {
         $I->execute(function($example) {

--- a/tests/unit/Codeception/TestLoaderTest.php
+++ b/tests/unit/Codeception/TestLoaderTest.php
@@ -89,4 +89,14 @@ class TestLoaderTest extends \PHPUnit\Framework\TestCase
     {
         $this->assertContains($name, $testNames, "$name not found in tests");
     }
+
+    public function testDataProviderReturningArray()
+    {
+        $this->testLoader->loadTest('SimpleWithDataProviderArrayCest.php');
+        $tests = $this->testLoader->getTests();
+        /** @var \PHPUnit\Framework\DataProviderTestSuite $firstTest */
+        $firstTest = $tests[0];
+
+        $this->assertEquals(3, $firstTest->count());
+    }
 }

--- a/tests/unit/Codeception/TestLoaderTest.php
+++ b/tests/unit/Codeception/TestLoaderTest.php
@@ -97,7 +97,7 @@ class TestLoaderTest extends \PHPUnit\Framework\TestCase
         /** @var \PHPUnit\Framework\DataProviderTestSuite $firstTest */
         $firstTest = $tests[0];
 
-        $this->assertEquals(3, $firstTest->count());
+        $this->assertEquals(5, $firstTest->count());
     }
 
     public function testDataProviderReturningGenerator()
@@ -107,6 +107,6 @@ class TestLoaderTest extends \PHPUnit\Framework\TestCase
         /** @var \PHPUnit\Framework\DataProviderTestSuite $firstTest */
         $firstTest = $tests[0];
 
-        $this->assertEquals(3, $firstTest->count());
+        $this->assertEquals(5, $firstTest->count());
     }
 }

--- a/tests/unit/Codeception/TestLoaderTest.php
+++ b/tests/unit/Codeception/TestLoaderTest.php
@@ -99,4 +99,14 @@ class TestLoaderTest extends \PHPUnit\Framework\TestCase
 
         $this->assertEquals(3, $firstTest->count());
     }
+
+    public function testDataProviderReturningGenerator()
+    {
+        $this->testLoader->loadTest('SimpleWithDataProviderYieldGeneratorCest.php');
+        $tests = $this->testLoader->getTests();
+        /** @var \PHPUnit\Framework\DataProviderTestSuite $firstTest */
+        $firstTest = $tests[0];
+
+        $this->assertEquals(3, $firstTest->count());
+    }
 }


### PR DESCRIPTION
Some days ago I wanted to write a data provider for test examples using `yield` instead of returning an array directly. This way the data provider method returns a `Generator`. Sadly this resulted in an exception:

```[PHPUnit\Framework\Exception] array_merge(): Argument #2 is not an array```

I'd really like Codeception to be able to work with `yield` in data providers, too, so I took some time to look into it. Basically I added a check if what we get from the data provider method is a Traversable (e.g. a Generator) and if so, convert it to a plain old array which in turn works with the `array_merge`. Additionally I added some tests for this, too.

I'm not sure if this is the 'correct' way like I implemented the tests. I just looked at the existing tests and tried to adopt what was already there. So please just let me know what you think :)