### PR TITLE
Fix doc for retry behaviour doubling wait interval

### DIFF
--- a/docs/03-AcceptanceTests.md
+++ b/docs/03-AcceptanceTests.md
@@ -516,17 +516,18 @@ $I->retryClick('flaky element');
 $I->retrySee('Something changed');
 ```
 
-Retry can be configured via `$I->retry()` command, where you can set number of retries and interval.
+Retry can be configured via `$I->retry()` command, where you can set number of retries and initial interval:
+interval will be doubled on each unsuccessful execution.
 
 ```php
 <?php
-// Retry up to 4 sec: 10 times, for 400ms interval 
-$I->retry(10, 400);
+// Retry up to 6 sec: 4 times, for 400ms initial interval => 400ms + 800ms + 1600ms + 3200ms = 6000ms
+$I->retry(4, 400);
 ```
 
 `$I->retry` takes 2 parameters:
 * number of retries (1 by default)
-* interval (200ms by default)
+* initial interval (200ms by default)
 
 Retries are disabled by default. To enable them you should add retry step decorators to suite config:
 


### PR DESCRIPTION
See https://github.com/Codeception/Codeception/blob/3.0/src/Codeception/Lib/Actor/Shared/Retry.php:
"Interval will be doubled on each unsuccessful execution."