### PR TITLE
maxRedirects parameter can be read from public getter

### DIFF
--- a/src/Codeception/Lib/InnerBrowser.php
+++ b/src/Codeception/Lib/InnerBrowser.php
@@ -196,7 +196,13 @@ class InnerBrowser extends Module implements Web, PageSourceSaver, ElementLocato
             return $result;
         }
 
-        $maxRedirects = ReflectionHelper::readPrivateProperty($this->client, 'maxRedirects', 'Symfony\Component\BrowserKit\Client');
+        $maxRedirects = method_exists($this->client, 'getMaxRedirects')
+            ? $this->client->getMaxRedirects()
+            : ReflectionHelper::readPrivateProperty(
+                $this->client,
+                'maxRedirects',
+                'Symfony\Component\BrowserKit\Client'
+            );
         $this->client->followRedirects(false);
         $result = $this->client->request($method, $uri, $parameters, $files, $server, $content, $changeHistory);
         $this->debugResponse($uri);


### PR DESCRIPTION
maxRedirects parameter can be read either from public getter (valid for current vendor/symfony/browser-kit/Client.php - 4.3.*@dev) or from private property via reflection (original unchanged behaviour)