### PR TITLE
Bump README copyright date to 2020

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -100,4 +100,4 @@ The documentation source files can be found at https://github.com/Codeception/co
 MIT
 
 (c) [Codeception Team](http://codeception.com/credits)
-2011-2019
+2011-2020


### PR DESCRIPTION
Update the copyright date below `License` section, since it was somehow stuck in 2019 😮 