### PR TITLE
Use path resolver for bootstrap file detection

### DIFF
--- a/src/Codeception/Configuration.php
+++ b/src/Codeception/Configuration.php
@@ -275,7 +275,7 @@ class Configuration
             return;
         }
 
-        $bootstrap = codecept_is_path_absolute($bootstrap)
+        $bootstrap = \Codeception\Util\PathResolver::isPathAbsolute($bootstrap)
             ? $bootstrap
             : rtrim($path, DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR . $bootstrap;
 


### PR DESCRIPTION
Somehow I got the following error:
_Call to undefined function Codeception\codecept_is_path_absolute() in /project/tests/vendor/codeception/codeception/src/Codeception/Configuration.php:278_

This patch uses the PathResolver.