### PR TITLE
Proposed solution for #5457 gherkin scenarios not loaded from group file

### DIFF
--- a/src/Codeception/Lib/GroupManager.php
+++ b/src/Codeception/Lib/GroupManager.php
@@ -5,6 +5,7 @@ use Codeception\Configuration;
 use Codeception\Test\Interfaces\Reported;
 use Codeception\Test\Descriptor;
 use Codeception\TestInterface;
+use Codeception\Test\Gherkin;
 use Symfony\Component\Finder\Finder;
 use Symfony\Component\Finder\SplFileInfo;
 
@@ -118,10 +119,8 @@ class GroupManager
                 if (strpos($filename . ':' . $test->getName(false), $testPattern) === 0) {
                     $groups[] = $group;
                 }
-                // TODO: consider mb_strtolower per https://stackoverflow.com/a/5473569
-                if (method_exists($test, 'getMetadata')
-                    && strcasecmp($filename . ':' . $test->getMetadata()->getFeature(), $testPattern) === 0
-                ) {
+                if ($test instanceof Gherkin
+                    && mb_strtolower($filename . ':' . $test->getMetadata()->getFeature()) === mb_strtolower($testPattern)) {
                     $groups[] = $group;
                 }
                 if ($test instanceof \PHPUnit\Framework\TestSuite\DataProvider) {

--- a/src/Codeception/Lib/GroupManager.php
+++ b/src/Codeception/Lib/GroupManager.php
@@ -119,7 +119,10 @@ class GroupManager
                     $groups[] = $group;
                 }
                 // TODO: consider mb_strtolower per https://stackoverflow.com/a/5473569
-                if (strcasecmp($filename . ':' . $test->getMetadata()->getFeature(), $testPattern) === 0) {
+                if (
+                    method_exists($test, 'getMetadata')
+                    && strcasecmp($filename . ':' . $test->getMetadata()->getFeature(), $testPattern) === 0
+                ) {
                     $groups[] = $group;
                 }
                 if ($test instanceof \PHPUnit\Framework\TestSuite\DataProvider) {

--- a/src/Codeception/Lib/GroupManager.php
+++ b/src/Codeception/Lib/GroupManager.php
@@ -119,8 +119,7 @@ class GroupManager
                     $groups[] = $group;
                 }
                 // TODO: consider mb_strtolower per https://stackoverflow.com/a/5473569
-                if (
-                    method_exists($test, 'getMetadata')
+                if (method_exists($test, 'getMetadata')
                     && strcasecmp($filename . ':' . $test->getMetadata()->getFeature(), $testPattern) === 0
                 ) {
                     $groups[] = $group;

--- a/src/Codeception/Lib/GroupManager.php
+++ b/src/Codeception/Lib/GroupManager.php
@@ -118,6 +118,10 @@ class GroupManager
                 if (strpos($filename . ':' . $test->getName(false), $testPattern) === 0) {
                     $groups[] = $group;
                 }
+                // TODO: consider mb_strtolower per https://stackoverflow.com/a/5473569
+                if (strcasecmp($filename . ':' . $test->getMetadata()->getFeature(), $testPattern) === 0) {
+                    $groups[] = $group;
+                }
                 if ($test instanceof \PHPUnit\Framework\TestSuite\DataProvider) {
                     $firstTest = $test->testAt(0);
                     if ($firstTest != false && $firstTest instanceof TestInterface) {

--- a/tests/data/gherkinGroup1
+++ b/tests/data/gherkinGroup1
@@ -1,0 +1,1 @@
+tests/data/refund.feature:Jeff returns a faulty microwave

--- a/tests/data/gherkinGroup2
+++ b/tests/data/gherkinGroup2
@@ -1,0 +1,1 @@
+tests/data/refund2.feature:ジェフは不完全な電子レンジを返します

--- a/tests/data/refund2.feature
+++ b/tests/data/refund2.feature
@@ -1,0 +1,10 @@
+@important
+Feature: Refund item
+  In order to get satisfaction
+  As a customer
+  I need to be able to get refunds
+
+  Scenario: ジェフは不完全な電子レンジを返します
+    Given Jeff has bought a microwave for "$100"
+    When he returns the microwave
+    Then Jeff should be refunded $100

--- a/tests/unit/Codeception/Lib/GroupManagerTest.php
+++ b/tests/unit/Codeception/Lib/GroupManagerTest.php
@@ -2,6 +2,7 @@
 namespace Codeception\Lib;
 
 use Codeception\Util\Stub;
+use Codeception\Test\Loader\Gherkin as GherkinLoader;
 
 class GroupManagerTest extends \Codeception\Test\Unit
 {
@@ -73,6 +74,24 @@ class GroupManagerTest extends \Codeception\Test\Unit
 
         $this->assertContains('whitespace_group_test', $this->manager->groupsForTest($goodTest));
         $this->assertEmpty($this->manager->groupsForTest($badTest));
+    }
+
+    public function testLoadSpecificScenarioFromFile()
+    {
+        $this->manager = new GroupManager(['gherkinGroup1' => 'tests/data/gherkinGroup1']);
+        $loader = new GherkinLoader();
+        $loader->loadTests(codecept_absolute_path('tests/data/refund.feature'));
+        $test = $loader->getTests()[0];
+        $this->assertContains('gherkinGroup1', $this->manager->groupsForTest($test));
+    }
+
+    public function testLoadSpecificScenarioWithMultibyteStringFromFile()
+    {
+        $this->manager = new GroupManager(['gherkinGroup2' => 'tests/data/gherkinGroup2']);
+        $loader = new GherkinLoader();
+        $loader->loadTests(codecept_absolute_path('tests/data/refund2.feature'));
+        $test = $loader->getTests()[0];
+        $this->assertContains('gherkinGroup2', $this->manager->groupsForTest($test));
     }
 
     protected function makeTestCase($file, $name = '')


### PR DESCRIPTION
A possible solution for the issue described in #5457. I have a couple of open questions though.

* I am not familiar with the Codeception framework. Is `Codeception\Lib\GroupManager` the best place to address this issue or is there a better place?
* I would like to write some tests to verify this issue. Can someone point me to a similar test to help me get started?
* My use of `strcasecmp` looks like it will fail for multibyte strings. Are there suggestions on better alternatives? One I saw (that I linked to in a comment in the code) suggests using `mb_strtolower` instead.

Any help, tips or advice would be appreciated. Thanks.