### PR TITLE
Gherkin Loader: Strip trailing backslash from namespace

### DIFF
--- a/src/Codeception/Test/Loader/Gherkin.php
+++ b/src/Codeception/Test/Loader/Gherkin.php
@@ -68,7 +68,7 @@ class Gherkin implements LoaderInterface
 
         if (empty($this->steps) && empty($contexts['default']) && $this->settings['actor']) { // if no context is set, actor to be a context
             $actorContext = $this->settings['namespace']
-                ? rtrim($this->settings['namespace'] . '\\' . $this->settings['actor'], '\\')
+                ? rtrim($this->settings['namespace'], '\\') . '\\' . rtrim($this->settings['actor'], '\\')
                 : $this->settings['actor'];
             if ($actorContext) {
                 $contexts['default'][] = $actorContext;


### PR DESCRIPTION
Allows to load methods from namespaced helper files when namespace has traling backslash,
e.g. `namespace: tests\` in https://github.com/Codeception/yii2-tests/blob/master/cases/closeConnections/codeception.yml


Fixes #6032