### PR TITLE
Adding Ability To Truncate Table Through Db Module

### DIFF
--- a/src/Codeception/Lib/Driver/Db.php
+++ b/src/Codeception/Lib/Driver/Db.php
@@ -378,4 +378,15 @@ class Db
     {
         return $this->options;
     }
+
+    /**
+     * Executes Truncate Against DB
+     * @param $tableName
+     *
+     * @throws \Codeception\Exception\ModuleException
+     */
+    public function truncateTable($tableName)
+    {
+        $this->sqlQuery('TRUNCATE ' . $this->getQuotedName($tableName));
+    }
 }

--- a/src/Codeception/Module/Db.php
+++ b/src/Codeception/Module/Db.php
@@ -639,6 +639,20 @@ class Db extends CodeceptionModule implements DbInterface
     }
 
     /**
+     * Executes a Truncate command on the table. Useful when creating records with frameworks/orm.
+     *
+     * ```php
+     * $I->truncateTable('users');
+     * ```
+     *
+     * @param $tableName
+     */
+    public function truncateTable($tableName)
+    {
+        return $this->_getDriver()->truncateTable($tableName);
+    }
+
+    /**
      * @param  array  $databaseConfig
      * @param  string $databaseKey
      * @return bool

--- a/tests/unit/Codeception/Module/Db/TestsForDb.php
+++ b/tests/unit/Codeception/Module/Db/TestsForDb.php
@@ -81,6 +81,14 @@ abstract class TestsForDb extends \Codeception\Test\Unit
         $this->module->dontSeeInDatabase('empty_table');
     }
 
+    public function testTruncateTable()
+    {
+        $this->module->_cleanup();
+        $this->module->haveInDatabase('users', ['name' => 'john', 'email' => 'john@doe.com']);
+        $this->module->truncateTable('users');
+        $this->module->dontSeeInDatabase('users', ['name' => 'john', 'email' => 'john@doe.com']);
+    }
+
     public function testCleanupDatabase()
     {
         $this->module->seeInDatabase('users', ['name' => 'davert']);


### PR DESCRIPTION
I've had a few instances where I needed to truncate a table because the ORM is generating a lot of records. I cannot use the clean up because the DB has over 600 tables and this causes severe delays in processing. This gives the ability to call `truncate` easily. 

Note: I've mostly worked with MySQL and Sqlite. I'm not sure if the truncate command is different on the others (or if it even exists).