### PR TITLE
detect the suite from a test path relative to the current working dir

### DIFF
--- a/src/Codeception/Command/Run.php
+++ b/src/Codeception/Command/Run.php
@@ -428,6 +428,12 @@ class Run extends Command
 
     protected function matchSingleTest($suite, $config)
     {
+        // Workaround when codeception.yml is inside tests directory and tests path is set to "."
+        // @see https://github.com/Codeception/Codeception/issues/4432
+        if (isset($config['paths']['tests']) && $config['paths']['tests'] === '.' && !preg_match('~^\.[/\\\]~', $suite)) {
+            $suite = './' . $suite;
+        }
+
         // running a single test when suite has a configured path
         if (isset($config['suites'])) {
             foreach ($config['suites'] as $s => $suiteConfig) {
@@ -436,9 +442,6 @@ class Run extends Command
                 }
                 $testsPath = $config['paths']['tests'] . DIRECTORY_SEPARATOR . $suiteConfig['path'];
                 if ($suiteConfig['path'] === '.') {
-                    if ($config['paths']['tests'] === '.') {
-                        return ['', $s, $suite];
-                    }
                     $testsPath = $config['paths']['tests'];
                 }
                 if (preg_match("~^$testsPath/(.*?)$~", $suite, $matches)) {

--- a/src/Codeception/Command/Run.php
+++ b/src/Codeception/Command/Run.php
@@ -436,6 +436,9 @@ class Run extends Command
                 }
                 $testsPath = $config['paths']['tests'] . DIRECTORY_SEPARATOR . $suiteConfig['path'];
                 if ($suiteConfig['path'] === '.') {
+                    if ($config['paths']['tests'] === '.') {
+                        return ['', $s, $suite];
+                    }
                     $testsPath = $config['paths']['tests'];
                 }
                 if (preg_match("~^$testsPath/(.*?)$~", $suite, $matches)) {
@@ -456,8 +459,11 @@ class Run extends Command
             $realTestDir = realpath(Configuration::testsDir());
             $cwd = getcwd();
             if (strpos($realTestDir, $cwd) === 0) {
-                list($path) = explode(':', $suite);
-                $realPath = $cwd . DIRECTORY_SEPARATOR . $path;
+                $file = $suite;
+                if (strpos($file, ':') !== false) {
+                    list($file) = explode(':', $suite, -1);
+                }
+                $realPath = $cwd . DIRECTORY_SEPARATOR . $file;
                 if (file_exists($realPath) || is_dir($realPath)) {
                     return $this->matchTestFromFilename(
                         $cwd . DIRECTORY_SEPARATOR . $suite,

--- a/tests/cli/CodeceptionYmlInRandomDirCest.php
+++ b/tests/cli/CodeceptionYmlInRandomDirCest.php
@@ -1,0 +1,16 @@
+<?php
+class CodeceptionYmlInRandomDirCest
+{
+    /**
+     * @param CliGuy $I
+     */
+    public function runTestPath(\CliGuy $I)
+    {
+        $I->amInPath('tests/data/codeception_yml_in_random_dir');
+        $I->executeCommand('run -c random/subdir/codeception.yml tests/unit/ExampleCest.php');
+
+        $I->seeResultCodeIs(0);
+        $I->dontSeeInShellOutput('RuntimeException');
+        $I->dontSeeInShellOutput('could not be found');
+    }
+}

--- a/tests/data/codeception_yml_in_random_dir/random/subdir/codeception.yml
+++ b/tests/data/codeception_yml_in_random_dir/random/subdir/codeception.yml
@@ -1,0 +1,8 @@
+actor: Tester
+paths:
+    tests: ../../tests
+    log: ../../tests/_output
+    data: ../../tests/_data
+    support: ../../tests/_support
+settings:
+    bootstrap: ../../tests/_bootstrap.php

--- a/tests/data/codeception_yml_in_random_dir/tests/_bootstrap.php
+++ b/tests/data/codeception_yml_in_random_dir/tests/_bootstrap.php
@@ -1,0 +1,2 @@
+<?php
+// This is global bootstrap for autoloading

--- a/tests/data/codeception_yml_in_random_dir/tests/_output/.gitignore
+++ b/tests/data/codeception_yml_in_random_dir/tests/_output/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/tests/data/codeception_yml_in_random_dir/tests/_support/UnitTester.php
+++ b/tests/data/codeception_yml_in_random_dir/tests/_support/UnitTester.php
@@ -1,0 +1,26 @@
+<?php
+
+
+/**
+ * Inherited Methods
+ * @method void wantToTest($text)
+ * @method void wantTo($text)
+ * @method void execute($callable)
+ * @method void expectTo($prediction)
+ * @method void expect($prediction)
+ * @method void amGoingTo($argumentation)
+ * @method void am($role)
+ * @method void lookForwardTo($achieveValue)
+ * @method void comment($description)
+ * @method \Codeception\Lib\Friend haveFriend($name, $actorClass = NULL)
+ *
+ * @SuppressWarnings(PHPMD)
+*/
+class UnitTester extends \Codeception\Actor
+{
+    use _generated\UnitTesterActions;
+
+   /**
+    * Define custom actions here
+    */
+}

--- a/tests/data/codeception_yml_in_random_dir/tests/_support/_generated/.gitignore
+++ b/tests/data/codeception_yml_in_random_dir/tests/_support/_generated/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/tests/data/codeception_yml_in_random_dir/tests/unit.suite.yml
+++ b/tests/data/codeception_yml_in_random_dir/tests/unit.suite.yml
@@ -1,0 +1,8 @@
+# Codeception Test Suite Configuration
+#
+# Suite for unit (internal) tests.
+
+class_name: UnitTester
+modules:
+    enabled:
+        - Asserts

--- a/tests/data/codeception_yml_in_random_dir/tests/unit/ExampleCest.php
+++ b/tests/data/codeception_yml_in_random_dir/tests/unit/ExampleCest.php
@@ -1,0 +1,9 @@
+<?php
+
+class ExampleCest
+{
+    public function successful(UnitTester $I)
+    {
+        $I->assertTrue(true);
+    }
+}

--- a/tests/data/codeception_yml_in_random_dir/tests/unit/_bootstrap.php
+++ b/tests/data/codeception_yml_in_random_dir/tests/unit/_bootstrap.php
@@ -1,0 +1,2 @@
+<?php
+// Here you can initialize variables that will be available to your tests


### PR DESCRIPTION
Detect the suite from a test file or path relative to the current working directory.

This fixes the issue that the suite cant be detected when `codeception.yml` is in any subdirectory, and subsequently also fixes the issue when it's inside the tests directory, for which there was a single use case fix in place.