### PR TITLE
Fixed issue #5820

### DIFF
--- a/src/Codeception/Subscriber/Console.php
+++ b/src/Codeception/Subscriber/Console.php
@@ -432,9 +432,10 @@ class Console implements EventSubscriberInterface
         if ($this->conditionalFails) {
             $failedStep = (string) array_shift($this->conditionalFails);
         } else {
-            $failedStep = (string) $failedTest->getScenario()->getMetaStep();
-            if ($failedStep === '') {
-                $failedStep = (string) array_shift($this->failedStep);
+            $failedMetaStep = (string) $failedTest->getScenario()->getMetaStep();
+            $failedStep = (string) array_shift($this->failedStep);
+            if ($failedMetaStep !== '') {
+                $failedStep = $failedMetaStep;
             }
         }
 


### PR DESCRIPTION
When an error occurs a failed step is always added. 
This needs to be shifted even if we're not using it.
Issue: #5820