### PR TITLE
Prepend backslash on class constant default values

### DIFF
--- a/src/Codeception/Util/ReflectionHelper.php
+++ b/src/Codeception/Util/ReflectionHelper.php
@@ -115,6 +115,8 @@ class ReflectionHelper
                     list($class, $const) = explode('::', $constName);
                     if (in_array($class, ['self', 'static'])) {
                         $constName = '\\' . $param->getDeclaringClass()->getName() . '::' . $const;
+                    } elseif (substr($class, 0, 1) !== '\\') {
+                        $constName = '\\' . $constName;
                     }
                 }
 

--- a/tests/unit/Codeception/Util/ReflectionHelperTest.php
+++ b/tests/unit/Codeception/Util/ReflectionHelperTest.php
@@ -113,6 +113,11 @@ class ReflectionHelperTest extends \Codeception\PHPUnit\TestCase
         );
 
         $this->assertEquals(
+            '\Codeception\Codecept::VERSION',
+            ReflectionHelper::getDefaultValue(new ReflectionParameter(array($object, 'setFlavorImportedDefault'), 'flavor'))
+        );
+
+        $this->assertEquals(
             PHP_VERSION_ID < 70100 ? 'null' : "''",
             ReflectionHelper::getDefaultValue(new ReflectionParameter(array($object, 'setValue'), 0))
         );

--- a/tests/unit/Codeception/Util/ReflectionTestClass56.php
+++ b/tests/unit/Codeception/Util/ReflectionTestClass56.php
@@ -1,6 +1,8 @@
 <?php
 namespace Codeception\Util;
 
+use Codeception\Codecept;
+
 class ReflectionTestClass
 {
     const FOO = 'bar';
@@ -44,6 +46,11 @@ class ReflectionTestClass
     }
 
     static public function setFlavor($flavor = self::FOO)
+    {
+        self::$flavorOfTheWeek = $flavor;
+    }
+
+    public function setFlavorImportedDefault($flavor = Codecept::VERSION)
     {
         self::$flavorOfTheWeek = $flavor;
     }

--- a/tests/unit/Codeception/Util/ReflectionTestClass70.php
+++ b/tests/unit/Codeception/Util/ReflectionTestClass70.php
@@ -1,6 +1,8 @@
 <?php
 namespace Codeception\Util;
 
+use Codeception\Codecept;
+
 class ReflectionTestClass
 {
     const FOO = 'bar';
@@ -43,7 +45,12 @@ class ReflectionTestClass
         return $this;
     }
 
-    static public function setFlavor(string $flavor = self::FOO)
+    static public function setFlavor(string $flavor = self::FOO): void
+    {
+        self::$flavorOfTheWeek = $flavor;
+    }
+
+    public function setFlavorImportedDefault(string $flavor = Codecept::VERSION): void
     {
         self::$flavorOfTheWeek = $flavor;
     }


### PR DESCRIPTION
Need to prepend a '\\' on imported class constants also, not just constants from the same class (which was already fixed by #6016).
Fixes the issue from #6024