### PR TITLE
Added return type hint to the generated actions above PHP 7.0

### DIFF
--- a/src/Codeception/Lib/Generator/Actions.php
+++ b/src/Codeception/Lib/Generator/Actions.php
@@ -38,7 +38,7 @@ EOF;
      {{doc}}
      * @see \{{module}}::{{method}}()
      */
-    public function {{action}}({{params}}) {
+    public function {{action}}({{params}}){{return_type}} {
         return \$this->getScenario()->runStep(new \Codeception\Step\{{step}}('{{method}}', func_get_args()));
     }
 EOF;
@@ -113,6 +113,7 @@ EOF;
         $methodTemplate = (new Template($this->methodTemplate))
             ->place('module', $module)
             ->place('method', $refMethod->name)
+            ->place('return_type', $this->createReturnTypeHint($refMethod))
             ->place('params', $params);
 
         if (0 === strpos($refMethod->name, 'see')) {
@@ -204,5 +205,27 @@ EOF;
     public function getNumMethods()
     {
         return $this->numMethods;
+    }
+
+    private function createReturnTypeHint(\ReflectionMethod $refMethod)
+    {
+        if (PHP_VERSION_ID < 70000) {
+            return '';
+        }
+
+        $returnType = $refMethod->getReturnType();
+
+        if ($returnType === null) {
+            return '';
+        }
+
+        return strtr(
+            ': {nullable}{trailingBackslash}{type}',
+            [
+                '{nullable}' => $returnType->allowsNull() ? '?' : '',
+                '{trailingBackslash}' => $returnType->isBuiltin() ? '' : '\\',
+                '{type}' => (string)$returnType
+            ]
+        );
     }
 }

--- a/src/Codeception/Lib/Generator/Actions.php
+++ b/src/Codeception/Lib/Generator/Actions.php
@@ -219,13 +219,11 @@ EOF;
             return '';
         }
 
-        return strtr(
-            ': {nullable}{trailingBackslash}{type}',
-            [
-                '{nullable}' => $returnType->allowsNull() ? '?' : '',
-                '{trailingBackslash}' => $returnType->isBuiltin() ? '' : '\\',
-                '{type}' => (string)$returnType
-            ]
+        return sprintf(
+            ': %s%s%s',
+            $returnType->allowsNull() ? '?' : '',
+            $returnType->isBuiltin() ? '' : '\\',
+            (string)$returnType
         );
     }
 }


### PR DESCRIPTION
The idea is that if the module specifies a return type hint, we generate actions that also have this hint. This way there are proper code completion and type checks in IDEs.

E.g.:
```php
<?php declare(strict_types=1);

namespace Foo\Bar;

use Codeception\Module;

class CustomModule extends Module {
    public function haveCustomModuleAction(): \DateTimeInterface {
       return new \DateTimeImmutable();
    }
}
```

```yaml
#foo.suite.yml
class_name: FooTester
modules:
  enabled:
    - \Foo\Bar\CustomModule
```

```php
<?php declare(strict_types=1);

class FooCest {
    public function foo(FooTester $I) {
        $I->haveCustomModuleAction()->format(DATE_ATOM);
    }
}

```