### PR TITLE
[ZendExpressive] recreateApplicationBetweenTests is on by default in 2.6

### DIFF
--- a/src/Codeception/Module/ZendExpressive.php
+++ b/src/Codeception/Module/ZendExpressive.php
@@ -33,7 +33,7 @@ class ZendExpressive extends Framework implements DoctrineProvider
 {
     protected $config = [
         'container'                          => 'config/container.php',
-        'recreateApplicationBetweenTests'    => false,
+        'recreateApplicationBetweenTests'    => true,
         'recreateApplicationBetweenRequests' => false,
     ];
 


### PR DESCRIPTION
I set it to `false` in 2.5 to avoid breaking anyones tests when this functionality was introduced.