### PR TITLE
Improved compatibility with PHPUnit 7+

### DIFF
--- a/autoload.php
+++ b/autoload.php
@@ -35,8 +35,6 @@ if (isset($_SERVER['argv'])) {
 }
 
 // @codingStandardsIgnoreStart
-
-include_once __DIR__ . DIRECTORY_SEPARATOR . 'shim.php';
 // compat
 if (PHP_MAJOR_VERSION < 7) {
     if (false === interface_exists('Throwable', false)) {
@@ -47,79 +45,3 @@ if (PHP_MAJOR_VERSION < 7) {
     }
 }
 // @codingStandardsIgnoreEnd
-
-// function not autoloaded in PHP, thus its a good place for them
-if (!function_exists('codecept_debug')) {
-    function codecept_debug($data)
-    {
-        \Codeception\Util\Debug::debug($data);
-    }
-}
-
-if (!function_exists('codecept_root_dir')) {
-    function codecept_root_dir($appendPath = '')
-    {
-        return \Codeception\Configuration::projectDir() . $appendPath;
-    }
-}
-
-if (!function_exists('codecept_output_dir')) {
-    function codecept_output_dir($appendPath = '')
-    {
-        return \Codeception\Configuration::outputDir() . $appendPath;
-    }
-}
-
-if (!function_exists('codecept_log_dir')) {
-    function codecept_log_dir($appendPath = '')
-    {
-        return \Codeception\Configuration::outputDir() . $appendPath;
-    }
-}
-
-if (!function_exists('codecept_data_dir')) {
-    function codecept_data_dir($appendPath = '')
-    {
-        return \Codeception\Configuration::dataDir() . $appendPath;
-    }
-}
-
-if (!function_exists('codecept_relative_path')) {
-    function codecept_relative_path($path)
-    {
-        return \Codeception\Util\PathResolver::getRelativeDir(
-            $path,
-            \Codeception\Configuration::projectDir(),
-            DIRECTORY_SEPARATOR
-        );
-    }
-}
-
-if (!function_exists('codecept_absolute_path')) {
-    /**
-     * If $path is absolute, it will be returned without changes.
-     * If $path is relative, it will be passed to `codecept_root_dir()` function
-     * to make it absolute.
-     *
-     * @param string $path
-     * @return string the absolute path
-     */
-    function codecept_absolute_path($path)
-    {
-        return codecept_is_path_absolute($path) ? $path : codecept_root_dir($path);
-    }
-}
-
-if (!function_exists('codecept_is_path_absolute')) {
-    /**
-     * Check whether the given $path is absolute.
-     *
-     * @param string $path
-     * @return bool
-     * @since 2.4.4
-     */
-    function codecept_is_path_absolute($path)
-    {
-        return \Codeception\Util\PathResolver::isPathAbsolute($path);
-    }
-}

--- a/composer.json
+++ b/composer.json
@@ -51,8 +51,11 @@
         "stecman/symfony-console-completion": "For BASH autocompletion"
     },
 
