### PR TITLE
update docs and web test config to use goog:chromeOptions

### DIFF
--- a/docs/modules/WebDriver.md
+++ b/docs/modules/WebDriver.md
@@ -45,10 +45,10 @@ To run tests in Chrome browser you may connect to ChromeDriver directly, without
              port: 9515
              browser: chrome
              capabilities:
-                 chromeOptions: # additional chrome options
+                 "goog:chromeOptions": # additional chrome options
 ```
 
-Additional [Chrome options](https://sites.google.com/a/chromium.org/chromedriver/capabilities) can be set in `chromeOptions` capabilities.
+Additional [Chrome options](https://sites.google.com/a/chromium.org/chromedriver/capabilities) can be set in `goog:chromeOptions` capabilities. Note that Selenium 3.8 renamed this capability from `chromeOptions` to `goog:chromeOptions`.
 
 
 ### PhantomJS

--- a/src/Codeception/Module/WebDriver.php
+++ b/src/Codeception/Module/WebDriver.php
@@ -95,10 +95,10 @@ use Symfony\Component\DomCrawler\Crawler;
  *              port: 9515
  *              browser: chrome
  *              capabilities:
- *                  chromeOptions: # additional chrome options
+ *                  "goog:chromeOptions": # additional chrome options
  * ```
  *
- * Additional [Chrome options](https://sites.google.com/a/chromium.org/chromedriver/capabilities) can be set in `chromeOptions` capabilities.
+ * Additional [Chrome options](https://sites.google.com/a/chromium.org/chromedriver/capabilities) can be set in `goog:chromeOptions` capabilities. Note that Selenium 3.8 renamed this capability from `chromeOptions` to `goog:chromeOptions`.
  *
  *
  * ### PhantomJS

--- a/tests/web.suite.yml
+++ b/tests/web.suite.yml
@@ -32,7 +32,7 @@ env:
           window_size: false
           restart: false
           capabilities:
-            chromeOptions:
+            "goog:chromeOptions":
               args: ["--headless", "--disable-gpu", "--disable-extensions"]
               binary: "/usr/bin/google-chrome"
   chromedriver:
@@ -43,6 +43,6 @@ env:
           port: 9515 # ChromeDriver port
           window_size: false
           capabilities:
-            chromeOptions:
+            "goog:chromeOptions":
               args: ["--headless", "--disable-gpu"]
               binary: "/usr/bin/google-chrome"


### PR DESCRIPTION
This PR updates the documentation to refer to the capability `chromeOptions` that was changed in Selenium 3.8 to `goog:chromeOptions`.

Fixes #5348 