### PR TITLE
WebDriver: print curl error to debug output if webdriver failed to connect

### DIFF
--- a/src/Codeception/Module/WebDriver.php
+++ b/src/Codeception/Module/WebDriver.php
@@ -1446,6 +1446,7 @@ class WebDriver extends CodeceptionModule implements
             $this->setBaseElement();
             $this->initialWindowSize();
         } catch (WebDriverCurlException $e) {
+            codecept_debug('Curl error: ' . $e->getMessage());
             throw new ConnectionException("Can't connect to Webdriver at {$this->wdHost}. Please make sure that Selenium Server or PhantomJS is running.");
         }
     }


### PR DESCRIPTION
It will help to debug issues like #5193

Example of output:

```
- WebDriverTest: Am on subdomain
  Curl error: Curl error thrown for http POST to /session with params: {"desiredCapabilities":{"browserName":"chrome"}}

  Failed to connect to 127.0.0.1 port 4444: Connection refused
  WebDriver::debugWebDriverLogs method has been called when webDriver is not set
  WebDriver::_saveScreenshot method has been called when webDriver is not set
  WebDriver::_savePageSource method has been called when webDriver is not set
  Screenshot and page source were saved into '/c/Projects/Codeception/tests/log/' dir
E WebDriverTest: Am on subdomain
```