### PR TITLE
hiding Symfony 4.3 deprecation warning

### DIFF
--- a/src/Codeception/Subscriber/ErrorHandler.php
+++ b/src/Codeception/Subscriber/ErrorHandler.php
@@ -146,6 +146,9 @@ class ErrorHandler implements EventSubscriberInterface
             call_user_func($this->oldHandler, $type, $message, $file, $line, $context);
             return;
         }
+        if (strpos($message, 'Symfony 4.3')) { // skip Symfony 4.3 deprecations
+            return;
+        }
         Notification::deprecate("$message", "$file:$line");
     }
 }


### PR DESCRIPTION
Let's hide this annoying message as this has no deal to Codeception users