### PR TITLE
Template fixes

### DIFF
--- a/src/Codeception/InitTemplate.php
+++ b/src/Codeception/InitTemplate.php
@@ -323,8 +323,20 @@ abstract class InitTemplate
                 $this->sayInfo('Composer installation failed. Please check composer.json and try to run "composer update" manually');
                 return;
             }
+            $this->updateComposerClassMap();
         }
 
         return $packageCounter;
+    }
+
+    private function updateComposerClassMap()
+    {
+        $loader = require 'vendor/autoload.php';
+        $classMap = require 'vendor/composer/autoload_classmap.php';
+        $loader->addClassMap($classMap);
+        $map = require 'vendor/composer/autoload_psr4.php';
+        foreach ($map as $namespace => $path) {
+            $loader->setPsr4($namespace, $path);
+        }
     }
 }

--- a/src/Codeception/Template/Api.php
+++ b/src/Codeception/Template/Api.php
@@ -55,7 +55,7 @@ EOF;
 
         $url = $this->ask("Start url for tests", "http://localhost/api");
 
-        if (!class_exists('\\Codeception\\Module\\REST') && !class_exists('\\Codeception\\Module\\PhpBrowser')) {
+        if (!class_exists('\\Codeception\\Module\\REST') || !class_exists('\\Codeception\\Module\\PhpBrowser')) {
             $this->addModulesToComposer(['REST', 'PhpBrowser']);
         }
 

--- a/src/Codeception/Template/Bootstrap.php
+++ b/src/Codeception/Template/Bootstrap.php
@@ -39,7 +39,7 @@ class Bootstrap extends InitTemplate
             return;
         }
 
-        if (!class_exists('\\Codeception\\Module\\Asserts') && !class_exists('\\Codeception\\Module\\PhpBrowser')) {
+        if (!class_exists('\\Codeception\\Module\\Asserts') || !class_exists('\\Codeception\\Module\\PhpBrowser')) {
             $this->addModulesToComposer(['PhpBrowser', 'Asserts']);
         }
 

--- a/src/Codeception/Template/Bootstrap.php
+++ b/src/Codeception/Template/Bootstrap.php
@@ -39,13 +39,13 @@ class Bootstrap extends InitTemplate
             return;
         }
 
-        $this->createUnitSuite();
-        $this->createFunctionalSuite();
-        $this->createAcceptanceSuite();
-
         if (!class_exists('\\Codeception\\Module\\Asserts') && !class_exists('\\Codeception\\Module\\PhpBrowser')) {
             $this->addModulesToComposer(['PhpBrowser', 'Asserts']);
         }
+
+        $this->createUnitSuite();
+        $this->createFunctionalSuite();
+        $this->createAcceptanceSuite();
 
         $this->say(" --- ");
         $this->say();


### PR DESCRIPTION
Fixes `bootstrap` and `init` commands.
They are failing to create actors after installing modules, because modules are not autoloadable.

Fixes issue reported in #5806