### PR TITLE
Update autoload.php to support --no-redirect

### DIFF
--- a/autoload.php
+++ b/autoload.php
@@ -28,10 +28,10 @@ if (( !isset($argv) || (isset($argv) && !in_array('--no-redirect', $argv)) ) && 
 }
 unset($autoloadFile);
 if (isset($argv)) {
-    $argv = array_diff($argv, ['--no-redirect']);
+    $argv = array_values(array_diff($argv, ['--no-redirect']));
 }
 if (isset($_SERVER['argv'])) {
-    $_SERVER['argv'] = array_diff($_SERVER['argv'], ['--no-redirect']);
+    $_SERVER['argv'] = array_values(array_diff($_SERVER['argv'], ['--no-redirect']));
 }
 
 // @codingStandardsIgnoreStart


### PR DESCRIPTION
This follows on from https://github.com/Codeception/Codeception/pull/5857

I can properly build my suite with `--no-redirect` but I cannot run them without an error

Build ✅

```
$ dev/dependencies/vendor/bin/codecept build -c dev/tests/codeception --no-redirect
Building Actor classes for suites: acceptance
 -> AcceptanceTesterActions.php generated successfully. 121 methods added
\AcceptanceTester includes modules: WebDriver, Db, Redis, Percy, \Helper\Acceptance
```

Run ⚠️

```
$ dev/dependencies/vendor/bin/codecept run acceptance --no-redirect --fail-fast -c dev/tests/codeception/ --env chrome-desktop -vvv
PHP Notice:  Undefined offset: 3 in /Users/lukerodgers/src/project/dev/dependencies/vendor/codeception/codeception/src/Codeception/Application.php on line 156
PHP Stack trace:
PHP   1. {main}() /Users/lukerodgers/src/project/dev/dependencies/vendor/codeception/codeception/codecept:0
PHP   2. require() /Users/lukerodgers/src/project/dev/dependencies/vendor/codeception/codeception/codecept:7
PHP   3. {closure:/Users/lukerodgers/src/project/dev/dependencies/vendor/codeception/codeception/app.php:7-47}() /Users/lukerodgers/src/project/dev/dependencies/vendor/codeception/codeception/app.php:47
PHP   4. Codeception\Application->registerCustomCommands() /Users/lukerodgers/src/project/dev/dependencies/vendor/codeception/codeception/app.php:39
PHP   5. Codeception\Application->readCustomCommandsFromConfig() /Users/lukerodgers/src/project/dev/dependencies/vendor/codeception/codeception/src/Codeception/Application.php:33
PHP   6. Codeception\Application->getCoreArguments() /Users/lukerodgers/src/project/dev/dependencies/vendor/codeception/codeception/src/Codeception/Application.php:63
```

At this point `$_SERVER['argv']` looks like the following with no index `3` as `--no-redirect` is stripped out. Using `array_values` to reset the keys seems to work.

```php
array(9) {
  [0] =>
  string(36) "dev/dependencies/vendor/bin/codecept"
  [1] =>
  string(3) "run"
  [2] =>
  string(10) "acceptance"
  [4] =>
  string(11) "--fail-fast"
  [5] =>
  string(2) "-c"
  [6] =>
  string(22) "dev/tests/codeception/"
  [7] =>
  string(5) "--env"
  [8] =>
  string(14) "chrome-desktop"
  [9] =>
  string(4) "-vvv"
}

```