### PR TITLE
PHP 8.0 compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ php:
   - 7.0
   - 7.1
   - 7.3
+  - 8.0
 env:
   global:
     - COVERAGE=
@@ -18,7 +19,8 @@ matrix:
   # Run our coverage suite on 7.4 (so it uses php-code-coverage 9)
   - php: 7.4
     env: SUITES=cli,unit,coverage COVERAGE=1
-
+  allow_failures:
+    - php: 8.0
 branches:
   except:
     - gh-pages

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     "minimum-stability": "RC",
 
     "require": {
-        "php": ">=5.6.0 <8.0",
+        "php": ">=5.6.0 <9.0",
         "ext-curl": "*",
         "ext-json": "*",
         "ext-mbstring": "*",

--- a/src/Codeception/Lib/Di.php
+++ b/src/Codeception/Lib/Di.php
@@ -2,6 +2,7 @@
 namespace Codeception\Lib;
 
 use Codeception\Exception\InjectionException;
+use Codeception\Util\ReflectionHelper;
 
 class Di
 {
@@ -138,7 +139,7 @@ class Di
         $args = [];
         $parameters = $method->getParameters();
         foreach ($parameters as $k => $parameter) {
-            $dependency = $parameter->getClass();
+            $dependency = ReflectionHelper::getClassFromParameter($parameter);
             if (is_null($dependency)) {
                 if (!$parameter->isOptional()) {
                     if (!isset($defaults[$k])) {
@@ -149,9 +150,9 @@ class Di
                 }
                 $args[] = $parameter->getDefaultValue();
             } else {
-                $arg = $this->instantiate($dependency->name);
+                $arg = $this->instantiate($dependency);
                 if (is_null($arg)) {
-                    throw new InjectionException("Failed to resolve dependency '{$dependency->name}'.");
+                    throw new InjectionException("Failed to resolve dependency '$dependency'.");
                 }
                 $args[] = $arg;
             }

--- a/src/Codeception/Lib/Parser.php
+++ b/src/Codeception/Lib/Parser.php
@@ -143,12 +143,11 @@ class Parser
             if ($tokens[$i][0] === T_NAMESPACE) {
                 $namespace = '';
                 for ($j = $i + 1; $j < $tokenCount; $j++) {
-                    if ($tokens[$j][0] === T_STRING) {
+                    if ($tokens[$j] === '{' || $tokens[$j] === ';') {
+                        break;
+                    }
+                    if ($tokens[$j][0] === T_STRING || (PHP_MAJOR_VERSION >= 8 && $tokens[$j][0] === T_NAME_QUALIFIED)) {
                         $namespace .= $tokens[$j][1] . '\\';
-                    } else {
-                        if ($tokens[$j] === '{' || $tokens[$j] === ';') {
-                            break;
-                        }
                     }
                 }
             }

--- a/src/Codeception/Step/Retry.php
+++ b/src/Codeception/Step/Retry.php
@@ -29,7 +29,7 @@ EOF;
     private $retryNum;
     private $retryInterval;
 
-    public function __construct($action, array $arguments = [], $retryNum, $retryInterval)
+    public function __construct($action, array $arguments, $retryNum, $retryInterval)
     {
         $this->action = $action;
         $this->arguments = $arguments;

--- a/src/Codeception/Util/ReflectionHelper.php
+++ b/src/Codeception/Util/ReflectionHelper.php
@@ -1,6 +1,10 @@
 <?php
 namespace Codeception\Util;
 
+use ReflectionClass;
+use ReflectionException;
+use ReflectionParameter;
+
 /**
  * This class contains helper methods to help with common Reflection tasks.
  */
@@ -59,5 +63,36 @@ class ReflectionHelper
     {
         $path = explode('\\', get_class($object));
         return array_pop($path);
+    }
+
+    /**
+     * Adapted from https://github.com/Behat/Behat/pull/1313
+     *
+     * @param ReflectionParameter $parameter
+     * @return string|null
+     */
+    public static function getClassFromParameter(ReflectionParameter $parameter)
+    {
+        if (PHP_VERSION_ID < 70100) {
+            $class = $parameter->getClass();
+            if ($class !== null) {
+                return $class->name;
+            }
+            return $class;
+        }
+
+        $type = $parameter->getType();
+        if ($type === null) {
+            return null;
+        }
+        $typeString = $type->getName();
+
+        if ($typeString === 'self') {
+            return $parameter->getDeclaringClass()->getName();
+        } elseif ($typeString === 'parent') {
+            return $parameter->getDeclaringClass()->getParentClass()->getName();
+        }
+
+        return $typeString;
     }
 }

--- a/tests/unit/Codeception/Lib/DiTest.php
+++ b/tests/unit/Codeception/Lib/DiTest.php
@@ -40,7 +40,12 @@ class DiTest extends \Codeception\Test\Unit
     public function testFailDependenciesNonExistent()
     {
         require_once codecept_data_dir().'FailDependenciesNonExistent.php';
-        $this->injectionShouldFail('Class FailDependenciesNonExistent\NonExistentClass does not exist');
+        if (PHP_MAJOR_VERSION < 8) {
+            $expectedExceptionMessage = 'Class FailDependenciesNonExistent\NonExistentClass does not exist';
+        } else {
+            $expectedExceptionMessage = 'Class "FailDependenciesNonExistent\NonExistentClass" does not exist';
+        }
+        $this->injectionShouldFail($expectedExceptionMessage);
         $this->di->instantiate('FailDependenciesNonExistent\IncorrectDependenciesClass');
     }
 


### PR DESCRIPTION
unit and cli test suites passed with PHP 8.0.0rc1 on my computer.
There is no PHP 8.0 on Travis yet.

Changes:
* Updated namespace parser in Codeception\Lib\Parser.
* Replaced deprecated ReflectionParameter::getClass() with workaroud.
* Removed default value of 2nd parameter (out of 4th) in Codeception\Step\Retry.
* DiTest::testFailDependenciesNonExistent matches different message on PHP 8.

TODO:
* Test all modules with PHP 8.0 and update version contraint in composer.json

Closes #5993