### PR TITLE
Update WebDriver documentation - typo in example

### DIFF
--- a/src/Codeception/Module/WebDriver.php
+++ b/src/Codeception/Module/WebDriver.php
@@ -2119,16 +2119,16 @@ class WebDriver extends CodeceptionModule implements
      *      'field1' => 'value',
      *      'checkbox' => [
      *          'value of first checkbox',
-     *          'value of second checkbox,
+     *          'value of second checkbox',
      *      ],
      *      'otherCheckboxes' => [
      *          true,
      *          false,
-     *          false
+     *          false,
      *      ],
      *      'multiselect' => [
      *          'first option value',
-     *          'second option value'
+     *          'second option value',
      *      ]
      * ]);
      * ?>


### PR DESCRIPTION
Missing `'` in an example which break the style