### PR TITLE
[WIP] New folder structure

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -64,7 +64,8 @@
     },
     "conflict": {
         "codeception/lib-innerbrowser": "<3.0",
-        "codeception/module-phpbrowser": "<3.0"
+        "codeception/module-phpbrowser": "<3.0",
+        "codeception/module-filesystem": "<3.0"
     },
     "suggest": {
         "ext-simplexml": "For loading params from XML files",

--- a/src/Codeception/Command/Console.php
+++ b/src/Codeception/Command/Console.php
@@ -99,7 +99,7 @@ class Console extends Command
             throw new ConfigurationException("Interactive shell can't be started without an actor");
         }
         if (isset($config["namespace"])) {
-            $settings['actor'] = $config["namespace"] . '\\' . $settings['actor'];
+            $settings['actor'] = $config["namespace"] . '\\Support\\' . $settings['actor'];
         }
         $actor = $settings['actor'];
         $I = new $actor($scenario);

--- a/src/Codeception/Command/GenerateHelper.php
+++ b/src/Codeception/Command/GenerateHelper.php
@@ -44,7 +44,7 @@ class GenerateHelper extends Command
         $path = $this->createDirectoryFor(Configuration::supportDir() . 'Helper', $name);
         $filename = $path . $this->getShortClassName($name) . '.php';
 
-        $res = $this->createFile($filename, (new Helper($name, $config['namespace']))->produce());
+        $res = $this->createFile($filename, (new Helper($config, $name))->produce());
         if ($res) {
             $output->writeln("<info>Helper {$filename} created</info>");
             return 0;

--- a/src/Codeception/Command/GenerateSuite.php
+++ b/src/Codeception/Command/GenerateSuite.php
@@ -6,7 +6,6 @@ namespace Codeception\Command;
 
 use Codeception\Configuration;
 use Codeception\Lib\Generator\Actor as ActorGenerator;
-use Codeception\Lib\Generator\Helper as HelperGenerator;
 use Codeception\Util\Template;
 use Exception;
 use Symfony\Component\Console\Command\Command;
@@ -78,34 +77,19 @@ class GenerateSuite extends Command
             );
         }
 
-        $helperName = ucfirst($suite);
-
-        $file = $this->createDirectoryFor(
-            Configuration::supportDir() . "Helper",
-            "{$helperName}.php"
-        ) . "{$helperName}.php";
-
-        $helper = new HelperGenerator($helperName, $config['namespace']);
-        // generate helper
-        $this->createFile(
-            $file,
-            $helper->produce()
-        );
-
-        $output->writeln("Helper <info>" . $helper->getHelperName() . "</info> was created in {$file}");
-
         $yamlSuiteConfigTemplate = <<<EOF
 actor: {{actor}}
+suite_namespace: {{suite_namespace}}
 modules:
-    enabled:
-        - {{helper}}
+    # enable helpers as array
+    enabled: []
 EOF;
 
         $this->createFile(
-            $dir . $suite . '.suite.yml',
+            $dir . ucfirst($suite) . '.suite.yml',
             $yamlSuiteConfig = (new Template($yamlSuiteConfigTemplate))
                 ->place('actor', $actor)
-                ->place('helper', $helper->getHelperName())
+                ->place('suite_namespace', $config['namespace']. '\\' . ucfirst($suite))
                 ->produce()
         );
 

