### PR TITLE
Add line break between opening tag and namespace in generated files

### DIFF
--- a/src/Codeception/Lib/Generator/Cest.php
+++ b/src/Codeception/Lib/Generator/Cest.php
@@ -11,8 +11,8 @@ class Cest
     use Namespaces;
 
     protected $template = <<<EOF
-<?php {{namespace}}
-
+<?php
+{{namespace}}
 class {{name}}Cest
 {
     public function _before({{actor}} \$I)

--- a/src/Codeception/Lib/Generator/Test.php
+++ b/src/Codeception/Lib/Generator/Test.php
@@ -11,7 +11,8 @@ class Test
     use Shared\Classname;
 
     protected $template = <<<EOF
-<?php {{namespace}}
+<?php
+{{namespace}}
 class {{name}}Test extends \Codeception\Test\Unit
 {
 {{tester}}


### PR DESCRIPTION
Test and Cest generators generate namespace on the same line as opening tag.
e.g.
```php
<?php namespace foo;
```

This change changes it to
```php
<?php
namespace foo;
```