### PR TITLE
Avoid removing required fields in cookies.

### DIFF
--- a/src/Codeception/Module/WebDriver.php
+++ b/src/Codeception/Module/WebDriver.php
@@ -825,13 +825,17 @@ class WebDriver extends CodeceptionModule implements
             }
         }
         // #5401 Supply defaults, otherwise chromedriver 2.46 complains.
-        $params = array_filter($params);
-        $params += [
+        $defaults = [
             'path' => '/',
             'expiry' => time() + 86400,
             'secure' => false,
             'httpOnly' => false,
         ];
+        foreach ($defaults as $key => $default) {
+            if (empty($params[$key])) {
+                $params[$key] = $default;
+            }
+        }
         $this->webDriver->manage()->addCookie($params);
         $this->debugSection('Cookies', json_encode($this->webDriver->manage()->getCookies()));
     }


### PR DESCRIPTION
A cookie with ['name' => 'test', 'value' => 0] would get it's value stripped, causing an "undefined index: value" notice in php-webdriver's Cookie.php
