### PR TITLE
Symfony 5 support for Codeception 4.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,13 +21,13 @@
         "ext-mbstring": "*",
         "codeception/lib-asserts": "^1.0",
         "guzzlehttp/psr7": "~1.4",
-        "symfony/finder": ">=2.7 <5.0",
-        "symfony/console": ">=2.7 <5.0",
-        "symfony/event-dispatcher": ">=2.7 <5.0",
-        "symfony/yaml": ">=2.7 <5.0",
-        "symfony/css-selector": ">=2.7 <5.0",
+        "symfony/finder": ">=2.7 <6.0",
+        "symfony/console": ">=2.7 <6.0",
+        "symfony/event-dispatcher": ">=2.7 <6.0",
+        "symfony/yaml": ">=2.7 <6.0",
+        "symfony/css-selector": ">=2.7 <6.0",
         "behat/gherkin": "^4.4.0",
-        "codeception/phpunit-wrapper": ">6.0.15 <6.1.0 | ^6.6.1 | ^7.7.1 | ^8.0.3",
+        "codeception/phpunit-wrapper": ">6.0.15 <6.1.0 | ^6.6.1 | ^7.7.1 | ^8.1.0",
         "codeception/stub": "^2.0 | ^3.0"
     },
     "require-dev": {
@@ -35,7 +35,7 @@
         "codeception/specify": "~0.3",
         "squizlabs/php_codesniffer": "~2.0",
         "vlucas/phpdotenv": "^3.0",
-        "symfony/process": ">=2.7 <5.0"
+        "symfony/process": ">=2.7 <6.0"
     },
     "suggest": {
         "hoa/console": "For interactive console functionality",

--- a/shim.php
+++ b/shim.php
@@ -35,4 +35,9 @@ namespace Codeception\Platform {
 
 namespace {
     class_alias('Codeception\TestInterface', 'Codeception\TestCase');
+
+    //Compatibility with Symfony 5
+    if (!class_exists('Symfony\Component\EventDispatcher\Event') && class_exists('Symfony\Contracts\EventDispatcher\Event')) {
+        class_alias('Symfony\Contracts\EventDispatcher\Event', 'Symfony\Component\EventDispatcher\Event');
+    }
 }

--- a/src/Codeception/Application.php
+++ b/src/Codeception/Application.php
@@ -35,11 +35,21 @@ class Application extends BaseApplication
             if ($e->getCode() === 404) {
                 return;
             }
-            $this->renderException($e, new ConsoleOutput());
+            $this->renderExceptionWrapper($e, new ConsoleOutput());
             exit(1);
         } catch (\Exception $e) {
-            $this->renderException($e, new ConsoleOutput());
+            $this->renderExceptionWrapper($e, new ConsoleOutput());
             exit(1);
+        }
+    }
+
+    public function renderExceptionWrapper(\Exception $e, OutputInterface $output)
+    {
+        if (method_exists('Symfony\Component\Console\Application', 'renderException')) {
+            //Symfony 5
+            parent::renderException($e, $output);
+        } else {
+            parent::renderThrowable($e, $output);
         }
     }
 

--- a/src/Codeception/Codecept.php
+++ b/src/Codeception/Codecept.php
@@ -1,12 +1,14 @@
 <?php
 namespace Codeception;
 
