### PR TITLE
Support absolute output dir path on Windows

### DIFF
--- a/src/Codeception/Configuration.php
+++ b/src/Codeception/Configuration.php
@@ -552,7 +552,7 @@ class Configuration
         }
 
         $dir = self::$outputDir . DIRECTORY_SEPARATOR;
-        if (strcmp(self::$outputDir[0], "/") !== 0) {
+        if (!codecept_is_path_absolute($dir)) {
             $dir = self::$dir . DIRECTORY_SEPARATOR . $dir;
         }
 


### PR DESCRIPTION
Use `codecept_is_path_absolute` function, which supports windows `C:\` style paths instead of using unix-specific condition.
Fixes https://github.com/infection/infection/issues/1296

I haven't had time to test it yet.