### PR TITLE
Ignore . namespace in generators

### DIFF
--- a/src/Codeception/Util/Shared/Namespaces.php
+++ b/src/Codeception/Util/Shared/Namespaces.php
@@ -5,15 +5,9 @@ trait Namespaces
 {
     protected function breakParts($class)
     {
-        $class      = str_replace('/', '\\', $class);
-        $namespaces = explode('\\', $class);
-        if (count($namespaces)) {
-            $namespaces[0] = ltrim($namespaces[0], '\\');
-        }
-        if (!$namespaces[0]) {
-            array_shift($namespaces);
-        } // remove empty namespace caused of \\
-        return $namespaces;
+        // removing leading slashes and dots first
+        $class = str_replace('/', '\\', ltrim($class, './\\'));
+        return explode('\\', $class);
     }
 
     protected function getShortClassName($class)


### PR DESCRIPTION
When someone pass path as a class name, e.g. ./foo

Fixes #5818