### PR TITLE
Test and do not add leading slash when there is one already #5473

### DIFF
--- a/src/Codeception/Module/REST.php
+++ b/src/Codeception/Module/REST.php
@@ -575,11 +575,10 @@ EOF;
     protected function execute($method, $url, $parameters = [], $files = [])
     {
         // allow full url to be requested
-        if (strpos($url, '://') === false) {
-            $url = $this->config['url'] . $url;
-            if ($this->config['url'] && strpos($url, '://') === false && strpos($url, '/') !== 0 && $this->config['url'][0] !== '/') {
-                $url = '/' . $url;
-            }
+        if (!$url) {
+            $url = $this->config['url'];
+        } elseif (strpos($url, '://') === false && $this->config['url']) {
+            $url = rtrim($this->config['url'], '/') . '/' . ltrim($url, '/');
         }
 
         $this->params = $parameters;


### PR DESCRIPTION
Redo url parts concatenations the right way.
Moved forward slash prefixing out of the branch to the main level of the function as that would be more consistent behaviour between cases when config['url'] set and empty... though I would rather remove that slash prefixing altogether L583-L585.

This is redo of https://github.com/Codeception/Codeception/pull/5474