### PR TITLE
Improve file path detection for groups

### DIFF
--- a/src/Codeception/Lib/GroupManager.php
+++ b/src/Codeception/Lib/GroupManager.php
@@ -98,7 +98,7 @@ class GroupManager
             if (isset($info['class'])) {
                 $groups = array_merge($groups, \PHPUnit\Util\Test::getGroups($info['class'], $info['name']));
             }
-            $filename = str_replace(['\\\\', '//'], ['\\', '/'], $info['file']);
+            $filename = str_replace(['\\\\', '//', '/./'], ['\\', '/', '/'], $info['file']);
         }
         if ($test instanceof \PHPUnit\Framework\TestCase) {
             $groups = array_merge($groups, \PHPUnit\Util\Test::getGroups(get_class($test), $test->getName(false)));


### PR DESCRIPTION
#### What are you trying to achieve?

Hi there, 
I was trying to add some groups to my suites but I encountered a weird case: some groups were unable to load tests, and some were able to do.

After some investigation, I found out that this case occurs :
- when you set your suite path to `.`
- when you define groups directly in your suite config file

🙈 no problem happens if you use annotation directly in your test files.

#### What do you get instead?

The binary does not run the tests.

```bash
application@356115a48d2a:/app$ php vendor/bin/codecept run -g api-package
Codeception PHP Testing Framework v3.0.0
Powered by PHPUnit 7.5.9 by Sebastian Bergmann and contributors.
Running with seed:

[Groups] api-package

Api Tests (0) -------------------------------------------------------------------------------------------------------------------------
---------------------------------------------------------------------------------------------------------------------------------------

Time: 251 ms, Memory: 26.00 MB

No tests executed!
```

### Details

* Codeception version: 3.0.0
* PHP Version: 7.2.15
* Operating System: Debian
* Installation type: Composer
* Suite configuration:

```yml
suites:
    api:
        actor: ApiTester
        path: .
        modules:
            enabled:
                - Symfony:
                    app_path: 'app'
                    environment: 'test'
                    kernel_class: MicroKernel
                - REST:
                    depends: Symfony
                - Doctrine2:
                    depends: Symfony
                - \Helper\ILoveMyHelper
        error_level: "E_ALL & ~E_STRICT & !E_DEPRECATED"
paths:
    tests: tests
    output: tests/_output
    data: tests/_data
    support: tests/_support

settings:
    shuffle: false
    lint: true

groups:
    api: [tests/]
    api-package: [tests/./package] # this works fine
    api-package-2: [tests/package] # this does not work without the fix
```