### PR TITLE
InnerBrowser: selectOption can match by text when option has no value attribute

### DIFF
--- a/src/Codeception/Lib/InnerBrowser.php
+++ b/src/Codeception/Lib/InnerBrowser.php
@@ -1122,13 +1122,16 @@ class InnerBrowser extends Module implements Web, PageSourceSaver, ElementLocato
         }
         $options = $field->filterXPath(sprintf('//option[text()=normalize-space("%s")]|//input[@type="radio" and @value=normalize-space("%s")]', $option, $option));
         if ($options->count()) {
-            if ($options->getNode(0)->tagName === 'option') {
-                $options->getNode(0)->setAttribute('selected', 'selected');
+            $firstMatchingDomNode = $options->getNode(0);
+            if ($firstMatchingDomNode->tagName === 'option') {
+                $firstMatchingDomNode->setAttribute('selected', 'selected');
             } else {
-                $options->getNode(0)->setAttribute('checked', 'checked');
+                $firstMatchingDomNode->setAttribute('checked', 'checked');
             }
-            if ($options->first()->attr('value') !== false) {
-                return $options->first()->attr('value');
+            $valueAttribute = $options->first()->attr('value');
+            //attr() returns null when option has no value attribute
+            if ($valueAttribute !== null) {
+                return $valueAttribute;
             }
             return $options->first()->text();
         }

--- a/tests/data/app/view/form/bug5547.php
+++ b/tests/data/app/view/form/bug5547.php
@@ -1,0 +1,12 @@
+<html>
+<body>
+<form action="/form/complex" method="POST">
+    <select id="_payment_type" name="payment_type" required="" class="form-control">
+        <option>За показы</option>
+        <option>За размещение</option>
+        <option>qwerty</option>
+    </select>
+    <input type="submit" value="Submit" />
+</form>
+</body>
+</html>

--- a/tests/unit/Codeception/Module/PhpBrowserTest.php
+++ b/tests/unit/Codeception/Module/PhpBrowserTest.php
@@ -720,4 +720,16 @@ HTML
         $this->module->amOnPage('https://httpstat.us/599');
         $this->module->seeResponseCodeIsServerError();
     }
+
+    /**
+     * @issue https://github.com/Codeception/Codeception/issues/5547
+     */
+    public function testSelectOptionByTextWhenItHasNoValue()
+    {
+        $this->module->amOnPage('/form/bug5547');
+        $this->module->selectOption('#_payment_type', 'qwerty');
+        $this->module->click('Submit');
+        $form = data::get('form');
+        $this->assertEquals('qwerty', $form['payment_type']);
+    }
 }


### PR DESCRIPTION
Fixes #5547