### PR TITLE
Fix generated files indentation and typo

### DIFF
--- a/src/Codeception/Lib/Generator/Actor.php
+++ b/src/Codeception/Lib/Generator/Actor.php
@@ -17,14 +17,14 @@ class Actor
 {{inheritedMethods}}
  *
  * @SuppressWarnings(PHPMD)
-*/
+ */
 class {{actor}} extends \Codeception\Actor
 {
     use _generated\{{actor}}Actions;
 
-   /**
-    * Define custom actions here
-    */
+    /**
+     * Define custom actions here
+     */
 }
 
 EOF;

--- a/src/Codeception/Lib/Generator/Cest.php
+++ b/src/Codeception/Lib/Generator/Cest.php
@@ -40,7 +40,7 @@ EOF;
     {
         $actor = $this->settings['actor'];
         if (!$actor) {
-            throw new ConfigurationException("Cept can't be created for suite without an actor. Add `actor: SomeTester` to suite config");
+            throw new ConfigurationException("Cest can't be created for suite without an actor. Add `actor: SomeTester` to suite config");
         }
 
         if (array_key_exists('suite_namespace', $this->settings)) {

--- a/src/Codeception/Lib/Generator/GherkinSnippets.php
+++ b/src/Codeception/Lib/Generator/GherkinSnippets.php
@@ -12,10 +12,10 @@ class GherkinSnippets
     /**
      * @{{type}} {{text}}
      */
-     public function {{methodName}}({{params}})
-     {
-         throw new \PHPUnit\Framework\IncompleteTestError("Step `{{text}}` is not defined");
-     }
+    public function {{methodName}}({{params}})
+    {
+        throw new \PHPUnit\Framework\IncompleteTestError("Step `{{text}}` is not defined");
+    }
 
 EOF;
 


### PR DESCRIPTION
I saw that the indentation in the generated files was a bit off, so checked the Generator classes (362bb8b) and thereby also found a typo and fixed it (82635ab).