### PR TITLE
Add patch to reopen closed entity manager

### DIFF
--- a/src/Codeception/Module/Doctrine2.php
+++ b/src/Codeception/Module/Doctrine2.php
@@ -114,7 +114,7 @@ EOF;
 
             if($this->em->getConnection()->isTransactionActive()) {
                 try {
-                    $this->rollbackTransaction();
+                    $this->rollbackTransactions();
                     $this->debugSection('Database', 'Transaction cancelled; all changes reverted.');
                 } catch (\PDOException $e) {
                 }
@@ -135,7 +135,7 @@ EOF;
         }
         if ($this->config['cleanup'] && $this->em->getConnection()->isTransactionActive()) {
             try {
-                $this->rollbackTransaction();
+                $this->rollbackTransactions();
                 $this->debugSection('Database', 'Transaction cancelled; all changes reverted.');
             } catch (\PDOException $e) {
             }
@@ -148,7 +148,7 @@ EOF;
 
             if($this->em->getConnection()->isTransactionActive()) {
                 try {
-                    $this->rollbackTransaction();
+                    $this->rollbackTransactions();
                     $this->debugSection('Database', 'Transaction cancelled; all changes reverted.');
                 } catch (\PDOException $e) {
                 }
@@ -199,7 +199,7 @@ EOF;
         }
         if ($this->config['cleanup'] && $this->em->getConnection()->isTransactionActive()) {
             try {
-                $this->rollbackTransaction();
+                $this->rollbackTransactions();
                 $this->debugSection('Database', 'Transaction cancelled; all changes reverted.');
             } catch (\PDOException $e) {
             }
@@ -571,7 +571,7 @@ EOF;
         return $this->em;
     }
 
-    private function rollbackTransaction(): void
+    private function rollbackTransactions(): void
     {
         while ($this->em->getConnection()->getTransactionNestingLevel() > 0) {
             $this->em->getConnection()->rollback();

--- a/src/Codeception/Module/Doctrine2.php
+++ b/src/Codeception/Module/Doctrine2.php
@@ -571,7 +571,7 @@ EOF;
         return $this->em;
     }
 
-    private function rollbackTransactions(): void
+    private function rollbackTransactions()
     {
         while ($this->em->getConnection()->getTransactionNestingLevel() > 0) {
             $this->em->getConnection()->rollback();

--- a/src/Codeception/Module/Doctrine2.php
+++ b/src/Codeception/Module/Doctrine2.php
@@ -114,9 +114,7 @@ EOF;
 
             if($this->em->getConnection()->isTransactionActive()) {
                 try {
-                    while ($this->em->getConnection()->getTransactionNestingLevel() > 0) {
-                        $this->em->getConnection()->rollback();
-                    }
+                    $this->rollbackTransaction();
                     $this->debugSection('Database', 'Transaction cancelled; all changes reverted.');
                 } catch (\PDOException $e) {
                 }
@@ -137,7 +135,7 @@ EOF;
         }
         if ($this->config['cleanup'] && $this->em->getConnection()->isTransactionActive()) {
             try {
-                $this->em->getConnection()->rollback();
+                $this->rollbackTransaction();
                 $this->debugSection('Database', 'Transaction cancelled; all changes reverted.');
             } catch (\PDOException $e) {
             }
@@ -150,9 +148,7 @@ EOF;
 
             if($this->em->getConnection()->isTransactionActive()) {
                 try {
-                    while ($this->em->getConnection()->getTransactionNestingLevel() > 0) {
-                        $this->em->getConnection()->rollback();
-                    }
+                    $this->rollbackTransaction();
                     $this->debugSection('Database', 'Transaction cancelled; all changes reverted.');
                 } catch (\PDOException $e) {
                 }
@@ -203,9 +199,7 @@ EOF;
         }
         if ($this->config['cleanup'] && $this->em->getConnection()->isTransactionActive()) {
             try {
-                while ($this->em->getConnection()->getTransactionNestingLevel() > 0) {
-                    $this->em->getConnection()->rollback();
-                }
+                $this->rollbackTransaction();
                 $this->debugSection('Database', 'Transaction cancelled; all changes reverted.');
             } catch (\PDOException $e) {
             }
@@ -481,7 +475,7 @@ EOF;
      *
      * @version 1.1
      * @param $entity
-     * @param array $params. For `IS NULL`, use `array('field'=>null)`
+     * @param array $params
      * @return array
      */
     public function grabEntitiesFromRepository($entity, $params = [])
@@ -512,7 +506,7 @@ EOF;
      *
      * @version 1.1
      * @param $entity
-     * @param array $params. For `IS NULL`, use `array('field'=>null)`
+     * @param array $params
      * @return object
      */
     public function grabEntityFromRepository($entity, $params = [])
@@ -576,4 +570,12 @@ EOF;
         }
         return $this->em;
     }
+
+    private function rollbackTransaction(): void
+    {
+        while ($this->em->getConnection()->getTransactionNestingLevel() > 0) {
+            $this->em->getConnection()->rollback();
+        }
+    }
 }
+

--- a/src/Codeception/Module/Symfony.php
+++ b/src/Codeception/Module/Symfony.php
@@ -238,9 +238,14 @@ class Symfony extends Framework implements DoctrineProvider, PartedModule
         if ($this->kernel === null) {
             $this->fail('Symfony2 platform module is not loaded');
         }
-        if (!isset($this->permanentServices[$this->config['em_service']])) {
+        if (!isset($this->permanentServices[$this->config['em_service']]) || !$this->permanentServices[$this->config['em_service']]->isOpen()) {
             // try to persist configured EM
             $this->persistService($this->config['em_service'], true);
+
+            if (!$this->permanentServices[$this->config['em_service']]->isOpen()) {
+                $this->grabService('doctrine')->resetManager();
+                $this->persistService($this->config['em_service'], true);
+            }
 
             if ($this->_getContainer()->has('doctrine')) {
                 $this->persistService('doctrine', true);


### PR DESCRIPTION
This patch is credited to @Amunak and can be found here https://github.com/Codeception/Codeception/issues/5107#issuecomment-430557559
Also relevant to the issue is this discussion https://github.com/symfony/symfony/issues/5339

This solves the issue of Entity Manager being closed (for example when a rollback is thrown in the application under test). The issue has been heavily discussed and the patch provided by @Amunak solved the issue for me.

Important note! 
For this patch to work, I also had to install the following `composer require --dev symfony/proxy-manager-bridge`, which I would presume requires Flex support.