+use Codeception\Event\DispatcherWrapper;
 use Codeception\Exception\ConfigurationException;
 use Codeception\Subscriber\ExtensionLoader;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 
 class Codecept
 {
+    use DispatcherWrapper;
     const VERSION = "4.0.0";
 
     /**
@@ -207,7 +209,7 @@ class Codecept
         $printer = $this->runner->getPrinter();
         $printer->printResult($result);
 
-        $this->dispatcher->dispatch(Events::RESULT_PRINT_AFTER, new Event\PrintResultEvent($result, $printer));
+        $this->dispatch($this->dispatcher, Events::RESULT_PRINT_AFTER, new Event\PrintResultEvent($result, $printer));
     }
 
     /**

--- a/src/Codeception/Command/Bootstrap.php
+++ b/src/Codeception/Command/Bootstrap.php
@@ -53,5 +53,6 @@ class Bootstrap extends Command
             $bootstrap->initDir($input->getArgument('path'));
         }
         $bootstrap->setup();
+        return 0;
     }
 }

--- a/src/Codeception/Command/Build.php
+++ b/src/Codeception/Command/Build.php
@@ -38,6 +38,7 @@ class Build extends Command
     {
         $this->output = $output;
         $this->buildActorsForConfig();
+        return 0;
     }
     
     private function buildActor(array $settings)

--- a/src/Codeception/Command/Clean.php
+++ b/src/Codeception/Command/Clean.php
@@ -27,6 +27,7 @@ class Clean extends Command
         $projectDir = Configuration::projectDir();
         $this->cleanProjectsRecursively($output, $projectDir);
         $output->writeln("Done");
+        return 0;
     }
 
     private function cleanProjectsRecursively(OutputInterface $output, $projectDir)

--- a/src/Codeception/Command/Completion.php
+++ b/src/Codeception/Command/Completion.php
@@ -67,6 +67,7 @@ class Completion extends CompletionCommand
         }
 
         parent::execute($input, $output);
+        return 0;
     }
 
     protected function createDefinition()

--- a/src/Codeception/Command/CompletionFallback.php
+++ b/src/Codeception/Command/CompletionFallback.php
@@ -36,5 +36,6 @@ END
     protected function execute(InputInterface $input, OutputInterface $output)
     {
         $output->writeln("Install optional <comment>stecman/symfony-console-completion</comment>");
+        return 0;
     }
 }

--- a/src/Codeception/Command/ConfigValidate.php
+++ b/src/Codeception/Command/ConfigValidate.php
@@ -63,7 +63,8 @@ class ConfigValidate extends Command
             $output->writeln("------------------------------\n");
             $output->writeln("<info>$suite Suite Config</info>:\n");
             $output->writeln($this->formatOutput($config));
-            return;
+
+            return 0;
         }
 
         $output->write("Validating global config... ");
@@ -95,6 +96,7 @@ class ConfigValidate extends Command
 
 
         $output->writeln("Execute <info>codecept config:validate [<suite>]</info> to see config for a suite");
+        return 0;
     }
 
     protected function formatOutput($config)

--- a/src/Codeception/Command/Console.php
+++ b/src/Codeception/Command/Console.php
@@ -111,6 +111,7 @@ class Console extends Command
         $dispatcher->dispatch(Events::SUITE_AFTER, new SuiteEvent($this->suite));
 
         $output->writeln("<info>Bye-bye!</info>");
+        return 0;
     }
 
     protected function listenToSignals()

--- a/src/Codeception/Command/Console.php
+++ b/src/Codeception/Command/Console.php
@@ -3,6 +3,7 @@ namespace Codeception\Command;
 
 use Codeception\Codecept;
 use Codeception\Configuration;
+use Codeception\Event\DispatcherWrapper;
 use Codeception\Event\SuiteEvent;
 use Codeception\Event\TestEvent;
 use Codeception\Events;
@@ -27,6 +28,8 @@ use Symfony\Component\Console\Question\Question;
  */
 class Console extends Command
 {
+    use DispatcherWrapper;
+
     protected $test;
     protected $codecept;
     protected $suite;
@@ -96,10 +99,10 @@ class Console extends Command
         $output->writeln("<info>Try Codeception commands without writing a test</info>");
 
         $suiteEvent = new SuiteEvent($this->suite, $this->codecept->getResult(), $settings);
-        $dispatcher->dispatch(Events::SUITE_BEFORE, $suiteEvent);
+        $this->dispatch($dispatcher, Events::SUITE_BEFORE, $suiteEvent);
 
-        $dispatcher->dispatch(Events::TEST_PARSED, new TestEvent($this->test));
-        $dispatcher->dispatch(Events::TEST_BEFORE, new TestEvent($this->test));
+        $this->dispatch($dispatcher, Events::TEST_PARSED, new TestEvent($this->test));
+        $this->dispatch($dispatcher, Events::TEST_BEFORE, new TestEvent($this->test));
 
         if (file_exists($settings['bootstrap'])) {
             require $settings['bootstrap'];
@@ -107,8 +110,8 @@ class Console extends Command
 
         $I->pause();
 
-        $dispatcher->dispatch(Events::TEST_AFTER, new TestEvent($this->test));
-        $dispatcher->dispatch(Events::SUITE_AFTER, new SuiteEvent($this->suite));
+        $this->dispatch($dispatcher, Events::TEST_AFTER, new TestEvent($this->test));
+        $this->dispatch($dispatcher, Events::SUITE_AFTER, new SuiteEvent($this->suite));
 
         $output->writeln("<info>Bye-bye!</info>");
         return 0;

--- a/src/Codeception/Command/DryRun.php
+++ b/src/Codeception/Command/DryRun.php
@@ -95,6 +95,7 @@ class DryRun extends Command
             }
         }
         $dispatcher->dispatch(Events::SUITE_AFTER, new SuiteEvent($suiteManager->getSuite()));
+        return 0;
     }
 
 

