### PR TITLE
[Doctrine2] Make debug message in haveInRepository support entities with composite keys of entities in bidirectional relations

### DIFF
--- a/src/Codeception/Module/Doctrine2.php
+++ b/src/Codeception/Module/Doctrine2.php
@@ -1024,7 +1024,8 @@ EOF;
         $message = get_class($instance).' entity created with ';
 
         if (!is_array($pks)) {
-            $pks = [$pks];
+            $pks     = [$pks];
+            $message .= 'primary key ';
         } else {
             $message .= 'composite primary key of ';
         }
@@ -1033,7 +1034,7 @@ EOF;
             if (is_object($pk)) {
                 $message .= get_class($pk).': '.var_export($this->extractPrimaryKey($pk), true).', ';
             } else {
-                $message .= 'primary key '.var_export($pk, true);
+                $message .= var_export($pk, true).', ';
             }
         }
 

--- a/src/Codeception/Module/Doctrine2.php
+++ b/src/Codeception/Module/Doctrine2.php
@@ -505,7 +505,7 @@ EOF;
 
         $pk = $this->extractPrimaryKey($instance);
 
-        $this->debug(get_class($instance) . " entity created with primary key " . var_export($pk, true));
+        $this->debugEntityCreation($instance, $pk);
 
         return $pk;
     }
@@ -1011,5 +1011,32 @@ EOF;
             $this->retrieveEntityManager();
         }
         return $this->em;
+    }
+
+    /**
+     * @param mixed $instance
+     * @param mixed $pks
+     *
+     * @throws \ReflectionException
+     */
+    private function debugEntityCreation($instance, $pks)
+    {
+        $message = get_class($instance).' entity created with ';
+
+        if (!is_array($pks)) {
+            $pks = [$pks];
+        } else {
+            $message .= 'composite primary key of ';
+        }
+
+        foreach ($pks as $pk) {
+            if (is_object($pk)) {
+                $message .= get_class($pk).': '.var_export($this->extractPrimaryKey($pk), true).', ';
+            } else {
+                $message .= 'primary key '.var_export($pk, true);
+            }
+        }
+
+        $this->debug(trim($message, ' ,'));
     }
 }

--- a/tests/data/doctrine2_entities/CircularRelations/A.php
+++ b/tests/data/doctrine2_entities/CircularRelations/A.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace CircularRelations;
+
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * @ORM\Entity
+ * @ORM\Table(name="circular_a")
+ */
+class A
+{
+    /**
+     * @var int|null
+     *
+     * @ORM\Id
+     * @ORM\Column(type="integer")
+     * @ORM\GeneratedValue
+     */
+    private $id;
+
+    /**
+     * @var \Doctrine\Common\Collections\ArrayCollection
+     * @ORM\OneToMany(targetEntity="C", mappedBy="a")
+     */
+    private $cs;
+
+    public function __construct()
+    {
+        $this->cs = new ArrayCollection();
+}
+
+    /**
+     * @return int|null
+     */
+    public function getId()
+    {
+        return $this->id;
+    }
+
+    /**
+     * @return \Doctrine\Common\Collections\ArrayCollection
+     */
+    public function getCs()
+    {
+        return $this->cs;
+    }
+}

--- a/tests/data/doctrine2_entities/CircularRelations/B.php
+++ b/tests/data/doctrine2_entities/CircularRelations/B.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace CircularRelations;
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * @ORM\Entity
+ * @ORM\Table(name="circular_b")
+ */
+class B
+{
+    /**
+     * @var int|null
+     *
+     * @ORM\Id
+     * @ORM\Column(type="integer")
+     * @ORM\GeneratedValue
+     */
+    private $id;
+
+    /**
+     * @var \Doctrine\Common\Collections\ArrayCollection
+     * @ORM\OneToMany(targetEntity="C", mappedBy="b")
+     */
+    private $cs;
+
+    public function __construct()
+    {
+        $this->cs = new ArrayCollection();
+    }
+
+    /**
+     * @return int|null
+     */
+    public function getId()
+    {
+        return $this->id;
+    }
+
+    /**
+     * @return \Doctrine\Common\Collections\ArrayCollection
+     */
+    public function getCs()
+    {
+        return $this->cs;
+    }
+}

