### PR TITLE
Fixing the bad build command message.

### DIFF
--- a/src/Codeception/Command/Build.php
+++ b/src/Codeception/Command/Build.php
@@ -61,13 +61,13 @@ class Build extends Command
     private function buildActions(array $settings)
     {
         $actionsGenerator = new ActionsGenerator($settings);
+        $content = $actionsGenerator->produce();
         $this->output->writeln(
             " -> {$settings['actor']}Actions.php generated successfully. "
             . $actionsGenerator->getNumMethods() . " methods added"
         );
-        
-        $content = $actionsGenerator->produce();
-        
+
+
         $file = $this->createDirectoryFor(Configuration::supportDir() . '_generated', $settings['actor']);
         $file .= $this->getShortClassName($settings['actor']) . 'Actions.php';
         return $this->createFile($file, $content, true);


### PR DESCRIPTION
Don't make any sense to run the `output->writeln` method before the `produce` method, cause `$actionsGenerator->getNumMethods()` will always return zero (`Action::$numMethods` property is not populated before running `Actions::produce()`).

I just changed the order of the execution, so you first generate the methods, and then you check for generated methods.