### PR TITLE
[Doctrine2] Bugfix: calling haveInRepository with preconstructed entity requires providing constructor parameters

### DIFF
--- a/src/Codeception/Util/ReflectionPropertyAccessor.php
+++ b/src/Codeception/Util/ReflectionPropertyAccessor.php
@@ -47,23 +47,26 @@ class ReflectionPropertyAccessor
     {
         $reflectedEntity = new ReflectionClass($class);
 
-        $constructorParameters = [];
-        $constructor = $reflectedEntity->getConstructor();
-        if (null !== $constructor) {
-            foreach ($constructor->getParameters() as $parameter) {
-                if ($parameter->isOptional()) {
-                    $constructorParameters[] = $parameter->getDefaultValue();
-                } elseif (array_key_exists($parameter->getName(), $data)) {
-                    $constructorParameters[] = $data[$parameter->getName()];
-                } else {
-                    throw new InvalidArgumentException(
-                        'Constructor parameter "'.$parameter->getName().'" missing'
-                    );
+        if (!$obj) {
+            $constructorParameters = [];
+            $constructor = $reflectedEntity->getConstructor();
+            if (null !== $constructor) {
+                foreach ($constructor->getParameters() as $parameter) {
+                    if ($parameter->isOptional()) {
+                        $constructorParameters[] = $parameter->getDefaultValue();
+                    } elseif (array_key_exists($parameter->getName(), $data)) {
+                        $constructorParameters[] = $data[$parameter->getName()];
+                    } else {
+                        throw new InvalidArgumentException(
+                            'Constructor parameter "'.$parameter->getName().'" missing'
+                        );
+                    }
                 }
             }
+
+            $obj = $reflectedEntity->newInstance(...$constructorParameters);
         }
 
-        $obj = $obj ?: $reflectedEntity->newInstance(...$constructorParameters);
         foreach ($reflectedEntity->getProperties() as $property) {
             if (isset($data[$property->name])) {
                 $property->setAccessible(true);

--- a/tests/unit/Codeception/Module/Doctrine2Test.php
+++ b/tests/unit/Codeception/Module/Doctrine2Test.php
@@ -120,6 +120,21 @@ class Doctrine2Test extends Unit
         );
     }
 
+    public function testPreconstructedEntityWithConstructorParameters()
+    {
+        $this->module->dontSeeInRepository(
+            EntityWithConstructorParameters::class,
+            ['name' => 'Constructor Test 1', 'foo' => 'test', 'bar' => 'foobar']
+        );
+
+        $entity = new EntityWithConstructorParameters('Constructor Test 1', 'test');
+        $this->module->haveInRepository($entity);
+
+        $this->module->seeInRepository(
+            EntityWithConstructorParameters::class,
+            ['name' => 'Constructor Test 1', 'foo' => 'test', 'bar' => 'foobar']
+        );
+    }
     public function testEntityWithConstructorParametersExceptionOnMissingParameter()
     {
         $this->expectException(\InvalidArgumentException::class);


### PR DESCRIPTION
As pointed out [here](https://github.com/Codeception/Codeception/pull/5633#issuecomment-523851706) my PR seems to have broken `haveInRepository` in that it doesn't work with preconstructed entities anymore if their constructor has non-optional parameters and you don't provide those properties when calling `haveInRepository`. :man_facepalming: 

As I already offered a pretty simple solution in a commend as a suggestion [here](https://github.com/Codeception/Codeception/pull/5662#issuecomment-523906151) and said PR was rejected as too complex, I'm now offering my suggested (hopefully simple enough) solution along with a test as a PR :)