### PR TITLE
Fix codeception/base

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,6 +22,7 @@
         "facebook/webdriver": "^1.6.0",
         "guzzlehttp/guzzle": "^6.3.0",
         "guzzlehttp/psr7": "~1.4",
+        "hoa/console": "~3.0",
         "symfony/finder": ">=2.7 <5.0",
         "symfony/console": ">=2.7 <5.0",
         "symfony/event-dispatcher": ">=2.7 <5.0",
@@ -31,8 +32,7 @@
         "symfony/dom-crawler": ">=2.7 <5.0",
         "behat/gherkin": "^4.4.0",
         "codeception/phpunit-wrapper": ">6.0.15 <6.1.0 | ^6.6.1 | ^7.7.1 | ^8.0.3",
-        "codeception/stub": "^2.0",
-        "hoa/console": "~3.0"
+        "codeception/stub": "^2.0"
     },
     "require-dev": {
         "monolog/monolog": "~1.8",


### PR DESCRIPTION
Move hoa/console to the middle of dependency list, because removing last dependency makes composer.json invalid.

Fixes #5604