-    "autoload":{
-        "psr-4":{
+    "autoload": {
+        "files": [
+            "shim.php"
+        ],
+        "psr-4": {
             "Codeception\\": "src/Codeception",
             "Codeception\\Extension\\": "ext"
         }

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
         "symfony/yaml": ">=2.7 <6.0",
         "symfony/css-selector": ">=2.7 <6.0",
         "behat/gherkin": "^4.4.0",
-        "codeception/phpunit-wrapper": ">6.0.15 <6.1.0 | ^6.6.1 | ^7.7.1 | ^8.1.1 | ^9.0",
+        "codeception/phpunit-wrapper": "dev-7.1-abstract-test as 7.9.99",
         "codeception/stub": "^2.0 | ^3.0"
     },
     "require-dev": {

--- a/shim.php
+++ b/shim.php
@@ -1,10 +1,6 @@
 <?php
 // @codingStandardsIgnoreStart
 
-namespace {
-    \Codeception\PHPUnit\Init::init();
-}
-
 namespace Symfony\Component\CssSelector {
     if (!class_exists('Symfony\Component\CssSelector\CssSelectorConverter')) {
         class CssSelectorConverter {
@@ -39,5 +35,81 @@ namespace {
     //Compatibility with Symfony 5
     if (!class_exists('Symfony\Component\EventDispatcher\Event') && class_exists('Symfony\Contracts\EventDispatcher\Event')) {
         class_alias('Symfony\Contracts\EventDispatcher\Event', 'Symfony\Component\EventDispatcher\Event');
+    }
+
+    // function not autoloaded in PHP, thus its a good place for them
+    if (!function_exists('codecept_debug')) {
+        function codecept_debug($data)
+        {
+            \Codeception\Util\Debug::debug($data);
+        }
+    }
+
+    if (!function_exists('codecept_root_dir')) {
+        function codecept_root_dir($appendPath = '')
+        {
+            return \Codeception\Configuration::projectDir() . $appendPath;
+        }
+    }
+
+    if (!function_exists('codecept_output_dir')) {
+        function codecept_output_dir($appendPath = '')
+        {
+            return \Codeception\Configuration::outputDir() . $appendPath;
+        }
+    }
+
+    if (!function_exists('codecept_log_dir')) {
+        function codecept_log_dir($appendPath = '')
+        {
+            return \Codeception\Configuration::outputDir() . $appendPath;
+        }
+    }
+
+    if (!function_exists('codecept_data_dir')) {
+        function codecept_data_dir($appendPath = '')
+        {
+            return \Codeception\Configuration::dataDir() . $appendPath;
+        }
+    }
+
+    if (!function_exists('codecept_relative_path')) {
+        function codecept_relative_path($path)
+        {
+            return \Codeception\Util\PathResolver::getRelativeDir(
+                $path,
+                \Codeception\Configuration::projectDir(),
+                DIRECTORY_SEPARATOR
+            );
+        }
+    }
+
+    if (!function_exists('codecept_absolute_path')) {
+        /**
+         * If $path is absolute, it will be returned without changes.
+         * If $path is relative, it will be passed to `codecept_root_dir()` function
+         * to make it absolute.
+         *
+         * @param string $path
+         * @return string the absolute path
+         */
+        function codecept_absolute_path($path)
+        {
+            return codecept_is_path_absolute($path) ? $path : codecept_root_dir($path);
+        }
+    }
+
+    if (!function_exists('codecept_is_path_absolute')) {
+        /**
+         * Check whether the given $path is absolute.
+         *
+         * @param string $path
+         * @return bool
+         * @since 2.4.4
+         */
+        function codecept_is_path_absolute($path)
+        {
+            return \Codeception\Util\PathResolver::isPathAbsolute($path);
+        }
     }
 }

--- a/src/Codeception/Test/Cept.php
+++ b/src/Codeception/Test/Cept.php
@@ -50,7 +50,7 @@ class Cept extends Test implements Interfaces\Plain, Interfaces\ScenarioDriven, 
         return $this->getMetadata()->getName() . 'Cept';
     }
 
-    public function toString()
+    public function _toString()
     {
         return $this->getSignature() . ': ' . Message::ucfirst($this->getFeature());
     }

--- a/src/Codeception/Test/Cest.php
+++ b/src/Codeception/Test/Cest.php
@@ -150,7 +150,7 @@ class Cest extends Test implements
         $this->invoke($this->testMethod, [$I, $this->scenario]);
     }
 
-    public function toString()
+    public function _toString()
     {
         return sprintf('%s: %s', ReflectionHelper::getClassShortName($this->getTestClass()), Message::ucfirst($this->getFeature()));
     }

--- a/src/Codeception/Test/Feature/IgnoreIfMetadataBlocked.php
+++ b/src/Codeception/Test/Feature/IgnoreIfMetadataBlocked.php
@@ -8,7 +8,7 @@ trait IgnoreIfMetadataBlocked
     /**
      * @return Metadata
      */
-    abstract protected function getMetadata();
+    abstract public function getMetadata();
 
     abstract protected function ignore($ignored);
 

--- a/src/Codeception/Test/Gherkin.php
+++ b/src/Codeception/Test/Gherkin.php
@@ -162,7 +162,7 @@ class Gherkin extends Test implements ScenarioDriven, Reported
         }
     }
 
-    public function toString()
+    public function _toString()
     {
         return $this->getFeature() . ': ' . $this->getScenarioTitle();
     }

--- a/src/Codeception/Test/Test.php
+++ b/src/Codeception/Test/Test.php
@@ -1,6 +1,7 @@
 <?php
 namespace Codeception\Test;
 
+use Codeception\PHPUnit\Test As TestAbstract;
 use Codeception\TestInterface;
 use Codeception\Util\ReflectionHelper;
 use SebastianBergmann\Timer\Timer;
@@ -15,7 +16,7 @@ use SebastianBergmann\Timer\Timer;
  *
  * Inherited class must implement `test` method.
  */
-abstract class Test implements TestInterface, Interfaces\Descriptive
+abstract class Test extends TestAbstract implements TestInterface
 {
     use Feature\AssertionCounter;
     use Feature\CodeCoverage;
@@ -51,20 +52,13 @@ abstract class Test implements TestInterface, Interfaces\Descriptive
     abstract public function test();
 
     /**
-     * Test representation
-     *
-     * @return mixed
-     */
-    abstract public function toString();
-
-    /**
      * Runs a test and collects its result in a TestResult instance.
      * Executes before/after hooks coming from traits.
      *
      * @param  \PHPUnit\Framework\TestResult $result
      * @return \PHPUnit\Framework\TestResult
      */
-    final public function run(\PHPUnit\Framework\TestResult $result = null)
+    final public function _run(\PHPUnit\Framework\TestResult $result = null)
     {
         $this->testResult = $result;
 


### PR DESCRIPTION
* Doesn't fail when used in combination with zend-test and some other testing libraries
* Keeps compatibility with PHPUnit 5 and 6
* Differences of PHPUnit's Test and SelfDescribing interfaces are hidden by phpunit-wrapper library
* shim.php is loaded by composer, so it is easier to use Codeception as a library

Fixes #5031 
Fixes #5886
