### PR TITLE
Add possibility to use absolute path for `settings.bootstrap` key in codeception.yml

### DIFF
--- a/src/Codeception/Subscriber/Bootstrap.php
+++ b/src/Codeception/Subscriber/Bootstrap.php
@@ -26,7 +26,10 @@ class Bootstrap implements EventSubscriberInterface
             return;
         }
 
-        $bootstrap = $settings['path'] . $settings['bootstrap'];
+        $bootstrap = codecept_is_path_absolute($settings['bootstrap'])
+            ? $settings['bootstrap']
+            : $settings['path'] . $settings['bootstrap'];
+
         if (!is_file($bootstrap)) {
             throw new ConfigurationException("Bootstrap file $bootstrap can't be loaded");
         }


### PR DESCRIPTION
* Fixes #5611
* fully backward compatible
* intentionally targeted to 3.0 branch as it is bugfix (I treat it like this) or a very small feature

As simple as that.
