### PR TITLE
Fix sqlite connection close when holding reference in PHP's GC

### DIFF
--- a/src/Codeception/Lib/Driver/Sqlite.php
+++ b/src/Codeception/Lib/Driver/Sqlite.php
@@ -25,6 +25,7 @@ class Sqlite extends Db
     public function cleanup()
     {
         $this->dbh = null;
+	gc_collect_cycles();
         file_put_contents($this->filename, '');
         $this->dbh = self::connect($this->dsn, $this->user, $this->password);
     }

--- a/src/Codeception/Lib/Driver/Sqlite.php
+++ b/src/Codeception/Lib/Driver/Sqlite.php
@@ -25,7 +25,7 @@ class Sqlite extends Db
     public function cleanup()
     {
         $this->dbh = null;
-	gc_collect_cycles();
+        gc_collect_cycles();
         file_put_contents($this->filename, '');
         $this->dbh = self::connect($this->dsn, $this->user, $this->password);
     }


### PR DESCRIPTION
This patch will safely close sqlite connections even if PHP's Garbage Collection is holding a refrence to a PDO instance referencing the same database file.

We noticed this issue in a medium size Zend Expressive installation while executing multiple acceptance tests. The PHP garbage collection was not able to close/unset all PDO references until the whole PHP process closes... So every time the Sqlite cleanup was executed the file wasn't truncated correctly. Instead a already open connection in PHP's garbage collection was blocking any write operations and has reverted the truncation of the sqlite database every time.

To challenge such issue the most effective way was to execute `gc_collect_cycles()` right after the cleanup method of the Sqlite Driver. At this point the PHP garbage collector seems to be able to cleanup all existing PDO references. On the filesystem can be seen that at this point the sqlite-journal file will be removed. This will release any connection from sqlite file and PHP's `file_put_contents()` call will really truncate the file before connecting again :)

PS: we tried to create a test for this but it's too hard to create a reproducable garbage collection issue :)
Hopefully this explanation is enough for you guys 😄 Thx 👍 