--- a/tests/data/doctrine2_entities/CircularRelations/C.php
+++ b/tests/data/doctrine2_entities/CircularRelations/C.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace CircularRelations;
+
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * @ORM\Entity
+ * @ORM\Table(name="circular_c")
+ */
+class C
+{
+    /**
+     * @var \CircularRelations\A
+     * @ORM\Id
+     * @ORM\ManyToOne(targetEntity="A", inversedBy="cs", cascade={"persist"})
+     */
+    private $a;
+
+    /**
+     * @var \CircularRelations\B
+     * @ORM\Id
+     * @ORM\ManyToOne(targetEntity="B", inversedBy="cs", cascade={"persist"})
+     */
+    private $b;
+
+    /**
+     * C constructor.
+     *
+     * @param \CircularRelations\A $a
+     * @param \CircularRelations\B $b
+     */
+    public function __construct(\CircularRelations\A $a, \CircularRelations\B $b)
+    {
+        $this->a = $a;
+        $this->b = $b;
+    }
+}

--- a/tests/unit/Codeception/Module/Doctrine2Test.php
+++ b/tests/unit/Codeception/Module/Doctrine2Test.php
@@ -50,6 +50,9 @@ class Doctrine2Test extends Unit
         require_once $dir . "/MultilevelRelations/A.php";
         require_once $dir . "/MultilevelRelations/B.php";
         require_once $dir . "/MultilevelRelations/C.php";
+        require_once $dir . "/CircularRelations/A.php";
+        require_once $dir . "/CircularRelations/B.php";
+        require_once $dir . "/CircularRelations/C.php";
 
         $this->em = EntityManager::create(
             ['url' => 'sqlite:///:memory:'],
@@ -71,6 +74,9 @@ class Doctrine2Test extends Unit
             $this->em->getClassMetadata(\MultilevelRelations\A::class),
             $this->em->getClassMetadata(\MultilevelRelations\B::class),
             $this->em->getClassMetadata(\MultilevelRelations\C::class),
+            $this->em->getClassMetadata(\CircularRelations\A::class),
+            $this->em->getClassMetadata(\CircularRelations\B::class),
+            $this->em->getClassMetadata(\CircularRelations\C::class),
         ]);
 
         $this->module = new Doctrine2(make_container(), [
@@ -373,6 +379,17 @@ class Doctrine2Test extends Unit
             'stringPart' => 'abc',
         ]);
         $this->assertEquals([123, 'abc'], $res);
+    }
+
+    public function testCompositePrimaryKeyWithEntities()
+    {
+        $a = new \CircularRelations\A();
+        $b = new \CircularRelations\B();
+        $c = new \CircularRelations\C($a, $b);
+
+        $pks = $this->module->haveInRepository($c);
+
+        $this->assertEquals([$a, $b], $pks);
     }
 
     public function testRefresh()

--- a/tests/unit/Codeception/Module/Doctrine2Test.php
+++ b/tests/unit/Codeception/Module/Doctrine2Test.php
@@ -381,6 +381,10 @@ class Doctrine2Test extends Unit
         $this->assertEquals([123, 'abc'], $res);
     }
 
+    /**
+     * The main purpose of this test is, that the debug call at the end of
+     * haveInRepository doesn't fail with "var_export does not handle circular references".
+     */
     public function testCompositePrimaryKeyWithEntities()
     {
         $a = new \CircularRelations\A();


### PR DESCRIPTION
Fixes #5663.

Other than in #5664, I only fixed the debug message creation for entities with composite keys of entities in bidirectional ManyToOne relations.

