### PR TITLE
RunFailed: fix path to file in the docblock

### DIFF
--- a/ext/RunFailed.php
+++ b/ext/RunFailed.php
@@ -7,7 +7,7 @@ use Codeception\Extension;
 use Codeception\Test\Descriptor;
 
 /**
- * Saves failed tests into tests/log/failed in order to rerun failed tests.
+ * Saves failed tests into tests/_output/failed in order to rerun failed tests.
  *
  * To rerun failed tests just run the `failed` group:
  *


### PR DESCRIPTION
Correct path was used at the bottom of docblock, but this line at the top is misleading.

This docblock is used to generate https://codeception.com/extensions#RunFailed page.