### PR TITLE
Changes for upcoming Travis' infra migration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,3 @@
-sudo: false
-
 language: php
 matrix:
   fast_finish: true


### PR DESCRIPTION
See: https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration

Travis is deprecating the `sudo` keyword and moves everything to the same infrastructure (sudo really selects between two infrastructures).