### PR TITLE
Updating docker PHP version to 7.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:7.2-cli
+FROM php:7.3-cli
 
 MAINTAINER Tobias Munk tobias@diemeisterei.de
 
@@ -8,6 +8,8 @@ RUN apt-get update && \
             git \
             zlib1g-dev \
             libssl-dev \
+            libzip-dev \
+            unzip \
         --no-install-recommends && \
         apt-get clean && \
         rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
@@ -20,7 +22,7 @@ RUN docker-php-ext-install \
 # Install pecl extensions
 RUN pecl install \
         mongodb \
-        xdebug-2.6.0beta1 && \
+        xdebug-2.7.0RC2 && \
     docker-php-ext-enable \
         mongodb.so \
         xdebug
@@ -41,7 +43,7 @@ WORKDIR /repo
 
 # Install vendor
 COPY ./composer.json /repo/composer.json
-RUN composer install --prefer-dist --optimize-autoloader
+RUN composer install --prefer-dist --no-interaction --optimize-autoloader --classmap-authoritative
 
 # Add source-code
 COPY . /repo


### PR DESCRIPTION
Closes #5325

Docker image updated:

- updated php-cli to 7.3
- updated xdebug to 2.7.0RC2 (stable version rather than beta),
- added zip functionality so composer could install from dist rather than source
- added classmap-authoritative option to composer for extra performance
- added no-interaction option to composer as without .lock files we'll pull latest version matched by .json definition, therefore build can fail any time if there's an interactive update [which is rare, but happens]

As requested, this is the same change as https://github.com/Codeception/Codeception/pull/5412 , but this is branched from upstream 2.6.