### PR TITLE
Fix PHP types being treated as a classes

### DIFF
--- a/src/Codeception/Util/ReflectionHelper.php
+++ b/src/Codeception/Util/ReflectionHelper.php
@@ -85,7 +85,7 @@ class ReflectionHelper
         }
 
         $type = $parameter->getType();
-        if ($type === null) {
+        if ($type === null || $type->isBuiltin()) {
             return null;
         }
         $typeString = $type->getName();

--- a/tests/unit/Codeception/Util/ReflectionHelperTest.php
+++ b/tests/unit/Codeception/Util/ReflectionHelperTest.php
@@ -90,6 +90,11 @@ class ReflectionHelperTest extends \Codeception\PHPUnit\TestCase
             null,
             ReflectionHelper::getClassFromParameter(new ReflectionParameter(array($object, 'setDebug'), 'flavor'))
         );
+
+        $this->assertEquals(
+            null,
+            ReflectionHelper::getClassFromParameter(new ReflectionParameter(array($object, 'setInt'), 'i'))
+        );
     }
 
     public function testGetDefaultValue()


### PR DESCRIPTION
Some of our tests have started failing with latest versions of Codeception because the DI code is trying to find an `int` class.﻿
