### PR TITLE
[JsonType] Fixed issue #5320

### DIFF
--- a/src/Codeception/Util/JsonType.php
+++ b/src/Codeception/Util/JsonType.php
@@ -130,10 +130,10 @@ class JsonType
                 continue;
             }
 
-            $regexMatcher = '/:regex\(((.).*?\2)\)/';
+            $regexMatcher = '/:regex\((((\()|(\{)|(\[)|(<)|(.)).*?(?(3)\)|(?(4)\}|(?(5)\]|(?(6)>|\7)))))\)/';
             $regexes = [];
 
-            // Match the string ':regex(' and any characters until a regex delimiter (matches 99.999% use cases) followed by character ')'
+            // Match the string ':regex(' and any characters until a ending regex delimiter followed by character ')'
             // Place the 'any character' + delimiter matches in to an array.
             preg_match_all($regexMatcher, $type, $regexes);
 

--- a/tests/unit/Codeception/Util/JsonTypeTest.php
+++ b/tests/unit/Codeception/Util/JsonTypeTest.php
@@ -239,4 +239,14 @@ class JsonTypeTest extends \Codeception\Test\Unit
         // currently produces a false negative
         $this->assertTrue($jsonType->matches(['test'    => 'string:regex(~^(\d\d@):\d\d$~)|integer']));
     }
+
+    public function testRegexFilterWithSpecialDelimiters()
+    {
+        $jsonType = new JsonType(['test' => 'xyz']);
+
+        $this->assertTrue($jsonType->matches(['test' => 'string:regex([xyz])']));
+        $this->assertTrue($jsonType->matches(['test' => 'string:regex({xyz})']));
+        $this->assertTrue($jsonType->matches(['test' => 'string:regex(<xyz>)']));
+        $this->assertTrue($jsonType->matches(['test' => 'string:regex((xyz))']));
+    }
 }


### PR DESCRIPTION
I changed regex matcher to use the first character after `regex(` as a delimiter (back reference `\2`),
so it matches pattern from `regex(~` until nearest `~)`,

Thanks to @Tenzian for reporting and test code.

@ellisgl Do you see any potential issues that this change could cause?