### PR TITLE
More practical ext logger

### DIFF
--- a/ext/Logger.php
+++ b/ext/Logger.php
@@ -86,13 +86,13 @@ class Logger extends Extension
 
     public function beforeSuite(SuiteEvent $e)
     {
-        $suite = str_replace('\\', '_', $e->getSuite()->getName());
+        $suite = str_replace('\\', '_', $e->getSuite()->getName()) . '.log';
         $this->logHandler = new RotatingFileHandler($this->path . $suite, $this->config['max_files']);
     }
 
     public function beforeTest(TestEvent $e)
     {
-        self::$logger = new \Monolog\Logger(Descriptor::getTestFileName($e->getTest()));
+        self::$logger = new \Monolog\Logger(Descriptor::getTestFullName($e->getTest()));
         self::$logger->pushHandler($this->logHandler);
         self::$logger->info('------------------------------------');
         self::$logger->info("STARTED: " . ucfirst(Descriptor::getTestAsString($e->getTest())));

--- a/ext/Logger.php
+++ b/ext/Logger.php
@@ -88,7 +88,7 @@ class Logger extends Extension
     public function beforeSuite(SuiteEvent $e)
     {
         $suiteLogFile = str_replace('\\', '_', $e->getSuite()->getName()) . '.log';
-        $this->logHandler = new RotatingFileHandler($this->path . $suite, $this->config['max_files']);
+        $this->logHandler = new RotatingFileHandler($this->path . $suiteLogFile, $this->config['max_files']);
     }
 
     public function beforeTest(TestEvent $e)

--- a/ext/Logger.php
+++ b/ext/Logger.php
@@ -22,7 +22,7 @@ use Monolog\Handler\RotatingFileHandler;
  * ```
  *
  * Codeception's core/internal stuff is logged into `tests/_output/codeception.log`.
- * Test suites' steps are logged into `tests/_outoput/<test_full_name>-<rotation_date>.log`.
+ * Test suites' steps are logged into `tests/_output/<test_full_name>-<rotation_date>.log`.
  *
  * To enable this module add to your `codeception.yml`:
  *

--- a/ext/Logger.php
+++ b/ext/Logger.php
@@ -22,7 +22,7 @@ use Monolog\Handler\RotatingFileHandler;
  * ```
  *
  * Codeception's core/internal stuff is logged into `tests/_output/codeception.log`.
- * Test suites' steps is logged into `tests/_outoput/<test_full_name>-<rotation_date>.log`.
+ * Test suites' steps are logged into `tests/_outoput/<test_full_name>-<rotation_date>.log`.
  *
  * To enable this module add to your `codeception.yml`:
  *

--- a/ext/Logger.php
+++ b/ext/Logger.php
@@ -21,7 +21,8 @@ use Monolog\Handler\RotatingFileHandler;
  * composer require monolog/monolog
  * ```
  *
- * Steps are logged into `tests/_output/codeception.log`
+ * Codeception's core/internal stuff is logged into `tests/_output/codeception.log`.
+ * Test suites steps is logged into `tests/_outoput/<test_full_name>-<rotation_date>.log`.
  *
  * To enable this module add to your `codeception.yml`:
  *
@@ -86,7 +87,7 @@ class Logger extends Extension
 
     public function beforeSuite(SuiteEvent $e)
     {
-        $suite = str_replace('\\', '_', $e->getSuite()->getName()) . '.log';
+        $suiteLogFile = str_replace('\\', '_', $e->getSuite()->getName()) . '.log';
         $this->logHandler = new RotatingFileHandler($this->path . $suite, $this->config['max_files']);
     }
 

--- a/ext/Logger.php
+++ b/ext/Logger.php
@@ -22,7 +22,7 @@ use Monolog\Handler\RotatingFileHandler;
  * ```
  *
  * Codeception's core/internal stuff is logged into `tests/_output/codeception.log`.
- * Test suites steps is logged into `tests/_outoput/<test_full_name>-<rotation_date>.log`.
+ * Test suites' steps is logged into `tests/_outoput/<test_full_name>-<rotation_date>.log`.
  *
  * To enable this module add to your `codeception.yml`:
  *


### PR DESCRIPTION
- `.log` extension is added to suite log files
-  create logger with a full test name in the `beforeTest`