### PR TITLE
Add —pause-on-fail option

### DIFF
--- a/src/Codeception/Codecept.php
+++ b/src/Codeception/Codecept.php
@@ -58,6 +58,7 @@ class Codecept
         'filter'          => null,
         'env'             => null,
         'fail-fast'       => false,
+        'pause-on-fail'   => false,
         'ansi'            => true,
         'verbosity'       => 1,
         'interactive'     => true,
@@ -129,6 +130,9 @@ class Codecept
         }
         if ($this->options['fail-fast']) {
             $this->dispatcher->addSubscriber(new Subscriber\FailFast());
+        }
+        if ($this->options['pause-on-fail']) {
+            $this->dispatcher->addSubscriber(new Subscriber\PauseOnFail());
         }
 
         if ($this->options['coverage']) {

--- a/src/Codeception/Command/Run.php
+++ b/src/Codeception/Command/Run.php
@@ -142,6 +142,7 @@ class Run extends Command
             new InputOption('silent', '', InputOption::VALUE_NONE, 'Only outputs suite names and final results'),
             new InputOption('steps', '', InputOption::VALUE_NONE, 'Show steps in output'),
             new InputOption('debug', 'd', InputOption::VALUE_NONE, 'Show debug and scenario output'),
+            new InputOption('pause-on-fail', '', InputOption::VALUE_NONE, 'Start interactive console after a failure'),
             new InputOption(
                 'coverage',
                 '',
@@ -262,6 +263,9 @@ class Run extends Command
         }
         if ($this->options['debug']) {
             $this->output->setVerbosity(OutputInterface::VERBOSITY_VERY_VERBOSE);
+        }
+        if ($this->options['pause-on-fail']) {
+            $userOptions['pause-on-fail'] = true;
         }
 
         $userOptions = array_intersect_key($this->options, array_flip($this->passedOptionKeys($input)));

--- a/src/Codeception/Subscriber/PauseOnFail.php
+++ b/src/Codeception/Subscriber/PauseOnFail.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Codeception\Subscriber;
+
+use Codeception\Event\FailEvent;
+use Codeception\Event\PrintResultEvent;
+use Codeception\Event\SuiteEvent;
+use Codeception\Events;
+use Codeception\Lib\Actor\Shared\Pause;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+class PauseOnFail implements EventSubscriberInterface
+{
+    use Shared\StaticEvents;
+    use Pause;
+
+    public static $events = [
+        Events::SUITE_BEFORE => 'stopOnFail',
+        Events::TEST_FAIL_PRINT => 'pauseOnFail',
+    ];
+
+    public function stopOnFail(SuiteEvent $e)
+    {
+        $e->getResult()->stopOnError(true);
+        $e->getResult()->stopOnFailure(true);
+    }
+
+    public function pauseOnFail(FailEvent $e)
+    {
+        $this->pause();
+    }
+}


### PR DESCRIPTION
before 3.0 i used to use a pauseExecution in the _failed hook combined with --fail-fast to have a way to jump in and debug when a Testcase fails. 
3.0 changed pauseExecution to pause which introduces the interactive shell, which is nice.
But combined with _failed that pause call is not as helpful anymore, because 3.0 does not output the failure information to the console anymore, so it's difficult to analyse what actually fails.
Sadly, i didn't find an easy way to have that behavior again in 3.0, so i looked around and came to a new option "--pause-on-fail" which fails as soon as a failure/error is encountered, prints the failure/error information to the console and then uses the pause trait to start that interactive shell.