### PR TITLE
Ignore files when exporting package

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -33,3 +33,11 @@
 *.ttf   binary
 *.woff  binary
 *.phar  binary
+
+# Exclude files that don't need to be present in packages (so they're not downloaded by Composer)
+/docs            export-ignore
+/tests           export-ignore
+/.gitattributes  export-ignore
+/.gitignore      export-ignore
+/*.md            export-ignore
+/*.yml           export-ignore


### PR DESCRIPTION
The [install file](https://github.com/Codeception/Codeception/archive/3.0.zip) downloaded by Composer is currently 1.1 MB.

These changes reduce it to ~0.4 MB, speeding up installs. Won't matter most of the time, CI servers etc. but noticeable when a developer is installing via a mobile tethered connection for example.

Codeception [is installed ~373,000 times per month](https://packagist.org/packages/codeception/codeception/stats), so transferring ~261 fewer GB every month should (i.e. impossible to calculate, but [one website estimates](https://www.emergeinteractive.com/insights/detail/does-irresponsible-web-development-contribute-to-global-warming/)) avoid 783kg of unnecessary CO2 emissions every month!

We use (and love!) Codeception daily, but someone more familiar with the package itself will hopefully be able to verify I've not excluded anything expected to be present on the developers machine after installing - and maybe even exclude some I haven't. I don't believe this to be a breaking change, since the files excluded are for developing Codeception, rather than to use it.

Background:

- https://madewithlove.be/gitattributes/
- https://www.reddit.com/r/PHP/comments/2jzp6k/i_dont_need_your_tests_in_my_production/