### PR TITLE
[ZendExpressive] Application recreate config entries are mixed up

### DIFF
--- a/src/Codeception/Exception/ElementNotFound.php
+++ b/src/Codeception/Exception/ElementNotFound.php
@@ -7,7 +7,9 @@ class ElementNotFound extends \PHPUnit\Framework\AssertionFailedError
 {
     public function __construct($selector, $message = null)
     {
-        $selector = Locator::humanReadableString($selector);
+        if (!is_string($selector) || $selector[0] !== "'") {
+            $selector = Locator::humanReadableString($selector);
+        }
         parent::__construct($message . " element with $selector was not found.");
     }
 }

--- a/src/Codeception/Lib/Connector/ZendExpressive.php
+++ b/src/Codeception/Lib/Connector/ZendExpressive.php
@@ -91,7 +91,7 @@ class ZendExpressive extends Client
         $cwd = getcwd();
         chdir(codecept_root_dir());
 
-        if ($this->config['recreateApplicationBetweenTests'] === true || $this->application === null) {
+        if ($this->config['recreateApplicationBetweenRequests'] === true || $this->application === null) {
             $application = $this->initApplication();
         } else {
             $application = $this->application;

--- a/src/Codeception/Lib/InnerBrowser.php
+++ b/src/Codeception/Lib/InnerBrowser.php
@@ -144,7 +144,7 @@ class InnerBrowser extends Module implements Web, PageSourceSaver, ElementLocato
      * // in Helper class
      * public function seeResponseContains($text)
      * {
-     *    $this->assertContains($text, $this->getModule('{{MODULE_NAME}}')->_getResponseContent(), "response contains");
+     *    $this->assertStringContainsString($text, $this->getModule('{{MODULE_NAME}}')->_getResponseContent(), "response contains");
      * }
      * ?>
      * ```
@@ -546,12 +546,12 @@ class InnerBrowser extends Module implements Web, PageSourceSaver, ElementLocato
 
     public function seeInCurrentUrl($uri)
     {
-        $this->assertContains($uri, $this->_getCurrentUri());
+        $this->assertStringContainsString($uri, $this->_getCurrentUri());
     }
 
     public function dontSeeInCurrentUrl($uri)
     {
-        $this->assertNotContains($uri, $this->_getCurrentUri());
+        $this->assertStringNotContainsString($uri, $this->_getCurrentUri());
     }
 
     public function seeCurrentUrlEquals($uri)
@@ -1662,7 +1662,7 @@ class InnerBrowser extends Module implements Web, PageSourceSaver, ElementLocato
         if (!$nodes->count()) {
             throw new ElementNotFound("<title>", "Tag");
         }
-        $this->assertContains($title, $nodes->first()->text(), "page title contains $title");
+        $this->assertStringContainsString($title, $nodes->first()->text(), "page title contains $title");
     }
 
     public function dontSeeInTitle($title)
@@ -1672,7 +1672,7 @@ class InnerBrowser extends Module implements Web, PageSourceSaver, ElementLocato
             $this->assertTrue(true);
             return;
         }
-        $this->assertNotContains($title, $nodes->first()->text(), "page title contains $title");
+        $this->assertStringNotContainsString($title, $nodes->first()->text(), "page title contains $title");
     }
 
     protected function assertDomContains($nodes, $message, $text = '')

--- a/src/Codeception/Module/AMQP.php
+++ b/src/Codeception/Module/AMQP.php
@@ -315,7 +315,7 @@ class AMQP extends CodeceptionModule implements RequiresPackage
             $this->fail("Received message is not format of AMQPMessage");
         }
         $this->debugSection("Message", $msg->body);
-        $this->assertContains($text, $msg->body);
+        $this->assertStringContainsString($text, $msg->body);
     }
 
     /**

--- a/src/Codeception/Module/Filesystem.php
+++ b/src/Codeception/Module/Filesystem.php
@@ -150,7 +150,7 @@ class Filesystem extends CodeceptionModule
      */
     public function seeInThisFile($text)
     {
-        $this->assertContains($text, $this->file, "No text '$text' in currently opened file");
+        $this->assertStringContainsString($text, $this->file, "No text '$text' in currently opened file");
     }
 
     /**
@@ -221,7 +221,7 @@ class Filesystem extends CodeceptionModule
      */
     public function dontSeeInThisFile($text)
     {
-        $this->assertNotContains($text, $this->file, "Found text '$text' in currently opened file");
+        $this->assertStringNotContainsString($text, $this->file, "Found text '$text' in currently opened file");
     }
 
     /**

--- a/src/Codeception/Module/Laravel5.php
+++ b/src/Codeception/Module/Laravel5.php
@@ -734,7 +734,7 @@ class Laravel5 extends Framework implements ActiveRecord, PartedModule
         }
 
         if (! is_null($expectedErrorMessage)) {
-            $this->assertContains($expectedErrorMessage, $viewErrorBag->first($key));
+            $this->assertStringContainsString($expectedErrorMessage, $viewErrorBag->first($key));
         }
     }
 

--- a/src/Codeception/Module/REST.php
+++ b/src/Codeception/Module/REST.php
@@ -750,7 +750,7 @@ EOF;
      */
     public function seeResponseContains($text)
     {
-        $this->assertContains($text, $this->connectionModule->_getResponseContent(), "REST response contains");
+        $this->assertStringContainsString($text, $this->connectionModule->_getResponseContent(), "REST response contains");
     }
 
     /**
@@ -762,7 +762,7 @@ EOF;
      */
     public function dontSeeResponseContains($text)
     {
-        $this->assertNotContains($text, $this->connectionModule->_getResponseContent(), "REST response contains");
+        $this->assertStringNotContainsString($text, $this->connectionModule->_getResponseContent(), "REST response contains");
     }
 
     /**
@@ -1347,7 +1347,7 @@ EOF;
      */
     public function seeXmlResponseIncludes($xml)
     {
-        $this->assertContains(
+        $this->assertStringContainsString(
             XmlUtils::toXml($xml)->C14N(),
             XmlUtils::toXml($this->connectionModule->_getResponseContent())->C14N(),
             "found in XML Response"
@@ -1364,7 +1364,7 @@ EOF;
      */
     public function dontSeeXmlResponseIncludes($xml)
     {
-        $this->assertNotContains(
+        $this->assertStringNotContainsString(
             XmlUtils::toXml($xml)->C14N(),
             XmlUtils::toXml($this->connectionModule->_getResponseContent())->C14N(),
             "found in XML Response"

--- a/src/Codeception/Module/SOAP.php
+++ b/src/Codeception/Module/SOAP.php
@@ -312,7 +312,7 @@ EOF;
     public function dontSeeSoapResponseIncludes($xml)
     {
         $xml = $this->canonicalize($xml);
-        $this->assertNotContains($xml, $this->getXmlResponse()->C14N(), "found in XML Response");
+        $this->assertStringNotContainsString($xml, $this->getXmlResponse()->C14N(), "found in XML Response");
     }
 
     /**

--- a/src/Codeception/Module/WebDriver.php
+++ b/src/Codeception/Module/WebDriver.php
@@ -1152,7 +1152,7 @@ class WebDriver extends CodeceptionModule implements
 
     public function seeInCurrentUrl($uri)
     {
-        $this->assertContains($uri, $this->_getCurrentUri());
+        $this->assertStringContainsString($uri, $this->_getCurrentUri());
     }
 
     public function seeCurrentUrlEquals($uri)
@@ -1167,7 +1167,7 @@ class WebDriver extends CodeceptionModule implements
 
     public function dontSeeInCurrentUrl($uri)
     {
-        $this->assertNotContains($uri, $this->_getCurrentUri());
+        $this->assertStringNotContainsString($uri, $this->_getCurrentUri());
     }
 
     public function dontSeeCurrentUrlEquals($uri)
@@ -1889,12 +1889,12 @@ class WebDriver extends CodeceptionModule implements
 
     public function seeInTitle($title)
     {
-        $this->assertContains($title, $this->webDriver->getTitle());
+        $this->assertStringContainsString($title, $this->webDriver->getTitle());
     }
 
     public function dontSeeInTitle($title)
     {
-        $this->assertNotContains($title, $this->webDriver->getTitle());
+        $this->assertStringNotContainsString($title, $this->webDriver->getTitle());
     }
 
     /**
@@ -1936,7 +1936,7 @@ class WebDriver extends CodeceptionModule implements
         }
         $alert = $this->webDriver->switchTo()->alert();
         try {
-            $this->assertContains($text, $alert->getText());
+            $this->assertStringContainsString($text, $alert->getText());
         } catch (\PHPUnit\Framework\AssertionFailedError $e) {
             $alert->dismiss();
             throw $e;
@@ -1958,7 +1958,7 @@ class WebDriver extends CodeceptionModule implements
         }
         $alert = $this->webDriver->switchTo()->alert();
         try {
-            $this->assertNotContains($text, $alert->getText());
+            $this->assertStringNotContainsString($text, $alert->getText());
         } catch (\PHPUnit\Framework\AssertionFailedError $e) {
             $alert->dismiss();
             throw $e;

--- a/src/Codeception/Util/Shared/Asserts.php
+++ b/src/Codeception/Util/Shared/Asserts.php
@@ -163,6 +163,16 @@ trait Asserts
         \PHPUnit\Framework\Assert::assertNotContains($needle, $haystack, $message);
     }
 
+    protected function assertStringContainsString($needle, $haystack, $message = '')
+    {
+        \Codeception\PHPUnit\TestCase::assertStringContainsString($needle, $haystack, $message = '');
+    }
+
+    protected function assertStringNotContainsString($needle, $haystack, $message = '')
+    {
+        \Codeception\PHPUnit\TestCase::assertStringNotContainsString($needle, $haystack, $message = '');
+    }
+
     /**
      * Checks that string match with pattern
      *

--- a/tests/unit/Codeception/ApplicationTest.php
+++ b/tests/unit/Codeception/ApplicationTest.php
@@ -2,7 +2,7 @@
 
 namespace Codeception;
 
-class ApplicationTest extends \PHPUnit\Framework\TestCase
+class ApplicationTest extends \Codeception\PHPUnit\TestCase
 {
 
     public static function _setUpBeforeClass()

--- a/tests/unit/Codeception/Command/BuildTest.php
+++ b/tests/unit/Codeception/Command/BuildTest.php
@@ -19,21 +19,21 @@ class BuildTest extends BaseCommandRunner
     public function testBuild()
     {
         $this->execute();
-        $this->assertContains('class HobbitGuy extends \Codeception\Actor', $this->content);
+        $this->assertStringContainsString('class HobbitGuy extends \Codeception\Actor', $this->content);
         // inherited methods from Actor
-        $this->assertContains('@method void wantTo($text)', $this->content);
-        $this->assertContains('@method void expectTo($prediction)', $this->content);
+        $this->assertStringContainsString('@method void wantTo($text)', $this->content);
+        $this->assertStringContainsString('@method void expectTo($prediction)', $this->content);
 
         $this->content = $this->log[0]['content'];
         // methods from Filesystem module
-        $this->assertContains('public function amInPath($path)', $this->content);
-        $this->assertContains('public function copyDir($src, $dst)', $this->content);
-        $this->assertContains('public function seeInThisFile($text)', $this->content);
+        $this->assertStringContainsString('public function amInPath($path)', $this->content);
+        $this->assertStringContainsString('public function copyDir($src, $dst)', $this->content);
+        $this->assertStringContainsString('public function seeInThisFile($text)', $this->content);
 
         // methods from EmulateHelper
-        $this->assertContains('public function seeEquals($expected, $actual)', $this->content);
+        $this->assertStringContainsString('public function seeEquals($expected, $actual)', $this->content);
 
-        $this->assertContains('HobbitGuyActions.php generated successfully.', $this->output);
+        $this->assertStringContainsString('HobbitGuyActions.php generated successfully.', $this->output);
         $this->assertIsValidPhp($this->content);
     }
 
@@ -41,9 +41,9 @@ class BuildTest extends BaseCommandRunner
     {
         $this->config['namespace'] = 'Shire';
         $this->execute();
-        $this->assertContains('namespace Shire;', $this->content);
-        $this->assertContains('class HobbitGuy extends \Codeception\Actor', $this->content);
-        $this->assertContains('use _generated\HobbitGuyActions;', $this->content);
+        $this->assertStringContainsString('namespace Shire;', $this->content);
+        $this->assertStringContainsString('class HobbitGuy extends \Codeception\Actor', $this->content);
+        $this->assertStringContainsString('use _generated\HobbitGuyActions;', $this->content);
         $this->assertIsValidPhp($this->content);
     }
 }

--- a/tests/unit/Codeception/Command/GenerateCeptTest.php
+++ b/tests/unit/Codeception/Command/GenerateCeptTest.php
@@ -17,8 +17,8 @@ class GenerateCeptTest extends BaseCommandRunner
     {
         $this->execute(array('suite' => 'shire', 'test' => 'HomeCanInclude12Dwarfs'));
         $this->assertEquals($this->filename, 'tests/shire/HomeCanInclude12DwarfsCept.php');
-        $this->assertContains('$I = new HobbitGuy($scenario);', $this->content);
-        $this->assertContains('Test was created in tests/shire/HomeCanInclude12DwarfsCept.php', $this->output);
+        $this->assertStringContainsString('$I = new HobbitGuy($scenario);', $this->content);
+        $this->assertStringContainsString('Test was created in tests/shire/HomeCanInclude12DwarfsCept.php', $this->output);
         $this->assertIsValidPhp($this->content);
     }
 
@@ -47,8 +47,8 @@ class GenerateCeptTest extends BaseCommandRunner
         $this->config['namespace'] = 'MiddleEarth';
         $this->execute(array('suite' => 'shire', 'test' => 'HomeCanInclude12Dwarfs'));
         $this->assertEquals($this->filename, 'tests/shire/HomeCanInclude12DwarfsCept.php');
-        $this->assertContains('use MiddleEarth\HobbitGuy;', $this->content);
-        $this->assertContains('$I = new HobbitGuy($scenario);', $this->content);
+        $this->assertStringContainsString('use MiddleEarth\HobbitGuy;', $this->content);
+        $this->assertStringContainsString('$I = new HobbitGuy($scenario);', $this->content);
         $this->assertIsValidPhp($this->content);
     }
 }

--- a/tests/unit/Codeception/Command/GenerateCestTest.php
+++ b/tests/unit/Codeception/Command/GenerateCestTest.php
@@ -21,10 +21,10 @@ class GenerateCestTest extends BaseCommandRunner
         $this->execute(array('suite' => 'shire', 'class' => 'HallUnderTheHill'));
         $this->assertEquals('tests/shire/HallUnderTheHillCest.php', $this->filename);
 
-        $this->assertContains('class HallUnderTheHillCest', $this->content);
-        $this->assertContains('public function _before(HobbitGuy $I)', $this->content);
-        $this->assertContains('public function tryToTest(HobbitGuy $I)', $this->content);
-        $this->assertContains('Test was created in tests/shire/HallUnderTheHillCest.php', $this->output);
+        $this->assertStringContainsString('class HallUnderTheHillCest', $this->content);
+        $this->assertStringContainsString('public function _before(HobbitGuy $I)', $this->content);
+        $this->assertStringContainsString('public function tryToTest(HobbitGuy $I)', $this->content);
+        $this->assertStringContainsString('Test was created in tests/shire/HallUnderTheHillCest.php', $this->output);
     }
 
     /**
@@ -34,9 +34,9 @@ class GenerateCestTest extends BaseCommandRunner
     {
         $this->config['namespace'] = 'Shire';
         $this->execute(array('suite' => 'shire', 'class' => 'HallUnderTheHill'));
-        $this->assertContains('namespace Shire;', $this->content);
-        $this->assertContains('use Shire\HobbitGuy;', $this->content);
-        $this->assertContains('class HallUnderTheHillCest', $this->content);
+        $this->assertStringContainsString('namespace Shire;', $this->content);
+        $this->assertStringContainsString('use Shire\HobbitGuy;', $this->content);
+        $this->assertStringContainsString('class HallUnderTheHillCest', $this->content);
     }
 
     /**
@@ -63,9 +63,9 @@ class GenerateCestTest extends BaseCommandRunner
         $this->config['namespace'] = 'MiddleEarth';
         $this->execute(array('suite' => 'shire', 'class' => 'HallUnderTheHillCest'));
         $this->assertEquals($this->filename, 'tests/shire/HallUnderTheHillCest.php');
-        $this->assertContains('namespace MiddleEarth;', $this->content);
-        $this->assertContains('use MiddleEarth\\HobbitGuy;', $this->content);
-        $this->assertContains('public function tryToTest(HobbitGuy $I)', $this->content);
+        $this->assertStringContainsString('namespace MiddleEarth;', $this->content);
+        $this->assertStringContainsString('use MiddleEarth\\HobbitGuy;', $this->content);
+        $this->assertStringContainsString('public function tryToTest(HobbitGuy $I)', $this->content);
         $this->assertIsValidPhp($this->content);
     }
 
@@ -73,9 +73,9 @@ class GenerateCestTest extends BaseCommandRunner
     {
         $this->execute(array('suite' => 'shire', 'class' => 'MiddleEarth\HallUnderTheHillCest'));
         $this->assertEquals('tests/shire/MiddleEarth/HallUnderTheHillCest.php', $this->filename);
-        $this->assertContains('namespace MiddleEarth;', $this->content);
-        $this->assertContains('class HallUnderTheHillCest', $this->content);
-        $this->assertContains('Test was created in tests/shire/MiddleEarth/HallUnderTheHillCest.php', $this->output);
+        $this->assertStringContainsString('namespace MiddleEarth;', $this->content);
+        $this->assertStringContainsString('class HallUnderTheHillCest', $this->content);
+        $this->assertStringContainsString('Test was created in tests/shire/MiddleEarth/HallUnderTheHillCest.php', $this->output);
     }
 
     public function testGenerateWithSuiteNamespace()
@@ -85,9 +85,9 @@ class GenerateCestTest extends BaseCommandRunner
         $this->config['actor'] = 'HobbitGuy';
         $this->execute(array('suite' => 'shire', 'class' => 'HallUnderTheHillCest'));
         $this->assertEquals($this->filename, 'tests/shire/HallUnderTheHillCest.php');
-        $this->assertContains('namespace MiddleEarth\\Bosses;', $this->content);
-        $this->assertContains('use MiddleEarth\\HobbitGuy', $this->content);
-        $this->assertContains('public function tryToTest(HobbitGuy $I)', $this->content);
+        $this->assertStringContainsString('namespace MiddleEarth\\Bosses;', $this->content);
+        $this->assertStringContainsString('use MiddleEarth\\HobbitGuy', $this->content);
+        $this->assertStringContainsString('public function tryToTest(HobbitGuy $I)', $this->content);
         $this->assertIsValidPhp($this->content);
 	}
 }

--- a/tests/unit/Codeception/Command/GenerateEnvironmentTest.php
+++ b/tests/unit/Codeception/Command/GenerateEnvironmentTest.php
@@ -17,7 +17,7 @@ class GenerateEnvironmentTest extends BaseCommandRunner
     public function testCreated()
     {
         $this->execute(['env' => 'firefox']);
-        $this->assertContains('firefox config was created in tests/_envs/firefox.yml', $this->output);
+        $this->assertStringContainsString('firefox config was created in tests/_envs/firefox.yml', $this->output);
         $this->assertEquals('tests/_envs/firefox.yml', $this->filename);
     }
 
@@ -25,6 +25,6 @@ class GenerateEnvironmentTest extends BaseCommandRunner
     {
         $this->makeCommand('\Codeception\Command\GenerateEnvironment', false);
         $this->execute(['env' => 'firefox']);
-        $this->assertContains('File tests/_envs/firefox.yml already exists', $this->output);
+        $this->assertStringContainsString('File tests/_envs/firefox.yml already exists', $this->output);
     }
 }

--- a/tests/unit/Codeception/Command/GenerateGroupTest.php
+++ b/tests/unit/Codeception/Command/GenerateGroupTest.php
@@ -21,11 +21,11 @@ class GenerateGroupTest extends BaseCommandRunner
 
         $generated = $this->log[0];
         $this->assertEquals(\Codeception\Configuration::supportDir().'Group/Core.php', $generated['filename']);
-        $this->assertContains('namespace Group;', $generated['content']);
-        $this->assertContains('class Core', $generated['content']);
-        $this->assertContains('public function _before', $generated['content']);
-        $this->assertContains('public function _after', $generated['content']);
-        $this->assertContains('static $group = \'core\'', $generated['content']);
+        $this->assertStringContainsString('namespace Group;', $generated['content']);
+        $this->assertStringContainsString('class Core', $generated['content']);
+        $this->assertStringContainsString('public function _before', $generated['content']);
+        $this->assertStringContainsString('public function _after', $generated['content']);
+        $this->assertStringContainsString('static $group = \'core\'', $generated['content']);
         $this->assertIsValidPhp($generated['content']);
     }
 
@@ -36,7 +36,7 @@ class GenerateGroupTest extends BaseCommandRunner
 
         $generated = $this->log[0];
         $this->assertEquals(\Codeception\Configuration::supportDir().'Group/Core.php', $generated['filename']);
-        $this->assertContains('namespace Shire\Group;', $generated['content']);
+        $this->assertStringContainsString('namespace Shire\Group;', $generated['content']);
         $this->assertIsValidPhp($generated['content']);
     }
 }

--- a/tests/unit/Codeception/Command/GeneratePageObjectTest.php
+++ b/tests/unit/Codeception/Command/GeneratePageObjectTest.php
@@ -20,9 +20,9 @@ class GeneratePageObjectTest extends BaseCommandRunner
         unset($this->config['actor']);
         $this->execute(array('suite' => 'Login'), false);
         $this->assertEquals(\Codeception\Configuration::supportDir().'Page/Login.php', $this->filename);
-        $this->assertContains('class Login', $this->content);
-        $this->assertContains('public static', $this->content);
-        $this->assertNotContains('public function __construct', $this->content);
+        $this->assertStringContainsString('class Login', $this->content);
+        $this->assertStringContainsString('public static', $this->content);
+        $this->assertStringNotContainsString('public function __construct', $this->content);
         $this->assertIsValidPhp($this->content);
     }
 
@@ -32,9 +32,9 @@ class GeneratePageObjectTest extends BaseCommandRunner
         $this->config['namespace'] = 'MiddleEarth';
         $this->execute(array('suite' => 'Login'), false);
         $this->assertEquals(\Codeception\Configuration::supportDir().'Page/Login.php', $this->filename);
-        $this->assertContains('namespace MiddleEarth\Page;', $this->content);
-        $this->assertContains('class Login', $this->content);
-        $this->assertContains('public static', $this->content);
+        $this->assertStringContainsString('namespace MiddleEarth\Page;', $this->content);
+        $this->assertStringContainsString('class Login', $this->content);
+        $this->assertStringContainsString('public static', $this->content);
         $this->assertIsValidPhp($this->content);
     }
 
@@ -42,10 +42,10 @@ class GeneratePageObjectTest extends BaseCommandRunner
     {
         $this->execute(array('suite' => 'shire', 'page' => 'Login'));
         $this->assertEquals(\Codeception\Configuration::supportDir().'Page/Shire/Login.php', $this->filename);
-        $this->assertContains('namespace Page\Shire;', $this->content);
-        $this->assertContains('class Login', $this->content);
-        $this->assertContains('protected $hobbitGuy;', $this->content);
-        $this->assertContains('public function __construct(\HobbitGuy $I)', $this->content);
+        $this->assertStringContainsString('namespace Page\Shire;', $this->content);
+        $this->assertStringContainsString('class Login', $this->content);
+        $this->assertStringContainsString('protected $hobbitGuy;', $this->content);
+        $this->assertStringContainsString('public function __construct(\HobbitGuy $I)', $this->content);
         $this->assertIsValidPhp($this->content);
     }
 
@@ -54,10 +54,10 @@ class GeneratePageObjectTest extends BaseCommandRunner
         $this->config['namespace'] = 'MiddleEarth';
         $this->execute(array('suite' => 'shire', 'page' => 'Login'));
         $this->assertEquals(\Codeception\Configuration::supportDir().'Page/Shire/Login.php', $this->filename);
-        $this->assertContains('namespace MiddleEarth\Page\Shire;', $this->content);
-        $this->assertContains('class Login', $this->content);
-        $this->assertContains('protected $hobbitGuy;', $this->content);
-        $this->assertContains('public function __construct(\MiddleEarth\HobbitGuy $I)', $this->content);
+        $this->assertStringContainsString('namespace MiddleEarth\Page\Shire;', $this->content);
+        $this->assertStringContainsString('class Login', $this->content);
+        $this->assertStringContainsString('protected $hobbitGuy;', $this->content);
+        $this->assertStringContainsString('public function __construct(\MiddleEarth\HobbitGuy $I)', $this->content);
         $this->assertIsValidPhp($this->content);
     }
 

--- a/tests/unit/Codeception/Command/GenerateScenarioTest.php
+++ b/tests/unit/Codeception/Command/GenerateScenarioTest.php
@@ -40,9 +40,9 @@ class GenerateScenarioTest extends BaseCommandRunner
         $file = codecept_root_dir().'tests/data/scenarios/dummy/File_Exists.txt';
         $this->assertArrayHasKey($file, $this->saved);
         $content = $this->saved[$file];
-        $this->assertContains('I WANT TO CHECK CONFIG EXISTS', $content);
-        $this->assertContains('I see file found "$codeception"', $content);
-        $this->assertContains('* File_Exists generated', $this->output);
+        $this->assertStringContainsString('I WANT TO CHECK CONFIG EXISTS', $content);
+        $this->assertStringContainsString('I see file found "$codeception"', $content);
+        $this->assertStringContainsString('* File_Exists generated', $this->output);
     }
 
     public function testMultipleTestsGeneration()
@@ -53,9 +53,9 @@ class GenerateScenarioTest extends BaseCommandRunner
         $file = codecept_root_dir().'tests/data/scenarios/dummy/File_Exists.txt';
         $this->assertArrayHasKey($file, $this->saved);
         $content = $this->saved[$file];
-        $this->assertContains('I WANT TO CHECK CONFIG EXISTS', $content);
-        $this->assertContains('I see file found "$codeception"', $content);
-        $this->assertContains('* File_Exists generated', $this->output);
+        $this->assertStringContainsString('I WANT TO CHECK CONFIG EXISTS', $content);
+        $this->assertStringContainsString('I see file found "$codeception"', $content);
+        $this->assertStringContainsString('* File_Exists generated', $this->output);
     }
 
     public function testHtml()
@@ -64,9 +64,9 @@ class GenerateScenarioTest extends BaseCommandRunner
         $file = codecept_root_dir().'tests/data/scenarios/dummy/File_Exists.html';
         $this->assertArrayHasKey($file, $this->saved);
         $content = $this->saved[$file];
-        $this->assertContains('<html><body><h3>I WANT TO CHECK CONFIG EXISTS</h3>', $content);
-        $this->assertContains('I see file found &quot;$codeception&quot;', strip_tags($content));
-        $this->assertContains('* File_Exists generated', $this->output);
+        $this->assertStringContainsString('<html><body><h3>I WANT TO CHECK CONFIG EXISTS</h3>', $content);
+        $this->assertStringContainsString('I see file found &quot;$codeception&quot;', strip_tags($content));
+        $this->assertStringContainsString('* File_Exists generated', $this->output);
     }
 
     public function testOneFile()
@@ -76,10 +76,10 @@ class GenerateScenarioTest extends BaseCommandRunner
 
         $this->execute(array('suite' => 'skipped', '--single-file' => true));
         $this->assertEquals(codecept_root_dir().'tests/data/scenarios/skipped.txt', $this->filename);
-        $this->assertContains('I WANT TO SKIP IT', $this->content);
-        $this->assertContains('I WANT TO MAKE IT INCOMPLETE', $this->content);
-        $this->assertContains('* Skip_Me rendered', $this->output);
-        $this->assertContains('* Incomplete_Me rendered', $this->output);
+        $this->assertStringContainsString('I WANT TO SKIP IT', $this->content);
+        $this->assertStringContainsString('I WANT TO MAKE IT INCOMPLETE', $this->content);
+        $this->assertStringContainsString('* Skip_Me rendered', $this->output);
+        $this->assertStringContainsString('* Incomplete_Me rendered', $this->output);
     }
 
     public function testOneFileWithHtml()
@@ -89,19 +89,19 @@ class GenerateScenarioTest extends BaseCommandRunner
 
         $this->execute(array('suite' => 'skipped', '--single-file' => true, '--format' => 'html'));
         $this->assertEquals(codecept_root_dir().'tests/data/scenarios/skipped.html', $this->filename);
-        $this->assertContains('<h3>I WANT TO MAKE IT INCOMPLETE</h3>', $this->content);
-        $this->assertContains('<h3>I WANT TO SKIP IT</h3>', $this->content);
-        $this->assertContains('<body><h3>', $this->content);
-        $this->assertContains('</body></html>', $this->content);
-        $this->assertContains('* Skip_Me rendered', $this->output);
-        $this->assertContains('* Incomplete_Me rendered', $this->output);
+        $this->assertStringContainsString('<h3>I WANT TO MAKE IT INCOMPLETE</h3>', $this->content);
+        $this->assertStringContainsString('<h3>I WANT TO SKIP IT</h3>', $this->content);
+        $this->assertStringContainsString('<body><h3>', $this->content);
+        $this->assertStringContainsString('</body></html>', $this->content);
+        $this->assertStringContainsString('* Skip_Me rendered', $this->output);
+        $this->assertStringContainsString('* Incomplete_Me rendered', $this->output);
     }
 
     public function testDifferentPath()
     {
         $this->execute(array('suite' => 'dummy', '--single-file' => true, '--path' => 'docs'));
         $this->assertEquals('docs/dummy.txt', $this->filename);
-        $this->assertContains('I WANT TO CHECK CONFIG EXISTS', $this->content);
-        $this->assertContains('* File_Exists rendered', $this->output);
+        $this->assertStringContainsString('I WANT TO CHECK CONFIG EXISTS', $this->content);
+        $this->assertStringContainsString('* File_Exists rendered', $this->output);
     }
 }

--- a/tests/unit/Codeception/Command/GenerateStepObjectTest.php
+++ b/tests/unit/Codeception/Command/GenerateStepObjectTest.php
@@ -19,8 +19,8 @@ class GenerateStepObjectTest extends BaseCommandRunner
 
         $generated = $this->log[0];
         $this->assertEquals(\Codeception\Configuration::supportDir().'Step/Shire/Login.php', $generated['filename']);
-        $this->assertContains('class Login extends \HobbitGuy', $generated['content']);
-        $this->assertContains('namespace Step\\Shire;', $generated['content']);
+        $this->assertStringContainsString('class Login extends \HobbitGuy', $generated['content']);
+        $this->assertStringContainsString('namespace Step\\Shire;', $generated['content']);
         $this->assertIsValidPhp($generated['content']);
 
         $this->assertIsValidPhp($this->content);
@@ -32,8 +32,8 @@ class GenerateStepObjectTest extends BaseCommandRunner
         $this->execute(array('suite' => 'shire', 'step' => 'Login', '--silent' => true));
         $generated = $this->log[0];
         $this->assertEquals(\Codeception\Configuration::supportDir().'Step/Shire/Login.php', $generated['filename']);
-        $this->assertContains('namespace MiddleEarth\Step\Shire;', $generated['content']);
-        $this->assertContains('class Login extends \MiddleEarth\HobbitGuy', $generated['content']);
+        $this->assertStringContainsString('namespace MiddleEarth\Step\Shire;', $generated['content']);
+        $this->assertStringContainsString('class Login extends \MiddleEarth\HobbitGuy', $generated['content']);
         $this->assertIsValidPhp($generated['content']);
 
         $this->assertIsValidPhp($this->content);

--- a/tests/unit/Codeception/Command/GenerateSuiteTest.php
+++ b/tests/unit/Codeception/Command/GenerateSuiteTest.php
@@ -20,17 +20,17 @@ class GenerateSuiteTest extends BaseCommandRunner
         $conf = \Symfony\Component\Yaml\Yaml::parse($configFile['content']);
         $this->assertEquals('Hobbit', $conf['actor']);
         $this->assertContains('\Helper\Shire', $conf['modules']['enabled']);
-        $this->assertContains('Suite shire generated', $this->output);
+        $this->assertStringContainsString('Suite shire generated', $this->output);
 
         $actor = $this->log[2];
         $this->assertEquals(\Codeception\Configuration::supportDir().'Hobbit.php', $actor['filename']);
-        $this->assertContains('class Hobbit extends \Codeception\Actor', $actor['content']);
+        $this->assertStringContainsString('class Hobbit extends \Codeception\Actor', $actor['content']);
 
 
         $helper = $this->log[0];
         $this->assertEquals(\Codeception\Configuration::supportDir().'Helper/Shire.php', $helper['filename']);
-        $this->assertContains('namespace Helper;', $helper['content']);
-        $this->assertContains('class Shire extends \Codeception\Module', $helper['content']);
+        $this->assertStringContainsString('namespace Helper;', $helper['content']);
+        $this->assertStringContainsString('class Shire extends \Codeception\Module', $helper['content']);
     }
 
     public function testGuyWithSuffix()
@@ -44,6 +44,6 @@ class GenerateSuiteTest extends BaseCommandRunner
 
         $helper = $this->log[0];
         $this->assertEquals(\Codeception\Configuration::supportDir().'Helper/Shire.php', $helper['filename']);
-        $this->assertContains('class Shire extends \Codeception\Module', $helper['content']);
+        $this->assertStringContainsString('class Shire extends \Codeception\Module', $helper['content']);
     }
 }

--- a/tests/unit/Codeception/Command/GenerateTestTest.php
+++ b/tests/unit/Codeception/Command/GenerateTestTest.php
@@ -17,36 +17,36 @@ class GenerateTestTest extends BaseCommandRunner
     {
         $this->execute(array('suite' => 'shire', 'class' => 'HallUnderTheHill'));
         $this->assertEquals('tests/shire/HallUnderTheHillTest.php', $this->filename);
-        $this->assertContains('class HallUnderTheHillTest extends \Codeception\Test\Unit', $this->content);
-        $this->assertContains('Test was created in tests/shire/HallUnderTheHillTest.php', $this->output);
-        $this->assertContains('protected function _before()', $this->content);
-        $this->assertContains('protected function _after()', $this->content);
+        $this->assertStringContainsString('class HallUnderTheHillTest extends \Codeception\Test\Unit', $this->content);
+        $this->assertStringContainsString('Test was created in tests/shire/HallUnderTheHillTest.php', $this->output);
+        $this->assertStringContainsString('protected function _before()', $this->content);
+        $this->assertStringContainsString('protected function _after()', $this->content);
     }
 
     public function testCreateWithSuffix()
     {
         $this->execute(array('suite' => 'shire', 'class' => 'HallUnderTheHillTest'));
         $this->assertEquals('tests/shire/HallUnderTheHillTest.php', $this->filename);
-        $this->assertContains('Test was created in tests/shire/HallUnderTheHillTest.php', $this->output);
+        $this->assertStringContainsString('Test was created in tests/shire/HallUnderTheHillTest.php', $this->output);
     }
 
     public function testCreateWithNamespace()
     {
         $this->execute(array('suite' => 'shire', 'class' => 'MiddleEarth\HallUnderTheHillTest'));
         $this->assertEquals('tests/shire/MiddleEarth/HallUnderTheHillTest.php', $this->filename);
-        $this->assertContains('namespace MiddleEarth;', $this->content);
-        $this->assertContains('class HallUnderTheHillTest extends \Codeception\Test\Unit', $this->content);
-        $this->assertContains('Test was created in tests/shire/MiddleEarth/HallUnderTheHillTest.php', $this->output);
+        $this->assertStringContainsString('namespace MiddleEarth;', $this->content);
+        $this->assertStringContainsString('class HallUnderTheHillTest extends \Codeception\Test\Unit', $this->content);
+        $this->assertStringContainsString('Test was created in tests/shire/MiddleEarth/HallUnderTheHillTest.php', $this->output);
     }
 
     public function testCreateWithExtension()
     {
         $this->execute(array('suite' => 'shire', 'class' => 'HallUnderTheHillTest.php'));
         $this->assertEquals('tests/shire/HallUnderTheHillTest.php', $this->filename);
-        $this->assertContains('class HallUnderTheHillTest extends \Codeception\Test\Unit', $this->content);
-        $this->assertContains('protected $tester;', $this->content);
-        $this->assertContains('@var \HobbitGuy', $this->content);
-        $this->assertContains('Test was created in tests/shire/HallUnderTheHillTest.php', $this->output);
+        $this->assertStringContainsString('class HallUnderTheHillTest extends \Codeception\Test\Unit', $this->content);
+        $this->assertStringContainsString('protected $tester;', $this->content);
+        $this->assertStringContainsString('@var \HobbitGuy', $this->content);
+        $this->assertStringContainsString('Test was created in tests/shire/HallUnderTheHillTest.php', $this->output);
     }
 
     public function testValidPHP()

--- a/tests/unit/Codeception/Command/MyCustomCommandTest.php
+++ b/tests/unit/Codeception/Command/MyCustomCommandTest.php
@@ -1,7 +1,7 @@
 <?php
 namespace Project\Command;
 
-class MyCustomCommandTest extends \PHPUnit\Framework\TestCase
+class MyCustomCommandTest extends \Codeception\PHPUnit\TestCase
 {
     public static function _setUpBeforeClass()
     {

--- a/tests/unit/Codeception/Command/SelfUpdateTest.php
+++ b/tests/unit/Codeception/Command/SelfUpdateTest.php
@@ -10,8 +10,8 @@ class SelfUpdateTest extends BaseCommandRunner
         $this->setUpCommand('2.1.2', ['2.1.0-beta', '2.1.2', '2.1.3', '2.2.0-RC2']);
         $this->execute();
 
-        $this->assertContains('Codeception version 2.1.2', $this->output);
-        $this->assertContains('A newer version is available: 2.1.3', $this->output);
+        $this->assertStringContainsString('Codeception version 2.1.2', $this->output);
+        $this->assertStringContainsString('A newer version is available: 2.1.3', $this->output);
     }
     
     public function testAlreadyLatest()
@@ -19,8 +19,8 @@ class SelfUpdateTest extends BaseCommandRunner
         $this->setUpCommand('2.1.8', ['2.1.0-beta', '2.1.7', '2.1.8', '2.2.0-RC2']);
         $this->execute();
 
-        $this->assertContains('Codeception version 2.1.8', $this->output);
-        $this->assertContains('You are already using the latest version.', $this->output);
+        $this->assertStringContainsString('Codeception version 2.1.8', $this->output);
+        $this->assertStringContainsString('You are already using the latest version.', $this->output);
     }
 
     /**

--- a/tests/unit/Codeception/Constraints/CrawlerConstraintTest.php
+++ b/tests/unit/Codeception/Constraints/CrawlerConstraintTest.php
@@ -24,12 +24,12 @@ class CrawlerConstraintTest extends \Codeception\PHPUnit\TestCase
         try {
             $this->constraint->evaluate($nodes->filter('p'), 'selector');
         } catch (\PHPUnit\Framework\AssertionFailedError $fail) {
-            $this->assertContains(
+            $this->assertStringContainsString(
                 "Failed asserting that any element by 'selector' on page /user",
                 $fail->getMessage()
             );
-            $this->assertContains('+ <p>Bye world</p>', $fail->getMessage());
-            $this->assertContains('+ <p>Bye warcraft</p>', $fail->getMessage());
+            $this->assertStringContainsString('+ <p>Bye world</p>', $fail->getMessage());
+            $this->assertStringContainsString('+ <p>Bye warcraft</p>', $fail->getMessage());
             return;
         }
         $this->fail("should have failed, but not");
@@ -45,13 +45,13 @@ class CrawlerConstraintTest extends \Codeception\PHPUnit\TestCase
         try {
             $this->constraint->evaluate($nodes->filter('p'), 'selector');
         } catch (\PHPUnit\Framework\AssertionFailedError $fail) {
-            $this->assertContains(
+            $this->assertStringContainsString(
                 "Failed asserting that any element by 'selector' on page /user",
                 $fail->getMessage()
             );
-            $this->assertNotContains('+ <p>item 0</p>', $fail->getMessage());
-            $this->assertNotContains('+ <p>item 14</p>', $fail->getMessage());
-            $this->assertContains('[total 15 elements]', $fail->getMessage());
+            $this->assertStringNotContainsString('+ <p>item 0</p>', $fail->getMessage());
+            $this->assertStringNotContainsString('+ <p>item 14</p>', $fail->getMessage());
+            $this->assertStringContainsString('[total 15 elements]', $fail->getMessage());
             return;
         }
         $this->fail("should have failed, but not");
@@ -64,8 +64,8 @@ class CrawlerConstraintTest extends \Codeception\PHPUnit\TestCase
         try {
             $this->constraint->evaluate($nodes->filter('p'), 'selector');
         } catch (\PHPUnit\Framework\AssertionFailedError $fail) {
-            $this->assertContains("Failed asserting that any element by 'selector'", $fail->getMessage());
-            $this->assertNotContains("Failed asserting that any element by 'selector' on page", $fail->getMessage());
+            $this->assertStringContainsString("Failed asserting that any element by 'selector'", $fail->getMessage());
+            $this->assertStringNotContainsString("Failed asserting that any element by 'selector' on page", $fail->getMessage());
             return;
         }
         $this->fail("should have failed, but not");

--- a/tests/unit/Codeception/Constraints/CrawlerNotConstraintTest.php
+++ b/tests/unit/Codeception/Constraints/CrawlerNotConstraintTest.php
@@ -25,9 +25,9 @@ class CrawlerNotConstraintTest extends \Codeception\PHPUnit\TestCase
         try {
             $this->constraint->evaluate($nodes->filter('p'), 'selector');
         } catch (\PHPUnit\Framework\AssertionFailedError $fail) {
-            $this->assertContains("There was 'selector' element on page /user", $fail->getMessage());
-            $this->assertNotContains('+ <p>Bye world</p>', $fail->getMessage());
-            $this->assertContains('+ <p>Bye warcraft</p>', $fail->getMessage());
+            $this->assertStringContainsString("There was 'selector' element on page /user", $fail->getMessage());
+            $this->assertStringNotContainsString('+ <p>Bye world</p>', $fail->getMessage());
+            $this->assertStringContainsString('+ <p>Bye warcraft</p>', $fail->getMessage());
             return;
         }
         $this->fail("should have failed, but not");
@@ -43,9 +43,9 @@ class CrawlerNotConstraintTest extends \Codeception\PHPUnit\TestCase
         try {
             $this->constraint->evaluate($nodes->filter('p'), 'selector');
         } catch (\PHPUnit\Framework\AssertionFailedError $fail) {
-            $this->assertContains("There was 'selector' element on page /user", $fail->getMessage());
-            $this->assertContains('+ <p>warcraft 0</p>', $fail->getMessage());
-            $this->assertContains('+ <p>warcraft 14</p>', $fail->getMessage());
+            $this->assertStringContainsString("There was 'selector' element on page /user", $fail->getMessage());
+            $this->assertStringContainsString('+ <p>warcraft 0</p>', $fail->getMessage());
+            $this->assertStringContainsString('+ <p>warcraft 14</p>', $fail->getMessage());
             return;
         }
         $this->fail("should have failed, but not");
@@ -58,8 +58,8 @@ class CrawlerNotConstraintTest extends \Codeception\PHPUnit\TestCase
         try {
             $this->constraint->evaluate($nodes->filter('p'), 'selector');
         } catch (\PHPUnit\Framework\AssertionFailedError $fail) {
-            $this->assertContains("There was 'selector' element", $fail->getMessage());
-            $this->assertNotContains("There was 'selector' element on page /user", $fail->getMessage());
+            $this->assertStringContainsString("There was 'selector' element", $fail->getMessage());
+            $this->assertStringNotContainsString("There was 'selector' element on page /user", $fail->getMessage());
             return;
         }
         $this->fail("should have failed, but not");

--- a/tests/unit/Codeception/Constraints/WebDriverConstraintTest.php
+++ b/tests/unit/Codeception/Constraints/WebDriverConstraintTest.php
@@ -26,12 +26,12 @@ class WebDriverConstraintTest extends \Codeception\PHPUnit\TestCase
         try {
             $this->constraint->evaluate($nodes, 'selector');
         } catch (\PHPUnit\Framework\AssertionFailedError $fail) {
-            $this->assertContains(
+            $this->assertStringContainsString(
                 "Failed asserting that any element by 'selector' on page /user",
                 $fail->getMessage()
             );
-            $this->assertContains('+ <p> Bye world', $fail->getMessage());
-            $this->assertContains('+ <p> Bye warcraft', $fail->getMessage());
+            $this->assertStringContainsString('+ <p> Bye world', $fail->getMessage());
+            $this->assertStringContainsString('+ <p> Bye warcraft', $fail->getMessage());
             return;
         }
         $this->fail("should have failed, but not");
@@ -43,11 +43,11 @@ class WebDriverConstraintTest extends \Codeception\PHPUnit\TestCase
         try {
             $this->constraint->evaluate($nodes, ['css' => 'p.mocked']);
         } catch (\PHPUnit\Framework\AssertionFailedError $fail) {
-            $this->assertContains(
+            $this->assertStringContainsString(
                 "Failed asserting that any element by css 'p.mocked' on page /user",
                 $fail->getMessage()
             );
-            $this->assertContains('+ <p> Bye warcraft', $fail->getMessage());
+            $this->assertStringContainsString('+ <p> Bye warcraft', $fail->getMessage());
             return;
         }
         $this->fail("should have failed, but not");
@@ -62,13 +62,13 @@ class WebDriverConstraintTest extends \Codeception\PHPUnit\TestCase
         try {
             $this->constraint->evaluate($nodes, 'selector');
         } catch (\PHPUnit\Framework\AssertionFailedError $fail) {
-            $this->assertContains(
+            $this->assertStringContainsString(
                 "Failed asserting that any element by 'selector' on page /user",
                 $fail->getMessage()
             );
-            $this->assertNotContains('+ <p> item 0', $fail->getMessage());
-            $this->assertNotContains('+ <p> item 14', $fail->getMessage());
-            $this->assertContains('[total 15 elements]', $fail->getMessage());
+            $this->assertStringNotContainsString('+ <p> item 0', $fail->getMessage());
+            $this->assertStringNotContainsString('+ <p> item 14', $fail->getMessage());
+            $this->assertStringContainsString('[total 15 elements]', $fail->getMessage());
             return;
         }
         $this->fail("should have failed, but not");
@@ -81,8 +81,8 @@ class WebDriverConstraintTest extends \Codeception\PHPUnit\TestCase
         try {
             $this->constraint->evaluate($nodes, 'selector');
         } catch (\PHPUnit\Framework\AssertionFailedError $fail) {
-            $this->assertContains("Failed asserting that any element by 'selector'", $fail->getMessage());
-            $this->assertNotContains("Failed asserting that any element by 'selector' on page", $fail->getMessage());
+            $this->assertStringContainsString("Failed asserting that any element by 'selector'", $fail->getMessage());
+            $this->assertStringNotContainsString("Failed asserting that any element by 'selector' on page", $fail->getMessage());
             return;
         }
         $this->fail("should have failed, but not");

--- a/tests/unit/Codeception/Constraints/WebDriverConstraintTest.php
+++ b/tests/unit/Codeception/Constraints/WebDriverConstraintTest.php
@@ -1,4 +1,7 @@
 <?php
+
+use Codeception\Util\Locator;
+
 require_once __DIR__.'/mocked_webelement.php';
 
 class WebDriverConstraintTest extends \Codeception\PHPUnit\TestCase
@@ -24,7 +27,7 @@ class WebDriverConstraintTest extends \Codeception\PHPUnit\TestCase
     {
         $nodes = array(new TestedWebElement('Bye warcraft'), new TestedWebElement('Bye world'));
         try {
-            $this->constraint->evaluate($nodes, 'selector');
+            $this->constraint->evaluate($nodes, "'selector'");
         } catch (\PHPUnit\Framework\AssertionFailedError $fail) {
             $this->assertStringContainsString(
                 "Failed asserting that any element by 'selector' on page /user",
@@ -41,7 +44,7 @@ class WebDriverConstraintTest extends \Codeception\PHPUnit\TestCase
     {
         $nodes = array(new TestedWebElement('Bye warcraft'));
         try {
-            $this->constraint->evaluate($nodes, ['css' => 'p.mocked']);
+            $this->constraint->evaluate($nodes, Locator::humanReadableString(['css' => 'p.mocked']));
         } catch (\PHPUnit\Framework\AssertionFailedError $fail) {
             $this->assertStringContainsString(
                 "Failed asserting that any element by css 'p.mocked' on page /user",
@@ -60,7 +63,7 @@ class WebDriverConstraintTest extends \Codeception\PHPUnit\TestCase
             $nodes[] = new TestedWebElement("item $i");
         }
         try {
-            $this->constraint->evaluate($nodes, 'selector');
+            $this->constraint->evaluate($nodes, "'selector'");
         } catch (\PHPUnit\Framework\AssertionFailedError $fail) {
             $this->assertStringContainsString(
                 "Failed asserting that any element by 'selector' on page /user",
@@ -79,7 +82,7 @@ class WebDriverConstraintTest extends \Codeception\PHPUnit\TestCase
         $this->constraint = new Codeception\PHPUnit\Constraint\WebDriver('hello');
         $nodes = array(new TestedWebElement('Bye warcraft'), new TestedWebElement('Bye world'));
         try {
-            $this->constraint->evaluate($nodes, 'selector');
+            $this->constraint->evaluate($nodes, "'selector'");
         } catch (\PHPUnit\Framework\AssertionFailedError $fail) {
             $this->assertStringContainsString("Failed asserting that any element by 'selector'", $fail->getMessage());
             $this->assertStringNotContainsString("Failed asserting that any element by 'selector' on page", $fail->getMessage());

--- a/tests/unit/Codeception/Constraints/WebDriverNotConstraintTest.php
+++ b/tests/unit/Codeception/Constraints/WebDriverNotConstraintTest.php
@@ -26,9 +26,9 @@ class WebDriverConstraintNotTest extends \Codeception\PHPUnit\TestCase
         try {
             $this->constraint->evaluate($nodes, 'selector');
         } catch (\PHPUnit\Framework\AssertionFailedError $fail) {
-            $this->assertContains("There was 'selector' element on page /user", $fail->getMessage());
-            $this->assertNotContains('+ <p> Bye world', $fail->getMessage());
-            $this->assertContains('+ <p> Bye warcraft', $fail->getMessage());
+            $this->assertStringContainsString("There was 'selector' element on page /user", $fail->getMessage());
+            $this->assertStringNotContainsString('+ <p> Bye world', $fail->getMessage());
+            $this->assertStringContainsString('+ <p> Bye warcraft', $fail->getMessage());
             return;
         }
         $this->fail("should have failed, but not");
@@ -40,8 +40,8 @@ class WebDriverConstraintNotTest extends \Codeception\PHPUnit\TestCase
         try {
             $this->constraint->evaluate($nodes, ['css' => 'p.mocked']);
         } catch (\PHPUnit\Framework\AssertionFailedError $fail) {
-            $this->assertContains("There was css 'p.mocked' element on page /user", $fail->getMessage());
-            $this->assertContains('+ <p> Bye warcraft', $fail->getMessage());
+            $this->assertStringContainsString("There was css 'p.mocked' element on page /user", $fail->getMessage());
+            $this->assertStringContainsString('+ <p> Bye warcraft', $fail->getMessage());
             return;
         }
         $this->fail("should have failed, but not");
@@ -56,9 +56,9 @@ class WebDriverConstraintNotTest extends \Codeception\PHPUnit\TestCase
         try {
             $this->constraint->evaluate($nodes, 'selector');
         } catch (\PHPUnit\Framework\AssertionFailedError $fail) {
-            $this->assertContains("There was 'selector' element on page /user", $fail->getMessage());
-            $this->assertContains('+ <p> warcraft 0', $fail->getMessage());
-            $this->assertContains('+ <p> warcraft 14', $fail->getMessage());
+            $this->assertStringContainsString("There was 'selector' element on page /user", $fail->getMessage());
+            $this->assertStringContainsString('+ <p> warcraft 0', $fail->getMessage());
+            $this->assertStringContainsString('+ <p> warcraft 14', $fail->getMessage());
             return;
         }
         $this->fail("should have failed, but not");
@@ -71,8 +71,8 @@ class WebDriverConstraintNotTest extends \Codeception\PHPUnit\TestCase
         try {
             $this->constraint->evaluate($nodes, 'selector');
         } catch (\PHPUnit\Framework\AssertionFailedError $fail) {
-            $this->assertContains("There was 'selector' element", $fail->getMessage());
-            $this->assertNotContains("There was 'selector' element on page", $fail->getMessage());
+            $this->assertStringContainsString("There was 'selector' element", $fail->getMessage());
+            $this->assertStringNotContainsString("There was 'selector' element on page", $fail->getMessage());
             return;
         }
         $this->fail("should have failed, but not");

--- a/tests/unit/Codeception/Constraints/WebDriverNotConstraintTest.php
+++ b/tests/unit/Codeception/Constraints/WebDriverNotConstraintTest.php
@@ -1,11 +1,14 @@
 <?php
+
+use Codeception\Util\Locator;
+
 require_once __DIR__.'/mocked_webelement.php';
 
 class WebDriverConstraintNotTest extends \Codeception\PHPUnit\TestCase
 {
 
     /**
-     * @var Codeception\PHPUnit\Constraint\WebDriver
+     * @var Codeception\PHPUnit\Constraint\WebDriverNot
      */
     protected $constraint;
 
@@ -24,7 +27,7 @@ class WebDriverConstraintNotTest extends \Codeception\PHPUnit\TestCase
     {
         $nodes = array(new TestedWebElement('Bye warcraft'), new TestedWebElement('Bye world'));
         try {
-            $this->constraint->evaluate($nodes, 'selector');
+            $this->constraint->evaluate($nodes, "'selector'");
         } catch (\PHPUnit\Framework\AssertionFailedError $fail) {
             $this->assertStringContainsString("There was 'selector' element on page /user", $fail->getMessage());
             $this->assertStringNotContainsString('+ <p> Bye world', $fail->getMessage());
@@ -38,7 +41,7 @@ class WebDriverConstraintNotTest extends \Codeception\PHPUnit\TestCase
     {
         $nodes = array(new TestedWebElement('Bye warcraft'));
         try {
-            $this->constraint->evaluate($nodes, ['css' => 'p.mocked']);
+            $this->constraint->evaluate($nodes, Locator::humanReadableString(['css' => 'p.mocked']));
         } catch (\PHPUnit\Framework\AssertionFailedError $fail) {
             $this->assertStringContainsString("There was css 'p.mocked' element on page /user", $fail->getMessage());
             $this->assertStringContainsString('+ <p> Bye warcraft', $fail->getMessage());
@@ -54,7 +57,7 @@ class WebDriverConstraintNotTest extends \Codeception\PHPUnit\TestCase
             $nodes[] = new TestedWebElement("warcraft $i");
         }
         try {
-            $this->constraint->evaluate($nodes, 'selector');
+            $this->constraint->evaluate($nodes, "'selector'");
         } catch (\PHPUnit\Framework\AssertionFailedError $fail) {
             $this->assertStringContainsString("There was 'selector' element on page /user", $fail->getMessage());
             $this->assertStringContainsString('+ <p> warcraft 0', $fail->getMessage());
@@ -69,7 +72,7 @@ class WebDriverConstraintNotTest extends \Codeception\PHPUnit\TestCase
         $this->constraint = new Codeception\PHPUnit\Constraint\WebDriverNot('warcraft');
         $nodes = array(new TestedWebElement('Bye warcraft'), new TestedWebElement('Bye world'));
         try {
-            $this->constraint->evaluate($nodes, 'selector');
+            $this->constraint->evaluate($nodes, "'selector'");
         } catch (\PHPUnit\Framework\AssertionFailedError $fail) {
             $this->assertStringContainsString("There was 'selector' element", $fail->getMessage());
             $this->assertStringNotContainsString("There was 'selector' element on page", $fail->getMessage());

--- a/tests/unit/Codeception/Lib/Driver/PostgresTest.php
+++ b/tests/unit/Codeception/Lib/Driver/PostgresTest.php
@@ -108,7 +108,7 @@ class PostgresTest extends Unit
         $emptyCriteria = [];
         $generatedSql = $this->postgres->select('test_column', 'test_table', $emptyCriteria);
 
-        $this->assertNotContains('where', $generatedSql);
+        $this->assertStringNotContainsString('where', $generatedSql);
     }
 
     public function testGetSingleColumnPrimaryKey()

--- a/tests/unit/Codeception/Lib/ParserTest.php
+++ b/tests/unit/Codeception/Lib/ParserTest.php
@@ -101,21 +101,21 @@ EOF;
     public function testSteps()
     {
         $code = file_get_contents(\Codeception\Configuration::projectDir().'tests/cli/UnitCept.php');
-        $this->assertContains('$I->seeInThisFile', $code);
+        $this->assertStringContainsString('$I->seeInThisFile', $code);
         $this->parser->parseSteps($code);
         $text = $this->scenario->getText();
-        $this->assertContains("I see in this file", $text);
+        $this->assertStringContainsString("I see in this file", $text);
     }
 
     public function testStepsWithFriends()
     {
         $code = file_get_contents(\Codeception\Configuration::projectDir().'tests/web/FriendsCept.php');
-        $this->assertContains('$I->haveFriend', $code);
+        $this->assertStringContainsString('$I->haveFriend', $code);
         $this->parser->parseSteps($code);
         $text = $this->scenario->getText();
-        $this->assertContains("jon does", $text);
-        $this->assertContains("I have friend", $text);
-        $this->assertContains("back to me", $text);
+        $this->assertStringContainsString("jon does", $text);
+        $this->assertStringContainsString("I have friend", $text);
+        $this->assertStringContainsString("back to me", $text);
     }
 
     public function testParseFile()

--- a/tests/unit/Codeception/ModuleTest.php
+++ b/tests/unit/Codeception/ModuleTest.php
@@ -10,10 +10,10 @@ class ModuleTest extends \PHPUnit\Framework\TestCase
         try {
             $module->_setConfig([]);
         } catch (\Exception $e) {
-            $this->assertContains('"error"', $e->getMessage());
-            $this->assertContains('no\such\class', $e->getMessage());
-            $this->assertContains('composer', $e->getMessage());
-            $this->assertNotContains('installed', $e->getMessage());
+            $this->assertStringContainsString('"error"', $e->getMessage());
+            $this->assertStringContainsString('no\such\class', $e->getMessage());
+            $this->assertStringContainsString('composer', $e->getMessage());
+            $this->assertStringNotContainsString('installed', $e->getMessage());
             return;
         }
         $this->fail('no exception thrown');

--- a/tests/unit/Codeception/Util/JsonArrayTest.php
+++ b/tests/unit/Codeception/Util/JsonArrayTest.php
@@ -18,7 +18,7 @@ class JsonArrayTest extends \Codeception\Test\Unit
 
     public function testXmlConversion()
     {
-        $this->assertContains(
+        $this->assertStringContainsString(
             '<ticket><title>Bug should be fixed</title><user><name>Davert</name></user><labels></labels></ticket>',
             $this->jsonArray->toXml()->saveXML()
         );
@@ -30,7 +30,7 @@ class JsonArrayTest extends \Codeception\Test\Unit
             '[{"user":"Blacknoir","age":27,"tags":["wed-dev","php"]},'
             . '{"user":"John Doe","age":27,"tags":["web-dev","java"]}]'
         );
-        $this->assertContains('<tags>wed-dev</tags>', $jsonArray->toXml()->saveXML());
+        $this->assertStringContainsString('<tags>wed-dev</tags>', $jsonArray->toXml()->saveXML());
         $this->assertEquals(2, $jsonArray->filterByXPath('//user')->length);
     }
 
@@ -76,7 +76,7 @@ class JsonArrayTest extends \Codeception\Test\Unit
         $jsonArray = new JsonArray('{"a":{"foo/bar":1,"":2},"b":{"foo/bar":1,"":2},"baz":2}');
         $expectedXml = '<a><invalidTag1>1</invalidTag1><invalidTag2>2</invalidTag2></a>'
             . '<b><invalidTag1>1</invalidTag1><invalidTag2>2</invalidTag2></b><baz>2</baz>';
-        $this->assertContains($expectedXml, $jsonArray->toXml()->saveXML());
+        $this->assertStringContainsString($expectedXml, $jsonArray->toXml()->saveXML());
     }
 
     public function testConvertsArrayHavingSingleElement()

--- a/tests/unit/Codeception/Util/JsonTypeTest.php
+++ b/tests/unit/Codeception/Util/JsonTypeTest.php
@@ -35,14 +35,14 @@ class JsonTypeTest extends \Codeception\Test\Unit
     {
         $this->data['in_reply_to_screen_name'] = true;
         $jsonType = new JsonType($this->data);
-        $this->assertContains('`in_reply_to_screen_name: true` is of type', $jsonType->matches($this->types));
+        $this->assertStringContainsString('`in_reply_to_screen_name: true` is of type', $jsonType->matches($this->types));
     }
 
     public function testIntegerFilter()
     {
         $jsonType = new JsonType($this->data);
-        $this->assertContains('`id: 11` is of type', $jsonType->matches(['id' => 'integer:<5']));
-        $this->assertContains('`id: 11` is of type', $jsonType->matches(['id' => 'integer:>15']));
+        $this->assertStringContainsString('`id: 11` is of type', $jsonType->matches(['id' => 'integer:<5']));
+        $this->assertStringContainsString('`id: 11` is of type', $jsonType->matches(['id' => 'integer:>15']));
         $this->assertTrue($jsonType->matches(['id' => 'integer:=11']));
         $this->assertTrue($jsonType->matches(['id' => 'integer:>5']));
         $this->assertTrue($jsonType->matches(['id' => 'integer:>5:<12']));
@@ -195,8 +195,8 @@ class JsonTypeTest extends \Codeception\Test\Unit
             'id' => 'integer:<3'
         ]));
 
-        $this->assertContains('3` is of type `integer:<3', $res);
-        $this->assertContains('5` is of type `integer:<3', $res);
+        $this->assertStringContainsString('3` is of type `integer:<3', $res);
+        $this->assertStringContainsString('5` is of type `integer:<3', $res);
     }
 
     /**

--- a/tests/unit/Codeception/Util/StubTest.php
+++ b/tests/unit/Codeception/Util/StubTest.php
@@ -276,7 +276,7 @@ class StubTest extends \Codeception\PHPUnit\TestCase
     private function resetMockObjects()
     {
         $refl = new ReflectionObject($this);
-        $refl = $refl->getParentClass();
+        $refl = $refl->getParentClass()->getParentClass();
         $prop = $refl->getProperty('mockObjects');
         $prop->setAccessible(true);
         $prop->setValue($this, array());

--- a/tests/web/WebDriverTest.php
+++ b/tests/web/WebDriverTest.php
@@ -893,7 +893,7 @@ class WebDriverTest extends TestsForBrowsers
 
         $lastStep = end($steps);
 
-        $this->assertContains(
+        $this->assertStringContainsString(
             "TypeError",
             $lastStep->getHtml()
         );


### PR DESCRIPTION
Application should not be recreated between requests with this config:
```
recreateApplicationBetweenTests: true
recreateApplicationBetweenRequests: false
```
But it does. I can't inject anything into container in test because of this issue.