### PR TITLE
[Doctrine2] Let haveInRepository handle composite keys of related entities properly.

### DIFF
--- a/src/Codeception/Module/Doctrine2.php
+++ b/src/Codeception/Module/Doctrine2.php
@@ -637,7 +637,11 @@ EOF;
         if ($metadata->isIdentifierComposite) {
             $pk = [];
             foreach ($metadata->identifier as $field) {
-                $pk[] = $rpa->getProperty($instance, $field);
+                $id = $rpa->getProperty($instance, $field);
+                if (is_object($id)) {
+                    $id = [get_class($id) => $this->extractPrimaryKey($id)];
+                }
+                $pk[] = $id;
             }
         } else {
             $pk = $rpa->getProperty($instance, $metadata->identifier[0]);

--- a/src/Codeception/Module/Doctrine2.php
+++ b/src/Codeception/Module/Doctrine2.php
@@ -427,7 +427,8 @@ EOF;
      * If the entity has a constructor, for optional parameters the default value will be used and for non-optional parameters the given fields (with a matching name) will be passed when calling the constructor before the properties get set directly (via reflection).
      *
      * Returns primary key of newly created entity. Primary key value is extracted using Reflection API.
-     * If primary key is composite, array of values is returned.
+     * If primary key is composite, array of values is returned. If primary key
+     * is composite of related entites, array of [classname, pk] arrays is returned.
      *
      * ```php
      * $I->haveInRepository('Entity\User', array('name' => 'davert'));
@@ -639,7 +640,7 @@ EOF;
             foreach ($metadata->identifier as $field) {
                 $id = $rpa->getProperty($instance, $field);
                 if (is_object($id)) {
-                    $id = [get_class($id) => $this->extractPrimaryKey($id)];
+                    $id = [get_class($id), $this->extractPrimaryKey($id)];
                 }
                 $pk[] = $id;
             }

--- a/tests/data/doctrine2_entities/CompositePrimaryKeyEntityWithManyToOneKeys.php
+++ b/tests/data/doctrine2_entities/CompositePrimaryKeyEntityWithManyToOneKeys.php
@@ -1,0 +1,37 @@
+<?php
+
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * Class EntityWithCompositeIdOfRelatedEntities
+ *
+ * @ORM\Entity
+ */
+class CompositePrimaryKeyEntityWithManyToOneKeys
+{
+    /**
+     * @var \PlainEntity
+     * @ORM\Id
+     * @ORM\ManyToOne(targetEntity="PlainEntity", cascade={"persist"})
+     */
+    private $firstComposite;
+
+    /**
+     * @var \PlainEntity
+     * @ORM\Id
+     * @ORM\ManyToOne(targetEntity="PlainEntity", cascade={"persist"})
+     */
+    private $secondComposite;
+
+    /**
+     * CompositePrimaryKeyEntityWithManyToOneKeys constructor.
+     *
+     * @param \PlainEntity $firstComposite
+     * @param \PlainEntity $secondComposite
+     */
+    public function __construct(PlainEntity $firstComposite, PlainEntity $secondComposite)
+    {
+        $this->firstComposite  = $firstComposite;
+        $this->secondComposite = $secondComposite;
+    }
+}

--- a/tests/unit/Codeception/Module/Doctrine2Test.php
+++ b/tests/unit/Codeception/Module/Doctrine2Test.php
@@ -37,6 +37,7 @@ class Doctrine2Test extends Unit
         $dir = __DIR__ . "/../../../data/doctrine2_entities";
 
         require_once $dir . "/CompositePrimaryKeyEntity.php";
+        require_once $dir . "/CompositePrimaryKeyEntityWithManyToOneKeys.php";
         require_once $dir . "/PlainEntity.php";
         require_once $dir . "/EntityWithConstructorParameters.php";
         require_once $dir . "/JoinedEntityBase.php";
@@ -58,6 +59,7 @@ class Doctrine2Test extends Unit
 
         (new SchemaTool($this->em))->createSchema([
             $this->em->getClassMetadata(CompositePrimaryKeyEntity::class),
+            $this->em->getClassMetadata(CompositePrimaryKeyEntityWithManyToOneKeys::class),
             $this->em->getClassMetadata(PlainEntity::class),
             $this->em->getClassMetadata(EntityWithConstructorParameters::class),
             $this->em->getClassMetadata(JoinedEntityBase::class),
@@ -358,6 +360,23 @@ class Doctrine2Test extends Unit
             'stringPart' => 'abc',
         ]);
         $this->assertEquals([123, 'abc'], $res);
+    }
+
+    public function testCompositePrimaryKeyWithManyToOneKeysReturnsArrayOfRelatedClassNamesAndKeys()
+    {
+        $firstComposite  = new PlainEntity();
+        $secondComposite = new PlainEntity();
+        $compositeEntity = new CompositePrimaryKeyEntityWithManyToOneKeys($firstComposite, $secondComposite);
+
+        $pks = $this->module->haveInRepository(
+          $compositeEntity,
+          ['firstComposite' => $firstComposite, 'secondComposite' => $secondComposite]
+        );
+
+        $this->assertEquals([
+          [PlainEntity::class => 1],
+          [PlainEntity::class => 2],
+        ], $pks);
     }
 
     public function testRefresh()

--- a/tests/unit/Codeception/Module/Doctrine2Test.php
+++ b/tests/unit/Codeception/Module/Doctrine2Test.php
@@ -374,8 +374,8 @@ class Doctrine2Test extends Unit
         );
 
         $this->assertEquals([
-          [PlainEntity::class => 1],
-          [PlainEntity::class => 2],
+          [PlainEntity::class, 1],
+          [PlainEntity::class, 2],
         ], $pks);
     }
 


### PR DESCRIPTION
Fixes #5663.

Maybe this is a BC break?!

Updated haveInRepository to return a hashmap of FQCN => $pk when composite ids are entities, as well.