### PR TITLE
[3.x] Add memory_limit to run command

### DIFF
--- a/src/Codeception/Command/Run.php
+++ b/src/Codeception/Command/Run.php
@@ -245,11 +245,10 @@ class Run extends Command
             $config = $this->overrideConfig($this->options['override']);
         }
 
-        ini_set(
-            'memory_limit',
-            isset($config['settings']['memory_limit']) ? $config['settings']['memory_limit'] : '1024M'
-        );
-
+        if (isset($config['settings']['memory_limit'])) {
+            ini_set('memory_limit', $config['settings']['memory_limit']);
+        }
+        
         if ($this->options['ext']) {
             $config = $this->enableExtensions($this->options['ext']);
         }

--- a/src/Codeception/Command/Run.php
+++ b/src/Codeception/Command/Run.php
@@ -244,6 +244,12 @@ class Run extends Command
         if (count($this->options['override'])) {
             $config = $this->overrideConfig($this->options['override']);
         }
+
+        ini_set(
+            'memory_limit',
+            isset($config['settings']['memory_limit']) ? $config['settings']['memory_limit'] : '1024M'
+        );
+
         if ($this->options['ext']) {
             $config = $this->enableExtensions($this->options['ext']);
         }


### PR DESCRIPTION
This patch prevent `run` command from out of memory with `codeception.yml` or `override option(-o "settings: memory_limit: 2048M")`.