--- a/src/Codeception/Command/DryRun.php
+++ b/src/Codeception/Command/DryRun.php
@@ -2,6 +2,7 @@
 namespace Codeception\Command;
 
 use Codeception\Configuration;
+use Codeception\Event\DispatcherWrapper;
 use Codeception\Event\SuiteEvent;
 use Codeception\Event\TestEvent;
 use Codeception\Events;
@@ -29,6 +30,7 @@ use Symfony\Component\EventDispatcher\EventDispatcher;
  */
 class DryRun extends Command
 {
+    use DispatcherWrapper;
     use Shared\Config;
     use Shared\Style;
 
@@ -80,8 +82,8 @@ class DryRun extends Command
         $suiteManager->loadTests($test);
         $tests = $suiteManager->getSuite()->tests();
 
-        $dispatcher->dispatch(Events::SUITE_INIT, new SuiteEvent($suiteManager->getSuite(), null, $settings));
-        $dispatcher->dispatch(Events::SUITE_BEFORE, new SuiteEvent($suiteManager->getSuite(), null, $settings));
+        $this->dispatch($dispatcher, Events::SUITE_INIT, new SuiteEvent($suiteManager->getSuite(), null, $settings));
+        $this->dispatch($dispatcher, Events::SUITE_BEFORE, new SuiteEvent($suiteManager->getSuite(), null, $settings));
         foreach ($tests as $test) {
             if ($test instanceof \PHPUnit\Framework\TestSuite\DataProvider) {
                 foreach ($test as $t) {
@@ -94,7 +96,7 @@ class DryRun extends Command
                 $this->dryRunTest($output, $dispatcher, $test);
             }
         }
-        $dispatcher->dispatch(Events::SUITE_AFTER, new SuiteEvent($suiteManager->getSuite()));
+        $this->dispatch($dispatcher, Events::SUITE_AFTER, new SuiteEvent($suiteManager->getSuite()));
         return 0;
     }
 
@@ -117,14 +119,14 @@ class DryRun extends Command
      */
     protected function dryRunTest(OutputInterface $output, EventDispatcher $dispatcher, Test $test)
     {
-        $dispatcher->dispatch(Events::TEST_START, new TestEvent($test));
-        $dispatcher->dispatch(Events::TEST_BEFORE, new TestEvent($test));
+        $this->dispatch($dispatcher, Events::TEST_START, new TestEvent($test));
+        $this->dispatch($dispatcher, Events::TEST_BEFORE, new TestEvent($test));
         try {
             $test->test();
         } catch (\Exception $e) {
         }
-        $dispatcher->dispatch(Events::TEST_AFTER, new TestEvent($test));
-        $dispatcher->dispatch(Events::TEST_END, new TestEvent($test));
+        $this->dispatch($dispatcher, Events::TEST_AFTER, new TestEvent($test));
+        $this->dispatch($dispatcher, Events::TEST_END, new TestEvent($test));
         if ($test->getMetadata()->isBlocked()) {
             $output->writeln('');
             if ($skip = $test->getMetadata()->getSkip()) {

--- a/src/Codeception/Command/GenerateCept.php
+++ b/src/Codeception/Command/GenerateCept.php
@@ -48,8 +48,9 @@ class GenerateCept extends Command
         $res = $this->createFile($full_path, $gen->produce());
         if (!$res) {
             $output->writeln("<error>Test $filename already exists</error>");
-            return;
+            return 1;
         }
         $output->writeln("<info>Test was created in $full_path</info>");
+        return 0;
     }
 }

--- a/src/Codeception/Command/GenerateCest.php
+++ b/src/Codeception/Command/GenerateCest.php
@@ -48,15 +48,16 @@ class GenerateCest extends Command
 
         if (file_exists($filename)) {
             $output->writeln("<error>Test $filename already exists</error>");
-            return;
+            return 1;
         }
         $gen = new CestGenerator($class, $config);
         $res = $this->createFile($filename, $gen->produce());
         if (!$res) {
             $output->writeln("<error>Test $filename already exists</error>");
-            return;
+            return 1;
         }
 
         $output->writeln("<info>Test was created in $filename</info>");
+        return 0;
     }
 }

