### PR TITLE
Prevent merged config array ballooning in memory

### DIFF
--- a/src/Codeception/Configuration.php
+++ b/src/Codeception/Configuration.php
@@ -670,7 +670,7 @@ class Configuration
 
         // for sequential arrays
         if (isset($a1[0], $a2[0])) {
-            return array_merge_recursive($a2, $a1);
+            return array_merge(array_unique(array_merge_recursive($a2, $a1), SORT_REGULAR));
         }
 
         // for associative arrays

--- a/src/Codeception/Configuration.php
+++ b/src/Codeception/Configuration.php
@@ -670,7 +670,7 @@ class Configuration
 
         // for sequential arrays
         if (isset($a1[0], $a2[0])) {
-            return array_merge(array_unique(array_merge_recursive($a2, $a1), SORT_REGULAR));
+            return array_values(array_unique(array_merge_recursive($a2, $a1), SORT_REGULAR));
         }
 
         // for associative arrays


### PR DESCRIPTION
Closes https://github.com/Codeception/Codeception/issues/5817

This change prevents an issue where the config array gets duplicated every time the mergeConfigs array is called causing the array to balloon in size in memory and the test suite to slow down as it progresses.

Original issue raised by and fix suggested by @tweber68