### PR TITLE
2.5 Fixed loadSessionSnapshot with php-webdriver 1.1.3

### DIFF
--- a/src/Codeception/Module/WebDriver.php
+++ b/src/Codeception/Module/WebDriver.php
@@ -3109,7 +3109,7 @@ class WebDriver extends CodeceptionModule implements
         }
         
         foreach ($this->sessionSnapshots[$name] as $cookie) {
-            $this->setCookie($cookie['name'], $cookie['value'], $cookie);
+            $this->setCookie($cookie['name'], $cookie['value'], (array)$cookie);
         }
         $this->debugSection('Snapshot', "Restored \"$name\" session snapshot");
         return true;

--- a/src/Codeception/Module/WebDriver.php
+++ b/src/Codeception/Module/WebDriver.php
@@ -3109,7 +3109,7 @@ class WebDriver extends CodeceptionModule implements
         }
         
         foreach ($this->sessionSnapshots[$name] as $cookie) {
-            $this->setCookie($cookie->getName(), $cookie->getValue(), $cookie->toArray());
+            $this->setCookie($cookie['name'], $cookie['value'], $cookie);
         }
         $this->debugSection('Snapshot', "Restored \"$name\" session snapshot");
         return true;

--- a/tests/web/WebDriverTest.php
+++ b/tests/web/WebDriverTest.php
@@ -676,17 +676,17 @@ class WebDriverTest extends TestsForBrowsers
         $fakeWdOptions = Stub::make('\Facebook\WebDriver\WebDriverOptions', [
             'getCookies' => Stub::atLeastOnce(function () {
                 return [
-                    Cookie::createFromArray([
+                    [
                         'name' => 'PHPSESSID',
                         'value' => '123456',
                         'path' => '/',
-                    ]),
-                    Cookie::createFromArray([
+                    ],
+                    [
                         'name' => '3rdParty',
                         'value' => '_value_',
                         'path' => '/',
                         'domain' => '.3rd-party.net',
-                    ]),
+                    ],
                 ];
             }),
         ]);


### PR DESCRIPTION
It is a minor issue which could affect a handful of Codeception 2.5 users
Closes #5456