### PR TITLE
Prevent reformating of method names in CLI output

### DIFF
--- a/src/Codeception/Test/Cest.php
+++ b/src/Codeception/Test/Cest.php
@@ -65,11 +65,7 @@ class Cest extends Test implements
 
     public function getSpecFromMethod()
     {
-        $text = $this->testMethod;
-        $text = preg_replace('/([A-Z]+)([A-Z][a-z])/', '\\1 \\2', $text);
-        $text = preg_replace('/([a-z\d])([A-Z])/', '\\1 \\2', $text);
-        $text = strtolower($text);
-        return $text;
+        return $this->testMethod;
     }
 
     public function test()


### PR DESCRIPTION
Currently the output is
> ✔ FooCest: Try to create a new user (0.13s)

This PR changes it to:

> ✔ FooCest: TryToCreateANewUser (0.13s)

Reason: Leave the method name as-is, to allow copy-pasting it.

TODO: The very first letter is still being capitalized - but before searching where this happens, I'm waiting for some overall feedback on this :-)