### PR TITLE
Updated release script

### DIFF
--- a/RoboFile.php
+++ b/RoboFile.php
@@ -11,8 +11,8 @@ class RoboFile extends \Robo\Tasks
 
     public function release()
     {
-        $this->say("CODECEPTION RELEASE: ".\Codeception\Codecept::VERSION);
         $this->versionBump();
+        $this->say("CODECEPTION RELEASE: ".\Codeception\Codecept::VERSION);
         $this->update();
         $this->buildDocs();
         $this->publishDocs();
@@ -35,6 +35,11 @@ class RoboFile extends \Robo\Tasks
         $this->taskReplaceInFile('src/Codeception/Codecept.php')
             ->from(\Codeception\Codecept::VERSION)
             ->to($version)
+            ->run();
+        $this->taskGitStack()
+            ->add('src/Codeception/Codecept.php')
+            ->commit("Bumped version to $version")
+            ->push()
             ->run();
     }
 


### PR DESCRIPTION
1. Commit version bump to git
2. Print version number after version bump, because if it is autoloaded before bump,
codeception/base is released using previous version number