### PR TITLE
Suppress warnings caused by class_exists

### DIFF
--- a/src/Codeception/Subscriber/ErrorHandler.php
+++ b/src/Codeception/Subscriber/ErrorHandler.php
@@ -118,7 +118,7 @@ class ErrorHandler implements EventSubscriberInterface
 
     private function registerDeprecationErrorHandler()
     {
-        if (class_exists('\Symfony\Bridge\PhpUnit\DeprecationErrorHandler') && 'disabled' !== getenv('SYMFONY_DEPRECATIONS_HELPER')) {
+        if (@class_exists('\Symfony\Bridge\PhpUnit\DeprecationErrorHandler') && 'disabled' !== getenv('SYMFONY_DEPRECATIONS_HELPER')) {
             // DeprecationErrorHandler only will be installed if array('PHPUnit\Util\ErrorHandler', 'handleError')
             // is installed or no other error handlers are installed.
             // So we will remove Symfony\Component\Debug\ErrorHandler if it's installed.


### PR DESCRIPTION
They cause issues for my projects that are still using ZF1