### PR TITLE
[InnerBrowser] clickButton throws exception if button is outside form…

### DIFF
--- a/src/Codeception/Lib/InnerBrowser.php
+++ b/src/Codeception/Lib/InnerBrowser.php
@@ -1,7 +1,6 @@
 <?php
 namespace Codeception\Lib;
 
-use Codeception\Configuration;
 use Codeception\Exception\ElementNotFound;
 use Codeception\Exception\ExternalUrlException;
 use Codeception\Exception\MalformedLocatorException;
@@ -445,8 +444,7 @@ class InnerBrowser extends Module implements Web, PageSourceSaver, ElementLocato
                 return true;
             }
         }
-        codecept_debug('Button is not inside a link or a form');
-        return false;
+        throw new TestRuntimeException('Button is not inside a link or a form');
     }
 
     private function openHrefFromDomNode(\DOMNode $node)

--- a/tests/data/app/view/form/button-not-in-form.php
+++ b/tests/data/app/view/form/button-not-in-form.php
@@ -1,7 +1,15 @@
 <html>
 <body>
+
 <div>
-    <button>The Button</button>
+    <form action="/form/button" method="POST" id="form-id">
+        <input type="hidden" name="text" value="val" />
+        <button type="submit" name="btn0">Submit</button>
+    </form>
+</div>
+
+<div>
+    <input type="submit" form="form-id" value="Submit 2" />
 </div>
 </body>
 </html>

--- a/tests/unit/Codeception/Module/PhpBrowserTest.php
+++ b/tests/unit/Codeception/Module/PhpBrowserTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use Codeception\Exception\TestRuntimeException;
 use Codeception\Util\Stub;
 
 require_once 'tests/data/app/data.php';
@@ -604,9 +605,10 @@ class PhpBrowserTest extends TestsForBrowsers
 
     public function testClickingOnButtonOutsideFormDoesNotCauseFatalError()
     {
-        $this->expectException(AssertionFailedError::class);
+        $this->expectException(TestRuntimeException::class);
+        $this->expectExceptionMessage('Button is not inside a link or a form');
         $this->module->amOnPage('/form/button-not-in-form');
-        $this->module->click('The Button');
+        $this->module->click(['xpath' => '//input[@type="submit"][@form="form-id"]']);
     }
 
     public function testSubmitFormWithoutEmptyOptionsInSelect()


### PR DESCRIPTION
[InnerBrowser] clickButton throws exception if button is outside form or link

The test fails with exception:
```
 [TestRuntimeException] Button is not inside a link or a form
```

Fixes #5425

I raised a separate issue for supporting HTML5 attributes.