### PR TITLE
Add assert equals canonicalizing

### DIFF
--- a/src/Codeception/Module/Asserts.php
+++ b/src/Codeception/Module/Asserts.php
@@ -67,6 +67,7 @@ class Asserts extends CodeceptionModule
         assertIsNotString  as public;
         assertIsNotScalar  as public;
         assertIsNotCallable  as public;
+        assertEqualsCanonicalizing as public;
         fail as public;
     }
 

--- a/src/Codeception/Util/Shared/Asserts.php
+++ b/src/Codeception/Util/Shared/Asserts.php
@@ -570,7 +570,6 @@ trait Asserts
      * @param        $expected
      * @param        $actual
      * @param string $message
-     * @param float  $delta
      */
     protected function assertEqualsCanonicalizing($expected, $actual, $message = '')
     {

--- a/src/Codeception/Util/Shared/Asserts.php
+++ b/src/Codeception/Util/Shared/Asserts.php
@@ -563,4 +563,17 @@ trait Asserts
     {
         \Codeception\PHPUnit\TestCase::assertIsNotCallable($actual, $message);
     }
+
+    /**
+     * Checks that two canonicalized variables are equal.
+     *
+     * @param        $expected
+     * @param        $actual
+     * @param string $message
+     * @param float  $delta
+     */
+    protected function assertEqualsCanonicalizing($expected, $actual, $message = '')
+    {
+        \PHPUnit\Framework\Assert::assertEqualsCanonicalizing($expected, $actual, $message);
+    }
 }


### PR DESCRIPTION
Today I wanted to test if two arrays have equal elements but without taking their order into account. After some research, I found that PHPUnit has this kind of assertion called
"assertEqualsCanonicalizing" which is not supported in Codeception.

I hope you will take a look. Best regards! :)