### PR TITLE
Add `mysqli` php extension to docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,7 @@ RUN apt-get update && \
 # Install php extensions
 RUN docker-php-ext-install \
     bcmath \
+    mysqli \
     pdo pdo_mysql pdo_pgsql \
     soap \
     sockets \


### PR DESCRIPTION
This PR follows the discussion at https://github.com/Codeception/Codeception/issues/5969

It just adds `mysqli` php extension by default in the docker image, specifically with the goal to enable it to support tesing WordPress application out of the box.

/cc @schmunk42 