### PR TITLE
[Symfony] Make grabService use the special test service container if available

### DIFF
--- a/src/Codeception/Module/Symfony.php
+++ b/src/Codeception/Module/Symfony.php
@@ -262,7 +262,17 @@ class Symfony extends Framework implements DoctrineProvider, PartedModule
      */
     public function _getContainer()
     {
-        return $this->kernel->getContainer();
+        $container = $this->kernel->getContainer();
+
+        if (!($container instanceof ContainerInterface)) {
+            $this->fail('Could not get Symfony container');
+        }
+
+        if ($container->has('test.service_container')) {
+            return $container->get('test.service_container');
+        }
+
+        return $container;
     }
 
     /**


### PR DESCRIPTION
As @ThomasLandauer  reported via https://github.com/Codeception/Codeception/issues/5073 quite some time ago, `grabService` seems to be somewhat broken for newer Symfony versions (>= 4.1 ?).

With Symfony 4.1 a special service container was added that can be accessed via `test.service_container` for testing purposes which also provides access to private services:
https://symfony.com/doc/current/testing.html#accessing-the-container

I also added a test to the symfony-demo project at https://github.com/Codeception/symfony-demo/compare/master...burned42:add_service_container_test and if this PR will get accepted then I'd also open a PR for that branch. 

I tried to let the CI run with these tests with:
* above mentioned branch: https://travis-ci.org/burned42/Codeception/builds/592171088
* branch `3.1` as base: https://travis-ci.org/burned42/Codeception/builds/592157281

So to me it seems like the issue is solved with these changes. Maybe someone more familiar with the Symfony module can also take a look at this :)