### PR TITLE
[WIP][Doctrine2] Change haveInRepository to invoke entities without constructor

### DIFF
--- a/src/Codeception/Module/Doctrine2.php
+++ b/src/Codeception/Module/Doctrine2.php
@@ -314,7 +314,7 @@ EOF;
     public function haveInRepository($entity, array $data)
     {
         $reflectedEntity = new \ReflectionClass($entity);
-        $entityObject = $reflectedEntity->newInstance();
+        $entityObject = $reflectedEntity->newInstanceWithoutConstructor();
         foreach ($reflectedEntity->getProperties() as $property) {
             /** @var $property \ReflectionProperty */
             if (!isset($data[$property->name])) {


### PR DESCRIPTION
This way you can persist entities which have a constructor that accepts
parameters. The down side is that you cannot relay on any side effects
from the constructor, but you shouldn't be doing that anyway.
Always set all expected fields using the second parameter `$data` of haveInRepository.

This is WIP, should this get accepted the docs also need to be updated to reflect this change.

There is a risk that tests which relied on constructor side-effect will no longer work with this change.
Since you have the possibility to set entity parameters via reflection and the primary concern of this method is storing entities for testing purposes, I think the constructor should have never been invoked in the first place.

Closes #5420.