### PR TITLE
support codception.yml file in any subdirectory

### DIFF
--- a/autoload.php
+++ b/autoload.php
@@ -59,7 +59,7 @@ if (!function_exists('codecept_debug')) {
 if (!function_exists('codecept_root_dir')) {
     function codecept_root_dir($appendPath = '')
     {
-        return \Codeception\Configuration::projectDir() . $appendPath;
+        return \Codeception\Configuration::rootDir() . $appendPath;
     }
 }
 
@@ -89,7 +89,7 @@ if (!function_exists('codecept_relative_path')) {
     {
         return \Codeception\Util\PathResolver::getRelativeDir(
             $path,
-            \Codeception\Configuration::projectDir(),
+            \Codeception\Configuration::rootDir(),
             DIRECTORY_SEPARATOR
         );
     }

--- a/src/Codeception/Coverage/Filter.php
+++ b/src/Codeception/Coverage/Filter.php
@@ -76,7 +76,7 @@ class Filter
             }
             foreach ($coverage['whitelist']['include'] as $fileOrDir) {
                 $finder = strpos($fileOrDir, '*') === false
-                    ? [Configuration::projectDir() . DIRECTORY_SEPARATOR . $fileOrDir]
+                    ? [Configuration::rootDir() . DIRECTORY_SEPARATOR . $fileOrDir]
                     : $this->matchWildcardPattern($fileOrDir);
 
                 foreach ($finder as $file) {
@@ -98,7 +98,7 @@ class Filter
             foreach ($coverage['whitelist']['exclude'] as $fileOrDir) {
                 try {
                     $finder = strpos($fileOrDir, '*') === false
-                        ? [Configuration::projectDir() . DIRECTORY_SEPARATOR . $fileOrDir]
+                        ? [Configuration::rootDir() . DIRECTORY_SEPARATOR . $fileOrDir]
                         : $this->matchWildcardPattern($fileOrDir);
 
                     foreach ($finder as $file) {
@@ -138,7 +138,7 @@ class Filter
             if (isset($coverage['blacklist']['include'])) {
                 foreach ($coverage['blacklist']['include'] as $fileOrDir) {
                     $finder = strpos($fileOrDir, '*') === false
-                        ? [Configuration::projectDir() . DIRECTORY_SEPARATOR . $fileOrDir]
+                        ? [Configuration::rootDir() . DIRECTORY_SEPARATOR . $fileOrDir]
                         : $this->matchWildcardPattern($fileOrDir);
 
                     foreach ($finder as $file) {
@@ -149,7 +149,7 @@ class Filter
             if (isset($coverage['blacklist']['exclude'])) {
                 foreach ($coverage['blacklist']['exclude'] as $fileOrDir) {
                     $finder = strpos($fileOrDir, '*') === false
-                        ? [Configuration::projectDir() . DIRECTORY_SEPARATOR . $fileOrDir]
+                        ? [Configuration::rootDir() . DIRECTORY_SEPARATOR . $fileOrDir]
                         : $this->matchWildcardPattern($fileOrDir);
 
                     foreach ($finder as $file) {
@@ -171,9 +171,9 @@ class Filter
         if (count($parts)) {
             $last_path = array_pop($parts);
             if ($last_path === '*') {
-                $finder->in(Configuration::projectDir() . implode('/', $parts));
+                $finder->in(Configuration::rootDir() . implode('/', $parts));
             } else {
-                $finder->in(Configuration::projectDir() . implode('/', $parts) . '/' . $last_path);
+                $finder->in(Configuration::rootDir() . implode('/', $parts) . '/' . $last_path);
             }
         }
         $finder->ignoreVCS(true)->files();

--- a/src/Codeception/Coverage/Subscriber/LocalServer.php
+++ b/src/Codeception/Coverage/Subscriber/LocalServer.php
@@ -140,15 +140,15 @@ class LocalServer extends SuiteSubscriber
         }
 
         $workDir    = rtrim($this->settings['work_dir'], '/\\') . DIRECTORY_SEPARATOR;
-        $projectDir = Configuration::projectDir();
+        $rootDir = Configuration::rootDir();
         $data       = $coverage->getData(true); //We only want covered files, not all whitelisted ones.
 
-        codecept_debug("Replacing all instances of {$workDir} with {$projectDir}");
+        codecept_debug("Replacing all instances of {$workDir} with {$rootDir}");
 
         foreach ($data as $path => $datum) {
             unset($data[$path]);
 
-            $path = str_replace($workDir, $projectDir, $path);
+            $path = str_replace($workDir, $rootDir, $path);
 
             $data[$path] = $datum;
         }


### PR DESCRIPTION
Although the command supports `-c [config file]` having this file in a subdirectory breaks things like running a test without a suite.

This PR adds a new config options: `paths.root` which is a path to the project root, relative to the directory containing the config file.

This fixes suite discovery in the run command when only a test file is passed. And also cleans the config file of any extraneous path configurations:

before (with file in `dev/tools/codeception.yml`):

```yaml
namespace: Tests
paths:
    tests: ../../tests
    output: ../../tests/_output
    data: ../../tests/_data
    support: ../../tests/_support
    envs: ../../tests/_envs
```

after:

```yaml
namespace: Tests
paths:
    root: ../..
    tests: tests
    output: tests/_output
    data: tests/_data
    support: tests/_support
    envs: tests/_envs
```