### PR TITLE
Small fix - remove redundant word from docs

### DIFF
--- a/docs/06-ModulesAndHelpers.md
+++ b/docs/06-ModulesAndHelpers.md
@@ -35,7 +35,7 @@ modules:
 
 The FunctionalTester class has its methods defined in modules. Actually, it doesn't contain any of them,
 but rather acts as a proxy. It knows which module executes this action and passes parameters into it.
-To make your IDE see all of the FunctionalTester methods, you should run use the `codecept build` command.
+To make your IDE see all of the FunctionalTester methods, you should run the `codecept build` command.
 It generates method signatures from enabled modules and saves them into a trait which is included in an actor.
 In the current example, the `tests/support/_generated/FunctionalTesterActions.php` file will be generated.
 By default, Codeception automatically rebuilds the Actions trait on each change of the suite configuration.


### PR DESCRIPTION
Small fix - remove redundant word from docs