### PR TITLE
A http 204 response indicates no content

### DIFF
--- a/src/Codeception/Lib/Connector/Yii2.php
+++ b/src/Codeception/Lib/Connector/Yii2.php
@@ -352,7 +352,12 @@ class Yii2 extends Client
         }
 
         $content = ob_get_clean();
-        if (empty($content) && !empty($response->content) && !isset($response->stream)) {
+        if (
+            $response->statusCode !== 204
+            && empty($content)
+            && !empty($response->content)
+            && !isset($response->stream)
+        ) {
             throw new \Exception('No content was sent from Yii application');
         }
 


### PR DESCRIPTION
This fixes an issue where the Yii module incorrectly throws an exception because the response content is empty