### PR TITLE
Initialize Codeception application in a single place

### DIFF
--- a/app.php
+++ b/app.php
@@ -1,5 +1,7 @@
 <?php
 
+require_once __DIR__ . '/autoload.php';
+
 use Codeception\Application;
 
 $app = new Application('Codeception', Codeception\Codecept::VERSION);

--- a/app.php
+++ b/app.php
@@ -4,34 +4,36 @@ require_once __DIR__ . '/autoload.php';
 
 use Codeception\Application;
 
-$app = new Application('Codeception', Codeception\Codecept::VERSION);
-$app->add(new Codeception\Command\Build('build'));
-$app->add(new Codeception\Command\Run('run'));
-$app->add(new Codeception\Command\Init('init'));
-$app->add(new Codeception\Command\Console('console'));
-$app->add(new Codeception\Command\Bootstrap('bootstrap'));
-$app->add(new Codeception\Command\GenerateCept('generate:cept'));
-$app->add(new Codeception\Command\GenerateCest('generate:cest'));
-$app->add(new Codeception\Command\GenerateTest('generate:test'));
-$app->add(new Codeception\Command\GenerateSuite('generate:suite'));
-$app->add(new Codeception\Command\GenerateHelper('generate:helper'));
-$app->add(new Codeception\Command\GenerateScenarios('generate:scenarios'));
-$app->add(new Codeception\Command\Clean('clean'));
-$app->add(new Codeception\Command\GenerateGroup('generate:groupobject'));
-$app->add(new Codeception\Command\GeneratePageObject('generate:pageobject'));
-$app->add(new Codeception\Command\GenerateStepObject('generate:stepobject'));
-$app->add(new Codeception\Command\GenerateSnapshot('generate:snapshot'));
-$app->add(new Codeception\Command\GenerateEnvironment('generate:environment'));
-$app->add(new Codeception\Command\GenerateFeature('generate:feature'));
-$app->add(new Codeception\Command\GherkinSnippets('gherkin:snippets'));
-$app->add(new Codeception\Command\GherkinSteps('gherkin:steps'));
-$app->add(new Codeception\Command\DryRun('dry-run'));
-$app->add(new Codeception\Command\ConfigValidate('config:validate'));
-$app->registerCustomCommands();
+call_user_func(static function () {
+    $app = new Application('Codeception', Codeception\Codecept::VERSION);
+    $app->add(new Codeception\Command\Build('build'));
+    $app->add(new Codeception\Command\Run('run'));
+    $app->add(new Codeception\Command\Init('init'));
+    $app->add(new Codeception\Command\Console('console'));
+    $app->add(new Codeception\Command\Bootstrap('bootstrap'));
+    $app->add(new Codeception\Command\GenerateCept('generate:cept'));
+    $app->add(new Codeception\Command\GenerateCest('generate:cest'));
+    $app->add(new Codeception\Command\GenerateTest('generate:test'));
+    $app->add(new Codeception\Command\GenerateSuite('generate:suite'));
+    $app->add(new Codeception\Command\GenerateHelper('generate:helper'));
+    $app->add(new Codeception\Command\GenerateScenarios('generate:scenarios'));
+    $app->add(new Codeception\Command\Clean('clean'));
+    $app->add(new Codeception\Command\GenerateGroup('generate:groupobject'));
+    $app->add(new Codeception\Command\GeneratePageObject('generate:pageobject'));
+    $app->add(new Codeception\Command\GenerateStepObject('generate:stepobject'));
+    $app->add(new Codeception\Command\GenerateSnapshot('generate:snapshot'));
+    $app->add(new Codeception\Command\GenerateEnvironment('generate:environment'));
+    $app->add(new Codeception\Command\GenerateFeature('generate:feature'));
+    $app->add(new Codeception\Command\GherkinSnippets('gherkin:snippets'));
+    $app->add(new Codeception\Command\GherkinSteps('gherkin:steps'));
+    $app->add(new Codeception\Command\DryRun('dry-run'));
+    $app->add(new Codeception\Command\ConfigValidate('config:validate'));
+    $app->registerCustomCommands();
 
-// add only if within a phar archive.
-if ('phar:' === substr(__FILE__, 0, 5)) {
-    $app->add(new Codeception\Command\SelfUpdate('self-update'));
-}
+    // add only if within a phar archive.
+    if ('phar:' === substr(__FILE__, 0, 5)) {
+        $app->add(new Codeception\Command\SelfUpdate('self-update'));
+    }
 
-$app->run();
+    $app->run();
+});

