### PR TITLE
Restore compatility with vlucas/phpdotenv v2

### DIFF
--- a/src/Codeception/Lib/ParamsLoader.php
+++ b/src/Codeception/Lib/ParamsLoader.php
@@ -115,7 +115,13 @@ class ParamsLoader
     protected function loadDotEnvFile()
     {
         if (class_exists('Dotenv\Dotenv')) {
-            $dotEnv = \Dotenv\Dotenv::create(codecept_root_dir(), $this->paramStorage);
+            if (method_exists('Dotenv\Dotenv', 'create')) {
+                //dotenv v3
+                $dotEnv = \Dotenv\Dotenv::create(codecept_root_dir(), $this->paramStorage);
+            } else {
+                //dotenv v2
+                $dotEnv = new \Dotenv\Dotenv(codecept_root_dir(), $this->paramStorage);
+            }
             $dotEnv->load();
             return $_SERVER;
         } elseif (class_exists('Symfony\Component\Dotenv\Dotenv')) {


### PR DESCRIPTION
`vlucas/phpdotenv` is a `require-dev` dependency for Codeception, so it does not enforce constraint on projects that are using Codeception.
Fot this reason we must keep backwards compatility with `vlucas/phpdotenv` v2.

Fixes https://github.com/lucatume/wp-browser/issues/210
Fixes #5380