### PR TITLE
Support Stub 3.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
         "symfony/dom-crawler": ">=2.7 <5.0",
         "behat/gherkin": "^4.4.0",
         "codeception/phpunit-wrapper": ">6.0.15 <6.1.0 | ^6.6.1 | ^7.7.1 | ^8.0.3",
-        "codeception/stub": "^2.0"
+        "codeception/stub": "^2.0 | ^3.0"
     },
     "require-dev": {
         "monolog/monolog": "~1.8",


### PR DESCRIPTION
Which doesn't use shim file and supports only PHPUnit 6.5+

Fixes #5508