### PR TITLE
Add input definition for --no-redirect in build command

### DIFF
--- a/autoload.php
+++ b/autoload.php
@@ -27,6 +27,8 @@ if (( !isset($argv) || (isset($argv) && !in_array('--no-redirect', $argv)) ) && 
     require_once __DIR__ . '/../../autoload.php';
 }
 unset($autoloadFile);
+$argv = array_diff($argv, ['--no-redirect']);
+$_SERVER['argv'] = array_diff($_SERVER['argv'], ['--no-redirect']);
 
 // @codingStandardsIgnoreStart
 

--- a/autoload.php
+++ b/autoload.php
@@ -27,8 +27,12 @@ if (( !isset($argv) || (isset($argv) && !in_array('--no-redirect', $argv)) ) && 
     require_once __DIR__ . '/../../autoload.php';
 }
 unset($autoloadFile);
-$argv = array_diff($argv, ['--no-redirect']);
-$_SERVER['argv'] = array_diff($_SERVER['argv'], ['--no-redirect']);
+if (isset($argv)) {
+    $argv = array_diff($argv, ['--no-redirect']);
+}
+if (isset($_SERVER['argv'])) {
+    $_SERVER['argv'] = array_diff($_SERVER['argv'], ['--no-redirect']);
+}
 
 // @codingStandardsIgnoreStart
 

--- a/src/Codeception/Command/Build.php
+++ b/src/Codeception/Command/Build.php
@@ -28,6 +28,19 @@ class Build extends Command
      */
     protected $output;
 
+    /**
+     * Sets Run arguments
+     * @throws \Symfony\Component\Console\Exception\InvalidArgumentException
+     */
+    protected function configure()
+    {
+        $this->setDefinition([
+            new InputOption('no-redirect', '', InputOption::VALUE_NONE, 'Do not redirect to Composer-installed version in vendor/codeception'),
+        ]);
+
+        parent::configure();
+    }
+
     public function getDescription()
     {
         return 'Generates base classes for all suites';

--- a/src/Codeception/Command/Build.php
+++ b/src/Codeception/Command/Build.php
@@ -7,6 +7,7 @@ use Codeception\Lib\Generator\Actor as ActorGenerator;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Input\InputOption;
 
 /**
  * Generates Actor classes (initially Guy classes) from suite configs.

--- a/src/Codeception/Command/Build.php
+++ b/src/Codeception/Command/Build.php
@@ -29,10 +29,6 @@ class Build extends Command
      */
     protected $output;
 
-    /**
-     * Sets Run arguments
-     * @throws \Symfony\Component\Console\Exception\InvalidArgumentException
-     */
     protected function configure()
     {
         $this->setDefinition([

--- a/src/Codeception/Command/Build.php
+++ b/src/Codeception/Command/Build.php
@@ -7,7 +7,6 @@ use Codeception\Lib\Generator\Actor as ActorGenerator;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
-use Symfony\Component\Console\Input\InputOption;
 
 /**
  * Generates Actor classes (initially Guy classes) from suite configs.
@@ -28,15 +27,6 @@ class Build extends Command
      * @var OutputInterface
      */
     protected $output;
-
-    protected function configure()
-    {
-        $this->setDefinition([
-            new InputOption('no-redirect', '', InputOption::VALUE_NONE, 'Do not redirect to Composer-installed version in vendor/codeception'),
-        ]);
-
-        parent::configure();
-    }
 
     public function getDescription()
     {


### PR DESCRIPTION
Description
-----------

When hosting composer dependencies outside of the standard vendor directory (similar to https://github.com/Codeception/Codeception/issues/5495) I have been getting the following error when running the build command:

```
dev/dependencies/vendor/bin/codecept build -c dev/tests/codeception

==== Redirecting to Composer-installed version in vendor/codeception. You can skip this using --no-redirect ====
Building Actor classes for suites: acceptance, api
 -> AcceptanceTesterActions.php generated successfully. 110 methods added
\AcceptanceTester includes modules: WebDriver, Db, Percy, \Helper\Acceptance

In ModuleContainer.php line 110:

  Module REST is not installed.
  Use Composer to install corresponding package:

  composer require codeception/module-rest --dev
```

This is of course because I do not have `codeception/module-rest` installed in my `vendor` directory in project root - it is instead installed in `dev/dependencies/vendor`.

The console log does mention to add `--no-redirect` to this command, which will in turn pass the initial vendor redirection step here https://github.com/Codeception/Codeception/blob/4.0/autoload.php#L4. This however fails for the `build` command as there is no input definition, resulting in:

```
dev/dependencies/vendor/bin/codecept build -c dev/tests/codeception --no-redirect


  The "--no-redirect" option does not exist.
```

This PR simply adds a definition for the `--no-redirect` argument in the build command to prevent these errors. With this applied, I can now build and subsequently run tests from my `dev/dependencies` directory:

```
dev/dependencies/vendor/bin/codecept build -c dev/tests/codeception --no-redirect
Building Actor classes for suites: acceptance, api
 -> AcceptanceTesterActions.php generated successfully. 110 methods added
\AcceptanceTester includes modules: WebDriver, Db, Percy, \Helper\Acceptance
 -> ApiTesterActions.php generated successfully. 57 methods added
\ApiTester includes modules: REST, PhpBrowser, \Helper\Api
dev/dependencies/vendor/bin/codecept run api -c dev/tests/codeception/ --no-redirect --env local -v
Codeception PHP Testing Framework v4.1.1
Powered by PHPUnit 8.5.2 by Sebastian Bergmann and contributors.
Running with seed:


Api (local) Tests (14) -----------------------------------------------------------------------------------------------
Modules: REST, PhpBrowser, \Helper\Api
----------------------------------------------------------------------------------------------------------------------
```