### PR TITLE
Declare module dependencies in require-dev

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,12 +34,6 @@ before_install:
   - composer global require hirak/prestissimo
 install:
   - '[[ -z "$CI_USER_TOKEN" ]] || composer config github-oauth.github.com ${CI_USER_TOKEN};'
-  - composer require --no-update codeception/module-asserts:"dev-master"
-  - composer require --no-update codeception/module-cli:"dev-master"
-  - composer require --no-update codeception/module-db:"dev-master"
-  - composer require --no-update codeception/module-filesystem:"dev-master"
-  - composer require --no-update codeception/module-phpbrowser:"dev-master"
-  - composer require --no-update codeception/util-universalframework:"dev-master"
   - composer install
 before_script:
   # starting demo server

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -34,12 +34,6 @@ install:
   - SET PATH=C:\tools\php71;%PATH%
   - cd %APPVEYOR_BUILD_FOLDER%
   - appveyor DownloadFile https://getcomposer.org/composer.phar
-  - php composer.phar require --no-update codeception/module-asserts:"dev-master"
-  - php composer.phar require --no-update codeception/module-cli:"dev-master"
-  - php composer.phar require --no-update codeception/module-db:"dev-master"
-  - php composer.phar require --no-update codeception/module-filesystem:"dev-master"
-  - php composer.phar require --no-update codeception/module-phpbrowser:"dev-master"
-  - php composer.phar require --no-update codeception/util-universalframework:"dev-master"
   - php composer.phar install --prefer-dist -n --no-ansi
 
 test_script:

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,13 @@
         "symfony/css-selector": ">=2.7 <5.0",
         "behat/gherkin": "^4.4.0",
         "codeception/phpunit-wrapper": ">6.0.15 <6.1.0 | ^6.6.1 | ^7.7.1 | ^8.0.3",
-        "codeception/stub": "^2.0 | ^3.0"
+        "codeception/stub": "^2.0 | ^3.0",
+        "codeception/module-asserts": "*@dev",
+        "codeception/module-cli": "*@dev",
+        "codeception/module-db": "*@dev",
+        "codeception/module-filesystem": "*@dev",
+        "codeception/module-phpbrowser": "*@dev",
+        "codeception/util-universalframework": "*@dev"
     },
     "require-dev": {
         "monolog/monolog": "~1.8",


### PR DESCRIPTION
They must be very loose and have stability set to dev
because they are circular dependencies and stricter rules would make branch builds of those modules fail.
If we need to add some restrictions in the future, they must be added as conflicts