### PR TITLE
New add_uncovered configuration property with bugfix for show_uncovered property

### DIFF
--- a/src/Codeception/Coverage/Subscriber/Printer.php
+++ b/src/Codeception/Coverage/Subscriber/Printer.php
@@ -36,6 +36,8 @@ class Printer implements EventSubscriberInterface
         $this->logDir = Configuration::outputDir();
         $this->settings = array_merge($this->settings, Configuration::config()['coverage']);
         self::$coverage = new \SebastianBergmann\CodeCoverage\CodeCoverage();
+        self::$coverage->setProcessUncoveredFilesFromWhitelist($this->settings['show_uncovered']);
+        self::$coverage->setAddUncoveredFilesFromWhitelist($this->settings['add_uncovered']);
 
         // Apply filter
         $filter = new Filter(self::$coverage);

--- a/src/Codeception/Coverage/Subscriber/Printer.php
+++ b/src/Codeception/Coverage/Subscriber/Printer.php
@@ -21,6 +21,7 @@ class Printer implements EventSubscriberInterface
         'low_limit'         => '35',
         'high_limit'        => '70',
         'show_uncovered'    => false,
+        'add_uncovered'     => false,
         'show_only_summary' => false
     ];
 

--- a/src/Codeception/Coverage/Subscriber/Printer.php
+++ b/src/Codeception/Coverage/Subscriber/Printer.php
@@ -21,7 +21,7 @@ class Printer implements EventSubscriberInterface
         'low_limit'         => '35',
         'high_limit'        => '70',
         'show_uncovered'    => false,
-        'add_uncovered'     => false,
+        'add_uncovered'     => true,
         'show_only_summary' => false
     ];
 

--- a/src/Codeception/Coverage/SuiteSubscriber.php
+++ b/src/Codeception/Coverage/SuiteSubscriber.php
@@ -21,6 +21,7 @@ abstract class SuiteSubscriber implements EventSubscriberInterface
         'xdebug_session' => 'codeception',
         'remote_config'  => null,
         'show_uncovered' => false,
+        'add_uncovered'  => false,
         'c3_url'         => null,
         'work_dir'       => null,
         'cookie_domain'  => null,
@@ -62,6 +63,7 @@ abstract class SuiteSubscriber implements EventSubscriberInterface
             }
         }
         $this->coverage->setProcessUncoveredFilesFromWhitelist($this->settings['show_uncovered']);
+        $this->coverage->setAddUncoveredFilesFromWhitelist($this->settings['add_uncovered']);
     }
 
     /**

--- a/src/Codeception/Coverage/SuiteSubscriber.php
+++ b/src/Codeception/Coverage/SuiteSubscriber.php
@@ -21,7 +21,7 @@ abstract class SuiteSubscriber implements EventSubscriberInterface
         'xdebug_session' => 'codeception',
         'remote_config'  => null,
         'show_uncovered' => false,
-        'add_uncovered'  => false,
+        'add_uncovered'  => true,
         'c3_url'         => null,
         'work_dir'       => null,
         'cookie_domain'  => null,


### PR DESCRIPTION
PHPUnit has two parameters:

addUncoveredFilesFromWhitelist
and
processUncoveredFilesFromWhitelist

The first one is responsible for adding uncovered files to the coverage list and the second one is responsible for include()'ing these files to find potentially executable lines.

Codeception now has the possibility to pass only processUncoveredFilesFromWhitelist (with bug) parameter to PHPUnit. 

To run coverage tests in parallel and then get the correct merge of the coverage results over the large codebase one needs to pass "processUncoveredFilesFromWhitelist = true" parameter. But on the large codebase, this causes each parallel execution to include all whitelisted codebase files to determine potentially executable lines.

To avoid this, it is better to run one of the coverage parts as "processUncoveredFilesFromWhitelist = true" and processUncoveredFilesFromWhitelist=true and run other coverage parts with both parameters to false.

In this case, the coverage merge will give valid coverage results much faster.

That's why this add_uncovered was introduced.

The other bug in "Printer.php" relates to "show_uncovered" parameter not being passed to $self::coverage. Because of that, when \Codeception\Coverage\Subscriber\Printer::printConsole is called, the $writer->process() gets self::$coverate without this processUncoveredFilesFromWhitelist set. to true, which causes \SebastianBergmann\CodeCoverage\Report\Text::process function to call $coverage->getReport() to call \SebastianBergmann\CodeCoverage\CodeCoverage::getData with default addUncoveredFilesFromWhitelist value instead of configured one.

This pull request fixes this issue too.