### PR TITLE
maxRedirects parameter can be read from public getter

### DIFF
--- a/src/Codeception/Lib/InnerBrowser.php
+++ b/src/Codeception/Lib/InnerBrowser.php
@@ -190,19 +190,21 @@ class InnerBrowser extends Module implements Web, PageSourceSaver, ElementLocato
             }
         }
 
-        if (!ReflectionHelper::readPrivateProperty($this->client, 'followRedirects')) {
+        if (method_exists($this->client, 'isFollowingRedirects')) {
+            $isFollowingRedirects = $this->client->isFollowingRedirects();
+            $maxRedirects = $this->client->getMaxRedirects();
+        } else {
+            //Symfony 2.7 support
+            $isFollowingRedirects = ReflectionHelper::readPrivateProperty($this->client, 'followRedirects');
+            $maxRedirects = ReflectionHelper::readPrivateProperty($this->client, 'maxRedirects', 'Symfony\Component\BrowserKit\Client');
+        }
+
+        if (!$isFollowingRedirects) {
             $result = $this->client->request($method, $uri, $parameters, $files, $server, $content, $changeHistory);
             $this->debugResponse($uri);
             return $result;
         }
 
-        $maxRedirects = method_exists($this->client, 'getMaxRedirects')
-            ? $this->client->getMaxRedirects()
-            : ReflectionHelper::readPrivateProperty(
-                $this->client,
-                'maxRedirects',
-                'Symfony\Component\BrowserKit\Client'
-            );
         $this->client->followRedirects(false);
         $result = $this->client->request($method, $uri, $parameters, $files, $server, $content, $changeHistory);
         $this->debugResponse($uri);

--- a/src/Codeception/Lib/InnerBrowser.php
+++ b/src/Codeception/Lib/InnerBrowser.php
@@ -196,7 +196,13 @@ class InnerBrowser extends Module implements Web, PageSourceSaver, ElementLocato
             return $result;
         }
 
-        $maxRedirects = ReflectionHelper::readPrivateProperty($this->client, 'maxRedirects', 'Symfony\Component\BrowserKit\Client');
+        $maxRedirects = method_exists($this->client, 'getMaxRedirects')
+            ? $this->client->getMaxRedirects()
+            : ReflectionHelper::readPrivateProperty(
+                $this->client,
+                'maxRedirects',
+                'Symfony\Component\BrowserKit\Client'
+            );
         $this->client->followRedirects(false);
         $result = $this->client->request($method, $uri, $parameters, $files, $server, $content, $changeHistory);
         $this->debugResponse($uri);

--- a/src/Codeception/Lib/InnerBrowser.php
+++ b/src/Codeception/Lib/InnerBrowser.php
@@ -196,7 +196,7 @@ class InnerBrowser extends Module implements Web, PageSourceSaver, ElementLocato
         } else {
             //Symfony 2.7 support
             $isFollowingRedirects = ReflectionHelper::readPrivateProperty($this->client, 'followRedirects');
-            $maxRedirects = ReflectionHelper::readPrivateProperty($this->client, 'maxRedirects', 'Symfony\Component\BrowserKit\Client');
+            $maxRedirects = ReflectionHelper::readPrivateProperty($this->client, 'maxRedirects');
         }
 
         if (!$isFollowingRedirects) {


### PR DESCRIPTION
maxRedirects parameter can be read either from public getter (valid for current vendor/symfony/browser-kit/Client.php - 4.3.*@dev) or from private property via reflection (original unchanged behaviour)

Fixes #5576