--- a/src/Codeception/Command/GenerateEnvironment.php
+++ b/src/Codeception/Command/GenerateEnvironment.php
@@ -51,8 +51,10 @@ class GenerateEnvironment extends Command
 
         if ($saved) {
             $output->writeln("<info>$env config was created in $relativePath/$file</info>");
+            return 0;
         } else {
             $output->writeln("<error>File $relativePath/$file already exists</error>");
+            return 1;
         }
     }
 }

--- a/src/Codeception/Command/GenerateFeature.php
+++ b/src/Codeception/Command/GenerateFeature.php
@@ -51,8 +51,9 @@ class GenerateFeature extends Command
         $res = $this->createFile($full_path, $gen->produce());
         if (!$res) {
             $output->writeln("<error>Feature $filename already exists</error>");
-            return;
+            return 1;
         }
         $output->writeln("<info>Feature was created in $full_path</info>");
+        return 0;
     }
 }

--- a/src/Codeception/Command/GenerateGroup.php
+++ b/src/Codeception/Command/GenerateGroup.php
@@ -45,12 +45,13 @@ class GenerateGroup extends Command
 
         if (!$res) {
             $output->writeln("<error>Group $filename already exists</error>");
-            return;
+            return 1;
         }
 
         $output->writeln("<info>Group extension was created in $filename</info>");
         $output->writeln(
             'To use this group extension, include it to "extensions" option of global Codeception config.'
         );
+        return 0;
     }
 }

--- a/src/Codeception/Command/GenerateHelper.php
+++ b/src/Codeception/Command/GenerateHelper.php
@@ -43,8 +43,10 @@ class GenerateHelper extends Command
         $res = $this->createFile($filename, (new Helper($name, $config['namespace']))->produce());
         if ($res) {
             $output->writeln("<info>Helper $filename created</info>");
+            return 0;
         } else {
             $output->writeln("<error>Error creating helper $filename</error>");
+            return 1;
         }
     }
 }

--- a/src/Codeception/Command/GeneratePageObject.php
+++ b/src/Codeception/Command/GeneratePageObject.php
@@ -64,9 +64,10 @@ class GeneratePageObject extends Command
 
         if (!$res) {
             $output->writeln("<error>PageObject $filename already exists</error>");
-            exit;
+            return 1;
         }
         $output->writeln("<info>PageObject was created in $filename</info>");
+        return 0;
     }
 
     protected function pathToPageObject($class, $suite)

--- a/src/Codeception/Command/GenerateScenarios.php
+++ b/src/Codeception/Command/GenerateScenarios.php
@@ -102,6 +102,7 @@ class GenerateScenarios extends Command
         if ($input->getOption('single-file')) {
             $this->createFile($path . $this->formatExtension($format), $this->decorate($scenarios, $format), true);
         }
+        return 0;
     }
 
     protected function decorate($text, $format)

--- a/src/Codeception/Command/GenerateSnapshot.php
+++ b/src/Codeception/Command/GenerateSnapshot.php
@@ -65,8 +65,9 @@ class GenerateSnapshot extends Command
 
         if (!$res) {
             $output->writeln("<error>Snapshot $filename already exists</error>");
-            exit;
+            return 1;
         }
         $output->writeln("<info>Snapshot was created in $filename</info>");
+        return 0;
     }
 }

--- a/src/Codeception/Command/GenerateStepObject.php
+++ b/src/Codeception/Command/GenerateStepObject.php
@@ -68,8 +68,9 @@ class GenerateStepObject extends Command
 
         if (!$res) {
             $output->writeln("<error>StepObject $filename already exists</error>");
-            exit;
+            return 1;
         }
         $output->writeln("<info>StepObject was created in $filename</info>");
+        return 0;
     }
 }

--- a/src/Codeception/Command/GenerateSuite.php
+++ b/src/Codeception/Command/GenerateSuite.php
@@ -47,7 +47,7 @@ class GenerateSuite extends Command
 
         if ($this->containsInvalidCharacters($suite)) {
             $output->writeln("<error>Suite name '$suite' contains invalid characters. ([A-Za-z0-9_]).</error>");
-            return;
+            return 1;
         }
 
         $config = $this->getGlobalConfig();
