### PR TITLE
Add error output for non-fatal errors and non-loaded classes

### DIFF
--- a/src/Codeception/Subscriber/ErrorHandler.php
+++ b/src/Codeception/Subscriber/ErrorHandler.php
@@ -107,8 +107,8 @@ class ErrorHandler implements EventSubscriberInterface
         }
         // not fatal
         if ($error['type'] > 1) {
-			echo "\n\n\nNot fatal error.\n";
-			echo sprintf("%s \nin %s:%d\n", $error['message'], $error['file'], $error['line']);
+            echo "\n\n\nNot fatal error.\n";
+            echo sprintf("%s \nin %s:%d\n", $error['message'], $error['file'], $error['line']);
             return;
         }
 

--- a/src/Codeception/Subscriber/ErrorHandler.php
+++ b/src/Codeception/Subscriber/ErrorHandler.php
@@ -107,6 +107,8 @@ class ErrorHandler implements EventSubscriberInterface
         }
         // not fatal
         if ($error['type'] > 1) {
+			echo "\n\n\nNot fatal error.\n";
+			echo sprintf("%s \nin %s:%d\n", $error['message'], $error['file'], $error['line']);
             return;
         }
 

--- a/src/Codeception/Util/Autoload.php
+++ b/src/Codeception/Util/Autoload.php
@@ -123,6 +123,7 @@ class Autoload
             }
         }
 
+        echo "\nClass " . $class . "not loaded.\n";
         return false;
     }
 


### PR DESCRIPTION
As a result of these not-critical errors we can get message "Process finished with exit code 255" without any explanation. Error output makes debug easier. 
Sometimes errors can be duplicated, but most often it saves hours of life.