--- a/src/Codeception/Command/GenerateSuite.php
+++ b/src/Codeception/Command/GenerateSuite.php
@@ -48,7 +48,7 @@ class GenerateSuite extends Command
     public function execute(InputInterface $input, OutputInterface $output): int
     {
         $this->addStyles($output);
-        $suite = (string)$input->getArgument('suite');
+        $suite = ucfirst((string)$input->getArgument('suite'));
         $actor = $input->getArgument('actor');
 
         if ($this->containsInvalidCharacters($suite)) {
@@ -58,7 +58,7 @@ class GenerateSuite extends Command
 
         $config = $this->getGlobalConfig();
         if (!$actor) {
-            $actor = ucfirst($suite) . $config['actor_suffix'];
+            $actor = $suite . $config['actor_suffix'];
         }
 
         $dir = Configuration::testsDir();
@@ -86,10 +86,10 @@ modules:
 EOF;
 
         $this->createFile(
-            $dir . ucfirst($suite) . '.suite.yml',
+            $dir . $suite . '.suite.yml',
             $yamlSuiteConfig = (new Template($yamlSuiteConfigTemplate))
                 ->place('actor', $actor)
-                ->place('suite_namespace', $config['namespace']. '\\' . ucfirst($suite))
+                ->place('suite_namespace', $config['namespace']. '\\' . $suite)
                 ->produce()
         );
 

--- a/src/Codeception/Configuration.php
+++ b/src/Codeception/Configuration.php
@@ -77,7 +77,9 @@ class Configuration
 
     public static array $defaultConfig = [
         'actor_suffix'=> 'Tester',
+        'support_namespace' => null,
         'namespace'  => '',
+
         'include'    => [],
         'paths'      => [],
         'extends'    => null,
@@ -251,7 +253,7 @@ class Configuration
             self::$envsDir = $config['paths']['envs'];
         }
 
-        Autoload::addNamespace(self::$config['namespace'], self::supportDir());
+        Autoload::addNamespace(self::$config['namespace'] . '\\' . self::$config['support_namespace'], self::supportDir());
 
         self::loadBootstrap($config['bootstrap'], self::testsDir());
         self::loadSuites();
@@ -319,11 +321,12 @@ class Configuration
 
         // load global config
         $globalConf = $config['settings'];
-        foreach (['modules', 'coverage', 'namespace', 'groups', 'env', 'gherkin', 'extensions'] as $key) {
+        foreach (['modules', 'coverage', 'support_namespace', 'namespace', 'groups', 'env', 'gherkin', 'extensions'] as $key) {
             if (isset($config[$key])) {
                 $globalConf[$key] = $config[$key];
             }
         }
+
         $settings = self::mergeConfigs(self::$defaultSuiteSettings, $globalConf);
 
         // load suite config
@@ -344,6 +347,8 @@ class Configuration
         $settings['path'] = self::$dir . DIRECTORY_SEPARATOR . $config['paths']['tests']
             . DIRECTORY_SEPARATOR . $settings['path'] . DIRECTORY_SEPARATOR;
 
+        $settings['suite'] = $suite;
+        $settings['suite_namespace'] = $settings['namespace'] . '\\' . $suite;
 
         return $settings;
     }

--- a/src/Codeception/InitTemplate.php
+++ b/src/Codeception/InitTemplate.php
@@ -47,9 +47,11 @@ abstract class InitTemplate
      */
     public const GIT_IGNORE = '.gitignore';
 
-    protected string $namespace = '';
+    protected string $namespace = 'Tests';
 
     protected string $actorSuffix = 'Tester';
+
+    protected string $supportNamespace = 'TestSupport';
 
     protected string $workDir = '.';
 
@@ -161,14 +163,15 @@ abstract class InitTemplate
     /**
      * Create a helper class inside a directory
      */
-    protected function createHelper(string $name, string $directory): void
+    protected function createHelper(string $name, string $directory, array $settings = []): void
     {
         $file = $this->createDirectoryFor(
             $dir = $directory . DIRECTORY_SEPARATOR . "Helper",
             "{$name}.php"
         ) . "{$name}.php";
 
-        $gen = new Helper($name, $this->namespace);
+        $gen = new Helper($settings, $name);
+
         // generate helper
         $this->createFile(
             $file,

--- a/src/Codeception/InitTemplate.php
+++ b/src/Codeception/InitTemplate.php
@@ -51,7 +51,7 @@ abstract class InitTemplate
 
     protected string $actorSuffix = 'Tester';
 
-    protected string $supportNamespace = 'TestSupport';
+    protected string $supportNamespace = 'Support';
 
     protected string $workDir = '.';
 

--- a/src/Codeception/Lib/Generator/Actions.php
+++ b/src/Codeception/Lib/Generator/Actions.php
@@ -7,6 +7,7 @@ namespace Codeception\Lib\Generator;
 use Codeception\Codecept;
 use Codeception\Configuration;
 use Codeception\Lib\Di;
+use Codeception\Lib\Generator\Shared\Classname;
 use Codeception\Lib\ModuleContainer;
 use Codeception\Step\GeneratedStep;
 use Codeception\Util\ReflectionHelper;
@@ -20,6 +21,8 @@ use ReflectionUnionType;
 
 class Actions
 {
+    use Classname;
+
     public Di $di;
 
     public ModuleContainer $moduleContainer;
@@ -90,7 +93,7 @@ EOF;
 
     public function produce(): string
     {
-        $namespace = rtrim($this->settings['namespace'], '\\');
+        $namespace = trim($this->supportNamespace(), '\\');
 
         $methods = [];
         $code = [];

--- a/src/Codeception/Lib/Generator/Actor.php
+++ b/src/Codeception/Lib/Generator/Actor.php
@@ -7,6 +7,7 @@ namespace Codeception\Lib\Generator;
 use Codeception\Configuration;
 use Codeception\Lib\Di;
 use Codeception\Lib\Friend;
+use Codeception\Lib\Generator\Shared\Classname;
 use Codeception\Lib\ModuleContainer;
 use Codeception\Util\ReflectionHelper;
 use Codeception\Util\Template;
@@ -15,6 +16,8 @@ use ReflectionMethod;
 
 class Actor
 {
+    use Classname;
+
     public Di $di;
 
     public ModuleContainer $moduleContainer;
@@ -64,7 +67,7 @@ EOF;
 
     public function produce(): string
     {
-        $namespace = rtrim($this->settings['namespace'], '\\');
+        $namespace = trim($this->supportNamespace(), '\\');
 
         return (new Template($this->template))
             ->place('hasNamespace', $namespace !== '' ? "namespace {$namespace};" : '')

--- a/src/Codeception/Lib/Generator/Cest.php
+++ b/src/Codeception/Lib/Generator/Cest.php
@@ -16,7 +16,9 @@ class Cest
 
     protected string $template = <<<EOF
 <?php
+
 {{namespace}}
+
 class {{name}}Cest
 {
     public function _before({{actor}} \$I)
@@ -45,21 +47,15 @@ EOF;
             throw new ConfigurationException("Cest can't be created for suite without an actor. Add `actor: SomeTester` to suite config");
         }
 
-        if (array_key_exists('suite_namespace', $this->settings)) {
-            $namespace = rtrim($this->settings['suite_namespace'], '\\');
-        } else {
-            $namespace = rtrim($this->settings['namespace'], '\\');
-        }
+        $namespaceHeader = $this->getNamespaceHeader($this->settings['namespace'] . '\\' . ucfirst($this->settings['suite']) . '\\' . $this->name);
 
-        $ns = $this->getNamespaceHeader($namespace . '\\' . $this->name);
-
-        if ($namespace !== '') {
-            $ns .= "use " . $this->settings['namespace'] . '\\' . $actor . ";";
+        if ($namespaceHeader) {
+            $namespaceHeader .= "\nuse ". $this->supportNamespace() . $actor.";";
         }
 
         return (new Template($this->template))
             ->place('name', $this->getShortClassName($this->name))
-            ->place('namespace', $ns)
+            ->place('namespace', $namespaceHeader)
             ->place('actor', $actor)
             ->produce();
     }

--- a/src/Codeception/Lib/Generator/Group.php
+++ b/src/Codeception/Lib/Generator/Group.php
@@ -50,7 +50,9 @@ EOF;
 
     public function __construct(protected array $settings, protected string $name)
     {
-        $this->namespace = $this->getNamespaceString($this->settings['namespace'] . '\\Group\\' . $name);
+        $this->settings = $settings;
+        $this->name = $name;
+        $this->namespace = $this->getNamespaceString($this->supportNamespace() . '\\Group\\' . $name);
     }
 
     public function produce(): string

--- a/src/Codeception/Lib/Generator/Helper.php
+++ b/src/Codeception/Lib/Generator/Helper.php
@@ -4,12 +4,14 @@ declare(strict_types=1);
 
 namespace Codeception\Lib\Generator;
 
+use Codeception\Lib\Generator\Shared\Classname;
 use Codeception\Util\Shared\Namespaces;
 use Codeception\Util\Template;
 
 class Helper
 {
     use Namespaces;
+    use Classname;
 
     protected string $template = <<<EOF
 <?php
@@ -26,20 +28,15 @@ class {{name}} extends \\Codeception\\Module
 
 EOF;
 
-    public function __construct(protected string $name, protected string $namespace = '')
+    public function __construct(protected array $settings, protected string $name)
     {
     }
 
     public function produce(): string
     {
         return (new Template($this->template))
-            ->place('namespace', $this->getNamespaceHeader($this->namespace . '\\Helper\\' . $this->name))
+            ->place('namespace', $this->getNamespaceHeader($this->supportNamespace() . 'Helper\\' . $this->name))
             ->place('name', $this->getShortClassName($this->name))
             ->produce();
-    }
-
-    public function getHelperName(): string
-    {
-        return rtrim('\\' . $this->namespace, '\\') . '\\Helper\\' . $this->name;
     }
 }

--- a/src/Codeception/Lib/Generator/PageObject.php
+++ b/src/Codeception/Lib/Generator/PageObject.php
@@ -22,24 +22,11 @@ namespace {{namespace}};
 
 class {{class}}
 {
-    // include url of current page
-    public static \$URL = '';
-
     /**
      * Declare UI map for this page here. CSS or XPath allowed.
-     * public static \$usernameField = '#username';
-     * public static \$formSubmitButton = "#mainForm input[type=submit]";
+     * public \$usernameField = '#username';
+     * public \$formSubmitButton = "#mainForm input[type=submit]";
      */
-
-    /**
-     * Basic route example for your current URL
-     * You can append any additional parameter to URL
-     * and use it in tests like: Page\\Edit::route('/123-post');
-     */
-    public static function route(\$param)
-    {
-        return static::\$URL.\$param;
-    }
 
 {{actions}}
 }
@@ -55,6 +42,7 @@ EOF;
     public function __construct(\\{{actorClass}} \$I)
     {
         \$this->{{actor}} = \$I;
+        // you can inject other page objects here as well
     }
 
 EOF;
@@ -68,7 +56,7 @@ EOF;
     public function __construct(protected array $settings, string $name)
     {
         $this->name = $this->getShortClassName($name);
-        $this->namespace = $this->getNamespaceString($this->settings['namespace'] . '\\Page\\' . $name);
+        $this->namespace = $this->getNamespaceString($this->supportNamespace() . '\\Page\\' . $name);
     }
 
     public function produce(): string
@@ -87,10 +75,7 @@ EOF;
         }
 
         $actor = lcfirst($this->settings['actor']);
-        $actorClass = $this->settings['actor'];
-        if (!empty($this->settings['namespace'])) {
-            $actorClass = rtrim($this->settings['namespace'], '\\') . '\\' . $actorClass;
-        }
+        $actorClass = ltrim($this->supportNamespace() . $this->settings['actor'], '\\');
 
         return (new Template($this->actionsTemplate))
             ->place('actorClass', $actorClass)

--- a/src/Codeception/Lib/Generator/Shared/Classname.php
+++ b/src/Codeception/Lib/Generator/Shared/Classname.php
@@ -11,4 +11,22 @@ trait Classname
         $classname = preg_replace('#\.php$#', '', $classname);
         return preg_replace("#{$suffix}$#", '', $classname);
     }
+
+    protected function supportNamespace(): string
+    {
+        if (!isset($this->settings)) {
+            return "\\";
+        }
+
+        $namespace = "";
+
+        if ($this->settings['namespace']) {
+            $namespace .= '\\' . $this->settings['namespace'];
+        }
+
+        if (isset($this->settings['support_namespace'])) {
+            $namespace .= '\\' . $this->settings['support_namespace'];
+        }
+        return rtrim($namespace, '\\') . '\\';
+    }
 }

--- a/src/Codeception/Lib/Generator/Snapshot.php
+++ b/src/Codeception/Lib/Generator/Snapshot.php
@@ -4,12 +4,14 @@ declare(strict_types=1);
 
 namespace Codeception\Lib\Generator;
 
+use Codeception\Lib\Generator\Shared\Classname;
 use Codeception\Util\Shared\Namespaces;
 use Codeception\Util\Template;
 
 class Snapshot
 {
     use Namespaces;
+    use Classname;
 
     protected string $template = <<<EOF
 <?php
@@ -49,7 +51,7 @@ EOF;
     public function __construct(protected array $settings, string $name)
     {
         $this->name = $this->getShortClassName($name);
-        $this->namespace = $this->getNamespaceString($this->settings['namespace'] . '\\Snapshot\\' . $name);
+        $this->namespace = $this->getNamespaceString($this->supportNamespace() . 'Snapshot\\' . $name);
     }
 
     public function produce(): string
@@ -68,10 +70,7 @@ EOF;
         }
 
         $actor = lcfirst($this->settings['actor']);
-        $actorClass = $this->settings['actor'];
-        if (!empty($this->settings['namespace'])) {
-            $actorClass = rtrim($this->settings['namespace'], '\\') . '\\' . $actorClass;
-        }
+        $actorClass = rtrim($this->supportNamespace(), '\\') . $this->settings['actor'];
 
         return (new Template($this->actionsTemplate))
             ->place('actorClass', $actorClass)

--- a/src/Codeception/Lib/Generator/StepObject.php
+++ b/src/Codeception/Lib/Generator/StepObject.php
@@ -45,7 +45,7 @@ EOF;
     public function __construct(protected array $settings, string $name)
     {
         $this->name = $this->getShortClassName($name);
-        $this->namespace = $this->getNamespaceString($this->settings['namespace'] . '\\Step\\' . $name);
+        $this->namespace = $this->getNamespaceString($this->supportNamespace() . 'Step\\' . $name);
     }
 
     public function produce(): string
@@ -54,10 +54,8 @@ EOF;
         if (!$actor) {
             throw new ConfigurationException("Steps can't be created for suite without an actor");
         }
-        $ns = $this->getNamespaceString($this->settings['namespace'] . '\\' . $actor . '\\' . $this->name);
-        $ns = ltrim($ns, '\\');
 
-        $extended = '\\' . ltrim('\\' . $this->settings['namespace'] . '\\' . $actor, '\\');
+        $extended = '\\' . ltrim($this->supportNamespace() . $actor, '\\');
 
         return (new Template($this->template))
             ->place('namespace', $this->namespace)

--- a/src/Codeception/Lib/Generator/Test.php
+++ b/src/Codeception/Lib/Generator/Test.php
@@ -16,15 +16,13 @@ class Test
 
     protected string $template = <<<EOF
 <?php
+
 {{namespace}}
+
 class {{name}}Test extends \Codeception\Test\Unit
 {
 {{tester}}
     protected function _before()
-    {
-    }
-
-    protected function _after()
     {
     }
 
@@ -37,14 +35,12 @@ class {{name}}Test extends \Codeception\Test\Unit
 EOF;
 
     protected string $testerTemplate = <<<EOF
-    /**
-     * @var \{{actorClass}}
-     */
-    protected \${{actor}};
-    
+
+    protected {{actorClass}} \${{actor}};
+
 EOF;
 
-    protected ?string $name;
+    protected string $name;
 
     public function __construct(protected array $settings, string $name)
     {
@@ -54,11 +50,13 @@ EOF;
     public function produce(): string
     {
         $actor = $this->settings['actor'];
-        if ($this->settings['namespace']) {
-            $actor = $this->settings['namespace'] . '\\' . $actor;
+
+        $ns = $this->getNamespaceHeader($this->settings['namespace'] . '\\' . ucfirst($this->settings['suite']) . '\\' . $this->name);
+
+        if ($ns) {
+            $ns .= "\nuse ". $this->supportNamespace() . $actor.";";
         }
 
-        $ns = $this->getNamespaceHeader($this->settings['namespace'] . '\\' . $this->name);
 
         $tester = '';
         if ($this->settings['actor']) {

--- a/src/Codeception/Subscriber/Console.php
+++ b/src/Codeception/Subscriber/Console.php
@@ -178,7 +178,7 @@ class Console implements EventSubscriberInterface
             $this->namespace = $settings['namespace'];
         }
         $this->message("%s Tests (%d) ")
-            ->with(ucfirst($event->getSuite()->getName()), $event->getSuite()->count())
+            ->with(ucfirst($event->getSuite()->getBaseName()), $event->getSuite()->count())
             ->style('bold')
             ->width($this->width, '-')
             ->prepend("\n")

--- a/src/Codeception/SuiteManager.php
+++ b/src/Codeception/SuiteManager.php
@@ -217,9 +217,19 @@ class SuiteManager
         if (!$this->settings['actor']) {
             return null;
         }
-        return $this->settings['namespace']
-            ? rtrim($this->settings['namespace'], '\\') . '\\' . $this->settings['actor']
-            : $this->settings['actor'];
+
+        $namespace = "";
+
+        if ($this->settings['namespace']) {
+            $namespace .= '\\' . $this->settings['namespace'];
+        }
+
+        if (isset($this->settings['support_namespace'])) {
+            $namespace .= '\\' . $this->settings['support_namespace'];
+        }
+        $namespace = rtrim($namespace, '\\') . '\\';
+
+        return $namespace . $this->settings['actor'];
     }
 
     protected function checkEnvironmentExists(TestInterface $test): void

--- a/src/Codeception/Template/Acceptance.php
+++ b/src/Codeception/Template/Acceptance.php
@@ -21,14 +21,14 @@ suites:
                 - WebDriver:
                     url: {{url}}
                     browser: {{browser}}
-                - \Helper\Acceptance
                 
         # add Codeception\Step\Retry trait to AcceptanceTester to enable retries
         step_decorators:
             - Codeception\Step\ConditionalAssertion
             - Codeception\Step\TryTo
             - Codeception\Step\Retry
-                
+
+support_namespace: TestSupport
 extensions:
     enabled: [Codeception\Extension\RunFailed]
 
@@ -41,8 +41,8 @@ gherkin: []
 paths:
     tests: {{baseDir}}
     output: {{baseDir}}/_output
-    data: {{baseDir}}/_data
-    support: {{baseDir}}/_support
+    data: {{baseDir}}/TestSupport/Data
+    support: {{baseDir}}/TestSupport
     envs: {{baseDir}}/_envs
 
 settings:
@@ -52,6 +52,11 @@ EOF;
 
     protected string $firstTest = <<<EOF
 <?php
+
+namespace {{namespace}};
+
+use {{support_namespace}}\AcceptanceTester;
+
 class LoginCest 
 {    
     public function _before(AcceptanceTester \$I)
@@ -71,7 +76,7 @@ class LoginCest
 }
 EOF;
 
-    public function setup()
+    public function setup(): void
     {
         $this->checkInstalled();
         $this->say("Let's prepare Codeception for acceptance testing");
@@ -90,8 +95,8 @@ EOF;
         $url = $this->ask("Start url for tests", "http://localhost");
 
         $this->createEmptyDirectory($outputDir = $dir . DIRECTORY_SEPARATOR . '_output');
-        $this->createEmptyDirectory($dir . DIRECTORY_SEPARATOR . '_data');
-        $this->createDirectoryFor($supportDir = $dir . DIRECTORY_SEPARATOR . '_support');
+        $this->createDirectoryFor($supportDir = $dir . DIRECTORY_SEPARATOR . 'TestSupport');
+        $this->createEmptyDirectory($supportDir . DIRECTORY_SEPARATOR . 'Data');
         $this->createDirectoryFor($supportDir . DIRECTORY_SEPARATOR . '_generated');
         $this->gitIgnore($outputDir);
         $this->gitIgnore($supportDir . DIRECTORY_SEPARATOR . '_generated');
@@ -108,17 +113,19 @@ EOF;
             ->place('baseDir', $dir)
             ->produce();
 
-        if ($this->namespace !== '') {
-            $namespace = rtrim($this->namespace, '\\');
-            $configFile = "namespace: {$namespace}\n" . $configFile;
-        }
+        $namespace = rtrim($this->namespace, '\\');
+        $configFile = "namespace: $namespace\nsupport_namespace: {$this->supportNamespace}\n" . $configFile;
 
         $this->createFile('codeception.yml', $configFile);
-        $this->createHelper('Acceptance', $supportDir);
         $this->createActor('AcceptanceTester', $supportDir, Yaml::parse($configFile)['suites']['acceptance']);
 
         $this->sayInfo("Created global config codeception.yml inside the root directory");
-        $this->createFile($dir . DIRECTORY_SEPARATOR . 'LoginCest.php', $this->firstTest);
+        $this->createFile($dir . DIRECTORY_SEPARATOR . 'LoginCest.php',
+            (new Template($this->firstTest))
+                ->place('namespace', $this->namespace)
+                ->place('support_namespace', $this->supportNamespace)
+                ->produce()
+        );
         $this->sayInfo("Created a demo test LoginCest.php");
 
         $this->say();

--- a/src/Codeception/Template/Acceptance.php
+++ b/src/Codeception/Template/Acceptance.php
@@ -28,7 +28,7 @@ suites:
             - Codeception\Step\TryTo
             - Codeception\Step\Retry
 
-support_namespace: TestSupport
+support_namespace: Support
 extensions:
     enabled: [Codeception\Extension\RunFailed]
 
@@ -41,8 +41,8 @@ gherkin: []
 paths:
     tests: {{baseDir}}
     output: {{baseDir}}/_output
-    data: {{baseDir}}/TestSupport/Data
-    support: {{baseDir}}/TestSupport
+    data: {{baseDir}}/Support/Data
+    support: {{baseDir}}/Support
     envs: {{baseDir}}/_envs
 
 settings:
@@ -95,7 +95,7 @@ EOF;
         $url = $this->ask("Start url for tests", "http://localhost");
 
         $this->createEmptyDirectory($outputDir = $dir . DIRECTORY_SEPARATOR . '_output');
-        $this->createDirectoryFor($supportDir = $dir . DIRECTORY_SEPARATOR . 'TestSupport');
+        $this->createDirectoryFor($supportDir = $dir . DIRECTORY_SEPARATOR . 'Support');
         $this->createEmptyDirectory($supportDir . DIRECTORY_SEPARATOR . 'Data');
         $this->createDirectoryFor($supportDir . DIRECTORY_SEPARATOR . '_generated');
         $this->gitIgnore($outputDir);

--- a/src/Codeception/Template/Api.php
+++ b/src/Codeception/Template/Api.php
@@ -14,7 +14,7 @@ class Api extends InitTemplate
     protected string $configTemplate = <<<EOF
 # suite config
 suites:
-    api:
+    Api:
         actor: ApiTester
         path: .
         modules:
@@ -28,8 +28,8 @@ suites:
 paths:
     tests: {{baseDir}}
     output: {{baseDir}}/_output
-    data: {{baseDir}}/_data
-    support: {{baseDir}}/_support
+    data: {{baseDir}}/TestSupport/Data
+    support: {{baseDir}}/TestSupport
 
 settings:
     shuffle: false
@@ -38,6 +38,10 @@ EOF;
 
     protected string $firstTest = <<<EOF
 <?php
+namespace {{namespace}};
+
+use {{support_namespace}}\ApiTester;
+
 class ApiCest 
 {    
     public function tryApi(ApiTester \$I)
@@ -49,7 +53,7 @@ class ApiCest
 }
 EOF;
 
-    public function setup()
+    public function setup(): void
     {
         $this->checkInstalled();
         $this->say("Let's prepare Codeception for REST API testing");
@@ -64,8 +68,8 @@ EOF;
         }
 
         $this->createEmptyDirectory($outputDir = $dir . DIRECTORY_SEPARATOR . '_output');
-        $this->createEmptyDirectory($dir . DIRECTORY_SEPARATOR . '_data');
-        $this->createDirectoryFor($supportDir = $dir . DIRECTORY_SEPARATOR . '_support');
+        $this->createDirectoryFor($supportDir = $dir . DIRECTORY_SEPARATOR . 'TestSupport');
+        $this->createEmptyDirectory($supportDir . DIRECTORY_SEPARATOR . 'Data');
         $this->createDirectoryFor($supportDir . DIRECTORY_SEPARATOR . '_generated');
         $this->gitIgnore($outputDir);
         $this->gitIgnore($supportDir . DIRECTORY_SEPARATOR . '_generated');
@@ -76,17 +80,21 @@ EOF;
             ->place('baseDir', $dir)
             ->produce();
 
-        if ($this->namespace !== '') {
-            $namespace = rtrim($this->namespace, '\\');
-            $configFile = "namespace: {$namespace}\n" . $configFile;
-        }
+        $namespace = rtrim($this->namespace, '\\');
+        $configFile = "namespace: $namespace\nsupport_namespace: {$this->supportNamespace}\n" . $configFile;
 
         $this->createFile('codeception.yml', $configFile);
-        $this->createHelper('Api', $supportDir);
         $this->createActor('ApiTester', $supportDir, Yaml::parse($configFile)['suites']['api']);
 
         $this->sayInfo("Created global config codeception.yml inside the root directory");
-        $this->createFile($dir . DIRECTORY_SEPARATOR . 'ApiCest.php', $this->firstTest);
+
+        $this->createFile($dir . DIRECTORY_SEPARATOR . 'ApiCest.php',
+            (new Template($this->firstTest))
+                ->place('namespace', $this->namespace)
+                ->place('support_namespace', $this->supportNamespace)
+                ->produce()
+        );
+
         $this->sayInfo("Created a demo test ApiCest.php");
 
         $this->say();

--- a/src/Codeception/Template/Api.php
+++ b/src/Codeception/Template/Api.php
@@ -28,8 +28,8 @@ suites:
 paths:
     tests: {{baseDir}}
     output: {{baseDir}}/_output
-    data: {{baseDir}}/TestSupport/Data
-    support: {{baseDir}}/TestSupport
+    data: {{baseDir}}/Support/Data
+    support: {{baseDir}}/Support
 
 settings:
     shuffle: false
@@ -68,7 +68,7 @@ EOF;
         }
 
         $this->createEmptyDirectory($outputDir = $dir . DIRECTORY_SEPARATOR . '_output');
-        $this->createDirectoryFor($supportDir = $dir . DIRECTORY_SEPARATOR . 'TestSupport');
+        $this->createDirectoryFor($supportDir = $dir . DIRECTORY_SEPARATOR . 'Support');
         $this->createEmptyDirectory($supportDir . DIRECTORY_SEPARATOR . 'Data');
         $this->createDirectoryFor($supportDir . DIRECTORY_SEPARATOR . '_generated');
         $this->gitIgnore($outputDir);

--- a/src/Codeception/Template/Bootstrap.php
+++ b/src/Codeception/Template/Bootstrap.php
@@ -14,9 +14,9 @@ use Symfony\Component\Yaml\Yaml;
 class Bootstrap extends InitTemplate
 {
     // defaults
-    protected string $supportDir = 'tests/TestSupport';
+    protected string $supportDir = 'tests/Support';
 
-    protected string $dataDir = 'tests/TestSupport/Data';
+    protected string $dataDir = 'tests/Support/Data';
 
     protected string $envsDir = 'tests/_envs';
 
@@ -26,7 +26,7 @@ class Bootstrap extends InitTemplate
     // default since v5
     protected string $namespace = 'Tests';
 
-    protected string $supportNamespace = 'TestSupport';
+    protected string $supportNamespace = 'Support';
 
     public function setup(): void
     {

--- a/src/Codeception/Template/Dependencies.php
+++ b/src/Codeception/Template/Dependencies.php
@@ -8,45 +8,29 @@ use Codeception\Configuration;
 use Codeception\InitTemplate;
 use Exception;
 
-class Upgrade4 extends InitTemplate
+class Dependencies extends InitTemplate
 {
-    /**
-     * @var string
-     */
-    public const SURVEY_LINK = 'https://bit.ly/codecept-survey';
     /**
      * @var string
      */
     public const DONATE_LINK = 'https://opencollective.com/codeception';
 
-    public function setup()
+    public function setup(): void
     {
         if (!$this->isInstalled()) {
             $this->sayWarning('Codeception is not installed in this dir.');
             return;
         }
-        $this->sayInfo('Welcome to Codeception v4 Upgrade wizard!');
+        $this->sayInfo('Install Codeception Modules as Composer Packages');
         $this->say('');
-        $this->say('Codeception is maintained since 2011, is free & open-source.');
-        $this->say('To make it better we need your feedback on it!');
-        $this->say('');
-        $this->say('Please take a minute and fill in a brief survey:');
-        $this->say('<bold>' . self::SURVEY_LINK . '</bold>');
-        sleep(5);
-        $this->say('');
-        $result = $this->ask('<question>Did you fill in the survey?</question>', true);
-        if ($result) {
-            $this->say('Thank you! ');
-        } else {
-            $this->say('Anyway...');
-        }
+
         $config = Configuration::config();
         $modules = [];
         $suites = Configuration::suites();
         if (empty($suites)) {
             $this->sayError("No suites found in current config.");
             $this->sayWarning('If you use sub-configs with `include` option, run this script on subconfigs:');
-            $this->sayWarning('Example: php vendor/bin/codecept init upgrade4 -c backend/');
+            $this->sayWarning('Example: php vendor/bin/codecept init dependencies -c backend/');
             throw new Exception("No suites found, can't upgrade");
         }
         foreach (Configuration::suites() as $suite) {
@@ -57,11 +41,11 @@ class Upgrade4 extends InitTemplate
         $numPackages = $this->addModulesToComposer($modules);
 
         if ($numPackages === 0) {
-            $this->sayWarning("No upgrade needed! Everything is fine already");
+            $this->sayWarning("No change needed! Everything is installed");
             return;
         }
 
-        $this->saySuccess("Done upgrading!");
+        $this->saySuccess("Done installing!");
         $this->say('');
 
         $this->say('Please consider donating to Codeception on regular basis:');

--- a/src/Codeception/Template/Unit.php
+++ b/src/Codeception/Template/Unit.php
@@ -22,7 +22,7 @@ settings:
 paths:
     tests: {{dir}}
     output: {{dir}}/_output
-    support: {{dir}}/_support
+    support: {{dir}}/TestSupport
     data: {{dir}}
      
 EOF;
@@ -36,7 +36,7 @@ EOF;
         step_decorators: ~ 
 EOF;
 
-    public function setup()
+    public function setup(): void
     {
         $this->sayInfo('This will install Codeception for unit testing only');
         $this->say();
@@ -59,10 +59,8 @@ EOF;
             ->place('tester', $haveTester ? $this->testerAndModules : '')
             ->produce();
 
-        if ($this->namespace !== '') {
-            $namespace = rtrim($this->namespace, '\\');
-            $configFile = "namespace: {$namespace}\n" . $configFile;
-        }
+        $namespace = rtrim($this->namespace, '\\');
+        $configFile = "namespace: $namespace\nsupport_namespace: {$this->supportNamespace}\n" . $configFile;
 
         $this->createFile('codeception.yml', $configFile);
 
@@ -71,7 +69,6 @@ EOF;
         }
 
         if ($haveTester) {
-            $this->createHelper('Unit', $supportDir);
             $this->createActor('UnitTester', $supportDir, Yaml::parse($configFile)['suites']['unit']);
         }
 

--- a/src/Codeception/Template/Unit.php
+++ b/src/Codeception/Template/Unit.php
@@ -22,7 +22,7 @@ settings:
 paths:
     tests: {{dir}}
     output: {{dir}}/_output
-    support: {{dir}}/TestSupport
+    support: {{dir}}/Support
     data: {{dir}}
      
 EOF;

--- a/src/Codeception/Test/Loader/Gherkin.php
+++ b/src/Codeception/Test/Loader/Gherkin.php
@@ -16,6 +16,7 @@ use Behat\Gherkin\Parser as GherkinParser;
 use Codeception\Configuration;
 use Codeception\Exception\ParseException;
 use Codeception\Exception\TestParseException;
+use Codeception\Lib\Generator\Shared\Classname;
 use Codeception\Test\Gherkin as GherkinFormat;
 use Codeception\Util\Annotation;
 use ReflectionClass;
@@ -37,6 +38,8 @@ use function str_replace;
 
 class Gherkin implements LoaderInterface
 {
+    use Classname;
+
     protected static array $defaultSettings = [
         'namespace' => '',
         'actor' => '',
@@ -87,9 +90,7 @@ class Gherkin implements LoaderInterface
         }
 
         if (empty($this->steps) && empty($contexts['default']) && $this->settings['actor']) { // if no context is set, actor to be a context
-            $actorContext = $this->settings['namespace']
-                ? rtrim($this->settings['namespace'], '\\') . '\\' . rtrim($this->settings['actor'], '\\')
-                : $this->settings['actor'];
+            $actorContext = $this->supportNamespace() . $this->settings['actor'];
             if ($actorContext) {
                 $contexts['default'][] = $actorContext;
             }
@@ -124,7 +125,8 @@ class Gherkin implements LoaderInterface
                     sprintf("Context class %s does not exist", $context)
                 );
             }
-            $methods = get_class_methods($context);
+            $methods = get_class_methods((new \ReflectionClass($context))->newInstanceWithoutConstructor());
+
             if ($methods === []) {
                 continue;
             }

--- a/tests/cli/BootstrapCest.php
+++ b/tests/cli/BootstrapCest.php
@@ -27,11 +27,8 @@ final class BootstrapCest
         $I->dontSeeInThisFile('namespace Generated\\');
         $this->checkFilesCreated($I);
 
-        $I->seeFileFound('Acceptance.php', 'tests/_support/Helper');
-        $I->seeInThisFile('namespace Generated\Helper;');
-
-        $I->seeFileFound('AcceptanceTester.php', 'tests/_support');
-        $I->seeInThisFile('namespace Generated;');
+        $I->seeFileFound('AcceptanceTester.php', 'tests/TestSupport');
+        $I->seeInThisFile('namespace Generated\\TestSupport;');
     }
 
     public function bootstrapWithNamespaceShortcut(CliGuy $I)
@@ -43,17 +40,14 @@ final class BootstrapCest
         $I->dontSeeInThisFile('namespace Generated\\');
         $this->checkFilesCreated($I);
 
-        $I->seeFileFound('Acceptance.php', 'tests/_support/Helper');
-        $I->seeInThisFile('namespace Generated\Helper;');
-
-        $I->seeFileFound('AcceptanceTester.php', 'tests/_support');
-        $I->seeInThisFile('namespace Generated;');
+        $I->seeFileFound('AcceptanceTester.php', 'tests/TestSupport');
+        $I->seeInThisFile('namespace Generated\\TestSupport;');
     }
 
     public function bootstrapWithActor(CliGuy $I)
     {
         $I->executeCommand('bootstrap --actor Ninja');
-        $I->seeFileFound('AcceptanceNinja.php', 'tests/_support/');
+        $I->seeFileFound('AcceptanceNinja.php', 'tests/TestSupport/');
     }
 
     public function bootstrapEmpty(CliGuy $I)
@@ -77,20 +71,16 @@ final class BootstrapCest
 
     private function checkFilesCreated(CliGuy $I)
     {
-        $I->seeDirFound('tests/_support');
-        $I->seeDirFound('tests/_data');
+        $I->seeDirFound('tests/TestSupport');
+        $I->seeDirFound('tests/TestSupport/Data');
         $I->seeDirFound('tests/_output');
 
-        $I->seeFileFound('functional.suite.yml', 'tests');
-        $I->seeFileFound('acceptance.suite.yml', 'tests');
-        $I->seeFileFound('unit.suite.yml', 'tests');
+        $I->seeFileFound('Functional.suite.yml', 'tests');
+        $I->seeFileFound('Acceptance.suite.yml', 'tests');
+        $I->seeFileFound('Unit.suite.yml', 'tests');
 
-        $I->seeFileFound('AcceptanceTester.php', 'tests/_support');
-        $I->seeFileFound('FunctionalTester.php', 'tests/_support');
-        $I->seeFileFound('UnitTester.php', 'tests/_support');
-
-        $I->seeFileFound('Acceptance.php', 'tests/_support/Helper');
-        $I->seeFileFound('Functional.php', 'tests/_support/Helper');
-        $I->seeFileFound('Unit.php', 'tests/_support/Helper');
+        $I->seeFileFound('AcceptanceTester.php', 'tests/TestSupport');
+        $I->seeFileFound('FunctionalTester.php', 'tests/TestSupport');
+        $I->seeFileFound('UnitTester.php', 'tests/TestSupport');
     }
 }

--- a/tests/cli/BootstrapCest.php
+++ b/tests/cli/BootstrapCest.php
@@ -27,8 +27,8 @@ final class BootstrapCest
         $I->dontSeeInThisFile('namespace Generated\\');
         $this->checkFilesCreated($I);
 
-        $I->seeFileFound('AcceptanceTester.php', 'tests/TestSupport');
-        $I->seeInThisFile('namespace Generated\\TestSupport;');
+        $I->seeFileFound('AcceptanceTester.php', 'tests/Support');
+        $I->seeInThisFile('namespace Generated\\Support;');
     }
 
     public function bootstrapWithNamespaceShortcut(CliGuy $I)
@@ -40,14 +40,14 @@ final class BootstrapCest
         $I->dontSeeInThisFile('namespace Generated\\');
         $this->checkFilesCreated($I);
 
-        $I->seeFileFound('AcceptanceTester.php', 'tests/TestSupport');
-        $I->seeInThisFile('namespace Generated\\TestSupport;');
+        $I->seeFileFound('AcceptanceTester.php', 'tests/Support');
+        $I->seeInThisFile('namespace Generated\\Support;');
     }
 
     public function bootstrapWithActor(CliGuy $I)
     {
         $I->executeCommand('bootstrap --actor Ninja');
-        $I->seeFileFound('AcceptanceNinja.php', 'tests/TestSupport/');
+        $I->seeFileFound('AcceptanceNinja.php', 'tests/Support/');
     }
 
     public function bootstrapEmpty(CliGuy $I)
@@ -71,16 +71,16 @@ final class BootstrapCest
 
     private function checkFilesCreated(CliGuy $I)
     {
-        $I->seeDirFound('tests/TestSupport');
-        $I->seeDirFound('tests/TestSupport/Data');
+        $I->seeDirFound('tests/Support');
+        $I->seeDirFound('tests/Support/Data');
         $I->seeDirFound('tests/_output');
 
         $I->seeFileFound('Functional.suite.yml', 'tests');
         $I->seeFileFound('Acceptance.suite.yml', 'tests');
         $I->seeFileFound('Unit.suite.yml', 'tests');
 
-        $I->seeFileFound('AcceptanceTester.php', 'tests/TestSupport');
-        $I->seeFileFound('FunctionalTester.php', 'tests/TestSupport');
-        $I->seeFileFound('UnitTester.php', 'tests/TestSupport');
+        $I->seeFileFound('AcceptanceTester.php', 'tests/Support');
+        $I->seeFileFound('FunctionalTester.php', 'tests/Support');
+        $I->seeFileFound('UnitTester.php', 'tests/Support');
     }
 }

--- a/tests/cli/BuildCest.php
+++ b/tests/cli/BuildCest.php
@@ -39,7 +39,9 @@ final class BuildCest
         $I->wantToTest('generate typehints with generated actions');
 
         $cliHelperContents = file_get_contents(codecept_root_dir('tests/support/CliHelper.php'));
-        $cliHelperContents = str_replace('public function grabFromOutput($regex)', 'public function grabFromOutput(string $regex): int', $cliHelperContents);
+
+        $cliHelperContents = str_replace('public function grabFromOutput($regex)', 'public function grabFromOutput(string $regex): string', $cliHelperContents);
+
         file_put_contents(codecept_root_dir('tests/support/CliHelper.php'), $cliHelperContents);
 
         $I->runShellCommand('php codecept build');
@@ -48,7 +50,7 @@ final class BuildCest
         $I->seeInThisFile('class CliGuy extends \Codeception\Actor');
         $I->seeInThisFile('use _generated\CliGuyActions');
         $I->seeFileFound('CliGuyActions.php', 'tests/support/_generated');
-        $I->seeInThisFile('public function grabFromOutput(string $regex): int');
+        $I->seeInThisFile('public function grabFromOutput(string $regex): string');
     }
 
     public function generatedUnionReturnType(CliGuy $I, Scenario $scenario): void

--- a/tests/cli/GeneratePageObjectCest.php
+++ b/tests/cli/GeneratePageObjectCest.php
@@ -12,7 +12,6 @@ final class GeneratePageObjectCest
         $I->amInPath('tests/data/sandbox');
         $I->executeCommand('generate:page Login');
         $I->seeFileWithGeneratedClass('Login', 'tests/_support/Page');
-        $I->seeInThisFile('static $URL = ');
         $I->dontSeeInThisFile('public function __construct(\DumbGuy $I)');
     }
 
@@ -32,7 +31,6 @@ final class GeneratePageObjectCest
         $I->executeCommand('generate:page Login -c tests/data/sandbox');
         $I->amInPath('tests/data/sandbox');
         $I->seeFileWithGeneratedClass('Login', 'tests/_support/Page');
-        $I->seeInThisFile('static $URL = ');
         $I->dontSeeInThisFile('public function __construct(\DumbGuy $I)');
     }
 }

--- a/tests/cli/GenerateSuiteCest.php
+++ b/tests/cli/GenerateSuiteCest.php
@@ -8,12 +8,9 @@ final class GenerateSuiteCest
     {
         $I->amInPath('tests/data/sandbox');
         $I->executeCommand('generate:suite house HouseGuy');
-        $I->seeFileFound('house.suite.yml', 'tests');
+        $I->seeFileFound('House.suite.yml', 'tests');
         $I->expect('actor class is generated');
         $I->seeInThisFile('actor: HouseGuy');
-        $I->seeInThisFile('- \Helper\House');
-        $I->seeFileFound('House.php', 'tests/_support/Helper');
-        $I->seeInThisFile('namespace Helper;');
         $I->seeDirFound('tests/house');
 
         $I->expect('suite is not created due to dashes');
@@ -28,12 +25,9 @@ final class GenerateSuiteCest
         $I->executeCommand('bootstrap --empty src/FooBar --namespace FooBar');
         $I->executeCommand('generate:suite house HouseGuy -c src/FooBar');
         $I->seeDirFound('src/FooBar/tests/house');
-        $I->seeFileFound('house.suite.yml', 'src/FooBar/tests');
+        $I->seeFileFound('House.suite.yml', 'src/FooBar/tests');
         $I->expect('guy class is generated');
         $I->seeInThisFile('actor: HouseGuy');
-        $I->seeInThisFile('- \FooBar\Helper\House');
-        $I->seeFileFound('House.php', 'src/FooBar/tests/_support/Helper');
-        $I->seeInThisFile('namespace FooBar\Helper;');
 
         $I->expect('suite is not created due to dashes');
         $I->executeCommand('generate:suite invalid-dash-suite', false);

--- a/tests/cli/GenerateSuiteCest.php
+++ b/tests/cli/GenerateSuiteCest.php
@@ -11,7 +11,7 @@ final class GenerateSuiteCest
         $I->seeFileFound('House.suite.yml', 'tests');
         $I->expect('actor class is generated');
         $I->seeInThisFile('actor: HouseGuy');
-        $I->seeDirFound('tests/house');
+        $I->seeDirFound('tests/House');
 
         $I->expect('suite is not created due to dashes');
         $I->executeCommand('generate:suite invalid-dash-suite', false);
@@ -24,7 +24,7 @@ final class GenerateSuiteCest
         $I->amInPath('tests/data/sandbox');
         $I->executeCommand('bootstrap --empty src/FooBar --namespace FooBar');
         $I->executeCommand('generate:suite house HouseGuy -c src/FooBar');
-        $I->seeDirFound('src/FooBar/tests/house');
+        $I->seeDirFound('src/FooBar/tests/House');
         $I->seeFileFound('House.suite.yml', 'src/FooBar/tests');
         $I->expect('guy class is generated');
         $I->seeInThisFile('actor: HouseGuy');

--- a/tests/cli/GenerateTestCept.php
+++ b/tests/cli/GenerateTestCept.php
@@ -6,5 +6,5 @@ $I->amInPath('tests/data/sandbox');
 $I->executeCommand('generate:test dummy Sommy');
 $I->seeFileWithGeneratedClass('SommyTest');
 $I->seeInThisFile('class SommyTest extends \Codeception\Test\Unit');
-$I->seeInThisFile('protected $tester');
+$I->seeInThisFile('protected DumbGuy $tester');
 $I->seeInThisFile("function _before(");

--- a/tests/cli/IncludedCest.php
+++ b/tests/cli/IncludedCest.php
@@ -24,11 +24,14 @@ final class IncludedCest
     {
         $I->executeCommand('run');
         $I->seeInShellOutput('[Jazz]');
-        $I->seeInShellOutput('Jazz.functional Tests');
+        $I->seeInShellOutput('Functional Tests');
+        $I->seeInShellOutput('DemoCept: Check that jazz musicians can add numbers');
         $I->seeInShellOutput('[Jazz\Pianist]');
-        $I->seeInShellOutput('Jazz\Pianist.functional Tests');
+        $I->dontSeeInShellOutput('Jazz\Pianist.functional Tests');
+        $I->seeInShellOutput('PianistCept: Check that jazz pianists can add numbers');
         $I->seeInShellOutput('[Shire]');
-        $I->seeInShellOutput('Shire.functional Tests');
+        $I->dontSeeInShellOutput('Shire.functional Tests');
+        $I->seeInShellOutput('Check that hobbits can add numbers');
     }
 
     /**
@@ -44,14 +47,12 @@ final class IncludedCest
         $I->dontSeeInShellOutput('[Jazz]');
 
         // DemoCept tests are run
-        $I->seeInShellOutput('Jazz.functional Tests');
         $I->seeInShellOutput('DemoCept');
-
         // Other include tests are not run
         $I->dontSeeInShellOutput('[Shire]');
         $I->dontSeeInShellOutput('Shire.functional Tests');
         $I->dontSeeInShellOutput('[Jazz\Pianist]');
-        $I->dontSeeInShellOutput('Jazz\Pianist.functional Tests');
+        $I->dontSeeInShellOutput('PianistCept: Check that jazz pianists can add numbers');
     }
 
     /**
@@ -66,12 +67,12 @@ final class IncludedCest
         $I->dontSeeInShellOutput('[Jazz\Pianist]');
 
         // DemoCept tests are run
-        $I->seeInShellOutput('Jazz\Pianist.functional Tests');
+        $I->seeInShellOutput('Functional Tests');
         $I->seeInShellOutput('PianistCept');
 
         // Other include tests are not run
         $I->dontSeeInShellOutput('[Shire]');
-        $I->dontSeeInShellOutput('Shire.functional Tests');
+        $I->dontSeeInShellOutput('Check that hobbits can add numbers');
         $I->dontSeeInShellOutput('[Jazz]');
         $I->dontSeeInShellOutput('Jazz.functional Tests');
     }
@@ -89,7 +90,7 @@ final class IncludedCest
         $I->dontSeeInShellOutput('[Jazz]');
 
         // SimpleTest:testSimple is run
-        $I->seeInShellOutput('Jazz.unit Tests');
+        $I->seeInShellOutput('Unit Tests');
         $I->dontSeeInShellOutput('Jazz.functional Tests');
         $I->seeInShellOutput('SimpleTest');
 
@@ -98,9 +99,9 @@ final class IncludedCest
 
         // Other include tests are not run
         $I->dontSeeInShellOutput('[Shire]');
-        $I->dontSeeInShellOutput('Shire.functional Tests');
+        $I->dontSeeInShellOutput('Check that hobbits can add numbers');
         $I->dontSeeInShellOutput('[Jazz\Pianist]');
-        $I->dontSeeInShellOutput('Jazz\Pianist.functional Tests');
+        $I->dontSeeInShellOutput('PianistCept: Check that jazz pianists can add numbers');
     }
 
     /**

--- a/tests/cli/MixedIncludeCest.php
+++ b/tests/cli/MixedIncludeCest.php
@@ -25,7 +25,9 @@ final class MixedIncludeCest
 
     private function checkAllSuitesExecuted(CliGuy $I)
     {
-        $I->seeInShellOutput('AcmePack.unit Tests (1)');
         $I->seeInShellOutput('Unit Tests (1)');
+        $I->seeInShellOutput('SimpleTest: Something');
+        $I->seeInShellOutput('[AcmePack]: tests from');
+        $I->seeInShellOutput('BasicTest: Assert');
     }
 }

--- a/tests/cli/WildcardIncludeCest.php
+++ b/tests/cli/WildcardIncludeCest.php
@@ -26,11 +26,10 @@ final class WildcardIncludeCest
     private function checkAllSuitesExecuted(CliGuy $I)
     {
         $I->seeInShellOutput('[ToastPack]');
-        $I->seeInShellOutput('ToastPack.unit Tests');
+        $I->seeInShellOutput('Unit Tests (0)');
         $I->seeInShellOutput('[EwokPack]');
-        $I->seeInShellOutput('EwokPack.unit Tests');
+        $I->seeInShellOutput('Unit Tests (1)');
         $I->seeInShellOutput('[AcmePack]');
-        $I->seeInShellOutput('AcmePack.unit Tests');
         $I->dontSeeInShellOutput('[Spam]');
         $I->dontSeeInShellOutput('[SpamPack]');
     }

--- a/tests/cli/v5Cest.php
+++ b/tests/cli/v5Cest.php
@@ -1,0 +1,80 @@
+<?php
+
+class v5Cest
+{
+    public function bootstrapCodecept5(CliGuy $I)
+    {
+        $I->amInPath('tests/data/sandbox');
+        $I->cleanDir('.');
+        $I->executeCommand('bootstrap');
+        $I->executeCommand('g:suite Api');
+        $I->executeCommand('g:cest Api Resource');
+        $I->executeCommand('g:test Api Resource');
+        $I->executeCommand('g:feature Acceptance UserStory');
+        $I->executeCommand('g:helper Api');
+        $I->executeCommand('run');
+        $I->seeInShellOutput('OK ');
+
+        $I->openFile('codeception.yml');
+        $I->seeInThisFile('namespace: Tests');
+
+        $I->openFile('tests/TestSupport/Helper/Api.php');
+        $I->seeInThisFile('namespace Tests\\TestSupport\\Helper');
+        $I->seeInThisFile('class Api');
+
+        $I->openFile('tests/TestSupport/AcceptanceTester.php');
+        $I->seeInThisFile('namespace Tests\\TestSupport');
+        $I->seeInThisFile('use _generated\AcceptanceTesterActions');
+
+        $I->openFile('tests/TestSupport/FunctionalTester.php');
+        $I->seeInThisFile('namespace Tests\\TestSupport');
+
+        $I->openFile('tests/Api/ResourceCest.php');
+        $I->seeInThisFile('namespace Tests\\Api;');
+        $I->seeInThisFile('use \Tests\TestSupport\ApiTester;');
+        $I->seeInThisFile('public function tryToTest(ApiTester $I)');
+
+        $I->openFile('tests/Api/ResourceTest.php');
+        $I->seeInThisFile('namespace Tests\\Api;');
+        $I->seeInThisFile('use \Tests\TestSupport\ApiTester;');
+        $I->seeInThisFile('protected ApiTester $tester;');
+    }
+
+    public function bootstrapCodecept5WithNamespace(CliGuy $I)
+    {
+        $I->amInPath('tests/data/sandbox');
+        $I->cleanDir('.');
+        $I->executeCommand('bootstrap --namespace Codecept5');
+        $I->executeCommand('g:suite Api');
+        $I->executeCommand('g:feature Acceptance UserStory');
+        $I->executeCommand('g:cest Api Resource');
+        $I->executeCommand('g:test Api Resource');
+        $I->executeCommand('g:helper Api');
+        $I->executeCommand('run');
+        $I->seeInShellOutput('OK ');
+
+        $I->openFile('codeception.yml');
+        $I->seeInThisFile('namespace: Codecept5');
+
+        $I->openFile('tests/TestSupport/Helper/Api.php');
+        $I->seeInThisFile('namespace Codecept5\\TestSupport\\Helper');
+        $I->seeInThisFile('class Api');
+
+        $I->openFile('tests/TestSupport/AcceptanceTester.php');
+        $I->seeInThisFile('namespace Codecept5\\TestSupport');
+        $I->seeInThisFile('use _generated\AcceptanceTesterActions');
+
+        $I->openFile('tests/TestSupport/FunctionalTester.php');
+        $I->seeInThisFile('namespace Codecept5\\TestSupport');
+
+        $I->openFile('tests/Api/ResourceCest.php');
+        $I->seeInThisFile('namespace Codecept5\\Api;');
+        $I->seeInThisFile('use \Codecept5\TestSupport\ApiTester;');
+        $I->seeInThisFile('public function tryToTest(ApiTester $I)');
+
+        $I->openFile('tests/Api/ResourceTest.php');
+        $I->seeInThisFile('namespace Codecept5\\Api;');
+        $I->seeInThisFile('use \Codecept5\TestSupport\ApiTester;');
+        $I->seeInThisFile('protected ApiTester $tester;');
+    }
+}

--- a/tests/cli/v5Cest.php
+++ b/tests/cli/v5Cest.php
@@ -1,11 +1,16 @@
 <?php
 
-class v5Cest
+final class v5Cest
 {
+    public function _before(CliGuy $I)
+    {
+        $bootstrapPath = 'tests/data/sandbox/boot'.uniqid();
+        @mkdir($bootstrapPath, 0777, true);
+        $I->amInPath($bootstrapPath);
+    }
+
     public function bootstrapCodecept5(CliGuy $I)
     {
-        $I->amInPath('tests/data/sandbox');
-        $I->cleanDir('.');
         $I->executeCommand('bootstrap');
         $I->executeCommand('g:suite Api');
         $I->executeCommand('g:cest Api Resource');
@@ -42,8 +47,6 @@ class v5Cest
 
     public function bootstrapCodecept5WithNamespace(CliGuy $I)
     {
-        $I->amInPath('tests/data/sandbox');
-        $I->cleanDir('.');
         $I->executeCommand('bootstrap --namespace Codecept5');
         $I->executeCommand('g:suite Api');
         $I->executeCommand('g:feature Acceptance UserStory');

--- a/tests/cli/v5Cest.php
+++ b/tests/cli/v5Cest.php
@@ -23,25 +23,25 @@ final class v5Cest
         $I->openFile('codeception.yml');
         $I->seeInThisFile('namespace: Tests');
 
-        $I->openFile('tests/TestSupport/Helper/Api.php');
-        $I->seeInThisFile('namespace Tests\\TestSupport\\Helper');
+        $I->openFile('tests/Support/Helper/Api.php');
+        $I->seeInThisFile('namespace Tests\\Support\\Helper');
         $I->seeInThisFile('class Api');
 
-        $I->openFile('tests/TestSupport/AcceptanceTester.php');
-        $I->seeInThisFile('namespace Tests\\TestSupport');
+        $I->openFile('tests/Support/AcceptanceTester.php');
+        $I->seeInThisFile('namespace Tests\\Support');
         $I->seeInThisFile('use _generated\AcceptanceTesterActions');
 
-        $I->openFile('tests/TestSupport/FunctionalTester.php');
-        $I->seeInThisFile('namespace Tests\\TestSupport');
+        $I->openFile('tests/Support/FunctionalTester.php');
+        $I->seeInThisFile('namespace Tests\\Support');
 
         $I->openFile('tests/Api/ResourceCest.php');
         $I->seeInThisFile('namespace Tests\\Api;');
-        $I->seeInThisFile('use \Tests\TestSupport\ApiTester;');
+        $I->seeInThisFile('use \Tests\Support\ApiTester;');
         $I->seeInThisFile('public function tryToTest(ApiTester $I)');
 
         $I->openFile('tests/Api/ResourceTest.php');
         $I->seeInThisFile('namespace Tests\\Api;');
-        $I->seeInThisFile('use \Tests\TestSupport\ApiTester;');
+        $I->seeInThisFile('use \Tests\Support\ApiTester;');
         $I->seeInThisFile('protected ApiTester $tester;');
     }
 
@@ -59,25 +59,25 @@ final class v5Cest
         $I->openFile('codeception.yml');
         $I->seeInThisFile('namespace: Codecept5');
 
-        $I->openFile('tests/TestSupport/Helper/Api.php');
-        $I->seeInThisFile('namespace Codecept5\\TestSupport\\Helper');
+        $I->openFile('tests/Support/Helper/Api.php');
+        $I->seeInThisFile('namespace Codecept5\\Support\\Helper');
         $I->seeInThisFile('class Api');
 
-        $I->openFile('tests/TestSupport/AcceptanceTester.php');
-        $I->seeInThisFile('namespace Codecept5\\TestSupport');
+        $I->openFile('tests/Support/AcceptanceTester.php');
+        $I->seeInThisFile('namespace Codecept5\\Support');
         $I->seeInThisFile('use _generated\AcceptanceTesterActions');
 
-        $I->openFile('tests/TestSupport/FunctionalTester.php');
-        $I->seeInThisFile('namespace Codecept5\\TestSupport');
+        $I->openFile('tests/Support/FunctionalTester.php');
+        $I->seeInThisFile('namespace Codecept5\\Support');
 
         $I->openFile('tests/Api/ResourceCest.php');
         $I->seeInThisFile('namespace Codecept5\\Api;');
-        $I->seeInThisFile('use \Codecept5\TestSupport\ApiTester;');
+        $I->seeInThisFile('use \Codecept5\Support\ApiTester;');
         $I->seeInThisFile('public function tryToTest(ApiTester $I)');
 
         $I->openFile('tests/Api/ResourceTest.php');
         $I->seeInThisFile('namespace Codecept5\\Api;');
-        $I->seeInThisFile('use \Codecept5\TestSupport\ApiTester;');
+        $I->seeInThisFile('use \Codecept5\Support\ApiTester;');
         $I->seeInThisFile('protected ApiTester $tester;');
     }
 }

--- a/tests/unit/Codeception/Command/GenerateCestTest.php
+++ b/tests/unit/Codeception/Command/GenerateCestTest.php
@@ -36,8 +36,8 @@ class GenerateCestTest extends BaseCommandRunner
     {
         $this->config['namespace'] = 'Shire';
         $this->execute(['suite' => 'shire', 'class' => 'HallUnderTheHill']);
-        $this->assertStringContainsString('namespace Shire;', $this->content);
-        $this->assertStringContainsString('use Shire\HobbitGuy;', $this->content);
+        $this->assertStringContainsString('namespace Shire\Unit;', $this->content);
+        $this->assertStringContainsString('use \Shire\HobbitGuy;', $this->content);
         $this->assertStringContainsString('class HallUnderTheHillCest', $this->content);
     }
 
@@ -60,13 +60,13 @@ class GenerateCestTest extends BaseCommandRunner
         $this->assertIsValidPhp($this->content);
     }
 
-    public function testGenerateWithGuyNamespaced()
+    public function testGenerateWithActorNamespaced()
     {
         $this->config['namespace'] = 'MiddleEarth';
         $this->execute(['suite' => 'shire', 'class' => 'HallUnderTheHillCest']);
         $this->assertSame($this->filename, 'tests/shire/HallUnderTheHillCest.php');
-        $this->assertStringContainsString('namespace MiddleEarth;', $this->content);
-        $this->assertStringContainsString('use MiddleEarth\\HobbitGuy;', $this->content);
+        $this->assertStringContainsString('namespace MiddleEarth\Unit;', $this->content);
+        $this->assertStringContainsString('use \MiddleEarth\\HobbitGuy;', $this->content);
         $this->assertStringContainsString('public function tryToTest(HobbitGuy $I)', $this->content);
         $this->assertIsValidPhp($this->content);
     }
@@ -75,21 +75,20 @@ class GenerateCestTest extends BaseCommandRunner
     {
         $this->execute(['suite' => 'shire', 'class' => 'MiddleEarth\HallUnderTheHillCest']);
         $this->assertSame('tests/shire/MiddleEarth/HallUnderTheHillCest.php', $this->filename);
-        $this->assertStringContainsString('namespace MiddleEarth;', $this->content);
+        $this->assertStringContainsString('namespace Unit\MiddleEarth;', $this->content);
         $this->assertStringContainsString('class HallUnderTheHillCest', $this->content);
         $this->assertStringContainsString('Test was created in tests/shire/MiddleEarth/HallUnderTheHillCest.php', $this->output);
     }
 
-    public function testGenerateWithSuiteNamespace()
-	{
-        $this->config['suite_namespace'] = 'MiddleEarth\\Bosses\\';
+    public function testGenerateWithSupportNamespaced()
+    {
         $this->config['namespace'] = 'MiddleEarth';
-        $this->config['actor'] = 'HobbitGuy';
+        $this->config['support_namespace'] = 'Gondor';
         $this->execute(['suite' => 'shire', 'class' => 'HallUnderTheHillCest']);
         $this->assertSame($this->filename, 'tests/shire/HallUnderTheHillCest.php');
-        $this->assertStringContainsString('namespace MiddleEarth\\Bosses;', $this->content);
-        $this->assertStringContainsString('use MiddleEarth\\HobbitGuy', $this->content);
+        $this->assertStringContainsString('namespace MiddleEarth\Unit;', $this->content);
+        $this->assertStringContainsString('use \MiddleEarth\\Gondor\\HobbitGuy;', $this->content);
         $this->assertStringContainsString('public function tryToTest(HobbitGuy $I)', $this->content);
         $this->assertIsValidPhp($this->content);
-	}
+    }
 }

--- a/tests/unit/Codeception/Command/GeneratePageObjectTest.php
+++ b/tests/unit/Codeception/Command/GeneratePageObjectTest.php
@@ -23,7 +23,6 @@ class GeneratePageObjectTest extends BaseCommandRunner
         $this->execute(['suite' => 'Login'], false);
         $this->assertSame(\Codeception\Configuration::supportDir().'Page/Login.php', $this->filename);
         $this->assertStringContainsString('class Login', $this->content);
-        $this->assertStringContainsString('public static', $this->content);
         $this->assertStringNotContainsString('public function __construct', $this->content);
         $this->assertIsValidPhp($this->content);
     }
@@ -36,7 +35,6 @@ class GeneratePageObjectTest extends BaseCommandRunner
         $this->assertSame(\Codeception\Configuration::supportDir().'Page/Login.php', $this->filename);
         $this->assertStringContainsString('namespace MiddleEarth\Page;', $this->content);
         $this->assertStringContainsString('class Login', $this->content);
-        $this->assertStringContainsString('public static', $this->content);
         $this->assertIsValidPhp($this->content);
     }
 

--- a/tests/unit/Codeception/Command/GenerateSuiteTest.php
+++ b/tests/unit/Codeception/Command/GenerateSuiteTest.php
@@ -25,36 +25,23 @@ class GenerateSuiteTest extends BaseCommandRunner
     {
         $this->execute(['suite' => 'shire', 'actor' => 'Hobbit'], false);
 
-        $configFile = $this->log[1];
+        $configFile = $this->log[0];
 
-        $this->assertSame(\Codeception\Configuration::projectDir().'tests/shire.suite.yml', $configFile['filename']);
+        $this->assertSame(\Codeception\Configuration::projectDir().'tests/Shire.suite.yml', $configFile['filename']);
         $conf = \Symfony\Component\Yaml\Yaml::parse($configFile['content']);
         $this->assertSame('Hobbit', $conf['actor']);
-        $this->assertContains('\Helper\Shire', $conf['modules']['enabled']);
         $this->assertStringContainsString('Suite shire generated', $this->output);
-
-        $actor = $this->log[2];
+        $actor = $this->log[1];
         $this->assertSame(\Codeception\Configuration::supportDir().'Hobbit.php', $actor['filename']);
         $this->assertStringContainsString('class Hobbit extends \Codeception\Actor', $actor['content']);
-
-
-        $helper = $this->log[0];
-        $this->assertSame(\Codeception\Configuration::supportDir().'Helper/Shire.php', $helper['filename']);
-        $this->assertStringContainsString('namespace Helper;', $helper['content']);
-        $this->assertStringContainsString('class Shire extends \Codeception\Module', $helper['content']);
     }
 
     public function testGuyWithSuffix()
     {
         $this->execute(['suite' => 'shire', 'actor' => 'HobbitTester'], false);
 
-        $configFile = $this->log[1];
+        $configFile = $this->log[0];
         $conf = \Symfony\Component\Yaml\Yaml::parse($configFile['content']);
         $this->assertSame('HobbitTester', $conf['actor']);
-        $this->assertContains('\Helper\Shire', $conf['modules']['enabled']);
-
-        $helper = $this->log[0];
-        $this->assertSame(\Codeception\Configuration::supportDir().'Helper/Shire.php', $helper['filename']);
-        $this->assertStringContainsString('class Shire extends \Codeception\Module', $helper['content']);
     }
 }

--- a/tests/unit/Codeception/Command/GenerateSuiteTest.php
+++ b/tests/unit/Codeception/Command/GenerateSuiteTest.php
@@ -30,7 +30,7 @@ class GenerateSuiteTest extends BaseCommandRunner
         $this->assertSame(\Codeception\Configuration::projectDir().'tests/Shire.suite.yml', $configFile['filename']);
         $conf = \Symfony\Component\Yaml\Yaml::parse($configFile['content']);
         $this->assertSame('Hobbit', $conf['actor']);
-        $this->assertStringContainsString('Suite shire generated', $this->output);
+        $this->assertStringContainsString('Suite Shire generated', $this->output);
         $actor = $this->log[1];
         $this->assertSame(\Codeception\Configuration::supportDir().'Hobbit.php', $actor['filename']);
         $this->assertStringContainsString('class Hobbit extends \Codeception\Actor', $actor['content']);

--- a/tests/unit/Codeception/Command/GenerateTestTest.php
+++ b/tests/unit/Codeception/Command/GenerateTestTest.php
@@ -23,7 +23,6 @@ class GenerateTestTest extends BaseCommandRunner
         $this->assertStringContainsString('class HallUnderTheHillTest extends \Codeception\Test\Unit', $this->content);
         $this->assertStringContainsString('Test was created in tests/shire/HallUnderTheHillTest.php', $this->output);
         $this->assertStringContainsString('protected function _before()', $this->content);
-        $this->assertStringContainsString('protected function _after()', $this->content);
     }
 
     public function testCreateWithSuffix()
@@ -37,7 +36,7 @@ class GenerateTestTest extends BaseCommandRunner
     {
         $this->execute(['suite' => 'shire', 'class' => 'MiddleEarth\HallUnderTheHillTest']);
         $this->assertSame('tests/shire/MiddleEarth/HallUnderTheHillTest.php', $this->filename);
-        $this->assertStringContainsString('namespace MiddleEarth;', $this->content);
+        $this->assertStringContainsString('namespace Unit\MiddleEarth;', $this->content);
         $this->assertStringContainsString('class HallUnderTheHillTest extends \Codeception\Test\Unit', $this->content);
         $this->assertStringContainsString('Test was created in tests/shire/MiddleEarth/HallUnderTheHillTest.php', $this->output);
     }
@@ -47,9 +46,19 @@ class GenerateTestTest extends BaseCommandRunner
         $this->execute(['suite' => 'shire', 'class' => 'HallUnderTheHillTest.php']);
         $this->assertSame('tests/shire/HallUnderTheHillTest.php', $this->filename);
         $this->assertStringContainsString('class HallUnderTheHillTest extends \Codeception\Test\Unit', $this->content);
-        $this->assertStringContainsString('protected $tester;', $this->content);
-        $this->assertStringContainsString('@var \HobbitGuy', $this->content);
+        $this->assertStringContainsString('protected HobbitGuy $tester;', $this->content);
         $this->assertStringContainsString('Test was created in tests/shire/HallUnderTheHillTest.php', $this->output);
+    }
+
+    public function testGenerateWithSupportNamespaced()
+    {
+        $this->config['namespace'] = 'MiddleEarth';
+        $this->config['support_namespace'] = 'Gondor';
+        $this->execute(array('suite' => 'shire', 'class' => 'HallUnderTheHill'));
+        $this->assertEquals($this->filename, 'tests/shire/HallUnderTheHillTest.php');
+        $this->assertStringContainsString('namespace MiddleEarth\Unit;', $this->content);
+        $this->assertStringContainsString('use \MiddleEarth\\Gondor\\HobbitGuy;', $this->content);
+        $this->assertIsValidPhp($this->content);
     }
 
     public function testValidPHP()


### PR DESCRIPTION
Please take a look on this PR and tell what you think of it as it introduces some new defaults to Codeception

The idea is to make all classes in Codeception to be PSR-compatible

1. all new installations have default namespace: `Tests`
2. all support files are stored in `TestSupport` directory under `Tests\TestSupport` namespace
3. all suite names are uppercases like `Acceptance`
4. all tests in suites contain suite name in a namespace like `Tests\Acceptance`
5. directory structure was changed:

```
tests/
  _output => yeah we got used to this folder so much, it doesn't need to belong to namespace
  Acceptance
  Functional
  TestSupport/
    Data/ => ok, let's  put all data things here, because Data can also contain classes
    Generated/ => we still need generated classes
    Helper/
  Unit/
```
7. Init templates updated correspondingly
8. These changes are not affecting any of the current installations

Additional changes:

* generate:test produces PHP 7.4 ready code with typed properties:

```php
<?php

namespace Tests\Unit;

use Tests\TestSupport\UnitTester;

class UserTest extends Codeception\Test\Unit
{
    protected UnitTester $tester;  

    //...
```

* bootstrap and init template does not create Helper files
* Upgrade4 init template was renamed to `Dependencies`, it is used to install all required modules for existing project:

```
./vendor/bin/codecept init dependencies
```
* Added new CLI tests v5Cest which test generators for new v5 project
