### PR TITLE
Fix for file extension of .fail files

### DIFF
--- a/src/Codeception/Lib/InnerBrowser.php
+++ b/src/Codeception/Lib/InnerBrowser.php
@@ -66,9 +66,10 @@ class InnerBrowser extends Module implements Web, PageSourceSaver, ElementLocato
         
         $internalResponse = $this->client->getInternalResponse();
         
-        $responseContentType = $internalResponse ? $internalResponse->getHeader('content-type') : null;
+        $responseContentType = $internalResponse ? $internalResponse->getHeader('content-type') : '';
+        list($responseMimeType) = explode(';', $responseContentType);
         
-        $extension = isset($extensions[$responseContentType]) ? $extensions[$responseContentType] : 'html';
+        $extension = isset($extensions[$responseMimeType]) ? $extensions[$responseMimeType] : 'html';
         
         $filename = mb_strcut($filename, 0, 244, 'utf-8') . '.fail.' . $extension;
         $this->_savePageSource($report = codecept_output_dir() . $filename);

--- a/src/Codeception/Lib/InnerBrowser.php
+++ b/src/Codeception/Lib/InnerBrowser.php
@@ -62,7 +62,12 @@ class InnerBrowser extends Module implements Web, PageSourceSaver, ElementLocato
         }
         $filename = preg_replace('~\W~', '.', Descriptor::getTestSignatureUnique($test));
         
-        $extensions = ['application/json' => 'json', 'text/xml' => 'xml', 'application/xml' => 'xml'];
+        $extensions = [
+            'application/json' => 'json',
+            'text/xml' => 'xml',
+            'application/xml' => 'xml',
+            'text/plain' => 'txt'
+        ];
         
         $internalResponse = $this->client->getInternalResponse();
         


### PR DESCRIPTION
The `Content-Type` header [may contain a charset](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Type#Syntax), which caused XML and JSON .fail files to have a .html extension.

    Content-Type: application/json; charset=utf-8

Also changed that if a REST API outputs text/plain content, the .fail file gets the .txt extension.