### PR TITLE
Remove complicated merge logic for environment configurations.

### DIFF
--- a/src/Codeception/Codecept.php
+++ b/src/Codeception/Codecept.php
@@ -157,21 +157,25 @@ class Codecept
         $settings = Configuration::suiteSettings($suite, $config);
 
         $selectedEnvironments = $this->options['env'];
-        $environments = Configuration::suiteEnvironments($suite);
 
-        if (!$selectedEnvironments or empty($environments)) {
+        if (!$selectedEnvironments or empty($settings['env'])) {
             $this->runSuite($settings, $suite, $test);
             return;
         }
 
         foreach (array_unique($selectedEnvironments) as $envList) {
             $envArray = explode(',', $envList);
-            $config = [];
+            $config = $settings;
             foreach ($envArray as $env) {
-                if (isset($environments[$env])) {
+                if (isset($settings['env'])) {
                     $currentEnvironment = isset($config['current_environment']) ? [$config['current_environment']] : [];
-                    $config = Configuration::mergeConfigs($config, $environments[$env]);
-                    $currentEnvironment[] = $config['current_environment'];
+
+                    if (!array_key_exists($env, $settings['env'])) {
+                        return;
+                    }
+
+                    $config = Configuration::mergeConfigs($config, $settings['env'][$env]);
+                    $currentEnvironment[] = $env;
                     $config['current_environment'] = implode(',', $currentEnvironment);
                 }
             }

--- a/src/Codeception/Configuration.php
+++ b/src/Codeception/Configuration.php
@@ -454,32 +454,6 @@ class Configuration
         return $nonExistentValue;
     }
 
-    /**
-     * Returns all possible suite configurations according environment rules.
-     * Suite configurations will contain `current_environment` key which specifies what environment used.
-     *
-     * @param $suite
-     * @return array
-     * @throws ConfigurationException
-     */
-    public static function suiteEnvironments($suite)
-    {
-        $settings = self::suiteSettings($suite, self::config());
-
-        if (!isset($settings['env']) || !is_array($settings['env'])) {
-            return [];
-        }
-
-        $environments = [];
-
-        foreach ($settings['env'] as $env => $envConfig) {
-            $environments[$env] = $envConfig ? self::mergeConfigs($settings, $envConfig) : $settings;
-            $environments[$env]['current_environment'] = $env;
-        }
-
-        return $environments;
-    }
-
     public static function suites()
     {
         return self::$suites;

--- a/tests/cli/RunEnvironmentCest.php
+++ b/tests/cli/RunEnvironmentCest.php
@@ -79,6 +79,23 @@ class RunEnvironmentCest
         $I->seeInShellOutput('message4: MESSAGE4 FROM SUITE-ENV1.');
     }
 
+    public function testSparseEnvMerging(CliGuy $I)
+    {
+        $I->wantTo('test that every configuration ' .
+            'in the list of environments gets merged in order of given environments');
+        $I->amInPath('tests/data/sandbox');
+        $I->executeCommand('run messages MessageCest.php:allMessages -vv --env envLayer1,envLayer2');
+        $I->seeInShellOutput('message1: MESSAGE1 FROM envLayer1.');
+        $I->seeInShellOutput('message2: MESSAGE2 FROM envLayer2.');
+        $I->seeInShellOutput('message3: MESSAGE3 FROM SUITE.');
+
+        $I->wantTo('test that the order in which sparse environments get configured are irrelevant');
+        $I->executeCommand('run messages MessageCest.php:allMessages -vv --env envLayer2,envLayer1');
+        $I->seeInShellOutput('message1: MESSAGE1 FROM envLayer1.');
+        $I->seeInShellOutput('message2: MESSAGE2 FROM envLayer2.');
+        $I->seeInShellOutput('message3: MESSAGE3 FROM SUITE.');
+    }
+
     public function runTestForMultipleEnvironments(CliGuy $I)
     {
         $I->wantTo('check that multiple required environments are taken into account');

--- a/tests/cli/RunEnvironmentCest.php
+++ b/tests/cli/RunEnvironmentCest.php
@@ -88,8 +88,12 @@ class RunEnvironmentCest
         $I->seeInShellOutput('message1: MESSAGE1 FROM envLayer1.');
         $I->seeInShellOutput('message2: MESSAGE2 FROM envLayer2.');
         $I->seeInShellOutput('message3: MESSAGE3 FROM SUITE.');
+    }
 
+    public function testSparseEnvMergingIsIdempotent(CliGuy $I)
+    {
         $I->wantTo('test that the order in which sparse environments get configured are irrelevant');
+        $I->amInPath('tests/data/sandbox');
         $I->executeCommand('run messages MessageCest.php:allMessages -vv --env envLayer2,envLayer1');
         $I->seeInShellOutput('message1: MESSAGE1 FROM envLayer1.');
         $I->seeInShellOutput('message2: MESSAGE2 FROM envLayer2.');

--- a/tests/data/claypit/tests/_envs/envLayer1.yml
+++ b/tests/data/claypit/tests/_envs/envLayer1.yml
@@ -1,0 +1,4 @@
+modules:
+      config:
+          MessageHelper:
+                message1: MESSAGE1 FROM envLayer1.

--- a/tests/data/claypit/tests/_envs/envLayer2.yml
+++ b/tests/data/claypit/tests/_envs/envLayer2.yml
@@ -1,0 +1,4 @@
+modules:
+      config:
+          MessageHelper:
+                message2: MESSAGE2 FROM envLayer2.

--- a/tests/data/claypit/tests/messages.suite.yml
+++ b/tests/data/claypit/tests/messages.suite.yml
@@ -15,6 +15,8 @@ modules:
           - MessageHelper
       config:
           MessageHelper:
+                message1: MESSAGE1 FROM SUITE.
+                message2: MESSAGE2 FROM SUITE.
                 message3: MESSAGE3 FROM SUITE.
 
 env:


### PR DESCRIPTION
* The logic was flawed because it prevented environments to modify the config subsequently if they where not complete.
* Only the last configured environment won and controlled the resulting configuration set. This should be fixed now.