### PR TITLE
ArrayContainsComparator do not Intersect correctry Empty expected nested array

### DIFF
--- a/src/Codeception/Util/ArrayContainsComparator.php
+++ b/src/Codeception/Util/ArrayContainsComparator.php
@@ -108,7 +108,7 @@ class ArrayContainsComparator
         $ret = [];
         foreach ($commonKeys as $key) {
             $return = $this->arrayIntersectRecursive($arr1[$key], $arr2[$key]);
-            if ($return) {
+            if ($return !== false) {
                 $ret[$key] = $return;
                 continue;
             }

--- a/tests/unit/Codeception/Util/ArrayContainsComparatorTest.php
+++ b/tests/unit/Codeception/Util/ArrayContainsComparatorTest.php
@@ -264,4 +264,20 @@ class ArrayContainsComparatorTest extends \Codeception\Test\Unit
             . "+ " . var_export($comparator->getHaystack(), true)
         );
     }
+
+    /**
+     * @issue https://github.com/Codeception/Codeception/issues/5303
+     */
+    public function testContainsArrayComparesAssociativeArrayIntersectCorrectlyWhenExpectedArrayKeyIsEmptyArray()
+    {
+        $comparator = new ArrayContainsComparator([
+            'key' => [
+                'foo' => 'bar',
+            ],
+        ]);
+        $expectedArray = [
+            'key' => [],
+        ];
+        $this->assertTrue($comparator->containsArray($expectedArray));
+    }
 }


### PR DESCRIPTION
 - [x] Provide broken test for ArrayContainsComparator
 - [x] fix ArrayContainsComparator 

close #5303 