### PR TITLE
Phalcon ActiveRecord: escape all column names using []

### DIFF
--- a/src/Codeception/Module/Phalcon.php
+++ b/src/Codeception/Module/Phalcon.php
@@ -564,9 +564,9 @@ class Phalcon extends Framework implements ActiveRecord, PartedModule
         $bind       = [];
         foreach ($attributes as $key => $value) {
             if ($value === null) {
-                $conditions[] = "$key IS NULL";
+                $conditions[] = "[$key] IS NULL";
             } else {
-                $conditions[] = "$key = :$key:";
+                $conditions[] = "[$key] = :$key:";
                 $bind[$key] = $value;
             }
         }
@@ -595,9 +595,9 @@ class Phalcon extends Framework implements ActiveRecord, PartedModule
         $bind       = [];
         foreach ($attributes as $key => $value) {
             if ($value === null) {
-                $conditions[] = "$key IS NULL";
+                $conditions[] = "[$key] IS NULL";
             } else {
-                $conditions[] = "$key = :$key:";
+                $conditions[] = "[$key] = :$key:";
                 $bind[$key] = $value;
             }
         }


### PR DESCRIPTION
This allows using column names like `from` or `left`
See: https://docs.phalconphp.com/3.4/en/db-phql#escaping-reserved-words