### PR TITLE
[Lumen] add support for Laravel\Lumen\Application::boot

### DIFF
--- a/src/Codeception/Lib/Connector/Lumen.php
+++ b/src/Codeception/Lib/Connector/Lumen.php
@@ -106,7 +106,12 @@ class Lumen extends Client
         }
 
         $this->app = $this->kernel = require $this->module->config['bootstrap_file'];
-
+        
+        // in version 5.6.*, lumen introduced the same design pattern like Laravel
+        // to load all service provider we need to call on Laravel\Lumen\Application::boot()
+        if (method_exists($this->app, 'boot')) {
+            $this->app->boot();
+        }
         // Lumen registers necessary bindings on demand when calling $app->make(),
         // so here we force the request binding before registering our own request object,
         // otherwise Lumen will overwrite our request object.


### PR DESCRIPTION
in version 5.6.*, lumen introduced the same design pattern to boot all services providers like Laravel.
The providers aren't booted until the request  is started
@see https://github.com/laravel/lumen-framework/commit/42cbc998375718b1a8a11883e033617024e57260


```php
<?php

use App\Example;

class ApiExampleCest
{
    public function openPageByRoute(\ApiTester $I)
    {
        // exampleId = 1
        $exampleId = Example::select('id')
            ->first()->id;
        $I->amOnPage('/' . $exampleId);
        $I->expect('one item is in response');
        $I->seeResponseContains('Lumen (5.8.0) (Laravel Components 5.8.*)');
    }
}
```

without Laravel\Lumen\Application::boot
```bash
$ ./vendor/bin/codecept run api

Api Tests (1) ------------------------------------------------------------------------------------
E ApiExampleCest: Open page by route (0.01s)
--------------------------------------------------------------------------------------------------
1) ApiExampleCest: Open page by route
 Test  tests/api/ExampleCest.php:openPageByRoute

  [Error] Call to a member function connection() on null
```

with Laravel\Lumen\Application::boot
```bash
$ ./vendor/bin/codecept run api

Api Tests (1) ------------------------------------------------------------------------------------
✔ ApiExampleCest: Open page by route (0.24s)
--------------------------------------------------------------------------------------------------
Time: 1.69 seconds, Memory: 18.00 MB

OK (1 test, 1 assertion)
```