### PR TITLE
Switch off c3Request call if 'remote' set to false

### DIFF
--- a/src/Codeception/Coverage/Subscriber/LocalServer.php
+++ b/src/Codeception/Coverage/Subscriber/LocalServer.php
@@ -67,18 +67,17 @@ class LocalServer extends SuiteSubscriber
 
         if ($this->settings['remote_config']) {
             $this->addC3AccessHeader(self::COVERAGE_HEADER_CONFIG, $this->settings['remote_config']);
-        }
-
-        $knock = $this->c3Request('clear');
-        if ($knock === false) {
-            throw new RemoteException(
-                '
-                CodeCoverage Error.
-                Check the file "c3.php" is included in your application.
-                We tried to access "/c3/report/clear" but this URI was not accessible.
-                You can review actual error messages in c3tmp dir.
-                '
-            );
+            $knock = $this->c3Request('clear');
+            if ($knock === false) {
+                throw new RemoteException(
+                    '
+                    CodeCoverage Error.
+                    Check the file "c3.php" is included in your application.
+                    We tried to access "/c3/report/clear" but this URI was not accessible.
+                    You can review actual error messages in c3tmp dir.
+                    '
+                );
+            }
         }
     }
 


### PR DESCRIPTION
Might have something to do with https://github.com/Codeception/Codeception/issues/5989

But for us running it locally never works and fails with
![Screenshot 2020-09-14 at 16 32 32](https://user-images.githubusercontent.com/39854/94684378-49ffad00-0328-11eb-92e7-e3153a8a36ae.png)

This solves it.