### PR TITLE
New Feature: Add ability to stash/unstash commands in interactive mode.

### DIFF
--- a/src/Codeception/Lib/Actor/Shared/Pause.php
+++ b/src/Codeception/Lib/Actor/Shared/Pause.php
@@ -15,15 +15,91 @@ trait Pause
             throw new \Exception('Hoa Console is not installed. Please add `hoa/console` to composer.json');
         }
 
+        $autoStash = false;
+        $stashedCommands = [];
+
         $I = $this;
+        $output = new ConsoleOutput();
         $readline = new \Hoa\Console\Readline\Readline();
 
         $readline->setAutocompleter(
             new \Hoa\Console\Readline\Autocompleter\Word(get_class_methods($this))
         );
-        $output = new ConsoleOutput();
+
+        $stashFn = function (\Hoa\Console\Readline\Readline $self, $isManual = true) use (&$stashedCommands) {
+            $lastCommand = $self->previousHistory();
+
+            \Hoa\Console\Cursor::clear('↔');
+
+            if (strlen($lastCommand) > 0) {
+                $stashedCommands[] = "\$I->{$lastCommand};";
+                codecept_debug("Command stashed: \$I->{$lastCommand};");
+            } else {
+                codecept_debug("Nothing to stash.");
+            }
+
+            if ($isManual) {
+                \Hoa\Console\Console::getOutput()->writeAll($self->getPrefix() . $self->getLine());
+            }
+
+            $self->nextHistory();
+
+            return \Hoa\Console\Readline\Readline::STATE_CONTINUE;
+        };
+
+        $clearStashFn = function (\Hoa\Console\Readline\Readline $self) use (&$stashedCommands) {
+            $stashedCommands = [];
+
+            \Hoa\Console\Cursor::clear('↔');
+
+            codecept_debug("Stash cleared.");
+
+            \Hoa\Console\Console::getOutput()->writeAll($self->getPrefix() . $self->getLine());
+
+            return \Hoa\Console\Readline\Readline::STATE_CONTINUE;
+        };
+
+        $viewStashedFn = function (\Hoa\Console\Readline\Readline $self) use (&$stashedCommands, $output) {
+            \Hoa\Console\Cursor::clear('↔');
+
+            if (!empty($stashedCommands)) {
+                $output->writeln("\n<comment>Stashed commands:</comment>");
+                codecept_debug(implode("\n", $stashedCommands) . "\n");
+            } else {
+                codecept_debug("No commands stashed.");
+            }
+
+            \Hoa\Console\Console::getOutput()->writeAll($self->getPrefix() . $self->getLine());
+
+            return \Hoa\Console\Readline\Readline::STATE_CONTINUE;
+        };
+
+        $toggleAutoStashFn = function (\Hoa\Console\Readline\Readline $self) use (&$autoStash) {
+            \Hoa\Console\Cursor::clear('↔');
+
+            $autoStash = !$autoStash;
+
+            codecept_debug("Autostash " . ($autoStash ? 'enabled' : 'disabled') . '.');
+
+            \Hoa\Console\Console::getOutput()->writeAll($self->getPrefix() . $self->getLine());
+
+            return \Hoa\Console\Readline\Readline::STATE_CONTINUE;
+        };
+
+        $tput = \Hoa\Console\Console::getTput();
+        $readline->addMapping($tput->get('key_f5'), $stashFn);
+        $readline->addMapping($tput->get('key_f6'), $toggleAutoStashFn);
+        $readline->addMapping($tput->get('key_f8'), $viewStashedFn);
+        $readline->addMapping($tput->get('key_f10'), $clearStashFn);
+
         $output->writeln("  <comment>Execution PAUSED, starting interactive shell...</comment>");
-        $output->writeln("  Type in commands to try them, ENTER to continue, TAB to auto-complete");
+        $output->writeln("  Type in commands to try them:");
+        $output->writeln("  - <info>ENTER</info> to continue");
+        $output->writeln("  - <info>TAB</info> to auto-complete");
+        $output->writeln("  - <info>F5</info> to stash a command");
+        $output->writeln("  - <info>F6</info> to toggle auto-stashing of successful commands");
+        $output->writeln("  - <info>F8</info> to view stashed commands");
+        $output->writeln("  - <info>F10</info> to clear stashed commands");
 
         $result = '';
 
@@ -43,7 +119,11 @@ trait Pause
                     if (!is_object($result)) {
                         codecept_debug($result);
                     }
