### PR TITLE
BUG FIX: Use fully qualified name for class constant defaults

### DIFF
--- a/src/Codeception/Util/ReflectionHelper.php
+++ b/src/Codeception/Util/ReflectionHelper.php
@@ -125,7 +125,7 @@ class ReflectionHelper
         }
 
         // Default to 'null' for PHP versions < 7.1.
-        if(PHP_VERSION_ID < 70100) {
+        if (PHP_VERSION_ID < 70100) {
             return 'null';
         }
 

--- a/src/Codeception/Util/ReflectionHelper.php
+++ b/src/Codeception/Util/ReflectionHelper.php
@@ -23,7 +23,7 @@ class ReflectionHelper
     public static function readPrivateProperty($object, $property, $class = null)
     {
         if (is_null($class)) {
-            $class = get_class($object);
+            $class = $object;
         }
 
         $property = new ReflectionProperty($class, $property);
@@ -45,7 +45,7 @@ class ReflectionHelper
     public static function invokePrivateMethod($object, $method, $args = [], $class = null)
     {
         if (is_null($class)) {
-            $class = get_class($object);
+            $class = $object;
         }
 
         $method = new ReflectionMethod($class, $method);

--- a/src/Codeception/Util/ReflectionHelper.php
+++ b/src/Codeception/Util/ReflectionHelper.php
@@ -126,15 +126,29 @@ class ReflectionHelper
 
         $type = $param->getType();
 
+        // Return 'null' as default if explicitly allowed or there is no specific type hint.
         if (!$type || $type->allowsNull() || !$type->isBuiltin()) {
             return 'null';
         }
 
-        $result = null;
-
-        settype($result, $type->getName());
-
-        return var_export($result, true);
+        // Default value should match the parameter type if 'null' is _not_ allowed.
+        switch ($type->getName()) {
+            case 'string':
+                return "''";
+            case 'array':
+                return '[]';
+            case 'boolean':
+                return 'false';
+            case 'int':
+            case 'integer':
+            case 'float':
+            case 'double':
+            case 'number':
+            case 'numeric':
+                return '0';
+            default:
+                return 'null';
+        }
     }
 
     /**

--- a/src/Codeception/Util/ReflectionHelper.php
+++ b/src/Codeception/Util/ReflectionHelper.php
@@ -1,9 +1,10 @@
 <?php
 namespace Codeception\Util;
 
-use ReflectionClass;
 use ReflectionException;
 use ReflectionParameter;
+use ReflectionProperty;
+use ReflectionMethod;
 
 /**
  * This class contains helper methods to help with common Reflection tasks.
@@ -17,14 +18,15 @@ class ReflectionHelper
      * @param string $property
      * @param string|null $class
      * @return mixed
+     * @throws ReflectionException
      */
     public static function readPrivateProperty($object, $property, $class = null)
     {
         if (is_null($class)) {
-            $class = $object;
+            $class = get_class($object);
         }
 
-        $property = new \ReflectionProperty($class, $property);
+        $property = new ReflectionProperty($class, $property);
         $property->setAccessible(true);
 
         return $property->getValue($object);
@@ -38,14 +40,15 @@ class ReflectionHelper
      * @param array $args
      * @param string|null $class
      * @return mixed
+     * @throws ReflectionException
      */
     public static function invokePrivateMethod($object, $method, $args = [], $class = null)
     {
         if (is_null($class)) {
-            $class = $object;
+            $class = get_class($object);
         }
 
-        $method = new \ReflectionMethod($class, $method);
+        $method = new ReflectionMethod($class, $method);
         $method->setAccessible(true);
 
         return $method->invokeArgs($object, $args);
@@ -99,11 +102,11 @@ class ReflectionHelper
     /**
      * Infer default parameter from the reflection object and format it as PHP (code) string
      *
-     * @param \ReflectionParameter $param
+     * @param ReflectionParameter $param
      *
      * @return string
      */
-    public static function getDefaultValue(\ReflectionParameter $param)
+    public static function getDefaultValue(ReflectionParameter $param)
     {
         if ($param->isDefaultValueAvailable()) {
             if (method_exists($param, 'isDefaultValueConstant') && $param->isDefaultValueConstant()) {
@@ -111,7 +114,7 @@ class ReflectionHelper
                 if (false !== strpos($constName, '::')) {
                     list($class, $const) = explode('::', $constName);
                     if (in_array($class, ['self', 'static'])) {
-                        $constName = $param->getDeclaringClass()->getName().'::'.$const;
+                        $constName = '\\' . $param->getDeclaringClass()->getName() . '::' . $const;
                     }
                 }
 
@@ -121,7 +124,17 @@ class ReflectionHelper
             return self::phpEncodeValue($param->getDefaultValue());
         }
 
-        return 'null';
+        $type = $param->getType();
+
+        if (!$type || $type->allowsNull() || !$type->isBuiltin()) {
+            return 'null';
+        }
+
+        $result = null;
+
+        settype($result, $type->getName());
+
+        return var_export($result, true);
     }
 
     /**
@@ -167,6 +180,6 @@ class ReflectionHelper
 
         return '[' . implode(', ', array_map(function ($key) use ($array) {
                 return self::phpEncodeValue($key) . ' => ' . self::phpEncodeValue($array[$key]);
-        }, array_keys($array))) . ']';
+            }, array_keys($array))) . ']';
     }
 }

--- a/src/Codeception/Util/ReflectionHelper.php
+++ b/src/Codeception/Util/ReflectionHelper.php
@@ -178,8 +178,13 @@ class ReflectionHelper
             return '[' . implode(', ', array_map([self::class, 'phpEncodeValue'], $array)) . ']';
         }
 
-        return '[' . implode(', ', array_map(function ($key) use ($array) {
+        $values = array_map(
+            function ($key) use ($array) {
                 return self::phpEncodeValue($key) . ' => ' . self::phpEncodeValue($array[$key]);
-            }, array_keys($array))) . ']';
+            },
+            array_keys($array)
+        );
+
+        return '[' . implode(', ', $values) . ']';
     }
 }

--- a/src/Codeception/Util/ReflectionHelper.php
+++ b/src/Codeception/Util/ReflectionHelper.php
@@ -124,14 +124,19 @@ class ReflectionHelper
             return self::phpEncodeValue($param->getDefaultValue());
         }
 
+        // Default to 'null' for PHP versions < 7.1.
+        if(PHP_VERSION_ID < 70100) {
+            return 'null';
+        }
+
         $type = $param->getType();
 
-        // Return 'null' as default if explicitly allowed or there is no specific type hint.
+        // Default to 'null' if explicitly allowed or there is no specific type hint.
         if (!$type || $type->allowsNull() || !$type->isBuiltin()) {
             return 'null';
         }
 
-        // Default value should match the parameter type if 'null' is _not_ allowed.
+        // Default value should match the parameter type if 'null' is NOT allowed.
         switch ($type->getName()) {
             case 'string':
                 return "''";

--- a/tests/unit/Codeception/Util/ReflectionHelperTest.php
+++ b/tests/unit/Codeception/Util/ReflectionHelperTest.php
@@ -1,0 +1,171 @@
+<?php
+namespace Codeception\Util;
+
+use ReflectionException;
+use ReflectionParameter;
+
+require_once 'ReflectionTestClass.php';
+
+class ReflectionHelperTest extends \Codeception\PHPUnit\TestCase
+{
+    public function testReadPrivateProperty()
+    {
+        $expected = 'fooBar123';
+
+        $object = new ReflectionTestClass();
+        $object->setValue($expected);
+
+        $this->assertEquals(
+            $expected,
+            ReflectionHelper::readPrivateProperty($object, 'value', ReflectionTestClass::class)
+        );
+
+        $this->assertEquals(
+            $expected,
+            ReflectionHelper::readPrivateProperty($object, 'value', null)
+        );
+
+        $this->expectException(ReflectionException::class);
+
+        $this->assertEquals(
+            $expected,
+            ReflectionHelper::readPrivateProperty($object, 'value', '')
+        );
+    }
+
+    public function testInvokePrivateMethod()
+    {
+        $expected = "I'm a cat!";
+
+        $object = new ReflectionTestClass();
+        $object->setValue($expected);
+
+        $this->assertEquals(
+            $expected,
+            ReflectionHelper::invokePrivateMethod($object, 'getSecret', ['cat'], ReflectionTestClass::class)
+        );
+
+        $this->assertEquals(
+            $expected,
+            ReflectionHelper::invokePrivateMethod($object, 'getSecret', ['cat'], null)
+        );
+
+        $this->expectException(ReflectionException::class);
+
+        $this->assertEquals(
+            $expected,
+            ReflectionHelper::invokePrivateMethod($object, 'getSecret', ['cat'], '')
+        );
+    }
+
+    public function testGetClassShortName()
+    {
+        $this->assertEquals(
+            'ReflectionTestClass',
+            ReflectionHelper::getClassShortName(new ReflectionTestClass())
+        );
+
+        $this->assertEquals(
+            'ReflectionHelper',
+            ReflectionHelper::getClassShortName(new ReflectionHelper())
+        );
+    }
+
+    public function testGetClassFromParameter()
+    {
+        $object = new ReflectionTestClass();
+        $object->setValue('elephant');
+
+        $this->assertEquals(
+            'Codeception\Util\Debug',
+            ReflectionHelper::getClassFromParameter(new ReflectionParameter(array($object, 'setDebug'), 0))
+        );
+
+        $this->assertEquals(
+            null,
+            ReflectionHelper::getClassFromParameter(new ReflectionParameter(array($object, 'setDebug'), 1))
+        );
+
+        $this->assertEquals(
+            null,
+            ReflectionHelper::getClassFromParameter(new ReflectionParameter(array($object, 'setDebug'), 'flavor'))
+        );
+    }
+
+    public function testGetDefaultValue()
+    {
+        $object = new ReflectionTestClass();
+        $object->setValue('elephant');
+
+        $this->assertEquals(
+            'null',
+            ReflectionHelper::getDefaultValue(new ReflectionParameter(array($object, 'setDebug'), 0))
+        );
+
+        $this->assertEquals(
+            '\Codeception\Util\ReflectionTestClass::FOO',
+            ReflectionHelper::getDefaultValue(new ReflectionParameter(array($object, 'setDebug'), 1))
+        );
+
+        $this->assertEquals(
+            '\Codeception\Util\ReflectionTestClass::FOO',
+            ReflectionHelper::getDefaultValue(new ReflectionParameter(array($object, 'setDebug'), 'flavor'))
+        );
+
+        $this->assertEquals(
+            "''",
+            ReflectionHelper::getDefaultValue(new ReflectionParameter(array($object, 'setValue'), 0))
+        );
+
+        $this->assertEquals(
+            '0',
+            ReflectionHelper::getDefaultValue(new ReflectionParameter(array($object, 'setInt'), 0))
+        );
+
+        $this->assertEquals(
+            'null',
+            ReflectionHelper::getDefaultValue(new ReflectionParameter(array($object, 'setMixed'), 0))
+        );
+    }
+
+    public function testPhpEncodeValue()
+    {
+        $this->assertEquals(
+            '0',
+            ReflectionHelper::phpEncodeValue(0)
+        );
+
+        $this->assertEquals(
+            '1',
+            ReflectionHelper::phpEncodeValue(1)
+        );
+
+        $this->assertEquals(
+            '"\\u00fcber"',
+            ReflectionHelper::phpEncodeValue('über')
+        );
+
+        $this->assertEquals(
+            '["foo" => "bar"]',
+            ReflectionHelper::phpEncodeValue(['foo' => 'bar'])
+        );
+
+        $this->assertEquals(
+            '["foo" => "bar", "baz" => ["cat", "dog"]]',
+            ReflectionHelper::phpEncodeValue(['foo' => 'bar', 'baz' => ['cat', 'dog']])
+        );
+    }
+
+    public function testPhpEncodeArray()
+    {
+        $this->assertEquals(
+            '["foo" => "bar"]',
+            ReflectionHelper::phpEncodeArray(['foo' => 'bar'])
+        );
+
+        $this->assertEquals(
+            '["foo" => "bar", "baz" => ["cat", "dog"]]',
+            ReflectionHelper::phpEncodeArray(['foo' => 'bar', 'baz' => ['cat', 'dog']])
+        );
+    }
+}

--- a/tests/unit/Codeception/Util/ReflectionHelperTest.php
+++ b/tests/unit/Codeception/Util/ReflectionHelperTest.php
@@ -113,12 +113,12 @@ class ReflectionHelperTest extends \Codeception\PHPUnit\TestCase
         );
 
         $this->assertEquals(
-            "''",
+            PHP_VERSION_ID < 70100 ? 'null' : "''",
             ReflectionHelper::getDefaultValue(new ReflectionParameter(array($object, 'setValue'), 0))
         );
 
         $this->assertEquals(
-            '0',
+            PHP_VERSION_ID < 70100 ? 'null' : '0',
             ReflectionHelper::getDefaultValue(new ReflectionParameter(array($object, 'setInt'), 0))
         );
 

--- a/tests/unit/Codeception/Util/ReflectionTestClass.php
+++ b/tests/unit/Codeception/Util/ReflectionTestClass.php
@@ -1,55 +1,8 @@
 <?php
 namespace Codeception\Util;
 
-class ReflectionTestClass
-{
-    const FOO = 'bar';
-
-    private $value = 'test';
-    protected $obj = null;
-    static $flavorOfTheWeek = '';
-
-    public function setInt(int $i): self
-    {
-        $this->value = (string)$i;
-
-        return $this;
-    }
-
-    public function setMixed($m): self
-    {
-        $this->value = (string)$m;
-
-        return $this;
-    }
-
-    public function setValue(string $s): self
-    {
-        $this->value = $s;
-
-        return $this;
-    }
-
-    public function getValue(): string
-    {
-        return $this->value;
-    }
-
-    public function setDebug(Debug $obj, $flavor = self::FOO): self
-    {
-        $this->obj = $obj;
-        self::$flavorOfTheWeek = $flavor;
-
-        return $this;
-    }
-
-    static public function setFlavor(string $flavor = self::FOO)
-    {
-        self::$flavorOfTheWeek = $flavor;
-    }
-
-    private function getSecret(string $s): string
-    {
-        return sprintf("I'm a %s!", $s);
-    }
+if (PHP_VERSION_ID < 70000) {
+    require_once 'ReflectionTestClass56.php';
+} else {
+    require_once 'ReflectionTestClass70.php';
 }

--- a/tests/unit/Codeception/Util/ReflectionTestClass.php
+++ b/tests/unit/Codeception/Util/ReflectionTestClass.php
@@ -5,9 +5,9 @@ class ReflectionTestClass
 {
     const FOO = 'bar';
 
-    private string $value = 'test';
-    protected Debug $obj;
-    static string $flavorOfTheWeek = '';
+    private $value = 'test';
+    protected $obj = null;
+    static $flavorOfTheWeek = '';
 
     public function setInt(int $i): self
     {

--- a/tests/unit/Codeception/Util/ReflectionTestClass.php
+++ b/tests/unit/Codeception/Util/ReflectionTestClass.php
@@ -1,0 +1,55 @@
+<?php
+namespace Codeception\Util;
+
+class ReflectionTestClass
+{
+    const FOO = 'bar';
+
+    private string $value = 'test';
+    protected Debug $obj;
+    static string $flavorOfTheWeek = '';
+
+    public function setInt(int $i): self
+    {
+        $this->value = (string)$i;
+
+        return $this;
+    }
+
+    public function setMixed($m): self
+    {
+        $this->value = (string)$m;
+
+        return $this;
+    }
+
+    public function setValue(string $s): self
+    {
+        $this->value = $s;
+
+        return $this;
+    }
+
+    public function getValue(): string
+    {
+        return $this->value;
+    }
+
+    public function setDebug(Debug $obj, $flavor = self::FOO): self
+    {
+        $this->obj = $obj;
+        self::$flavorOfTheWeek = $flavor;
+
+        return $this;
+    }
+
+    static public function setFlavor(string $flavor = self::FOO)
+    {
+        self::$flavorOfTheWeek = $flavor;
+    }
+
+    private function getSecret(string $s): string
+    {
+        return sprintf("I'm a %s!", $s);
+    }
+}

--- a/tests/unit/Codeception/Util/ReflectionTestClass56.php
+++ b/tests/unit/Codeception/Util/ReflectionTestClass56.php
@@ -1,0 +1,55 @@
+<?php
+namespace Codeception\Util;
+
+class ReflectionTestClass
+{
+    const FOO = 'bar';
+
+    private $value = 'test';
+    protected $obj = null;
+    static $flavorOfTheWeek = '';
+
+    public function setInt($i)
+    {
+        $this->value = (string)$i;
+
+        return $this;
+    }
+
+    public function setMixed($m)
+    {
+        $this->value = (string)$m;
+
+        return $this;
+    }
+
+    public function setValue($s)
+    {
+        $this->value = $s;
+
+        return $this;
+    }
+
+    public function getValue()
+    {
+        return $this->value;
+    }
+
+    public function setDebug(Debug $obj, $flavor = self::FOO)
+    {
+        $this->obj = $obj;
+        self::$flavorOfTheWeek = $flavor;
+
+        return $this;
+    }
+
+    static public function setFlavor($flavor = self::FOO)
+    {
+        self::$flavorOfTheWeek = $flavor;
+    }
+
+    private function getSecret($s)
+    {
+        return sprintf("I'm a %s!", $s);
+    }
+}

--- a/tests/unit/Codeception/Util/ReflectionTestClass70.php
+++ b/tests/unit/Codeception/Util/ReflectionTestClass70.php
@@ -1,0 +1,55 @@
+<?php
+namespace Codeception\Util;
+
+class ReflectionTestClass
+{
+    const FOO = 'bar';
+
+    private $value = 'test';
+    protected $obj = null;
+    static $flavorOfTheWeek = '';
+
+    public function setInt(int $i): self
+    {
+        $this->value = (string)$i;
+
+        return $this;
+    }
+
+    public function setMixed($m): self
+    {
+        $this->value = (string)$m;
+
+        return $this;
+    }
+
+    public function setValue(string $s): self
+    {
+        $this->value = $s;
+
+        return $this;
+    }
+
+    public function getValue(): string
+    {
+        return $this->value;
+    }
+
+    public function setDebug(Debug $obj, $flavor = self::FOO): self
+    {
+        $this->obj = $obj;
+        self::$flavorOfTheWeek = $flavor;
+
+        return $this;
+    }
+
+    static public function setFlavor(string $flavor = self::FOO)
+    {
+        self::$flavorOfTheWeek = $flavor;
+    }
+
+    private function getSecret(string $s): string
+    {
+        return sprintf("I'm a %s!", $s);
+    }
+}


### PR DESCRIPTION
A recent fix for #5987 added support for action parameter defaults, primarily used for generating actor traits from what I see.
This PR makes sure `ReflectionHelper::getDefaultValue()` returns fully qualified names for class constant defaults referencing "self".

In addition, it adds unit tests and makes sure empty defaults have the same type as the parameter they belong to if null is not allowed (even though that may not cause issues just yet).

*Note: This was developed & tested using PHP 7.4.3 while >=5.6.0 is supported according to composer.json (true?). Minor changes might be needed for full compatibility. Travis CI should report potential issues.*

**Our test suite broke completely after upgrading Codeception from  v4.1.8 to v4.1.9 - likely to be the case for other users as well, so I'd consider this an important bug fix that should be released as soon as possible. Thank you very much! :)**