### PR TITLE
Fix persistent service for Symfony 3

### DIFF
--- a/src/Codeception/Lib/Connector/Symfony.php
+++ b/src/Codeception/Lib/Connector/Symfony.php
@@ -77,8 +77,11 @@ class Symfony extends \Symfony\Component\HttpKernel\Client
         $this->container = $this->kernel->getContainer();
 
         foreach ($this->persistentServices as $serviceName => $service) {
-            if (!$this->container->initialized($serviceName)) {
+            try {
                 $this->container->set($serviceName, $service);
+            } catch (\InvalidArgumentException $e) {
+                //Private services can't be set in Symfony 4
+                codecept_debug("[Symfony] Can't set persistent service $serviceName: " . $e->getMessage());
             }
         }
 


### PR DESCRIPTION
Improvement over #5262

This way persistent services keep working for Symfony 3 the way they worked before.
Exceptions thrown by Symfony 4 are caught and ignored.

Closes #5362