### PR TITLE
Relaxing docker php image tag version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:7.3.7-cli-buster
+FROM php:7.3-cli
 
 MAINTAINER Tobias Munk tobias@diemeisterei.de
 


### PR DESCRIPTION
Now that the buster based PHP images are the default, and now that the existing default tags have been switched to from stretch, It makes sense to relax the docker tag to major version only.