### PR TITLE
Fix issue when using includes in combination with override config

### DIFF
--- a/src/Codeception/Command/Run.php
+++ b/src/Codeception/Command/Run.php
@@ -337,19 +337,22 @@ class Run extends Command
                     // Find if the suite begins with an include path
                     if (strpos($suite, $include) === 0) {
                         // Use include config
-                        $config = Configuration::config($projectDir.$include);
+                        $includeConfig = Configuration::config($projectDir.$include);
 
-                        if (!isset($config['paths']['tests'])) {
+                        if (!isset($includeConfig['paths']['tests'])) {
                             throw new \RuntimeException(
                                 sprintf("Included '%s' has no tests path configured", $include)
                             );
                         }
 
-                        $testsPath = $include . DIRECTORY_SEPARATOR.  $config['paths']['tests'];
+                        $testsPath = $include . DIRECTORY_SEPARATOR.  $includeConfig['paths']['tests'];
 
                         try {
                             list(, $suite, $test) = $this->matchTestFromFilename($suite, $testsPath);
-                            $isIncludeTest = true;
+                            $config = $includeConfig;
+                            if (count($this->options['override'])) {
+                                $config = $this->overrideConfig($this->options['override']);
+                            }
                         } catch (\InvalidArgumentException $e) {
                             // Incorrect include match, continue trying to find one
                             continue;
@@ -360,11 +363,6 @@ class Run extends Command
                             list(, $suite, $test) = $result;
                         }
                     }
-                }
-
-                // Restore main config
-                if (!$isIncludeTest) {
-                    $config = Configuration::config($projectDir);
                 }
             } elseif (!empty($suite)) {
                 $result = $this->matchSingleTest($suite, $config);


### PR DESCRIPTION
I am using include configs in my project to run multiple applications/modules in a single test run. https://codeception.com/docs/08-Customization#One-Runner-for-Multiple-Applications

In my root `codeception.yml`:
```yml
include:
    - src/OtherModule/*
paths:
    tests: tests
...
```

In my `src/OtherModule` I have another `codeception.yml` and seperate tests.
This is working perfectly and tests of the other module are also executed when I run `vendor/bin codecept run`.

However when using these feature the overriden configs (using `-o` parameter) are removed from the test run.
This was caused by line 365-368 which reset the complete config object to that of the main `codeception.yml`, but don't apply the `override` config again.
PHPStorm also uses this method to set a custom reporter `-o "reporters: report: PhpStorm_Codeception_ReportPrinter"`, but because this was removed the complete UI reporting in PHPStorm was broken for me.

I also refactored to ONLY override the config when the test should be run by an include config. This seems less fragile to me.