### PR TITLE
[FTP] Make sure _directory() will return its directory

### DIFF
--- a/src/Codeception/Module/FTP.php
+++ b/src/Codeception/Module/FTP.php
@@ -614,6 +614,7 @@ class FTP extends Filesystem
         if (!$pwd) {
             $this->fail("couldn't get current directory");
         }
+        return $pwd;
     }
 
     /**


### PR DESCRIPTION
The `_directory()` method in `FTP` was missing its return statement, meaning all paths were being expanded from root, rather than the client's current working directory.