--- a/app.php
+++ b/app.php
@@ -1,0 +1,35 @@
+<?php
+
+use Codeception\Application;
+
+$app = new Application('Codeception', Codeception\Codecept::VERSION);
+$app->add(new Codeception\Command\Build('build'));
+$app->add(new Codeception\Command\Run('run'));
+$app->add(new Codeception\Command\Init('init'));
+$app->add(new Codeception\Command\Console('console'));
+$app->add(new Codeception\Command\Bootstrap('bootstrap'));
+$app->add(new Codeception\Command\GenerateCept('generate:cept'));
+$app->add(new Codeception\Command\GenerateCest('generate:cest'));
+$app->add(new Codeception\Command\GenerateTest('generate:test'));
+$app->add(new Codeception\Command\GenerateSuite('generate:suite'));
+$app->add(new Codeception\Command\GenerateHelper('generate:helper'));
+$app->add(new Codeception\Command\GenerateScenarios('generate:scenarios'));
+$app->add(new Codeception\Command\Clean('clean'));
+$app->add(new Codeception\Command\GenerateGroup('generate:groupobject'));
+$app->add(new Codeception\Command\GeneratePageObject('generate:pageobject'));
+$app->add(new Codeception\Command\GenerateStepObject('generate:stepobject'));
+$app->add(new Codeception\Command\GenerateSnapshot('generate:snapshot'));
+$app->add(new Codeception\Command\GenerateEnvironment('generate:environment'));
+$app->add(new Codeception\Command\GenerateFeature('generate:feature'));
+$app->add(new Codeception\Command\GherkinSnippets('gherkin:snippets'));
+$app->add(new Codeception\Command\GherkinSteps('gherkin:steps'));
+$app->add(new Codeception\Command\DryRun('dry-run'));
+$app->add(new Codeception\Command\ConfigValidate('config:validate'));
+$app->registerCustomCommands();
+
+// add only if within a phar archive.
+if ('phar:' === substr(__FILE__, 0, 5)) {
+    $app->add(new Codeception\Command\SelfUpdate('self-update'));
+}
+
+$app->run();

--- a/autoload.php
+++ b/autoload.php
@@ -7,9 +7,17 @@ if (( !isset($argv) || (isset($argv) && !in_array('--no-redirect', $argv)) ) && 
         STDERR,
         "\n==== Redirecting to Composer-installed version in vendor/codeception. You can skip this using --no-redirect ====\n"
     );
