### PR TITLE
Fail on ambiguous step definition

### DIFF
--- a/src/Codeception/Test/Gherkin.php
+++ b/src/Codeception/Test/Gherkin.php
@@ -103,10 +103,6 @@ class Gherkin extends Test implements ScenarioDriven, Reported
             }
             $matches[$pattern] = $context;
         }
-        if (count($matches) === 1) {
-            // Exactly one step definition matches the given step
-            return;
-        }
         if (count($matches) === 0) {
             // There were no matches, meaning that the user should first add a step definition for this step
             $incomplete = $this->getMetadata()->getIncomplete();

--- a/src/Codeception/Test/Gherkin.php
+++ b/src/Codeception/Test/Gherkin.php
@@ -64,7 +64,7 @@ class Gherkin extends Test implements ScenarioDriven, Reported
             $this->getMetadata()->setIncomplete($this->getMetadata()->getIncomplete() . "\nRun gherkin:snippets to define missing steps");
         }
     }
-    
+
     public function getSignature()
     {
         return basename($this->getFileName(), '.feature') . ':' . $this->getScenarioTitle();
@@ -95,15 +95,28 @@ class Gherkin extends Test implements ScenarioDriven, Reported
         if (GherkinSnippets::stepHasPyStringArgument($stepNode)) {
             $stepText .= ' ""';
         }
+        $matches = [];
         foreach ($this->steps as $pattern => $context) {
             $res = preg_match($pattern, $stepText);
             if (!$res) {
                 continue;
             }
+            $matches[] = [$pattern, $context];
+        }
+        if (count($matches) === 1) {
+            // Exactly one step definition matches the given step
             return;
         }
-        $incomplete = $this->getMetadata()->getIncomplete();
-        $this->getMetadata()->setIncomplete("$incomplete\nStep definition for `$stepText` not found in contexts");
+        if (count($matches) === 0) {
+            // There were no matches, meaning that the user should first add a step definition for this step
+            $incomplete = $this->getMetadata()->getIncomplete();
+            $this->getMetadata()->setIncomplete("$incomplete\nStep definition for `$stepText` not found in contexts");
+        }
+        if (count($matches) > 1) {
+            // There were more than one match, meaning that we don't know which step definition to execute for this step
+            $incomplete = $this->getMetadata()->getIncomplete();
+            $this->getMetadata()->setIncomplete("$incomplete\nAmbiguous step: `$stepText` matches multiple definitions");
+        }
     }
 
     protected function runStep(StepNode $stepNode)

--- a/tests/cli/GherkinCest.php
+++ b/tests/cli/GherkinCest.php
@@ -78,6 +78,10 @@ class GherkinCest
         $I->executeCommand('run scenario "AmbiguousStep.feature" --steps');
         $I->dontSeeInShellOutput('definition1 was executed');
         $I->dontSeeInShellOutput('definition2 was executed');
-        $I->seeInShellOutput('Ambiguous step: `a step which matches multiple step definitions` matches multiple definitions');
+        $I->seeInShellOutput(
+            "Ambiguous step: `a step which matches multiple step definitions` matches multiple definitions:\n" .
+            "- /multiple step definitions/ (ScenarioGuy:definition1)\n" .
+            "- /a step which matches/ (ScenarioGuy:definition2)"
+        );
     }
 }

--- a/tests/cli/GherkinCest.php
+++ b/tests/cli/GherkinCest.php
@@ -72,4 +72,12 @@ class GherkinCest
         $I->seeInShellOutput('@Given я написал сценарий на языке :arg1');
         $I->seeInShellOutput('public function step_62e20dc62($arg1)');
     }
+
+    public function ambigiousStepDefinitions(CliGuy $I)
+    {
+        $I->executeCommand('run scenario "AmbiguousStep.feature" --steps');
+        $I->dontSeeInShellOutput('definition1 was executed');
+        $I->dontSeeInShellOutput('definition2 was executed');
+        $I->seeInShellOutput('Ambiguous step: `a step which matches multiple step definitions` matches multiple definitions');
+    }
 }

--- a/tests/data/claypit/tests/_support/ScenarioGuy.php
+++ b/tests/data/claypit/tests/_support/ScenarioGuy.php
@@ -85,4 +85,20 @@ class ScenarioGuy extends \Codeception\Actor
      {
         echo "Argument: $arg1\n";
      }
+
+    /**
+     * @Given /multiple step definitions/
+     */
+    public function definition1()
+    {
+        echo __METHOD__ . ' was executed';
+    }
+
+    /**
+     * @Given /a step which matches/
+     */
+    public function definition2()
+    {
+        echo __METHOD__ . ' was executed';
+    }
 }

--- a/tests/data/claypit/tests/scenario/AmbiguousStep.feature
+++ b/tests/data/claypit/tests/scenario/AmbiguousStep.feature
@@ -1,0 +1,7 @@
+Feature:
+  In order to know that the right step will be executed
+  As a user
+  I should be notified about steps that are ambiguous
+
+  Scenario: We have multiple step definitions that match a given step
+    Given a step which matches multiple step definitions


### PR DESCRIPTION
This fixes #5864

I've decided to hook into the existing step validation code and not throw an exception but use the already present behavior of marking a step as incomplete.