### PR TITLE
Build: Use non-deprecated method to get return type hint

### DIFF
--- a/src/Codeception/Lib/Generator/Actions.php
+++ b/src/Codeception/Lib/Generator/Actions.php
@@ -219,11 +219,16 @@ EOF;
             return '';
         }
 
+        if (PHP_VERSION_ID < 70100) {
+            $returnTypeString = (string)$returnType;
+        } else {
+            $returnTypeString = $returnType->getName();
+        }
         return sprintf(
             ': %s%s%s',
             $returnType->allowsNull() ? '?' : '',
             $returnType->isBuiltin() ? '' : '\\',
-            (string)$returnType
+            $returnTypeString
         );
     }
 }


### PR DESCRIPTION
Fixes #5875