### PR TITLE
[Asserts] Added specialized assertEquals methods

### DIFF
--- a/src/Codeception/Module/Asserts.php
+++ b/src/Codeception/Module/Asserts.php
@@ -12,6 +12,12 @@ class Asserts extends CodeceptionModule
     use SharedAsserts {
         assertEquals as public;
         assertNotEquals as public;
+        assertEqualsCanonicalizing as public;
+        assertNotEqualsCanonicalizing as public;
+        assertEqualsIgnoringCase as public;
+        assertNotEqualsIgnoringCase as public;
+        assertEqualsWithDelta as public;
+        assertNotEqualsWithDelta as public;
         assertSame as public;
         assertNotSame as public;
         assertGreaterThan as public;

--- a/src/Codeception/Util/Shared/Asserts.php
+++ b/src/Codeception/Util/Shared/Asserts.php
@@ -563,4 +563,34 @@ trait Asserts
     {
         \Codeception\PHPUnit\TestCase::assertIsNotCallable($actual, $message);
     }
+
+    protected function assertEqualsCanonicalizing($expected, $actual, $message = '')
+    {
+        \Codeception\PHPUnit\TestCase::assertEqualsCanonicalizing($expected, $actual, $message);
+    }
+
+    protected function assertNotEqualsCanonicalizing($expected, $actual, $message = '')
+    {
+        \Codeception\PHPUnit\TestCase::assertNotEqualsCanonicalizing($expected, $actual, $message);
+    }
+
+    protected function assertEqualsIgnoringCase($expected, $actual, $message = '')
+    {
+        \Codeception\PHPUnit\TestCase::assertEqualsIgnoringCase($expected, $actual, $message);
+    }
+
+    protected function assertNotEqualsIgnoringCase($expected, $actual, $message = '')
+    {
+        \Codeception\PHPUnit\TestCase::assertNotEqualsIgnoringCase($expected, $actual, $message);
+    }
+
+    protected function assertEqualsWithDelta($expected, $actual, $delta, $message = '')
+    {
+        \Codeception\PHPUnit\TestCase::assertEqualsWithDelta($expected, $actual, $delta, $message);
+    }
+
+    protected function assertNotEqualsWithDelta($expected, $actual, $delta, $message = '')
+    {
+        \Codeception\PHPUnit\TestCase::assertNotEqualsWithDelta($expected, $actual, $delta, $message);
+    }
 }

--- a/tests/unit/Codeception/Module/AssertsTest.php
+++ b/tests/unit/Codeception/Module/AssertsTest.php
@@ -69,6 +69,13 @@ class AssertsTest extends \Codeception\PHPUnit\TestCase
         $this->module->assertIsNotString(false);
         $this->module->assertIsNotScalar(function() {});
         $this->module->assertIsNotCallable('test');
+
+        $this->module->assertEqualsCanonicalizing([3, 2, 1], [1, 2, 3]);
+        $this->module->assertNotEqualsCanonicalizing([3, 2, 1], [2, 3, 0, 1]);
+        $this->module->assertEqualsIgnoringCase('foo', 'FOO');
+        $this->module->assertNotEqualsIgnoringCase('foo', 'BAR');
+        $this->module->assertEqualsWithDelta(1.0, 1.01, 0.1);
+        $this->module->assertNotEqualsWithDelta(1.0, 1.5, 0.1);
     }
 
     public function testExceptions()


### PR DESCRIPTION
* assertEqualsCanonicalizing
* assertNotEqualsCanonicalizing
* assertEqualsIgnoringCase
* assertNotEqualsIgnoringCase
* assertEqualsWithDelta
* assertNotEqualsWithDelta

Backported them to PHPUnit 5.7 - 6.5 too.