### PR TITLE
allow to override default Yii2 Logger class via DI container

### DIFF
--- a/src/Codeception/Lib/Connector/Yii2.php
+++ b/src/Codeception/Lib/Connector/Yii2.php
@@ -272,7 +272,7 @@ class Yii2 extends Client
         $config = $this->mockMailer($config);
         /** @var \yii\web\Application $app */
         Yii::$app = Yii::createObject($config);
-        Yii::setLogger(new Logger());
+        Yii::setLogger(Yii::createObject(Logger::className()));
     }
 
     /**


### PR DESCRIPTION
I have an enhanced Logger class which implements my `LoggerInterface`. All of my tests are failing because the default Logger class of Codeception is not implements this interface. I made a custom Logger class which extends the Codeception's Logger class and implements my LoggerInterface, but the Logger class is hardcoded.

With this PR it is possible to override  in the test application via the configuration of the DI container, with the following way:

```php
return [
     'components' => [
          ...
     ],
     'container' => [
          'definitions' => [
               \Codeception\Lib\Connector\Yii2\Logger::class => \tests\codeception\support\Logger::class,
          ],
     ],
];
```