### PR TITLE
[Doctrine2] fixing issue where `haveInRepository` doesn't supported instantiated objects anymore

### DIFF
--- a/src/Codeception/Util/ReflectionPropertyAccessor.php
+++ b/src/Codeception/Util/ReflectionPropertyAccessor.php
@@ -53,11 +53,17 @@ class ReflectionPropertyAccessor
             foreach ($constructor->getParameters() as $parameter) {
                 if ($parameter->isOptional()) {
                     $constructorParameters[] = $parameter->getDefaultValue();
-                } elseif (array_key_exists($parameter->getName(), $data)) {
+                } elseif (\array_key_exists($parameter->getName(), $data)) {
                     $constructorParameters[] = $data[$parameter->getName()];
-                } else {
+                } elseif (false === \is_a($obj, $class)) {
+                    /*
+                     * In case we need to create the entity via reflection, we need to have all constructor parameters
+                     * in the $data array, in case we only want to enhance an existing instance, the given $obj has
+                     * already been constructed with all of its parameters outside of this function,
+                     * so we can skip throwing this exception.
+                     */
                     throw new InvalidArgumentException(
-                        'Constructor parameter "'.$parameter->getName().'" missing'
+                      'Constructor parameter "'.$parameter->getName().'" missing'
                     );
                 }
             }

--- a/src/Codeception/Util/ReflectionPropertyAccessor.php
+++ b/src/Codeception/Util/ReflectionPropertyAccessor.php
@@ -53,7 +53,7 @@ class ReflectionPropertyAccessor
          * already been constructed with all of its parameters outside of this function,
          * so we can skip creating it via reflection.
          */
-        if ($this->isObjectOf($obj, $class)) {
+        if ($this->isNoObjectOf($obj, $class)) {
             $obj = $this->createObjectViaReflection($reflectedEntity, $data);
         }
 
@@ -106,7 +106,7 @@ class ReflectionPropertyAccessor
      *
      * @return bool
      */
-    private function isObjectOf($obj, $class)
+    private function isNoObjectOf($obj, $class)
     {
         return false === \is_a($obj, $class);
     }

--- a/src/Codeception/Util/ReflectionPropertyAccessor.php
+++ b/src/Codeception/Util/ReflectionPropertyAccessor.php
@@ -130,7 +130,7 @@ class ReflectionPropertyAccessor
                     $constructorParameters[] = $data[$parameter->getName()];
                 } else {
                     throw new InvalidArgumentException(
-                      'Constructor parameter "'.$parameter->getName().'" missing'
+                        'Constructor parameter "'.$parameter->getName().'" missing'
                     );
                 }
             }

--- a/src/Codeception/Util/ReflectionPropertyAccessor.php
+++ b/src/Codeception/Util/ReflectionPropertyAccessor.php
@@ -51,7 +51,7 @@ class ReflectionPropertyAccessor
          * In case we need to create the entity via reflection, we need to have all constructor parameters
          * in the $data array, in case we only want to enhance an existing instance, the given $obj has
          * already been constructed with all of its parameters outside of this function,
-         * so we can skip throwing this exception.
+         * so we can skip creating it via reflection.
          */
         if ($this->isObjectOf($obj, $class)) {
             $obj = $this->createObjectViaReflection($reflectedEntity, $data);

--- a/tests/unit/Codeception/Module/Doctrine2Test.php
+++ b/tests/unit/Codeception/Module/Doctrine2Test.php
@@ -128,6 +128,44 @@ class Doctrine2Test extends Unit
         $this->module->haveInRepository(EntityWithConstructorParameters::class);
     }
 
+    public function testInstatiatedEntityWithConstructorParameter()
+    {
+        $name    = 'Constructor Test 2';
+        $entity = new EntityWithConstructorParameters($name);
+
+        $this->module->dontSeeInRepository(
+          EntityWithConstructorParameters::class,
+          ['name' => $name, 'foo' => 'test', 'bar' => 'foobar']
+        );
+
+        $this->module->haveInRepository($entity, ['foo' => 'test', 'bar' => 'foobar']);
+
+        $this->module->seeInRepository(
+          EntityWithConstructorParameters::class,
+          ['name' => $name, 'foo' => 'test', 'bar' => 'foobar']
+        );
+    }
+
+    public function testInstatiatedEntityWithConstructorParameterOverwritingConstructorValueFromDataArray()
+    {
+        $name   = 'Constructor Test 3';
+        $changedName = 'Changed name';
+
+        $entity = new EntityWithConstructorParameters($name);
+
+        $this->module->dontSeeInRepository(
+          EntityWithConstructorParameters::class,
+          ['name' => $name, 'foo' => 'test', 'bar' => 'foobar']
+        );
+
+        $this->module->haveInRepository($entity, ['name' => $changedName, 'foo' => 'test', 'bar' => 'foobar']);
+
+        $this->module->seeInRepository(
+          EntityWithConstructorParameters::class,
+          ['name' => $changedName, 'foo' => 'test', 'bar' => 'foobar']
+        );
+    }
+
     public function testJoinedEntityOwnField()
     {
         $this->module->dontSeeInRepository(JoinedEntity::class, ['own' => 'Test 1']);

--- a/tests/unit/Codeception/Module/Doctrine2Test.php
+++ b/tests/unit/Codeception/Module/Doctrine2Test.php
@@ -146,6 +146,26 @@ class Doctrine2Test extends Unit
         );
     }
 
+    public function testEntityWithOptionalConstructorParameters()
+    {
+        $name = 'Constructor Test 4';
+
+        $this->module->dontSeeInRepository(
+          EntityWithConstructorParameters::class,
+          ['name' => $name, 'foo' => 'test']
+        );
+
+        $this->module->haveInRepository(
+          EntityWithConstructorParameters::class,
+          ['name' => $name, 'foo' => 'test']
+        );
+
+        $this->module->seeInRepository(
+          EntityWithConstructorParameters::class,
+          ['name' => $name, 'foo' => 'test']
+        );
+    }
+
     public function testInstatiatedEntityWithConstructorParameterOverwritingConstructorValueFromDataArray()
     {
         $name   = 'Constructor Test 3';


### PR DESCRIPTION
In addition to #5633.
Fixing issue where `haveInRepository` doesn't supported instantiated objects anymore.

In general I'm not a friend of comments in code, but the one in `ReflectionPropertyAccessor.php` describes the behaviour and why we do the `is_a()` call.