### PR TITLE
fix: Correct env substitution in Db module example

### DIFF
--- a/docs/06-ModulesAndHelpers.md
+++ b/docs/06-ModulesAndHelpers.md
@@ -453,7 +453,7 @@ module:
         - Db:
             dsn: "mysql:host=%DB_HOST%;dbname=%DB_DATABASE%"
             user: "%DB_USERNAME%"
-            password: "DB_PASSWORD"
+            password: "%DB_PASSWORD%"
 ```
 
 ### Runtime Configuration


### PR DESCRIPTION
Add missing `%` around `DB_PASSWORD` example