### PR TITLE
Add option to recurse includes when a single suite is selected

### DIFF
--- a/src/Codeception/Command/Run.php
+++ b/src/Codeception/Command/Run.php
@@ -403,6 +403,9 @@ class Run extends Command
 
             if (!empty($config['include']) && (!$suite || $this->options['recurse-includes'])) {
                 $current_dir = Configuration::projectDir();
+                if (empty($suites)) {
+                    $suites = Configuration::suites();
+                }
                 $this->runIncludedSuites($config['include'], $current_dir, $suites);
             }
 


### PR DESCRIPTION
A change merged in codeception 2.1 excludes tests defined in `include` when a suite was selected (`unit`, `functional`, ...).
This change makes it impossible to selectively run a suite of a multi-app project.

To preserve backwards compatibility the default behavior will not be changed in this PR, instead a new option is introduced that will include the sub-projects again. It is called `--recurse-includes`.

I successfully ran the CLI tests with my changes.