### PR TITLE
Fix Gherkin Test Setup 

### DIFF
--- a/src/Codeception/Test/Gherkin.php
+++ b/src/Codeception/Test/Gherkin.php
@@ -40,8 +40,8 @@ class Gherkin extends Test implements ScenarioDriven, Reported
         $this->steps = $steps;
         $this->setMetadata(new Metadata());
         $this->scenario = new Scenario($this);
-        $this->getMetadata()->setName($featureNode->getTitle());
-        $this->getMetadata()->setFeature($scenarioNode->getTitle());
+        $this->getMetadata()->setName($scenarioNode->getTitle());
+        $this->getMetadata()->setFeature($featureNode->getTitle());
         $this->getMetadata()->setFilename($featureNode->getFile());
     }
 

--- a/src/Codeception/Test/Gherkin.php
+++ b/src/Codeception/Test/Gherkin.php
@@ -67,7 +67,7 @@ class Gherkin extends Test implements ScenarioDriven, Reported
     
     public function getSignature()
     {
-        return basename($this->getFileName(), '.feature') . ':' . $this->getFeature();
+        return basename($this->getFileName(), '.feature') . ':' . $this->getScenarioTitle();
     }
 
     public function test()
@@ -170,6 +170,11 @@ class Gherkin extends Test implements ScenarioDriven, Reported
     public function getFeature()
     {
         return $this->getMetadata()->getFeature();
+    }
+
+    public function getScenarioTitle()
+    {
+        return $this->getMetadata()->getName();
     }
 
     /**

--- a/tests/unit/Codeception/Test/GherkinTest.php
+++ b/tests/unit/Codeception/Test/GherkinTest.php
@@ -47,7 +47,18 @@ class GherkinTest extends \Codeception\Test\Unit
         /** @var $test \Codeception\Test\Gherkin  * */
         $test = $tests[0];
         $this->assertInstanceOf('\Codeception\Test\Gherkin', $test);
-        $this->assertEquals('Jeff returns a faulty microwave', $test->getFeature());
+        $this->assertEquals('Refund item', $test->getFeature());
+    }
+
+    public function testGherkinScenario()
+    {
+        $this->loader->loadTests(codecept_data_dir('refund.feature'));
+        $tests = $this->loader->getTests();
+        $this->assertCount(1, $tests);
+        /** @var $test \Codeception\Test\Gherkin  * */
+        $test = $tests[0];
+        $this->assertInstanceOf('\Codeception\Test\Gherkin', $test);
+        $this->assertEquals('Jeff returns a faulty microwave', $test->getScenarioNode()->getTitle());
     }
 
     /**

--- a/tests/unit/Codeception/Test/GherkinTest.php
+++ b/tests/unit/Codeception/Test/GherkinTest.php
@@ -58,7 +58,7 @@ class GherkinTest extends \Codeception\Test\Unit
         /** @var $test \Codeception\Test\Gherkin  * */
         $test = $tests[0];
         $this->assertInstanceOf('\Codeception\Test\Gherkin', $test);
-        $this->assertEquals('Jeff returns a faulty microwave', $test->getScenarioNode()->getTitle());
+        $this->assertEquals('Jeff returns a faulty microwave', $test->getScenarioTitle());
     }
 
     /**


### PR DESCRIPTION
The Gherkin Test was configured incorrectly. The scenario was assigned as feature name where as the feature was assigned the scenario name. This caused issues when trying to run a single scenario from group file.

This should fix it now. 

Fixes #4867 