### PR TITLE
Ensure that the return keyword is not used when method returns void type

### DIFF
--- a/src/Codeception/Lib/Generator/Actions.php
+++ b/src/Codeception/Lib/Generator/Actions.php
@@ -39,7 +39,7 @@ EOF;
      * @see \{{module}}::{{method}}()
      */
     public function {{action}}({{params}}){{return_type}} {
-        return \$this->getScenario()->runStep(new \Codeception\Step\{{step}}('{{method}}', func_get_args()));
+        {{return}}\$this->getScenario()->runStep(new \Codeception\Step\{{step}}('{{method}}', func_get_args()));
     }
 EOF;
 
@@ -113,7 +113,8 @@ EOF;
         $methodTemplate = (new Template($this->methodTemplate))
             ->place('module', $module)
             ->place('method', $refMethod->name)
-            ->place('return_type', $this->createReturnTypeHint($refMethod))
+            ->place('return_type', $returnType = $this->createReturnTypeHint($refMethod))
+            ->place('return', $returnType === 'void' ? '' : 'return ')
             ->place('params', $params);
 
         if (0 === strpos($refMethod->name, 'see')) {

--- a/src/Codeception/Lib/Generator/Actions.php
+++ b/src/Codeception/Lib/Generator/Actions.php
@@ -109,11 +109,12 @@ EOF;
         if (!$doc) {
             $doc = "*";
         }
+        $returnType = $this->createReturnTypeHint($refMethod);
 
         $methodTemplate = (new Template($this->methodTemplate))
             ->place('module', $module)
             ->place('method', $refMethod->name)
-            ->place('return_type', $returnType = $this->createReturnTypeHint($refMethod))
+            ->place('return_type', $returnType)
             ->place('return', $returnType === 'void' ? '' : 'return ')
             ->place('params', $params);
 


### PR DESCRIPTION
Fixes #5877 

When Codeception generates a method action for a method which returns a `void` type, the method still uses the `return` keyword causing a PHP error:

```
Fatal error:  A void function must not return a value
```

This PR makes the `return` keyword variable, so that when we're dealing with a method which has a return type of `void`, we don't use the `return` keyword at all.