### PR TITLE
Fix "conditional assertions" doc: enabled by default

### DIFF
--- a/docs/03-AcceptanceTests.md
+++ b/docs/03-AcceptanceTests.md
@@ -273,7 +273,7 @@ $I->cantSeeInField('user[name]', 'Miles');
 
 Each failed assertion will be shown in the test results, but it won't stop the test.
 
-Conditional assertions are disabled in bootstrap setup. To enable them you should add corresponding step decorators to suite config:
+Conditional assertions are enabled by default suite config step decorator settings (unless overridden):
 
 > If you started project as `codecept init acceptance` they should be already enabled in config
 


### PR DESCRIPTION
Cf. https://github.com/Codeception/Codeception/blob/582ffe3c9747875062f8569e71694b04cfe6bc42/src/Codeception/Configuration.php#L114

I think current documentation is not correct or at least a bit misleading. Frankly I have doubts that my suggested change is ideal though, maybe it can be still improved...

Question concerning the documentation code comment (right afterwards) "_# or in codeception.yml insides suites section_":
* I naively tried and failed with the following approach in "codeception.yml":
```
...
extensions:
    ...
suites:
    step_decorators:
        - \Codeception\Step\Retry
```
* How is that supposed to work?