@@ -125,6 +125,7 @@ EOF;
         $output->writeln("3. Run tests of this suite with <bold>codecept run $suite</bold> command");
 
         $output->writeln("<info>Suite $suite generated</info>");
+        return 0;
     }
 
     private function containsInvalidCharacters($suite)

--- a/src/Codeception/Command/GenerateTest.php
+++ b/src/Codeception/Command/GenerateTest.php
@@ -53,8 +53,9 @@ class GenerateTest extends Command
 
         if (!$res) {
             $output->writeln("<error>Test $filename already exists</error>");
-            return;
+            return 1;
         }
         $output->writeln("<info>Test was created in $filename</info>");
+        return 0;
     }
 }

--- a/src/Codeception/Command/GherkinSnippets.php
+++ b/src/Codeception/Command/GherkinSnippets.php
@@ -54,7 +54,7 @@ class GherkinSnippets extends Command
 
         if (empty($snippets)) {
             $output->writeln("<notice> All Gherkin steps are defined. Exiting... </notice>");
-            return;
+            return 0;
         }
         $output->writeln("<comment> Snippets found in: </comment>");
         foreach ($features as $feature) {
@@ -68,5 +68,6 @@ class GherkinSnippets extends Command
         $output->writeln("<info> ----------------------------------------- </info>");
         $output->writeln(sprintf(' <bold>%d</bold> snippets proposed', count($snippets)));
         $output->writeln("<notice> Copy generated snippets to {$config['actor']} or a specific Gherkin context </notice>");
+        return 0;
     }
 }

--- a/src/Codeception/Command/GherkinSteps.php
+++ b/src/Codeception/Command/GherkinSteps.php
@@ -67,5 +67,6 @@ class GherkinSteps extends Command
         if (!isset($table)) {
             $output->writeln("No steps are defined, start creating them by running <bold>gherkin:snippets</bold>");
         }
+        return 0;
     }
 }

--- a/src/Codeception/Command/Init.php
+++ b/src/Codeception/Command/Init.php
@@ -51,5 +51,6 @@ class Init extends Command
             $initProcess->initDir($input->getOption('path'));
         }
         $initProcess->setup();
+        return 0;
     }
 }

--- a/src/Codeception/Command/Run.php
+++ b/src/Codeception/Command/Run.php
@@ -416,6 +416,7 @@ class Run extends Command
                 exit(1);
             }
         }
+        return 0;
     }
 
     protected function matchSingleTest($suite, $config)

--- a/src/Codeception/Command/SelfUpdate.php
+++ b/src/Codeception/Command/SelfUpdate.php
@@ -101,7 +101,10 @@ class SelfUpdate extends Command
                     $e->getMessage()
                 )
             );
+            return 1;
         }
+
+        return 0;
     }
 
     /**

--- a/src/Codeception/Event/DispatcherWrapper.php
+++ b/src/Codeception/Event/DispatcherWrapper.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Codeception\Event;
+
+use Symfony\Component\EventDispatcher\Event;
+use Symfony\Component\EventDispatcher\EventDispatcher;
+
+trait DispatcherWrapper
+{
+    /**
+     * Compatibility wrapper for dispatcher change between Symfony 4 and 5
+     * @param EventDispatcher $dispatcher
+     * @param string $eventType
+     * @param Event $eventObject
+     */
+    protected function dispatch(EventDispatcher $dispatcher, $eventType, Event $eventObject)
+    {
+        if (class_exists('Symfony\Contracts\EventDispatcher\Event')) {
+            //Symfony 5
+            $dispatcher->dispatch($eventObject, $eventType);
+        } else {
+            //Symfony 2,3 or 4
+            $dispatcher->dispatch($eventType, $eventObject);
+        }
+    }
+}

--- a/src/Codeception/SuiteManager.php
+++ b/src/Codeception/SuiteManager.php
@@ -1,6 +1,7 @@
 <?php
 namespace Codeception;
 
+use Codeception\Event\DispatcherWrapper;
 use Codeception\Lib\Di;
 use Codeception\Lib\GroupManager;
 use Codeception\Lib\ModuleContainer;
