### PR TITLE
Check the composer option config.vendor_dir when updating composer

### DIFF
--- a/src/Codeception/InitTemplate.php
+++ b/src/Codeception/InitTemplate.php
@@ -323,10 +323,9 @@ abstract class InitTemplate
                 $this->sayInfo('Composer installation failed. Please check composer.json and try to run "composer update" manually');
                 return;
             }
-            if(!empty($composer['config']['vendor_dir'])) {
+            if (!empty($composer['config']['vendor_dir'])) {
                 $this->updateComposerClassMap($composer['config']['vendor_dir']);
-            }
-            else {
+            } else {
                 $this->updateComposerClassMap();
             }
         }

--- a/src/Codeception/InitTemplate.php
+++ b/src/Codeception/InitTemplate.php
@@ -323,18 +323,23 @@ abstract class InitTemplate
                 $this->sayInfo('Composer installation failed. Please check composer.json and try to run "composer update" manually');
                 return;
             }
-            $this->updateComposerClassMap();
+            if(!empty($composer['config']['vendor_dir'])) {
+                $this->updateComposerClassMap($composer['config']['vendor_dir']);
+            }
+            else {
+                $this->updateComposerClassMap();
+            }
         }
 
         return $packageCounter;
     }
 
-    private function updateComposerClassMap()
+    private function updateComposerClassMap($vendorDir = 'vendor')
     {
-        $loader = require 'vendor/autoload.php';
-        $classMap = require 'vendor/composer/autoload_classmap.php';
+        $loader = require $vendorDir . '/autoload.php';
+        $classMap = require $vendorDir . '/composer/autoload_classmap.php';
         $loader->addClassMap($classMap);
-        $map = require 'vendor/composer/autoload_psr4.php';
+        $map = require $vendorDir . '/composer/autoload_psr4.php';
         foreach ($map as $namespace => $path) {
             $loader->setPsr4($namespace, $path);
         }


### PR DESCRIPTION
Details on issue #5868.

Check if the composer.json have a [vendor_dir](https://getcomposer.org/doc/06-config.md#vendor-dir) and then use this path on the method updateComposerClassMap of the class InitTemplate, used on the `codecept bootstrap`.