### PR TITLE
Use Symfony5 class names in connectors

### DIFF
--- a/shim.php
+++ b/shim.php
@@ -69,4 +69,9 @@ namespace {
         class WebDriverWindow extends Facebook\WebDriver\WebDriverWindow {};
         interface WebDriverElement extends Facebook\WebDriver\WebDriverElement {};
     }
+
+    //Alias for Symfony < 4.3
+    if (!class_exists('Symfony\Component\BrowserKit\AbstractBrowser') && class_exists('Symfony\Component\BrowserKit\Client')) {
+        class_alias('Symfony\Component\BrowserKit\Client', 'Symfony\Component\BrowserKit\AbstractBrowser');
+    }
 }

--- a/src/Codeception/Lib/Connector/Guzzle.php
+++ b/src/Codeception/Lib/Connector/Guzzle.php
@@ -14,7 +14,7 @@ use GuzzleHttp\HandlerStack;
 use GuzzleHttp\Psr7\Request as Psr7Request;
 use GuzzleHttp\Psr7\Response as Psr7Response;
 use GuzzleHttp\Psr7\Uri as Psr7Uri;
-use Symfony\Component\BrowserKit\Client;
+use Symfony\Component\BrowserKit\AbstractBrowser as Client;
 use Symfony\Component\BrowserKit\Cookie;
 use Symfony\Component\BrowserKit\Request as BrowserKitRequest;
 use Symfony\Component\BrowserKit\Response as BrowserKitResponse;

--- a/src/Codeception/Lib/Connector/Laravel5.php
+++ b/src/Codeception/Lib/Connector/Laravel5.php
@@ -10,7 +10,12 @@ use Illuminate\Http\Request;
 use Illuminate\Http\UploadedFile;
 use Symfony\Component\HttpFoundation\Request as SymfonyRequest;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\HttpKernel\Client;
