### PR TITLE
Do not truncate arguments for --html options

### DIFF
--- a/src/Codeception/Step.php
+++ b/src/Codeception/Step.php
@@ -9,6 +9,8 @@ use PHPUnit\Framework\MockObject\MockObject;
 
 abstract class Step
 {
+    const ARGUMENTS_DEFAULT_LENGTH = 200;
+
     const STACK_POSITION = 3;
     /**
      * @var    string
@@ -94,7 +96,7 @@ abstract class Step
         return $this->arguments;
     }
 
-    public function getArgumentsAsString($maxLength = 200)
+    public function getArgumentsAsString($maxLength = self::ARGUMENTS_DEFAULT_LENGTH)
     {
         $arguments = $this->arguments;
 
@@ -232,7 +234,7 @@ abstract class Step
         return $this->humanize($this->getAction());
     }
 
-    public function getHumanizedArguments($maxLength = 200)
+    public function getHumanizedArguments($maxLength = self::ARGUMENTS_DEFAULT_LENGTH)
     {
         return $this->getArgumentsAsString($maxLength);
     }

--- a/src/Codeception/Step.php
+++ b/src/Codeception/Step.php
@@ -224,7 +224,7 @@ abstract class Step
             return sprintf('%s %s', ucfirst($this->prefix), $this->humanize($this->getAction()));
         }
 
-        return sprintf('%s %s <span style="color: %s">%s</span>', ucfirst($this->prefix), htmlspecialchars($this->humanize($this->getAction())), $highlightColor, htmlspecialchars($this->getHumanizedArguments()));
+        return sprintf('%s %s <span style="color: %s">%s</span>', ucfirst($this->prefix), htmlspecialchars($this->humanize($this->getAction())), $highlightColor, htmlspecialchars($this->getHumanizedArguments(0)));
     }
 
     public function getHumanizedActionWithoutArguments()

--- a/tests/unit/Codeception/StepTest.php
+++ b/tests/unit/Codeception/StepTest.php
@@ -3,6 +3,7 @@
 use Codeception\Util\Stub;
 use Facebook\WebDriver\WebDriverBy;
 use Codeception\Util\Locator;
+use Codeception\Step;
 
 class StepTest extends \PHPUnit\Framework\TestCase
 {
@@ -51,6 +52,10 @@ class StepTest extends \PHPUnit\Framework\TestCase
 
         $step = $this->getStep(['Do some testing', []]);
         $this->assertSame('I do some testing', $step->getHtml());
+
+        $argument = str_repeat("A string with a length exceeding Step::ARGUMENTS_DEFAULT_LENGTH.", Step::ARGUMENTS_DEFAULT_LENGTH);
+        $step = $this->getStep(['Do some testing', [$argument]]);
+        $this->assertSame('I do some testing <span style="color: #732E81">&quot;' . $argument . '&quot;</span>', $step->getHtml());
     }
 
     public function testLongArguments()


### PR DESCRIPTION
By running the `run --html`, we can have a report.html file that is generated.
However, the content of this file is truncated, thus making the report sometimes unusable.

This is a quick proposal but IMO it should not be merged as it is.
We should rather create an optional conf input (or whatever) to let the user chose if yes or not, he wants the truncate to happen, and how maximal characters he desires.

Fixes #5869