### PR TITLE
Fixed condition for void return type on generated action.

### DIFF
--- a/src/Codeception/Lib/Generator/Actions.php
+++ b/src/Codeception/Lib/Generator/Actions.php
@@ -115,7 +115,7 @@ EOF;
             ->place('module', $module)
             ->place('method', $refMethod->name)
             ->place('return_type', $returnType)
-            ->place('return', $returnType === 'void' ? '' : 'return ')
+            ->place('return', $returnType === ': void' ? '' : 'return ')
             ->place('params', $params);
 
         if (0 === strpos($refMethod->name, 'see')) {


### PR DESCRIPTION
Fixes condition used in #5878 - colon is part of return type string.