+use Symfony\Component\HttpKernel\HttpKernelBrowser as Client;
+
+//Alias for Symfony < 4.3
+if (!class_exists('Symfony\Component\HttpKernel\HttpKernelBrowser') && class_exists('Symfony\Component\HttpKernel\Client')) {
+    class_alias('Symfony\Component\HttpKernel\Client', 'Symfony\Component\HttpKernel\HttpKernelBrowser');
+}
 
 class Laravel5 extends Client
 {

--- a/src/Codeception/Lib/Connector/Lumen.php
+++ b/src/Codeception/Lib/Connector/Lumen.php
@@ -8,8 +8,13 @@ use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Facade;
 use Symfony\Component\HttpFoundation\Request as SymfonyRequest;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\HttpKernel\Client;
+use Symfony\Component\HttpKernel\HttpKernelBrowser as Client;
 use Illuminate\Http\UploadedFile;
+
+//Alias for Symfony < 4.3
+if (!class_exists('Symfony\Component\HttpKernel\HttpKernelBrowser') && class_exists('Symfony\Component\HttpKernel\Client')) {
+    class_alias('Symfony\Component\HttpKernel\Client', 'Symfony\Component\HttpKernel\HttpKernelBrowser');
+}
 
 class Lumen extends Client
 {

--- a/src/Codeception/Lib/Connector/Phalcon.php
+++ b/src/Codeception/Lib/Connector/Phalcon.php
@@ -9,7 +9,7 @@ use ReflectionProperty;
 use Codeception\Util\Stub;
 use Phalcon\Mvc\Application;
 use Symfony\Component\BrowserKit\Cookie;
-use Symfony\Component\BrowserKit\Client;
+use Symfony\Component\BrowserKit\AbstractBrowser as Client;
 use Phalcon\Mvc\Micro as MicroApplication;
 use Symfony\Component\BrowserKit\Response;
 use Codeception\Lib\Connector\Shared\PhpSuperGlobalsConverter;

--- a/src/Codeception/Lib/Connector/Symfony.php
+++ b/src/Codeception/Lib/Connector/Symfony.php
@@ -1,7 +1,14 @@
 <?php
 namespace Codeception\Lib\Connector;
 
-class Symfony extends \Symfony\Component\HttpKernel\Client
+use Symfony\Component\HttpKernel\HttpKernelBrowser;
+
+//Alias for Symfony < 4.3
+if (!class_exists('Symfony\Component\HttpKernel\HttpKernelBrowser') && class_exists('Symfony\Component\HttpKernel\Client')) {
+    class_alias('Symfony\Component\HttpKernel\Client', 'Symfony\Component\HttpKernel\HttpKernelBrowser');
+}
+
+class Symfony extends HttpKernelBrowser
 {
     /**
      * @var boolean

--- a/src/Codeception/Lib/Connector/Universal.php
+++ b/src/Codeception/Lib/Connector/Universal.php
@@ -1,7 +1,7 @@
 <?php
 namespace Codeception\Lib\Connector;
 
-use Symfony\Component\BrowserKit\Client;
+use Symfony\Component\BrowserKit\AbstractBrowser as Client;
 use Symfony\Component\BrowserKit\Response;
 
 class Universal extends Client

--- a/src/Codeception/Lib/Connector/Yii1.php
+++ b/src/Codeception/Lib/Connector/Yii1.php
@@ -2,7 +2,7 @@
 namespace Codeception\Lib\Connector;
 
 use Codeception\Util\Stub;
-use Symfony\Component\BrowserKit\Client;
+use Symfony\Component\BrowserKit\AbstractBrowser as Client;
 use Symfony\Component\BrowserKit\Response;
 
 class Yii1 extends Client

--- a/src/Codeception/Lib/Connector/Yii2.php
+++ b/src/Codeception/Lib/Connector/Yii2.php
@@ -2,12 +2,10 @@
 namespace Codeception\Lib\Connector;
 
 use Codeception\Exception\ConfigurationException;
-use Codeception\Exception\ModuleException;
 use Codeception\Lib\Connector\Yii2\Logger;
 use Codeception\Lib\Connector\Yii2\TestMailer;
-use Codeception\Lib\InnerBrowser;
 use Codeception\Util\Debug;
-use Symfony\Component\BrowserKit\Client;
+use Symfony\Component\BrowserKit\AbstractBrowser as Client;
 use Symfony\Component\BrowserKit\Cookie;
 use Symfony\Component\BrowserKit\Response;
 use Yii;

--- a/src/Codeception/Lib/Connector/ZF2.php
+++ b/src/Codeception/Lib/Connector/ZF2.php
@@ -2,7 +2,7 @@
 namespace Codeception\Lib\Connector;
 
 use Codeception\Lib\Connector\ZF2\PersistentServiceManager;
-use Symfony\Component\BrowserKit\Client;
+use Symfony\Component\BrowserKit\AbstractBrowser as Client;
 use Symfony\Component\BrowserKit\Response;
 use Zend\Http\Request as HttpRequest;
 use Zend\Http\Headers as HttpHeaders;

--- a/src/Codeception/Lib/Connector/ZendExpressive.php
+++ b/src/Codeception/Lib/Connector/ZendExpressive.php
@@ -3,7 +3,7 @@ namespace Codeception\Lib\Connector;
 
 use Codeception\Configuration;
 use Codeception\Lib\Connector\ZendExpressive\ResponseCollector;
-use Symfony\Component\BrowserKit\Client;
+use Symfony\Component\BrowserKit\AbstractBrowser as Client;
 use Symfony\Component\BrowserKit\Response;
 use Symfony\Component\BrowserKit\Request as BrowserKitRequest;
 use Zend\Diactoros\ServerRequest;

--- a/src/Codeception/Lib/InnerBrowser.php
+++ b/src/Codeception/Lib/InnerBrowser.php
@@ -38,7 +38,7 @@ class InnerBrowser extends Module implements Web, PageSourceSaver, ElementLocato
 
     /**
      * @api
-     * @var \Symfony\Component\BrowserKit\Client
+     * @var \Symfony\Component\BrowserKit\AbstractBrowser
      */
     public $client;
 

--- a/src/Codeception/Module/REST.php
+++ b/src/Codeception/Module/REST.php
@@ -82,7 +82,7 @@ EOF;
     protected $DEFAULT_SHORTEN_VALUE = 150;
 
     /**
-     * @var \Symfony\Component\HttpKernel\Client|\Symfony\Component\BrowserKit\Client
+     * @var \Symfony\Component\HttpKernel\HttpKernelBrowser|\Symfony\Component\BrowserKit\AbstractBrowser
      */
     public $client = null;
     public $isFunctional = false;

--- a/src/Codeception/Module/SOAP.php
+++ b/src/Codeception/Module/SOAP.php
@@ -66,7 +66,7 @@ Framework modules can be used as well for functional testing of SOAP API.
 EOF;
 
     /**
-     * @var \Symfony\Component\BrowserKit\Client
+     * @var \Symfony\Component\BrowserKit\AbstractBrowser
      */
     public $client = null;
     public $isFunctional = false;


### PR DESCRIPTION
#5532

Preparation for Symfony 5, also removes deprecation message when Symfony 4.3 components are used.

HttpKernelBrowser alias must be set in module file because Symfony/HttpKernel package isn't loaded yet by the time shim.php runs because it isn't dependency of Codeception.