### PR TITLE
Fix missing HTML snapshots of failing PhpBrowser acceptance tests in HTML Report after update to v3.0.x 3.1 (#5568)

### DIFF
--- a/src/Codeception/Lib/InnerBrowser.php
+++ b/src/Codeception/Lib/InnerBrowser.php
@@ -72,6 +72,7 @@ class InnerBrowser extends Module implements Web, PageSourceSaver, ElementLocato
         
         $filename = mb_strcut($filename, 0, 244, 'utf-8') . '.fail.' . $extension;
         $this->_savePageSource($report = codecept_output_dir() . $filename);
+        $test->getMetadata()->addReport('html', $report);
         $test->getMetadata()->addReport('response', $report);
     }
 

--- a/tests/cli/RunCest.php
+++ b/tests/cli/RunCest.php
@@ -644,7 +644,7 @@ EOF
         $I->executeFailCommand('run phpbrowser_html_report --html');
         $I->seeResultCodeIsNot(0);
         $expectedReportFilename    = 'CodeceptionIssue5568Cest.failureShouldCreateHtmlSnapshot.fail.html';
-        $expectedReportAbsFilename = getcwd() . '/tests/_output/' . $expectedReportFilename;
+        $expectedReportAbsFilename = join(DIRECTORY_SEPARATOR, array(getcwd(), 'tests', '_output', $expectedReportFilename));
         $I->seeInShellOutput('Html: ' . $expectedReportAbsFilename);
         $I->seeInShellOutput('Response: ' . $expectedReportAbsFilename);
         $I->seeFileFound('report.html', 'tests/_output');

--- a/tests/cli/RunCest.php
+++ b/tests/cli/RunCest.php
@@ -633,4 +633,22 @@ EOF
         $I->seeInShellOutput("OK (");
     }
 
+    /**
+     * @group reports
+     *
+     * @param CliGuy $I
+     */
+    public function runHtmlWithPhpBrowserCheckReport(\CliGuy $I)
+    {
+        $I->wantTo('execute tests with PhpBrowser with html output and check html');
+        $I->executeFailCommand('run phpbrowser_html_report --html');
+        $I->seeResultCodeIsNot(0);
+        $expectedReportFilename    = 'CodeceptionIssue5568Cest.failureShouldCreateHtmlSnapshot.fail.html';
+        $expectedReportAbsFilename = getcwd() . '/tests/_output/' . $expectedReportFilename;
+        $I->seeInShellOutput('Html: ' . $expectedReportAbsFilename);
+        $I->seeInShellOutput('Response: ' . $expectedReportAbsFilename);
+        $I->seeFileFound('report.html', 'tests/_output');
+        $I->seeInThisFile("See <a href='" . $expectedReportFilename . "' target='_blank'>HTML snapshot</a> of a failed page");
+    }
+
 }

--- a/tests/cli/RunCest.php
+++ b/tests/cli/RunCest.php
@@ -643,11 +643,12 @@ EOF
         $I->wantTo('execute tests with PhpBrowser with html output and check html');
         $I->executeFailCommand('run phpbrowser_html_report --html');
         $I->seeResultCodeIsNot(0);
+        $expectedRelReportPath = 'tests/_output';
         $expectedReportFilename    = 'CodeceptionIssue5568Cest.failureShouldCreateHtmlSnapshot.fail.html';
-        $expectedReportAbsFilename = join(DIRECTORY_SEPARATOR, array(getcwd(), 'tests', '_output', $expectedReportFilename));
+        $expectedReportAbsFilename = join(DIRECTORY_SEPARATOR, array(getcwd(), $expectedRelReportPath, $expectedReportFilename));
         $I->seeInShellOutput('Html: ' . $expectedReportAbsFilename);
         $I->seeInShellOutput('Response: ' . $expectedReportAbsFilename);
-        $I->seeFileFound('report.html', 'tests/_output');
+        $I->seeFileFound('report.html', $expectedRelReportPath);
         $I->seeInThisFile("See <a href='" . $expectedReportFilename . "' target='_blank'>HTML snapshot</a> of a failed page");
     }
 

--- a/tests/data/claypit/tests/_support/AcceptanceTester.php
+++ b/tests/data/claypit/tests/_support/AcceptanceTester.php
@@ -1,0 +1,26 @@
+<?php
+
+
+/**
+ * Inherited Methods
+ * @method void wantToTest($text)
+ * @method void wantTo($text)
+ * @method void execute($callable)
+ * @method void expectTo($prediction)
+ * @method void expect($prediction)
+ * @method void amGoingTo($argumentation)
+ * @method void am($role)
+ * @method void lookForwardTo($achieveValue)
+ * @method void comment($description)
+ * @method void pause()
+ *
+ * @SuppressWarnings(PHPMD)
+*/
+class AcceptanceTester extends \Codeception\Actor
+{
+    use _generated\AcceptanceTesterActions;
+
+   /**
+    * Define custom actions here
+    */
+}

--- a/tests/data/claypit/tests/phpbrowser_html_report.suite.yml
+++ b/tests/data/claypit/tests/phpbrowser_html_report.suite.yml
@@ -3,7 +3,7 @@ modules:
     enabled: [PhpBrowser]
     config:
         PhpBrowser:
-            url: http://127.0.0.1:8000
+            url: https://www.google.com
 
 env:
     dev: []

--- a/tests/data/claypit/tests/phpbrowser_html_report.suite.yml
+++ b/tests/data/claypit/tests/phpbrowser_html_report.suite.yml
@@ -1,0 +1,9 @@
+class_name: AcceptanceTester
+modules:
+    enabled: [PhpBrowser]
+    config:
+        PhpBrowser:
+            url: http://127.0.0.1:8000
+
+env:
+    dev: []

--- a/tests/data/claypit/tests/phpbrowser_html_report/CodeceptionIssue5568Cest.php
+++ b/tests/data/claypit/tests/phpbrowser_html_report/CodeceptionIssue5568Cest.php
@@ -1,0 +1,10 @@
+<?php
+
+class CodeceptionIssue5568Cest {
+
+  public function failureShouldCreateHtmlSnapshot(AcceptanceTester $I) {
+    $I->amOnPage('/');
+    $I->see('SomethingThatIsNotThereToFailTheTest');
+  }
+
+}


### PR DESCRIPTION
Fixes #5568

Bug was introduced via https://github.com/Codeception/Codeception/commit/cca5463cdefd12120783bca94081496f02f226e9 for "Improved output for failed tests" or "Print artifacts on test failure"

Fix: In addition to saving the PhpBrowser as report 'response', also again save it as report 'html' (which is then picked up by HTML report generator in https://github.com/Codeception/phpunit-wrapper/blob/04a825f35706fce8be1c51bb975c20b450aa4571/src/ResultPrinter/HTML.php#L139-L150)

Add reproducer test case in RunCest based on new "phpbrowser_html_report" test suite