### PR TITLE
Fix AppVeyor build

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,4 @@
 build: false
-shallow_clone: true
 platform: 'x86'
 branches:
   except:


### PR DESCRIPTION
Don't use shallow clone, because export-ignore rules ignore tests directory.