### PR TITLE
Fix XPath example

### DIFF
--- a/docs/modules/PhpBrowser.md
+++ b/docs/modules/PhpBrowser.md
@@ -288,7 +288,7 @@ $I->click('Submit');
 // CSS button
 $I->click('#form input[type=submit]');
 // XPath
-$I->click('//form/*[@type=submit]');
+$I->click('//form/*[@type="submit"]');
 // link in context
 $I->click('Logout', '#nav');
 // using strict locator


### PR DESCRIPTION
XPath does not work without `"`. 

Just test something like `$I->click('//form[1]/button[@type=submit]')` vs  `$I->click('//form[1]/button[@type="submit"]');`. The first will not find the button submit.