@@ -12,6 +13,8 @@ use Symfony\Component\EventDispatcher\EventDispatcher;
 
 class SuiteManager
 {
+    use DispatcherWrapper;
+
     public static $environment;
     public static $name;
 
@@ -75,7 +78,7 @@ class SuiteManager
 
     public function initialize()
     {
-        $this->dispatcher->dispatch(Events::MODULE_INIT, new Event\SuiteEvent($this->suite, null, $this->settings));
+        $this->dispatch($this->dispatcher, Events::MODULE_INIT, new Event\SuiteEvent($this->suite, null, $this->settings));
         foreach ($this->moduleContainer->all() as $module) {
             $module->_initialize();
         }
@@ -85,7 +88,7 @@ class SuiteManager
                 . " class doesn't exist in suite folder.\nRun the 'build' command to generate it"
             );
         }
-        $this->dispatcher->dispatch(Events::SUITE_INIT, new Event\SuiteEvent($this->suite, null, $this->settings));
+        $this->dispatch($this->dispatcher, Events::SUITE_INIT, new Event\SuiteEvent($this->suite, null, $this->settings));
         ini_set('xdebug.show_exception_trace', 0); // Issue https://github.com/symfony/symfony/issues/7646
     }
 
@@ -153,11 +156,11 @@ class SuiteManager
     public function run(PHPUnit\Runner $runner, \PHPUnit\Framework\TestResult $result, $options)
     {
         $runner->prepareSuite($this->suite, $options);
-        $this->dispatcher->dispatch(Events::SUITE_BEFORE, new Event\SuiteEvent($this->suite, $result, $this->settings));
+        $this->dispatch($this->dispatcher, Events::SUITE_BEFORE, new Event\SuiteEvent($this->suite, $result, $this->settings));
         try {
             $runner->doEnhancedRun($this->suite, $result, $options);
         } finally {
-            $this->dispatcher->dispatch(Events::SUITE_AFTER, new Event\SuiteEvent($this->suite, $result, $this->settings));
+            $this->dispatch($this->dispatcher, Events::SUITE_AFTER, new Event\SuiteEvent($this->suite, $result, $this->settings));
         }
     }
 

--- a/tests/cli/GenerateSuiteCest.php
+++ b/tests/cli/GenerateSuiteCest.php
@@ -14,7 +14,8 @@ class GenerateSuiteCest
         $I->seeDirFound('tests/house');
 
         $I->expect('suite is not created due to dashes');
-        $I->executeCommand('generate:suite invalid-dash-suite');
+        $I->executeCommand('generate:suite invalid-dash-suite', false);
+        $I->seeResultCodeIs(1);
         $I->seeInShellOutput('contains invalid characters');
     }
 
@@ -32,7 +33,8 @@ class GenerateSuiteCest
         $I->seeInThisFile('namespace FooBar\Helper;');
 
         $I->expect('suite is not created due to dashes');
-        $I->executeCommand('generate:suite invalid-dash-suite');
+        $I->executeCommand('generate:suite invalid-dash-suite', false);
+        $I->seeResultCodeIs(1);
         $I->seeInShellOutput('contains invalid characters');
     }
 }

--- a/tests/data/register_command/examples/MyCustomCommand.php
+++ b/tests/data/register_command/examples/MyCustomCommand.php
@@ -79,5 +79,6 @@ class MyCustomCommand extends Command implements CustomCommandInterface
 
         echo "Hello " . get_current_user();
         echo $messageEnd . PHP_EOL;
+        return 0;
     }
 }

--- a/tests/unit/Codeception/Test/GherkinTest.php
+++ b/tests/unit/Codeception/Test/GherkinTest.php
@@ -34,7 +34,7 @@ class GherkinTest extends \Codeception\Test\Unit
     {
         return [
             'di'         => new \Codeception\Lib\Di(),
-            'dispatcher' => new \Codeception\Util\Maybe(),
+            'dispatcher' => \Codeception\Util\Stub::makeEmpty('Symfony\Component\EventDispatcher\EventDispatcher'),
             'modules'    => \Codeception\Util\Stub::makeEmpty('Codeception\Lib\ModuleContainer')
         ];
     }


### PR DESCRIPTION
There is no need to wait for Codeception 5, required changes are quite small and can be accomodated by Codeception 4.

Replaces #5765
Closes #5758
Closes #5532
