### PR TITLE
Add possibility to dynamically load contexts

### DIFF
--- a/docs/07-BDD.md
+++ b/docs/07-BDD.md
@@ -525,6 +525,17 @@ gherkin:
                 - "Step\FastLogin"
 ```
 
+Contexts can be autoloaded as well:
+```yaml
+gherkin:
+    contexts:
+        path: tests/_support/Steps
+        namespace_prefix: Steps
+        default:
+            - AcceptanceTester
+```
+This will load all context from the given path and prefix it with the given namespace.
+
 ## Migrating From Behat
 
 While Behat is a great tool for Behavior Driven Development, you still may prefer to use Codeception as your primary testing framework. In case you want to unify all your tests (unit/functional/acceptance), and make them be executed with one runner, Codeception is a good choice. Also Codeception provides rich set of well-maintained modules for various testing backends like Selenium Webdriver, Symfony, Laravel, etc.


### PR DESCRIPTION
This PR will add the possibility to dynamically load context for Gherkin tests. When using the suggested method of adding contexts to your ```codeception.yml``` file. This soon will become a long list of context files and quite a pain to maintain. 

By adding the following line to configuration contexts will automatically be loaded:

```yaml
gherkin:
    contexts:
        path: tests/_support/Steps
        namespace_prefix: Steps
        default:
            - AcceptanceTester
```

Unfortunately this cannot be solved via a Customer loader, because the GherkinSnippet class directly instantiates the Gherkin loader instead of the specified Gherkin loader. Something that could be fixed but with a lot more work.