### PR TITLE
[Doctrine2] Fix return type of grabFromRepository

### DIFF
--- a/src/Codeception/Module/Doctrine2.php
+++ b/src/Codeception/Module/Doctrine2.php
@@ -880,7 +880,7 @@ EOF;
      * @param $entity
      * @param $field
      * @param array $params
-     * @return array
+     * @return mixed
      */
     public function grabFromRepository($entity, $field, $params = [])
     {


### PR DESCRIPTION
`grabFromRepository` returns the result of `getSingleScalarResult`, which according to the documentation returns `mixed`, but the PHPDoc currently says the return type is `array` which in most cases it isn't.

https://www.doctrine-project.org/api/orm/2.6/Doctrine/ORM/Query.html#method_getSingleScalarResult