### PR TITLE
[Laravel] Fix missing declaration shouldReport

### DIFF
--- a/src/Codeception/Lib/Connector/Laravel5/ExceptionHandlerDecorator.php
+++ b/src/Codeception/Lib/Connector/Laravel5/ExceptionHandlerDecorator.php
@@ -49,6 +49,17 @@ class ExceptionHandlerDecorator implements ExceptionHandlerContract
     {
         $this->laravelExceptionHandler->report($e);
     }
+    
+    /**
+      * Determine if the exception should be reported.
+     *
+     * @param  \Exception $e
+     * @return bool
+     */
+    public function shouldReport(Exception $e)
+    {
+        return $this->exceptionHandlingDisabled;
+    }
 
     /**
      * @param $request


### PR DESCRIPTION
shouldReport() declaration has been added to [Illuminate\Contracts\Debug\ExceptionHandler in Laravel 5.8](https://github.com/laravel/framework/blob/3949bd8bb9697e005ebf4ac3d8eacd6c190e6930/src/Illuminate/Contracts/Debug/ExceptionHandler.php#L23)