### PR TITLE
Switching to buster php build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:7.3-cli
+FROM php:7.3.7-cli-buster
 
 MAINTAINER Tobias Munk tobias@diemeisterei.de
 
@@ -23,7 +23,7 @@ RUN docker-php-ext-install \
 RUN pecl install \
         mongodb \
         apcu \
-        xdebug-2.7.1 && \
+        xdebug-2.7.2 && \
     docker-php-ext-enable \
         apcu.so \
         mongodb.so \


### PR DESCRIPTION
PHP has now has new builds with buster bases.
Docker file has been changed to use those builds instead of stretch.
While I was in there, I also made a cheeky little xdebug update to latest.


This build has been tested with 2 bigger projects of mine, one is lower level (API), and the other is e2e (selenium) based.
Both seemed to be fine without any further changes.