### PR TITLE
Update extension example code

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -55,7 +55,9 @@
         "league/factory-muffin": "For DataFactory module",
         "league/factory-muffin-faker": "For Faker support in DataFactory module",
         "symfony/phpunit-bridge": "For phpunit-bridge support",
-        "stecman/symfony-console-completion": "For BASH autocompletion"
+        "stecman/symfony-console-completion": "For BASH autocompletion",
+        "monolog/monolog": "For Logger extension",
+        "symfony/process": "For RunBefore and RunProcess extensions"
     },
 
     "autoload":{

--- a/docs/08-Customization.md
+++ b/docs/08-Customization.md
@@ -132,7 +132,7 @@ class MyCustomExtension extends \Codeception\Extension
 
     public static $events = array(
         Events::SUITE_AFTER  => 'afterSuite',
-        Events::SUITE_BEFORE => 'beforeTest',
+        Events::TEST_BEFORE => 'beforeTest',
         Events::STEP_BEFORE => 'beforeStep',
         Events::TEST_FAIL => 'testFailed',
         Events::RESULT_PRINT_AFTER => 'print',

--- a/src/Codeception/Module.php
+++ b/src/Codeception/Module.php
@@ -106,7 +106,7 @@ abstract class Module
      * <?php
      * // cleanup DB only for specific group of tests
      * public function _before(Test $test) {
-     *     if (in_array('cleanup', $test->getMetadata()->getGroups()) {
+     *     if (in_array('cleanup', $test->getMetadata()->getGroups())) {
      *         $this->getModule('Db')->_reconfigure(['cleanup' => true]);
      *     }
      * }


### PR DESCRIPTION
Second value in `$events` array did hold `SUITE_BEFORE`, while the function is `beforeTest` and calls for a `TestEvent`

previous code threw error:
```
Error: Argument 1 passed to MyCustomExtension::beforeTest() must  be an instance of 
Codeception\Event\TestEvent, instance of Codeception\Event\SuiteEvent given
```