-    require $autoloadFile;
-    //require package/bin instead of codecept to avoid printing hashbang line
-    require './vendor/codeception/codeception/package/bin';
+
+    if (file_exists('./vendor/codeception/codeception/app.php')) {
+        //codeception v4+
+        require './vendor/codeception/codeception/app.php';
+    } else {
+        //older version
+        require $autoloadFile;
+        //require package/bin instead of codecept to avoid printing hashbang line
+        require './vendor/codeception/codeception/package/bin';
+    }
+
     die;
 } elseif (file_exists(__DIR__ . '/vendor/autoload.php')) {
     // for phar

--- a/codecept
+++ b/codecept
@@ -4,40 +4,6 @@
  * Codeception CLI
  */
 
-require_once __DIR__.'/autoload.php';
+require_once __DIR__ . '/autoload.php';
 
-use Codeception\Application;
-
-$app = new Application('Codeception', Codeception\Codecept::VERSION);
-$app->add(new Codeception\Command\Build('build'));
-$app->add(new Codeception\Command\Run('run'));
-$app->add(new Codeception\Command\Init('init'));
-$app->add(new Codeception\Command\Console('console'));
-$app->add(new Codeception\Command\Bootstrap('bootstrap'));
-$app->add(new Codeception\Command\GenerateCept('generate:cept'));
-$app->add(new Codeception\Command\GenerateCest('generate:cest'));
-$app->add(new Codeception\Command\GenerateTest('generate:test'));
-$app->add(new Codeception\Command\GenerateSuite('generate:suite'));
-$app->add(new Codeception\Command\GenerateHelper('generate:helper'));
-$app->add(new Codeception\Command\GenerateScenarios('generate:scenarios'));
-$app->add(new Codeception\Command\Clean('clean'));
-$app->add(new Codeception\Command\GenerateGroup('generate:groupobject'));
-$app->add(new Codeception\Command\GeneratePageObject('generate:pageobject'));
-$app->add(new Codeception\Command\GenerateSnapshot('generate:snapshot'));
-$app->add(new Codeception\Command\GenerateStepObject('generate:stepobject'));
-$app->add(new Codeception\Command\GenerateEnvironment('generate:environment'));
-$app->add(new Codeception\Command\GenerateFeature('generate:feature'));
-$app->add(new Codeception\Command\GherkinSnippets('gherkin:snippets'));
-$app->add(new Codeception\Command\GherkinSteps('gherkin:steps'));
-$app->add(new Codeception\Command\DryRun('dry-run'));
-$app->add(new Codeception\Command\ConfigValidate('config:validate'));
-
-// Suggests package
-if (class_exists('Stecman\Component\Symfony\Console\BashCompletion\CompletionCommand')) {
-    $app->add(new Codeception\Command\Completion());
-} else {
-    $app->add(new Codeception\Command\CompletionFallback());
-}
-
-$app->registerCustomCommands();
-$app->run();
+require __DIR__ . '/app.php';

--- a/codecept
+++ b/codecept
@@ -4,6 +4,4 @@
  * Codeception CLI
  */
 
-require_once __DIR__ . '/autoload.php';
-
 require __DIR__ . '/app.php';

--- a/package/bin
+++ b/package/bin
@@ -1,38 +1,3 @@
 <?php
-/**
- * Codeception CLI
- */
 
-use Codeception\Application;
-
-$app = new Application('Codeception', Codeception\Codecept::VERSION);
-$app->add(new Codeception\Command\Build('build'));
-$app->add(new Codeception\Command\Run('run'));
-$app->add(new Codeception\Command\Init('init'));
-$app->add(new Codeception\Command\Console('console'));
-$app->add(new Codeception\Command\Bootstrap('bootstrap'));
-$app->add(new Codeception\Command\GenerateCept('generate:cept'));
-$app->add(new Codeception\Command\GenerateCest('generate:cest'));
-$app->add(new Codeception\Command\GenerateTest('generate:test'));
-$app->add(new Codeception\Command\GenerateSuite('generate:suite'));
-$app->add(new Codeception\Command\GenerateHelper('generate:helper'));
-$app->add(new Codeception\Command\GenerateScenarios('generate:scenarios'));
-$app->add(new Codeception\Command\Clean('clean'));
-$app->add(new Codeception\Command\GenerateGroup('generate:groupobject'));
-$app->add(new Codeception\Command\GeneratePageObject('generate:pageobject'));
-$app->add(new Codeception\Command\GenerateStepObject('generate:stepobject'));
-$app->add(new Codeception\Command\GenerateSnapshot('generate:snapshot'));
-$app->add(new Codeception\Command\GenerateEnvironment('generate:environment'));
-$app->add(new Codeception\Command\GenerateFeature('generate:feature'));
-$app->add(new Codeception\Command\GherkinSnippets('gherkin:snippets'));
-$app->add(new Codeception\Command\GherkinSteps('gherkin:steps'));
-$app->add(new Codeception\Command\DryRun('dry-run'));
-$app->add(new Codeception\Command\ConfigValidate('config:validate'));
-$app->registerCustomCommands();
-
- // add only if within a phar archive.
- if ('phar:' === substr(__FILE__, 0, 5)) {
-	 $app->add(new Codeception\Command\SelfUpdate('self-update'));
- }
-
- $app->run();
+require __DIR__ . '/../app.php';


### PR DESCRIPTION
Historically Codeception Application was initialized in 2 different places -
`codecept` file is the main entry point when Codeception is installed using composer,
`package/bin` replaces it in phar file.

The most signifficant difference between them is that `codecept` file starts with `#!/usr/bin/env php`.
Second difference is that `codecept` includes `autoload.php` itself, but phar stub includes `autoload.php` before `package/bin`. It seems like accidental difference.

Over the time some differences accumulates by accident - phar file missed custom commands and shell auto-completion.

To avoid such accidents in the future, I moved Application initialization to `app.php` and included in from both places.
In the future, phar file will be able to include `app.php` directly instead of including `package/bin`, but it is better to keep `package/bin` for backwards compatibility - to avoid breaking `Redirect to Composer-installed version` feature of old phar files.
