### PR TITLE
Add the function addToAssertionCount to the Assertion trait

### DIFF
--- a/src/Codeception/Test/Feature/AssertionCounter.php
+++ b/src/Codeception/Test/Feature/AssertionCounter.php
@@ -13,7 +13,7 @@ trait AssertionCounter
      * This method is not covered by the backward compatibility promise
      * for PHPUnit, but is nice to have for extensions.
      */
-    public function addToAssertionCount(int $count): void
+    public function addToAssertionCount($count)
     {
         $this->numAssertions += $count;
     }

--- a/src/Codeception/Test/Feature/AssertionCounter.php
+++ b/src/Codeception/Test/Feature/AssertionCounter.php
@@ -9,6 +9,14 @@ trait AssertionCounter
     {
         return $this->numAssertions;
     }
+    /**
+     * This method is not covered by the backward compatibility promise 
+     * for PHPUnit, but is nice to have for extensions.
+     */
+    public function addToAssertionCount(int $count): void
+    {
+        $this->numAssertions += $count;
+    }
 
     protected function assertionCounterStart()
     {

--- a/src/Codeception/Test/Feature/AssertionCounter.php
+++ b/src/Codeception/Test/Feature/AssertionCounter.php
@@ -10,7 +10,7 @@ trait AssertionCounter
         return $this->numAssertions;
     }
     /**
-     * This method is not covered by the backward compatibility promise 
+     * This method is not covered by the backward compatibility promise
      * for PHPUnit, but is nice to have for extensions.
      */
     public function addToAssertionCount(int $count): void


### PR DESCRIPTION
I've been missing this functionality, since I'm using mockery for mocks, and I'd like to be able to include the expectations as assertions in the count.
For the PHPUnit (see link: https://github.com/sebastianbergmann/phpunit/blob/master/src/Framework/TestCase.php#L1309) project, there is this function on the test cases.

For a Cest I had to do the following in an extension 
```php
<?php
//...
if ($container = Mockery::getContainer()) {
    $expectationCount = $container->mockery_getExpectationCount();
    Mockery::close();
    if ($test instanceof Cest) {
        // This is... beyond whacky-hacky
        $accessor = new ReflectionPropertyAccessor();
        $numAssertionsOnClass = $accessor->getProperty($test, 'numAssertions');
        $accessor->setProperties($test, ['numAssertions' => $numAssertionsOnClass + $expectationCount]);
    }
    if ($test instanceof TestCase) {
        $test->addToAssertionCount($expectationCount);
    }
}
```