### PR TITLE
Fix single line style dataprovider (#5944)

### DIFF
--- a/src/Codeception/Util/Annotation.php
+++ b/src/Codeception/Util/Annotation.php
@@ -7,7 +7,7 @@ namespace Codeception\Util;
 class Annotation
 {
     protected static $reflectedClasses = [];
-    protected static $regex = '/@%s(?:[ \t]*(.*?))?[ \t]*\r?$/m';
+    protected static $regex = '/@%s(?:[ \t]*(.*?))?[ \t]*(?:\*\/)?\r?$/m';
     protected static $lastReflected = null;
 
     /**

--- a/tests/cli/RunCest.php
+++ b/tests/cli/RunCest.php
@@ -530,7 +530,7 @@ EOF
     public function runTestWithAnnotationDataprovider(CliGuy $I)
     {
         $I->executeCommand('run scenario -g dataprovider --steps');
-        $I->seeInShellOutput('OK (15 tests');
+        $I->seeInShellOutput('OK (18 tests');
     }
 
     public function runFailedTestAndCheckOutput(CliGuy $I)

--- a/tests/data/claypit/tests/scenario/DataProviderCest.php
+++ b/tests/data/claypit/tests/scenario/DataProviderCest.php
@@ -1,6 +1,9 @@
 <?php
 use Codeception\Example;
 
+/**
+* @group dataprovider
+*/
 class DataProviderCest
 {
      /**
@@ -53,6 +56,13 @@ class DataProviderCest
        {
            return true;
        }
+
+     /** @dataProvider __exampleDataSource */
+      public function singleLineAnnotationDataProvider(ScenarioGuy $I, Example $example)
+      {
+          $I->amInPath($example['path']);
+          $I->seeFileFound($example['file']);
+      }
 
       /**
        * @return array

--- a/tests/unit/Codeception/Util/AnnotationTest.php
+++ b/tests/unit/Codeception/Util/AnnotationTest.php
@@ -83,4 +83,12 @@ EOF;
         $values = Annotation::arrayValue('( code="200", user="davert", email = "davert@gmail.com")');
         $this->assertEquals(['code' => '200', 'user' => 'davert', 'email' => 'davert@gmail.com'], $values);
     }
+
+    /** @value foobar */
+    public function testSingleLineAnnotation()
+    {
+        $this->assertEquals('foobar', Annotation::forClass(__CLASS__)
+                ->method('testSingleLineAnnotation')
+                ->fetch('value'));
+    }
 }


### PR DESCRIPTION
Update regex for capturing annotations.

This fixes the issue #5944 