### PR TITLE
Update FTP.php (key param is not needed for sftp type)

### DIFF
--- a/src/Codeception/Module/FTP.php
+++ b/src/Codeception/Module/FTP.php
@@ -117,7 +117,7 @@ class FTP extends Filesystem
         'timeout'  => 90,
         'user'     => 'anonymous',
         'password' => '',
-        //'key'      => '',
+        'key'      => '',
         'tmp'      => 'tests/_data',
         'passive'  => false,
         'cleanup'  => true
@@ -861,17 +861,20 @@ class FTP extends Filesystem
         }
 
         if (isset($this->config['key'])) {
-            $keyFile = file_get_contents($this->config['key']);
 
-            if (class_exists('Crypt_RSA')) {
-                $password = new \Crypt_RSA();
-            } elseif (class_exists('phpseclib\Crypt\RSA')) {
-                $password = new \phpseclib\Crypt\RSA();
-            } else {
-                throw new ModuleException('phpseclib/phpseclib library is not installed');
+            if ($this->config['key'] != '') {
+                $keyFile = file_get_contents($this->config['key']);
+
+                if (class_exists('Crypt_RSA')) {
+                    $password = new \Crypt_RSA();
+                } elseif (class_exists('phpseclib\Crypt\RSA')) {
+                    $password = new \phpseclib\Crypt\RSA();
+                } else {
+                    throw new ModuleException('phpseclib/phpseclib library is not installed');
+                }
+
+                $password->loadKey($keyFile);
             }
-
-            $password->loadKey($keyFile);
         }
 
         if (!$this->ftp->login($user, $password)) {

--- a/src/Codeception/Module/FTP.php
+++ b/src/Codeception/Module/FTP.php
@@ -82,7 +82,19 @@ use Codeception\Exception\ModuleException;
  *              key: ''
  *              tmp: 'tests/_data/ftp'
  *              cleanup: false
+ * *  *  * #### Example (SFTP) for symphony
  *
+ *     modules:
+ *        enabled:
+ *           - FTP:
+ *              type: sftp
+ *              host: '127.0.0.1'
+ *              port: 22
+ *              timeout: 120
+ *              user: 'root'
+ *              password: 'root'
+ *              tmp: 'tests/_data/ftp'
+ *              cleanup: false
  *
  * This module extends the Filesystem module, file contents methods are inherited from this module.
  */
@@ -105,7 +117,7 @@ class FTP extends Filesystem
         'timeout'  => 90,
         'user'     => 'anonymous',
         'password' => '',
-        'key'      => '',
+        //'key'      => '',
         'tmp'      => 'tests/_data',
         'passive'  => false,
         'cleanup'  => true

--- a/src/Codeception/Module/FTP.php
+++ b/src/Codeception/Module/FTP.php
@@ -82,7 +82,7 @@ use Codeception\Exception\ModuleException;
  *              key: ''
  *              tmp: 'tests/_data/ftp'
  *              cleanup: false
- * *  *  * #### Example (SFTP) for framework symfony
+ * *  *  * #### Example (SFTP)
  *
  *     modules:
  *        enabled:

--- a/src/Codeception/Module/FTP.php
+++ b/src/Codeception/Module/FTP.php
@@ -82,7 +82,7 @@ use Codeception\Exception\ModuleException;
  *              key: ''
  *              tmp: 'tests/_data/ftp'
  *              cleanup: false
- * *  *  * #### Example (SFTP) for symphony
+ * *  *  * #### Example (SFTP) for framework symfony
  *
  *     modules:
  *        enabled:


### PR DESCRIPTION
for symphony sftp doesnt work
  [PHPUnit\Framework\Exception] file_get_contents(): Filename cannot be empty  

so key is not needed in this case