### PR TITLE
ErrorHandler prints info about more fatal error types

### DIFF
--- a/src/Codeception/Subscriber/ErrorHandler.php
+++ b/src/Codeception/Subscriber/ErrorHandler.php
@@ -106,7 +106,7 @@ class ErrorHandler implements EventSubscriberInterface
             return;
         }
         // not fatal
-        if ($error['type'] > 1) {
+        if (!in_array($error['type'], [E_ERROR, E_COMPILE_ERROR, E_CORE_ERROR])) {
             return;
         }
 


### PR DESCRIPTION
Previously only E_ERROR was considered fatal, this change adds E_COMPILE_ERROR and E_CORE_ERROR to the list.

Replaces #5452
Provided example was caused by E_COMPILE_ERROR.

I haven't managed to reproduce the issue, all compile errors were handled by PHP to me,
but I didn't test exact case with Page objects.
This logic is consistent with DidNotFinish logic:
```php
if (!$this->suiteFinished && (
    $error === null || !in_array($error['type'], [E_ERROR, E_COMPILE_ERROR, E_CORE_ERROR])
)) {
    throw new \RuntimeException('Command Did Not Finish Properly');
```