### PR TITLE
[Yii2] Allow to preserve session with recreateApplication enabled

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ env:
     - SYMFONY_DEPRECATIONS_HELPER=weak
   matrix:
   - FRAMEWORK=Codeception SUITES=cli,unit TEST_PATH=. XDEBUG=1 PECL=mongodb
-  - FRAMEWORK=Yii2 TEST_REPO="https://github.com/Codeception/yii2-tests"
+  - FRAMEWORK=Yii2 TEST_REPO="https://github.com/Slamdunk/yii2-tests -b closeSessionOnRecreateApplication"
   - FRAMEWORK=Symfony VERSION=2.8 TEST_REPO='-b 2.1 https://github.com/Codeception/symfony-demo.git' SUITES=functional TEST_PATH=framework-tests/src/AppBundle
   - FRAMEWORK=Symfony VERSION=3.4 TEST_REPO='--recurse-submodules https://github.com/Naktibalda/codeception-symfony-tests'
   - FRAMEWORK=Symfony VERSION=4 TEST_REPO='https://github.com/Codeception/symfony-demo.git' SUITES=functional,unit

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ env:
     - SYMFONY_DEPRECATIONS_HELPER=weak
   matrix:
   - FRAMEWORK=Codeception SUITES=cli,unit TEST_PATH=. XDEBUG=1 PECL=mongodb
-  - FRAMEWORK=Yii2 TEST_REPO="https://github.com/Slamdunk/yii2-tests  -b closeSessionOnRecreateApplication"
+  - FRAMEWORK=Yii2 TEST_REPO="https://github.com/Codeception/yii2-tests"
   - FRAMEWORK=Symfony VERSION=2.8 TEST_REPO='-b 2.1 https://github.com/Codeception/symfony-demo.git' SUITES=functional TEST_PATH=framework-tests/src/AppBundle
   - FRAMEWORK=Symfony VERSION=3.4 TEST_REPO='--recurse-submodules https://github.com/Naktibalda/codeception-symfony-tests'
   - FRAMEWORK=Symfony VERSION=4 TEST_REPO='https://github.com/Codeception/symfony-demo.git' SUITES=functional,unit

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ env:
     - SYMFONY_DEPRECATIONS_HELPER=weak
   matrix:
   - FRAMEWORK=Codeception SUITES=cli,unit TEST_PATH=. XDEBUG=1 PECL=mongodb
-  - FRAMEWORK=Yii2 TEST_REPO="https://github.com/Slamdunk/yii2-tests -b closeSessionOnRecreateApplication"
+  - FRAMEWORK=Yii2 TEST_REPO="https://github.com/Slamdunk/yii2-tests  -b closeSessionOnRecreateApplication"
   - FRAMEWORK=Symfony VERSION=2.8 TEST_REPO='-b 2.1 https://github.com/Codeception/symfony-demo.git' SUITES=functional TEST_PATH=framework-tests/src/AppBundle
   - FRAMEWORK=Symfony VERSION=3.4 TEST_REPO='--recurse-submodules https://github.com/Naktibalda/codeception-symfony-tests'
   - FRAMEWORK=Symfony VERSION=4 TEST_REPO='https://github.com/Codeception/symfony-demo.git' SUITES=functional,unit

--- a/src/Codeception/Lib/Connector/Yii2.php
+++ b/src/Codeception/Lib/Connector/Yii2.php
@@ -80,6 +80,11 @@ class Yii2 extends Client
      */
     public $recreateApplication = false;
 
+    /**
+     * @var bool whether to close the session in between requests inside a single test, if recreateApplication is set to true
+     */
+    public $closeSessionOnRecreateApplication = true;
+
 
     private $emails = [];
 
@@ -96,10 +101,15 @@ class Yii2 extends Client
         return Yii::$app;
     }
 
-    public function resetApplication()
+    /**
+     * @param bool $closeSession
+     */
+    public function resetApplication($closeSession = true)
     {
         codecept_debug('Destroying application');
-        $this->closeSession();
+        if (true === $closeSession) {
+            $this->closeSession();
+        }
         Yii::$app = null;
         \yii\web\UploadedFile::reset();
         if (method_exists(\yii\base\Event::className(), 'offAll')) {
@@ -542,7 +552,7 @@ TEXT
     protected function beforeRequest()
     {
         if ($this->recreateApplication) {
-            $this->resetApplication();
+            $this->resetApplication($this->closeSessionOnRecreateApplication);
             return;
         }
 

--- a/src/Codeception/Module/Yii2.php
+++ b/src/Codeception/Module/Yii2.php
@@ -46,8 +46,9 @@ use yii\db\Transaction;
  * * `recreateComponents` - (default: []) Some components change their state making them unsuitable for processing multiple requests. In production this is usually
  * not a problem since web apps tend to die and start over after each request. This allows you to list application components that need to be recreated before each request.
  * As a consequence, any components specified here should not be changed inside a test since those changes will get regarded.
- * You can use this module by setting params in your functional.suite.yml:
  * * `recreateApplication` - (default: false) whether to recreate the whole application before each request
+ * * `closeSessionOnRecreateApplication` - (default: true) whether to close the session in between requests inside a single test,
+ * * if recreateApplication is set to true
  * You can use this module by setting params in your functional.suite.yml:
  * ```yaml
  * actor: FunctionalTester
@@ -162,7 +163,8 @@ class Yii2 extends Framework implements ActiveRecord, PartedModule
         'responseCleanMethod' => Yii2Connector::CLEAN_CLEAR,
         'requestCleanMethod' => Yii2Connector::CLEAN_RECREATE,
         'recreateComponents' => [],
-        'recreateApplication' => false
+        'recreateApplication' => false,
+        'closeSessionOnRecreateApplication' => true,
     ];
 
     protected $requiredFields = ['configFile'];


### PR DESCRIPTION
Yii2 module allows you to either

1. Preserve application state after a request was handled, the default behavior, useful for white box inspection
1. Or reset the whole application in between requests inside a single test, with `recreateApplication` set to true

While the first approach may be faster and opens the possibility to test internal state, I had impassable issues with third party libraries that don't get the developer proper ways to clear state and mimic real stateless multiple requests.

So I must use `recreateApplication` to get fast functional tests work, but as mentioned in https://github.com/Codeception/Codeception/pull/5173/files#r220501466 now this options is basically useless since session is close and thrown away if `recreateApplication` is enabled.

This PR aims to restore the benefits stateless multiple consequent requests of `recreateApplication`  preserving session inside single test, and dropping it only after each test.

I would have loved to add tests for this, but https://github.com/Codeception/yii2-tests seems outdated and unmaintained: it would be better to integrate it in the code library test suite.