### PR TITLE
fix recorder filename with special chars

### DIFF
--- a/ext/Recorder.php
+++ b/ext/Recorder.php
@@ -623,7 +623,7 @@ EOF;
      */
     private function getTestName($e)
     {
-        return basename($e->getTest()->getMetadata()->getFilename()) . '_' . $e->getTest()->getMetadata()->getName();
+        return basename($e->getTest()->getMetadata()->getFilename()) . '_' . preg_replace('/[^A-Za-z0-9\-\_]/', '_', $e->getTest()->getMetadata()->getName());
     }
 
     /**


### PR DESCRIPTION
When you have special chars in your scenario titles the recorder can't create the directory.

example `Scenario: Simple Login/Logout`