-                    codecept_debug('>> Result saved to $result variable, you can use it in next commands');
+                    codecept_debug('>> Result saved to $result variable, you can usZZe it in next commands');
+                }
+
+                if ($autoStash) {
+                    call_user_func($stashFn, $readline, false);
                 }
             } catch (\PHPUnit\Framework\AssertionFailedError $fail) {
                 $output->writeln("<error>fail</error> " . $fail->getMessage());

--- a/src/Codeception/Lib/Console/ReplHistory.php
+++ b/src/Codeception/Lib/Console/ReplHistory.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace Codeception\Lib\Console;
+
+class ReplHistory
+{
+    protected $outputFile;
+
+    protected $stashedCommands = [];
+
+    /**
+     * @var ReplHistory
+     */
+    protected static $instance;
+
+    private function __construct()
+    {
+        $this->outputFile = codecept_output_dir('stashed-commands');
+
+        if (file_exists($this->outputFile)) {
+            unlink($this->outputFile);
+        }
+    }
+
+    /**
+     * @return ReplHistory
+     */
+    public static function getInstance()
+    {
+        if (static::$instance == null) {
+            static::$instance = new static();
+        }
+
+        return static::$instance;
+    }
+
+    public function add($command)
+    {
+        $this->stashedCommands[] = $command;
+    }
+
+    public function getAll()
+    {
+        return $this->stashedCommands;
+    }
+
+    public function clear()
+    {
+        $this->stashedCommands = [];
+    }
+
+    public function save()
+    {
+        if (empty($this->stashedCommands)) {
+            return;
+        }
+
+        file_put_contents($this->outputFile, implode("\n", $this->stashedCommands) . "\n", FILE_APPEND);
+
+        codecept_debug("Stashed commands have been saved to {$this->outputFile}");
+
+        $this->clear();
+    }
+}

--- a/tests/unit/Codeception/Lib/Console/ReplHistoryTest.php
+++ b/tests/unit/Codeception/Lib/Console/ReplHistoryTest.php
@@ -1,0 +1,65 @@
+<?php namespace Codeception\Lib\Console;
+
+use Codeception\Configuration;
+use Codeception\Test\Unit;
+
+class ReplHistoryTest extends Unit
+{
+    /**
+     * @var ReplHistory
+     */
+    protected $replHistory;
+
+    protected function _setUp()
+    {
+        $this->replHistory = ReplHistory::getInstance();
+    }
+
+    protected function _tearDown()
+    {
+        $this->replHistory->clear();
+    }
+
+    // tests
+    public function testAdd()
+    {
+        $this->replHistory->add('$I->click(".something")');
+        $this->replHistory->add('$I->anotherCommand()');
+
+        $commands = $this->replHistory->getAll();
+        $this->assertCount(2, $commands);
+        $this->assertEquals('$I->click(".something")', $commands[0]);
+        $this->assertEquals('$I->anotherCommand()', $commands[1]);
+    }
+
+    public function testClear()
+    {
+        $this->replHistory->add('$I->click(".command-1")');
+        $this->replHistory->add('$I->click(".command-2")');
+        $this->replHistory->add('$I->click(".command-3")');
+
+        $this->replHistory->clear();
+
+        $this->assertCount(0, $this->replHistory->getAll());
+    }
+
+    public function testSave()
+    {
+        $this->replHistory->add('$I->click(".command-1");');
+        $this->replHistory->add('$I->click(".command-2");');
+        $this->replHistory->save();
+
+        $this->replHistory->add('$I->click(".command-3");');
+        $this->replHistory->save();
+
+        $history = Configuration::outputDir() . 'stashed-commands';
+        $this->assertFileExists($history);
+        $this->assertStringEqualsFile($history, <<<CONTENTS
+\$I->click(".command-1");
+\$I->click(".command-2");
+\$I->click(".command-3");
+
+CONTENTS
+        );
+    }
+}


### PR DESCRIPTION
It's currently very cumbersome to retrieve successful commands performed in Interactive Mode. You often have to copy and paste commands line by line, and the commands do not have a trailing semi-colon.

This PR improves the interactive shell by adding 4 new keyboard shortcuts to allow the user to quickly stash and unstash the last run command.

1. Pressing F5 stashes the last run command.
2. Pressing F8 displays all the stashed commands with trailing semi-colons, so that it can be quickly pasted back into your IDE.
3. Pressing F10 clears the stashed commands.
4. Pressing F6 toggles 'auto-stashing', which will automatically stash a command if it successfully executes.

The following screenshot illustrates how it works:
![image](https://user-images.githubusercontent.com/846343/70369505-896e9000-18f5-11ea-8f31-76d6846a859c.png)

I have not written any test cases for this because I'm not sure about to go about writing test cases. Would appreciate if maintainers or other contributors help add it in.
