### PR TITLE
[5.0] Update code standards in Commands

### DIFF
--- a/src/Codeception/Command/Bootstrap.php
+++ b/src/Codeception/Command/Bootstrap.php
@@ -44,12 +44,12 @@ class Bootstrap extends Command
         );
     }
 
-    public function getDescription()
+    public function getDescription(): string
     {
         return "Creates default test suites and generates all required files";
     }
 
-    public function execute(InputInterface $input, OutputInterface $output)
+    public function execute(InputInterface $input, OutputInterface $output): int
     {
         $bootstrap = new BootstrapTemplate($input, $output);
         if ($input->getArgument('path')) {

--- a/src/Codeception/Command/Bootstrap.php
+++ b/src/Codeception/Command/Bootstrap.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Codeception\Command;
 
 use Codeception\Template\Bootstrap as BootstrapTemplate;

--- a/src/Codeception/Command/Bootstrap.php
+++ b/src/Codeception/Command/Bootstrap.php
@@ -26,8 +26,7 @@ use Symfony\Component\Console\Output\OutputInterface;
  */
 class Bootstrap extends Command
 {
-
-    protected function configure()
+    protected function configure(): void
     {
         $this->setDefinition(
             [

--- a/src/Codeception/Command/Build.php
+++ b/src/Codeception/Command/Build.php
@@ -25,6 +25,9 @@ class Build extends Command
     use Shared\Config;
     use Shared\FileSystem;
 
+    /**
+     * @var string
+     */
     protected $inheritedMethodTemplate = ' * @method void %s(%s)';
 
     /**
@@ -78,7 +81,7 @@ class Build extends Command
         return $this->createFile($file, $content, true);
     }
 
-    private function buildSuiteActors()
+    private function buildSuiteActors(): void
     {
         $suites = $this->getSuites();
         if (!empty($suites)) {
@@ -98,7 +101,7 @@ class Build extends Command
         }
     }
 
-    protected function buildActorsForConfig($configFile = null)
+    protected function buildActorsForConfig($configFile = null): void
     {
         $config = $this->getGlobalConfig($configFile);
 

--- a/src/Codeception/Command/Build.php
+++ b/src/Codeception/Command/Build.php
@@ -22,8 +22,8 @@ use function implode;
  */
 class Build extends Command
 {
-    use Shared\Config;
-    use Shared\FileSystem;
+    use Shared\ConfigTrait;
+    use Shared\FileSystemTrait;
 
     /**
      * @var string

--- a/src/Codeception/Command/Build.php
+++ b/src/Codeception/Command/Build.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Codeception\Command;
 
 use Codeception\Configuration;

--- a/src/Codeception/Command/Build.php
+++ b/src/Codeception/Command/Build.php
@@ -31,27 +31,27 @@ class Build extends Command
      */
     protected $output;
 
-    public function getDescription()
+    public function getDescription(): string
     {
         return 'Generates base classes for all suites';
     }
 
 
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $this->output = $output;
         $this->buildActorsForConfig();
         return 0;
     }
-    
-    private function buildActor(array $settings)
+
+    private function buildActor(array $settings): bool
     {
         $actorGenerator = new ActorGenerator($settings);
         $this->output->writeln(
             '<info>' . Configuration::config()['namespace'] . '\\' . $actorGenerator->getActorName()
             . "</info> includes modules: " . implode(', ', $actorGenerator->getModules())
         );
-        
+
         $content = $actorGenerator->produce();
 
         $file = $this->createDirectoryFor(
@@ -61,8 +61,8 @@ class Build extends Command
         $file .=  '.php';
         return $this->createFile($file, $content);
     }
-    
-    private function buildActions(array $settings)
+
+    private function buildActions(array $settings): bool
     {
         $actionsGenerator = new ActionsGenerator($settings);
         $content = $actionsGenerator->produce();
@@ -90,17 +90,17 @@ class Build extends Command
             }
             $this->buildActions($settings);
             $actorBuilt = $this->buildActor($settings);
-            
+
             if ($actorBuilt) {
                 $this->output->writeln("{$settings['actor']}.php created.");
             }
         }
     }
-    
+
     protected function buildActorsForConfig($configFile = null)
     {
         $config = $this->getGlobalConfig($configFile);
-        
+
         $dir = Configuration::projectDir();
         $this->buildSuiteActors();
 

--- a/src/Codeception/Command/Build.php
+++ b/src/Codeception/Command/Build.php
@@ -10,6 +10,7 @@ use Codeception\Lib\Generator\Actor as ActorGenerator;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
+use function implode;
 
 /**
  * Generates Actor classes (initially Guy classes) from suite configs.

--- a/src/Codeception/Command/Clean.php
+++ b/src/Codeception/Command/Clean.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Codeception\Command;
 
 use Codeception\Configuration;

--- a/src/Codeception/Command/Clean.php
+++ b/src/Codeception/Command/Clean.php
@@ -20,12 +20,12 @@ class Clean extends Command
 {
     use Shared\Config;
 
-    public function getDescription()
+    public function getDescription(): string
     {
         return 'Recursively cleans log and generated code';
     }
 
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $projectDir = Configuration::projectDir();
         $this->cleanProjectsRecursively($output, $projectDir);

--- a/src/Codeception/Command/Clean.php
+++ b/src/Codeception/Command/Clean.php
@@ -33,7 +33,7 @@ class Clean extends Command
         return 0;
     }
 
-    private function cleanProjectsRecursively(OutputInterface $output, $projectDir)
+    private function cleanProjectsRecursively(OutputInterface $output, $projectDir): void
     {
         $logDir = Configuration::logDir();
         $output->writeln("<info>Cleaning up output " . $logDir . "...</info>");

--- a/src/Codeception/Command/Clean.php
+++ b/src/Codeception/Command/Clean.php
@@ -18,7 +18,7 @@ use Symfony\Component\Console\Output\OutputInterface;
  */
 class Clean extends Command
 {
-    use Shared\Config;
+    use Shared\ConfigTrait;
 
     public function getDescription(): string
     {

--- a/src/Codeception/Command/Completion.php
+++ b/src/Codeception/Command/Completion.php
@@ -11,9 +11,9 @@ if (!class_exists('Stecman\Component\Symfony\Console\BashCompletion\Completion')
 
 use Codeception\Configuration;
 use Stecman\Component\Symfony\Console\BashCompletion\Completion as ConsoleCompletion;
+use Stecman\Component\Symfony\Console\BashCompletion\Completion\ShellPathCompletion;
 use Stecman\Component\Symfony\Console\BashCompletion\CompletionCommand;
 use Stecman\Component\Symfony\Console\BashCompletion\CompletionHandler;
-use Stecman\Component\Symfony\Console\BashCompletion\Completion\ShellPathCompletion;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -62,7 +62,7 @@ class Completion extends CompletionCommand
         ]);
     }
 
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         if ($input->getOption('generate-hook') && $input->getOption('use-vendor-bin')) {
             global $argv;

--- a/src/Codeception/Command/Completion.php
+++ b/src/Codeception/Command/Completion.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Codeception\Command;
 
 if (!class_exists('Stecman\Component\Symfony\Console\BashCompletion\Completion')) {

--- a/src/Codeception/Command/CompletionFallback.php
+++ b/src/Codeception/Command/CompletionFallback.php
@@ -13,21 +13,22 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class CompletionFallback extends Command
 {
-    protected function configure()
+    /**
+     * @var string
+     */
+    protected static $defaultName = '_completion';
+
+    protected function configure(): void
     {
         $this
-            ->setName('_completion')
             ->setDescription('BASH completion hook.')
+            ->setHidden(true) // Hide from listing
             ->setHelp(<<<END
 To enable BASH completion, install optional stecman/symfony-console-completion first:
 
     <comment>composer require stecman/symfony-console-completion</comment>
 
-END
-            );
-
-        // Hide this command from listing
-        $this->setHidden(true);
+END);
     }
     protected function execute(InputInterface $input, OutputInterface $output): int
     {

--- a/src/Codeception/Command/CompletionFallback.php
+++ b/src/Codeception/Command/CompletionFallback.php
@@ -4,15 +4,11 @@ declare(strict_types=1);
 
 namespace Codeception\Command;
 
-use Codeception\Configuration;
-use Stecman\Component\Symfony\Console\BashCompletion\Completion as ConsoleCompletion;
+use Stecman\Component\Symfony\Console\BashCompletion\Completion\ShellPathCompletion;
 use Stecman\Component\Symfony\Console\BashCompletion\CompletionCommand;
 use Stecman\Component\Symfony\Console\BashCompletion\CompletionHandler;
-use Stecman\Component\Symfony\Console\BashCompletion\Completion\ShellPathCompletion;
 use Symfony\Component\Console\Command\Command;
-use Symfony\Component\Console\Input\InputDefinition;
 use Symfony\Component\Console\Input\InputInterface;
-use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
 class CompletionFallback extends Command
@@ -33,7 +29,7 @@ END
         // Hide this command from listing
         $this->setHidden(true);
     }
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $output->writeln("Install optional <comment>stecman/symfony-console-completion</comment>");
         return 0;

--- a/src/Codeception/Command/CompletionFallback.php
+++ b/src/Codeception/Command/CompletionFallback.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Codeception\Command;
 
 use Codeception\Configuration;

--- a/src/Codeception/Command/ConfigValidate.php
+++ b/src/Codeception/Command/ConfigValidate.php
@@ -41,8 +41,8 @@ use function print_r;
  */
 class ConfigValidate extends Command
 {
-    use Shared\Config;
-    use Shared\Style;
+    use Shared\ConfigTrait;
+    use Shared\StyleTrait;
 
     protected function configure(): void
     {

--- a/src/Codeception/Command/ConfigValidate.php
+++ b/src/Codeception/Command/ConfigValidate.php
@@ -44,7 +44,7 @@ class ConfigValidate extends Command
     use Shared\Config;
     use Shared\Style;
 
-    protected function configure()
+    protected function configure(): void
     {
         $this->setDefinition(
             [
@@ -60,7 +60,6 @@ class ConfigValidate extends Command
     {
         return 'Validates and prints config to screen';
     }
-
 
     public function execute(InputInterface $input, OutputInterface $output): int
     {
@@ -109,7 +108,7 @@ class ConfigValidate extends Command
         return 0;
     }
 
-    protected function formatOutput($config)
+    protected function formatOutput($config): ?string
     {
         $output = print_r($config, true);
         return preg_replace('~\[(.*?)\] =>~', "<fg=yellow>$1</fg=yellow> =>", $output);

--- a/src/Codeception/Command/ConfigValidate.php
+++ b/src/Codeception/Command/ConfigValidate.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Codeception\Command;
 
 use Codeception\Configuration;

--- a/src/Codeception/Command/ConfigValidate.php
+++ b/src/Codeception/Command/ConfigValidate.php
@@ -10,6 +10,13 @@ use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
+use function codecept_data_dir;
+use function codecept_output_dir;
+use function codecept_root_dir;
+use function count;
+use function implode;
+use function preg_replace;
+use function print_r;
 
 /**
  * Validates and prints Codeception config.

--- a/src/Codeception/Command/ConfigValidate.php
+++ b/src/Codeception/Command/ConfigValidate.php
@@ -49,13 +49,13 @@ class ConfigValidate extends Command
         parent::configure();
     }
 
-    public function getDescription()
+    public function getDescription(): string
     {
         return 'Validates and prints config to screen';
     }
 
 
-    public function execute(InputInterface $input, OutputInterface $output)
+    public function execute(InputInterface $input, OutputInterface $output): int
     {
         $this->addStyles($output);
 

--- a/src/Codeception/Command/Console.php
+++ b/src/Codeception/Command/Console.php
@@ -86,10 +86,11 @@ class Console extends Command
         Debug::setOutput(new Output($options));
 
         $this->codecept = new Codecept($options);
-        $dispatcher = $this->codecept->getDispatcher();
+        $eventDispatcher = $this->codecept->getDispatcher();
 
-        $suiteManager = new SuiteManager($dispatcher, $suiteName, $settings);
+        $suiteManager = new SuiteManager($eventDispatcher, $suiteName, $settings);
         $suiteManager->initialize();
+
         $this->suite = $suiteManager->getSuite();
         $moduleContainer = $suiteManager->getModuleContainer();
 
@@ -97,7 +98,7 @@ class Console extends Command
 
         $this->test = new Cept(null, null);
         $this->test->getMetadata()->setServices([
-           'dispatcher' => $dispatcher,
+           'dispatcher' => $eventDispatcher,
            'modules' =>  $moduleContainer
         ]);
 
@@ -117,9 +118,9 @@ class Console extends Command
         $output->writeln("<info>Try Codeception commands without writing a test</info>");
 
         $suiteEvent = new SuiteEvent($this->suite, $this->codecept->getResult(), $settings);
-        $dispatcher->dispatch($suiteEvent, Events::SUITE_INIT);
-        $dispatcher->dispatch(new TestEvent($this->test), Events::TEST_PARSED);
-        $dispatcher->dispatch(new TestEvent($this->test), Events::TEST_BEFORE);
+        $eventDispatcher->dispatch($suiteEvent, Events::SUITE_INIT);
+        $eventDispatcher->dispatch(new TestEvent($this->test), Events::TEST_PARSED);
+        $eventDispatcher->dispatch(new TestEvent($this->test), Events::TEST_BEFORE);
 
         if (file_exists($settings['bootstrap'])) {
             require $settings['bootstrap'];
@@ -127,8 +128,8 @@ class Console extends Command
 
         $I->pause();
 
-        $dispatcher->dispatch(new TestEvent($this->test), Events::TEST_AFTER);
-        $dispatcher->dispatch(new SuiteEvent($this->suite), Events::SUITE_AFTER);
+        $eventDispatcher->dispatch(new TestEvent($this->test), Events::TEST_AFTER);
+        $eventDispatcher->dispatch(new SuiteEvent($this->suite), Events::SUITE_AFTER);
         $output->writeln("<info>Bye-bye!</info>");
         return 0;
     }

--- a/src/Codeception/Command/Console.php
+++ b/src/Codeception/Command/Console.php
@@ -20,6 +20,10 @@ use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
+use function array_keys;
+use function file_exists;
+use function function_exists;
+use function pcntl_signal;
 
 /**
  * Try to execute test commands in run-time. You may try commands before writing the test.

--- a/src/Codeception/Command/Console.php
+++ b/src/Codeception/Command/Console.php
@@ -16,12 +16,10 @@ use Codeception\SuiteManager;
 use Codeception\Test\Cept;
 use Codeception\Util\Debug;
 use Symfony\Component\Console\Command\Command;
-use Symfony\Component\Console\Helper\QuestionHelper;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
-use Symfony\Component\Console\Question\Question;
 
 /**
  * Try to execute test commands in run-time. You may try commands before writing the test.
@@ -46,12 +44,12 @@ class Console extends Command
         parent::configure();
     }
 
-    public function getDescription()
+    public function getDescription(): string
     {
         return 'Launches interactive test console';
     }
 
-    public function execute(InputInterface $input, OutputInterface $output)
+    public function execute(InputInterface $input, OutputInterface $output): int
     {
         $suiteName = $input->getArgument('suite');
         $this->output = $output;

--- a/src/Codeception/Command/Console.php
+++ b/src/Codeception/Command/Console.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Codeception\Command;
 
 use Codeception\Codecept;

--- a/src/Codeception/Command/Console.php
+++ b/src/Codeception/Command/Console.php
@@ -12,6 +12,7 @@ use Codeception\Events;
 use Codeception\Exception\ConfigurationException;
 use Codeception\Lib\Console\Output;
 use Codeception\Scenario;
+use Codeception\Suite;
 use Codeception\SuiteManager;
 use Codeception\Test\Cept;
 use Codeception\Util\Debug;
@@ -32,13 +33,28 @@ use function pcntl_signal;
  */
 class Console extends Command
 {
+    /**
+     * @var Cept|null
+     */
     protected $test;
+    /**
+     * @var Codecept|null
+     */
     protected $codecept;
+    /**
+     * @var Suite|null
+     */
     protected $suite;
+    /**
+     * @var OutputInterface|null
+     */
     protected $output;
+    /**
+     * @var int[]|string[]
+     */
     protected $actions = [];
 
-    protected function configure()
+    protected function configure(): void
     {
         $this->setDefinition([
             new InputArgument('suite', InputArgument::REQUIRED, 'suite to be executed'),
@@ -117,7 +133,7 @@ class Console extends Command
         return 0;
     }
 
-    protected function listenToSignals()
+    protected function listenToSignals(): void
     {
         if (function_exists('pcntl_signal')) {
             declare (ticks = 1);

--- a/src/Codeception/Command/Console.php
+++ b/src/Codeception/Command/Console.php
@@ -50,7 +50,7 @@ class Console extends Command
      */
     protected $output;
     /**
-     * @var int[]|string[]
+     * @var string[]
      */
     protected $actions = [];
 

--- a/src/Codeception/Command/DryRun.php
+++ b/src/Codeception/Command/DryRun.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Codeception\Command;
 
 use Codeception\Configuration;

--- a/src/Codeception/Command/DryRun.php
+++ b/src/Codeception/Command/DryRun.php
@@ -14,6 +14,9 @@ use Codeception\SuiteManager;
 use Codeception\Test\Interfaces\ScenarioDriven;
 use Codeception\Test\Test;
 use Codeception\Util\Maybe;
+use Exception;
+use InvalidArgumentException;
+use PHPUnit\Framework\TestSuite\DataProvider;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
@@ -86,7 +89,7 @@ class DryRun extends Command
         $dispatcher->dispatch(new SuiteEvent($suiteManager->getSuite(), null, $settings), Events::SUITE_BEFORE);
 
         foreach ($tests as $test) {
-            if ($test instanceof \PHPUnit\Framework\TestSuite\DataProvider) {
+            if ($test instanceof DataProvider) {
                 foreach ($test as $t) {
                     if ($t instanceof Test) {
                         $this->dryRunTest($output, $dispatcher, $t);
@@ -107,7 +110,7 @@ class DryRun extends Command
         $filename = str_replace(['//', '\/', '\\'], '/', $filename);
         $res = preg_match("~^$tests_path/(.*?)/(.*)$~", $filename, $matches);
         if (!$res) {
-            throw new \InvalidArgumentException("Test file can't be matched");
+            throw new InvalidArgumentException("Test file can't be matched");
         }
 
         return $matches;
@@ -124,7 +127,7 @@ class DryRun extends Command
         $dispatcher->dispatch(new TestEvent($test), Events::TEST_BEFORE);
         try {
             $test->test();
-        } catch (\Exception $e) {
+        } catch (Exception $e) {
         }
         $dispatcher->dispatch(new TestEvent($test), Events::TEST_AFTER);
         $dispatcher->dispatch(new TestEvent($test), Events::TEST_END);

--- a/src/Codeception/Command/DryRun.php
+++ b/src/Codeception/Command/DryRun.php
@@ -38,8 +38,8 @@ use function strpos;
  */
 class DryRun extends Command
 {
-    use Shared\Config;
-    use Shared\Style;
+    use Shared\ConfigTrait;
+    use Shared\StyleTrait;
 
     protected function configure(): void
     {

--- a/src/Codeception/Command/DryRun.php
+++ b/src/Codeception/Command/DryRun.php
@@ -41,7 +41,7 @@ class DryRun extends Command
     use Shared\Config;
     use Shared\Style;
 
-    protected function configure()
+    protected function configure(): void
     {
         $this->setDefinition(
             [

--- a/src/Codeception/Command/DryRun.php
+++ b/src/Codeception/Command/DryRun.php
@@ -17,7 +17,6 @@ use Codeception\Util\Maybe;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
-use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 
@@ -46,12 +45,12 @@ class DryRun extends Command
         parent::configure();
     }
 
-    public function getDescription()
+    public function getDescription(): string
     {
         return 'Prints step-by-step scenario-driven test or a feature';
     }
 
-    public function execute(InputInterface $input, OutputInterface $output)
+    public function execute(InputInterface $input, OutputInterface $output): int
     {
         $this->addStyles($output);
         $suite = $input->getArgument('suite');

--- a/src/Codeception/Command/DryRun.php
+++ b/src/Codeception/Command/DryRun.php
@@ -22,6 +22,10 @@ use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\EventDispatcher\EventDispatcher;
+use function ini_set;
+use function preg_match;
+use function str_replace;
+use function strpos;
 
 /**
  * Shows step by step execution process for scenario driven tests without actually running them.

--- a/src/Codeception/Command/GenerateCept.php
+++ b/src/Codeception/Command/GenerateCept.php
@@ -21,8 +21,8 @@ use function rtrim;
  */
 class GenerateCept extends Command
 {
-    use Shared\FileSystem;
-    use Shared\Config;
+    use Shared\FileSystemTrait;
+    use Shared\ConfigTrait;
 
     protected function configure(): void
     {

--- a/src/Codeception/Command/GenerateCept.php
+++ b/src/Codeception/Command/GenerateCept.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Codeception\Command;
 
 use Codeception\Lib\Generator\Cept;

--- a/src/Codeception/Command/GenerateCept.php
+++ b/src/Codeception/Command/GenerateCept.php
@@ -31,12 +31,12 @@ class GenerateCept extends Command
         ]);
     }
 
-    public function getDescription()
+    public function getDescription(): string
     {
         return 'Generates empty Cept file in suite';
     }
 
-    public function execute(InputInterface $input, OutputInterface $output)
+    public function execute(InputInterface $input, OutputInterface $output): int
     {
         $suite = $input->getArgument('suite');
         $filename = $input->getArgument('test');

--- a/src/Codeception/Command/GenerateCept.php
+++ b/src/Codeception/Command/GenerateCept.php
@@ -9,6 +9,7 @@ use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
+use function rtrim;
 
 /**
  * Generates Cept (scenario-driven test) file:

--- a/src/Codeception/Command/GenerateCept.php
+++ b/src/Codeception/Command/GenerateCept.php
@@ -46,15 +46,15 @@ class GenerateCept extends Command
         $this->createDirectoryFor($config['path'], $filename);
 
         $filename = $this->completeSuffix($filename, 'Cept');
-        $gen = new Cept($config);
+        $cept = new Cept($config);
 
-        $full_path = rtrim($config['path'], DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR . $filename;
-        $res = $this->createFile($full_path, $gen->produce());
+        $fullPath = rtrim($config['path'], DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR . $filename;
+        $res = $this->createFile($fullPath, $cept->produce());
         if (!$res) {
             $output->writeln("<error>Test $filename already exists</error>");
             return 1;
         }
-        $output->writeln("<info>Test was created in $full_path</info>");
+        $output->writeln("<info>Test was created in $fullPath</info>");
         return 0;
     }
 }

--- a/src/Codeception/Command/GenerateCept.php
+++ b/src/Codeception/Command/GenerateCept.php
@@ -24,7 +24,7 @@ class GenerateCept extends Command
     use Shared\FileSystem;
     use Shared\Config;
 
-    protected function configure()
+    protected function configure(): void
     {
         $this->setDefinition([
             new InputArgument('suite', InputArgument::REQUIRED, 'suite to be tested'),

--- a/src/Codeception/Command/GenerateCest.php
+++ b/src/Codeception/Command/GenerateCest.php
@@ -25,7 +25,7 @@ class GenerateCest extends Command
     use Shared\FileSystem;
     use Shared\Config;
 
-    protected function configure()
+    protected function configure(): void
     {
         $this->setDefinition([
             new InputArgument('suite', InputArgument::REQUIRED, 'suite where tests will be put'),

--- a/src/Codeception/Command/GenerateCest.php
+++ b/src/Codeception/Command/GenerateCest.php
@@ -54,8 +54,8 @@ class GenerateCest extends Command
             $output->writeln("<error>Test $filename already exists</error>");
             return 1;
         }
-        $gen = new CestGenerator($class, $config);
-        $res = $this->createFile($filename, $gen->produce());
+        $cest = new CestGenerator($class, $config);
+        $res = $this->createFile($filename, $cest->produce());
         if (!$res) {
             $output->writeln("<error>Test $filename already exists</error>");
             return 1;

--- a/src/Codeception/Command/GenerateCest.php
+++ b/src/Codeception/Command/GenerateCest.php
@@ -9,6 +9,7 @@ use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
+use function file_exists;
 
 /**
  * Generates Cest (scenario-driven object-oriented test) file:

--- a/src/Codeception/Command/GenerateCest.php
+++ b/src/Codeception/Command/GenerateCest.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Codeception\Command;
 
 use Codeception\Lib\Generator\Cest as CestGenerator;

--- a/src/Codeception/Command/GenerateCest.php
+++ b/src/Codeception/Command/GenerateCest.php
@@ -32,12 +32,12 @@ class GenerateCest extends Command
         ]);
     }
 
-    public function getDescription()
+    public function getDescription(): string
     {
         return 'Generates empty Cest file in suite';
     }
 
-    public function execute(InputInterface $input, OutputInterface $output)
+    public function execute(InputInterface $input, OutputInterface $output): int
     {
         $suite = $input->getArgument('suite');
         $class = $input->getArgument('class');

--- a/src/Codeception/Command/GenerateCest.php
+++ b/src/Codeception/Command/GenerateCest.php
@@ -22,8 +22,8 @@ use function file_exists;
  */
 class GenerateCest extends Command
 {
-    use Shared\FileSystem;
-    use Shared\Config;
+    use Shared\FileSystemTrait;
+    use Shared\ConfigTrait;
 
     protected function configure(): void
     {

--- a/src/Codeception/Command/GenerateEnvironment.php
+++ b/src/Codeception/Command/GenerateEnvironment.php
@@ -30,12 +30,12 @@ class GenerateEnvironment extends Command
         ]);
     }
 
-    public function getDescription()
+    public function getDescription(): string
     {
         return 'Generates empty environment config';
     }
 
-    public function execute(InputInterface $input, OutputInterface $output)
+    public function execute(InputInterface $input, OutputInterface $output): int
     {
         $conf = $this->getGlobalConfig();
         if (!Configuration::envsDir()) {

--- a/src/Codeception/Command/GenerateEnvironment.php
+++ b/src/Codeception/Command/GenerateEnvironment.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Codeception\Command;
 
 use Codeception\Configuration;

--- a/src/Codeception/Command/GenerateEnvironment.php
+++ b/src/Codeception/Command/GenerateEnvironment.php
@@ -37,7 +37,7 @@ class GenerateEnvironment extends Command
 
     public function execute(InputInterface $input, OutputInterface $output): int
     {
-        $conf = $this->getGlobalConfig();
+        $config = $this->getGlobalConfig();
         if (!Configuration::envsDir()) {
             throw new ConfigurationException(
                 "Path for environments configuration is not set.\n"
@@ -45,7 +45,7 @@ class GenerateEnvironment extends Command
                 . "envs: tests/_envs"
             );
         }
-        $relativePath = $conf['paths']['envs'];
+        $relativePath = $config['paths']['envs'];
         $env = $input->getArgument('env');
         $file = "$env.yml";
 

--- a/src/Codeception/Command/GenerateEnvironment.php
+++ b/src/Codeception/Command/GenerateEnvironment.php
@@ -23,7 +23,7 @@ class GenerateEnvironment extends Command
     use Shared\FileSystem;
     use Shared\Config;
 
-    protected function configure()
+    protected function configure(): void
     {
         $this->setDefinition([
             new InputArgument('env', InputArgument::REQUIRED, 'Environment name'),

--- a/src/Codeception/Command/GenerateEnvironment.php
+++ b/src/Codeception/Command/GenerateEnvironment.php
@@ -20,8 +20,8 @@ use Symfony\Component\Console\Output\OutputInterface;
  */
 class GenerateEnvironment extends Command
 {
-    use Shared\FileSystem;
-    use Shared\Config;
+    use Shared\FileSystemTrait;
+    use Shared\ConfigTrait;
 
     protected function configure(): void
     {

--- a/src/Codeception/Command/GenerateFeature.php
+++ b/src/Codeception/Command/GenerateFeature.php
@@ -33,12 +33,12 @@ class GenerateFeature extends Command
         ]);
     }
 
-    public function getDescription()
+    public function getDescription(): string
     {
         return 'Generates empty feature file in suite';
     }
 
-    public function execute(InputInterface $input, OutputInterface $output)
+    public function execute(InputInterface $input, OutputInterface $output): int
     {
         $suite = $input->getArgument('suite');
         $filename = $input->getArgument('feature');

--- a/src/Codeception/Command/GenerateFeature.php
+++ b/src/Codeception/Command/GenerateFeature.php
@@ -24,8 +24,8 @@ use function rtrim;
  */
 class GenerateFeature extends Command
 {
-    use Shared\FileSystem;
-    use Shared\Config;
+    use Shared\FileSystemTrait;
+    use Shared\ConfigTrait;
 
     protected function configure(): void
     {

--- a/src/Codeception/Command/GenerateFeature.php
+++ b/src/Codeception/Command/GenerateFeature.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Codeception\Command;
 
 use Codeception\Lib\Generator\Feature;

--- a/src/Codeception/Command/GenerateFeature.php
+++ b/src/Codeception/Command/GenerateFeature.php
@@ -49,17 +49,17 @@ class GenerateFeature extends Command
         $config = $this->getSuiteConfig($suite);
         $this->createDirectoryFor($config['path'], $filename);
 
-        $gen = new Feature(basename($filename));
+        $feature = new Feature(basename($filename));
         if (!preg_match('~\.feature$~', $filename)) {
             $filename .= '.feature';
         }
-        $full_path = rtrim($config['path'], DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR . $filename;
-        $res = $this->createFile($full_path, $gen->produce());
+        $fullPath = rtrim($config['path'], DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR . $filename;
+        $res = $this->createFile($fullPath, $feature->produce());
         if (!$res) {
             $output->writeln("<error>Feature $filename already exists</error>");
             return 1;
         }
-        $output->writeln("<info>Feature was created in $full_path</info>");
+        $output->writeln("<info>Feature was created in $fullPath</info>");
         return 0;
     }
 }

--- a/src/Codeception/Command/GenerateFeature.php
+++ b/src/Codeception/Command/GenerateFeature.php
@@ -10,6 +10,9 @@ use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
+use function basename;
+use function preg_match;
+use function rtrim;
 
 /**
  * Generates Feature file (in Gherkin):

--- a/src/Codeception/Command/GenerateFeature.php
+++ b/src/Codeception/Command/GenerateFeature.php
@@ -27,7 +27,7 @@ class GenerateFeature extends Command
     use Shared\FileSystem;
     use Shared\Config;
 
-    protected function configure()
+    protected function configure(): void
     {
         $this->setDefinition([
             new InputArgument('suite', InputArgument::REQUIRED, 'suite to be tested'),

--- a/src/Codeception/Command/GenerateGroup.php
+++ b/src/Codeception/Command/GenerateGroup.php
@@ -10,6 +10,7 @@ use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
+use function ucfirst;
 
 /**
  * Creates empty GroupObject - extension which handles all group events.

--- a/src/Codeception/Command/GenerateGroup.php
+++ b/src/Codeception/Command/GenerateGroup.php
@@ -22,7 +22,7 @@ class GenerateGroup extends Command
     use Shared\FileSystem;
     use Shared\Config;
 
-    protected function configure()
+    protected function configure(): void
     {
         $this->setDefinition([
             new InputArgument('group', InputArgument::REQUIRED, 'Group class name'),

--- a/src/Codeception/Command/GenerateGroup.php
+++ b/src/Codeception/Command/GenerateGroup.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Codeception\Command;
 
 use Codeception\Configuration;
@@ -33,7 +36,7 @@ class GenerateGroup extends Command
     public function execute(InputInterface $input, OutputInterface $output)
     {
         $config = $this->getGlobalConfig();
-        $group = $input->getArgument('group');
+        $group = (string)$input->getArgument('group');
 
         $class = ucfirst($group);
         $path = $this->createDirectoryFor(Configuration::supportDir() . 'Group' . DIRECTORY_SEPARATOR, $class);

--- a/src/Codeception/Command/GenerateGroup.php
+++ b/src/Codeception/Command/GenerateGroup.php
@@ -19,8 +19,8 @@ use function ucfirst;
  */
 class GenerateGroup extends Command
 {
-    use Shared\FileSystem;
-    use Shared\Config;
+    use Shared\FileSystemTrait;
+    use Shared\ConfigTrait;
 
     protected function configure(): void
     {

--- a/src/Codeception/Command/GenerateGroup.php
+++ b/src/Codeception/Command/GenerateGroup.php
@@ -37,15 +37,15 @@ class GenerateGroup extends Command
     public function execute(InputInterface $input, OutputInterface $output): int
     {
         $config = $this->getGlobalConfig();
-        $group = (string)$input->getArgument('group');
+        $groupInputArgument = (string)$input->getArgument('group');
 
-        $class = ucfirst($group);
+        $class = ucfirst($groupInputArgument);
         $path = $this->createDirectoryFor(Configuration::supportDir() . 'Group' . DIRECTORY_SEPARATOR, $class);
 
         $filename = $path . $class . '.php';
 
-        $gen = new GroupGenerator($config, $group);
-        $res = $this->createFile($filename, $gen->produce());
+        $group = new GroupGenerator($config, $groupInputArgument);
+        $res = $this->createFile($filename, $group->produce());
 
         if (!$res) {
             $output->writeln("<error>Group $filename already exists</error>");

--- a/src/Codeception/Command/GenerateGroup.php
+++ b/src/Codeception/Command/GenerateGroup.php
@@ -28,12 +28,12 @@ class GenerateGroup extends Command
         ]);
     }
 
-    public function getDescription()
+    public function getDescription(): string
     {
         return 'Generates Group subscriber';
     }
 
-    public function execute(InputInterface $input, OutputInterface $output)
+    public function execute(InputInterface $input, OutputInterface $output): int
     {
         $config = $this->getGlobalConfig();
         $group = (string)$input->getArgument('group');

--- a/src/Codeception/Command/GenerateHelper.php
+++ b/src/Codeception/Command/GenerateHelper.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Codeception\Command;
 
 use Codeception\Configuration;
@@ -34,7 +37,7 @@ class GenerateHelper extends Command
 
     public function execute(InputInterface $input, OutputInterface $output)
     {
-        $name = ucfirst($input->getArgument('name'));
+        $name = ucfirst((string)$input->getArgument('name'));
         $config = $this->getGlobalConfig();
 
         $path = $this->createDirectoryFor(Configuration::supportDir() . 'Helper', $name);

--- a/src/Codeception/Command/GenerateHelper.php
+++ b/src/Codeception/Command/GenerateHelper.php
@@ -21,8 +21,8 @@ use function ucfirst;
  */
 class GenerateHelper extends Command
 {
-    use Shared\FileSystem;
-    use Shared\Config;
+    use Shared\FileSystemTrait;
+    use Shared\ConfigTrait;
 
     protected function configure(): void
     {

--- a/src/Codeception/Command/GenerateHelper.php
+++ b/src/Codeception/Command/GenerateHelper.php
@@ -10,6 +10,7 @@ use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
+use function ucfirst;
 
 /**
  * Creates empty Helper class.

--- a/src/Codeception/Command/GenerateHelper.php
+++ b/src/Codeception/Command/GenerateHelper.php
@@ -30,12 +30,12 @@ class GenerateHelper extends Command
         ]);
     }
 
-    public function getDescription()
+    public function getDescription(): string
     {
         return 'Generates new helper';
     }
 
-    public function execute(InputInterface $input, OutputInterface $output)
+    public function execute(InputInterface $input, OutputInterface $output): int
     {
         $name = ucfirst((string)$input->getArgument('name'));
         $config = $this->getGlobalConfig();

--- a/src/Codeception/Command/GenerateHelper.php
+++ b/src/Codeception/Command/GenerateHelper.php
@@ -24,7 +24,7 @@ class GenerateHelper extends Command
     use Shared\FileSystem;
     use Shared\Config;
 
-    protected function configure()
+    protected function configure(): void
     {
         $this->setDefinition([
             new InputArgument('name', InputArgument::REQUIRED, 'helper name'),

--- a/src/Codeception/Command/GeneratePageObject.php
+++ b/src/Codeception/Command/GeneratePageObject.php
@@ -25,7 +25,7 @@ class GeneratePageObject extends Command
     use Shared\FileSystem;
     use Shared\Config;
 
-    protected function configure()
+    protected function configure(): void
     {
         $this->setDefinition([
             new InputArgument('suite', InputArgument::REQUIRED, 'Either suite name or page object name)'),

--- a/src/Codeception/Command/GeneratePageObject.php
+++ b/src/Codeception/Command/GeneratePageObject.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Codeception\Command;
 
 use Codeception\Configuration;
@@ -37,12 +40,12 @@ class GeneratePageObject extends Command
 
     public function execute(InputInterface $input, OutputInterface $output)
     {
-        $suite = $input->getArgument('suite');
+        $suite = (string)$input->getArgument('suite');
         $class = $input->getArgument('page');
 
         if (!$class) {
             $class = $suite;
-            $suite = null;
+            $suite = '';
         }
 
         $conf = $suite

--- a/src/Codeception/Command/GeneratePageObject.php
+++ b/src/Codeception/Command/GeneratePageObject.php
@@ -63,8 +63,8 @@ class GeneratePageObject extends Command
 
         $output->writeln($filename);
 
-        $gen = new PageObjectGenerator($conf, ucfirst($suite) . '\\' . $class);
-        $res = $this->createFile($filename, $gen->produce());
+        $pageObject = new PageObjectGenerator($conf, ucfirst($suite) . '\\' . $class);
+        $res = $this->createFile($filename, $pageObject->produce());
 
         if (!$res) {
             $output->writeln("<error>PageObject $filename already exists</error>");
@@ -72,9 +72,5 @@ class GeneratePageObject extends Command
         }
         $output->writeln("<info>PageObject was created in $filename</info>");
         return 0;
-    }
-
-    protected function pathToPageObject($class, $suite)
-    {
     }
 }

--- a/src/Codeception/Command/GeneratePageObject.php
+++ b/src/Codeception/Command/GeneratePageObject.php
@@ -33,12 +33,12 @@ class GeneratePageObject extends Command
         parent::configure();
     }
 
-    public function getDescription()
+    public function getDescription(): string
     {
         return 'Generates empty PageObject class';
     }
 
-    public function execute(InputInterface $input, OutputInterface $output)
+    public function execute(InputInterface $input, OutputInterface $output): int
     {
         $suite = (string)$input->getArgument('suite');
         $class = $input->getArgument('page');

--- a/src/Codeception/Command/GeneratePageObject.php
+++ b/src/Codeception/Command/GeneratePageObject.php
@@ -10,6 +10,7 @@ use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
+use function ucfirst;
 
 /**
  * Generates PageObject. Can be generated either globally, or just for one suite.

--- a/src/Codeception/Command/GeneratePageObject.php
+++ b/src/Codeception/Command/GeneratePageObject.php
@@ -22,8 +22,8 @@ use function ucfirst;
  */
 class GeneratePageObject extends Command
 {
-    use Shared\FileSystem;
-    use Shared\Config;
+    use Shared\FileSystemTrait;
+    use Shared\ConfigTrait;
 
     protected function configure(): void
     {

--- a/src/Codeception/Command/GenerateScenarios.php
+++ b/src/Codeception/Command/GenerateScenarios.php
@@ -15,6 +15,11 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\EventDispatcher\EventDispatcher;
+use function basename;
+use function file_exists;
+use function is_writable;
+use function mkdir;
+use function preg_replace;
 
 /**
  * Generates user-friendly text scenarios from scenario-driven tests (Cest, Cept).

--- a/src/Codeception/Command/GenerateScenarios.php
+++ b/src/Codeception/Command/GenerateScenarios.php
@@ -38,12 +38,12 @@ class GenerateScenarios extends Command
         parent::configure();
     }
 
-    public function getDescription()
+    public function getDescription(): string
     {
         return 'Generates text representation for all scenarios';
     }
 
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $suite = $input->getArgument('suite');
 
@@ -108,7 +108,7 @@ class GenerateScenarios extends Command
         return 0;
     }
 
-    protected function decorate($text, $format)
+    protected function decorate($text, $format): string
     {
         switch ($format) {
             case 'text':
@@ -124,7 +124,7 @@ class GenerateScenarios extends Command
         return $suiteManager->getSuite()->tests();
     }
 
-    protected function formatExtension($format)
+    protected function formatExtension($format): string
     {
         switch ($format) {
             case 'text':

--- a/src/Codeception/Command/GenerateScenarios.php
+++ b/src/Codeception/Command/GenerateScenarios.php
@@ -33,7 +33,7 @@ class GenerateScenarios extends Command
     use Shared\FileSystem;
     use Shared\Config;
 
-    protected function configure()
+    protected function configure(): void
     {
         $this->setDefinition([
             new InputArgument('suite', InputArgument::REQUIRED, 'suite from which texts should be generated'),
@@ -114,7 +114,7 @@ class GenerateScenarios extends Command
         return 0;
     }
 
-    protected function decorate($text, $format): string
+    protected function decorate(string $text, string $format): string
     {
         switch ($format) {
             case 'text':
@@ -130,7 +130,7 @@ class GenerateScenarios extends Command
         return $suiteManager->getSuite()->tests();
     }
 
-    protected function formatExtension($format): string
+    protected function formatExtension(string $format): string
     {
         switch ($format) {
             case 'text':
@@ -140,6 +140,10 @@ class GenerateScenarios extends Command
         }
     }
 
+    /**
+     * @param string|string[] $name
+     * @return mixed[]|string|null
+     */
     private function underscore($name)
     {
         $name = preg_replace('/([A-Z]+)([A-Z][a-z])/', '\\1_\\2', $name);

--- a/src/Codeception/Command/GenerateScenarios.php
+++ b/src/Codeception/Command/GenerateScenarios.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Codeception\Command;
 
 use Codeception\Configuration;

--- a/src/Codeception/Command/GenerateScenarios.php
+++ b/src/Codeception/Command/GenerateScenarios.php
@@ -138,11 +138,7 @@ class GenerateScenarios extends Command
         }
     }
 
-    /**
-     * @param string|string[] $name
-     * @return mixed[]|string|null
-     */
-    private function underscore($name)
+    private function underscore(string $name): string
     {
         $name = preg_replace('/([A-Z]+)([A-Z][a-z])/', '\\1_\\2', $name);
         $name = preg_replace('/([a-z\d])([A-Z])/', '\\1_\\2', $name);

--- a/src/Codeception/Command/GenerateScenarios.php
+++ b/src/Codeception/Command/GenerateScenarios.php
@@ -6,6 +6,7 @@ namespace Codeception\Command;
 
 use Codeception\Configuration;
 use Codeception\Exception\ConfigurationException;
+use Codeception\SuiteManager;
 use Codeception\Test\Cest;
 use Codeception\Test\Interfaces\ScenarioDriven;
 use Symfony\Component\Console\Command\Command;
@@ -68,7 +69,7 @@ class GenerateScenarios extends Command
             @mkdir($path);
         }
 
-        $suiteManager = new \Codeception\SuiteManager(new EventDispatcher(), $suite, $suiteConf);
+        $suiteManager = new SuiteManager(new EventDispatcher(), $suite, $suiteConf);
 
         if ($suiteConf['bootstrap']) {
             if (file_exists($suiteConf['path'] . $suiteConf['bootstrap'])) {

--- a/src/Codeception/Command/GenerateScenarios.php
+++ b/src/Codeception/Command/GenerateScenarios.php
@@ -30,8 +30,8 @@ use function preg_replace;
  */
 class GenerateScenarios extends Command
 {
-    use Shared\FileSystem;
-    use Shared\Config;
+    use Shared\FileSystemTrait;
+    use Shared\ConfigTrait;
 
     protected function configure(): void
     {

--- a/src/Codeception/Command/GenerateScenarios.php
+++ b/src/Codeception/Command/GenerateScenarios.php
@@ -76,10 +76,8 @@ class GenerateScenarios extends Command
 
         $suiteManager = new SuiteManager(new EventDispatcher(), $suite, $suiteConf);
 
-        if ($suiteConf['bootstrap']) {
-            if (file_exists($suiteConf['path'] . $suiteConf['bootstrap'])) {
-                require_once $suiteConf['path'] . $suiteConf['bootstrap'];
-            }
+        if ($suiteConf['bootstrap'] && file_exists($suiteConf['path'] . $suiteConf['bootstrap'])) {
+            require_once $suiteConf['path'] . $suiteConf['bootstrap'];
         }
 
         $tests = $this->getTests($suiteManager);

--- a/src/Codeception/Command/GenerateSnapshot.php
+++ b/src/Codeception/Command/GenerateSnapshot.php
@@ -26,7 +26,7 @@ class GenerateSnapshot extends Command
     use Shared\FileSystem;
     use Shared\Config;
 
-    protected function configure()
+    protected function configure(): void
     {
         $this->setDefinition([
             new InputArgument('suite', InputArgument::REQUIRED, 'Suite name or snapshot name)'),

--- a/src/Codeception/Command/GenerateSnapshot.php
+++ b/src/Codeception/Command/GenerateSnapshot.php
@@ -23,8 +23,8 @@ use function ucfirst;
  */
 class GenerateSnapshot extends Command
 {
-    use Shared\FileSystem;
-    use Shared\Config;
+    use Shared\FileSystemTrait;
+    use Shared\ConfigTrait;
 
     protected function configure(): void
     {

--- a/src/Codeception/Command/GenerateSnapshot.php
+++ b/src/Codeception/Command/GenerateSnapshot.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Codeception\Command;
 
 use Codeception\Configuration;
@@ -38,12 +41,12 @@ class GenerateSnapshot extends Command
 
     public function execute(InputInterface $input, OutputInterface $output)
     {
-        $suite = $input->getArgument('suite');
+        $suite = (string)$input->getArgument('suite');
         $class = $input->getArgument('snapshot');
 
         if (!$class) {
             $class = $suite;
-            $suite = null;
+            $suite = '';
         }
 
         $conf = $suite

--- a/src/Codeception/Command/GenerateSnapshot.php
+++ b/src/Codeception/Command/GenerateSnapshot.php
@@ -64,8 +64,8 @@ class GenerateSnapshot extends Command
 
         $output->writeln($filename);
 
-        $gen = new SnapshotGenerator($conf, ucfirst($suite) . '\\' . $class);
-        $res = $this->createFile($filename, $gen->produce());
+        $snapshot = new SnapshotGenerator($conf, ucfirst($suite) . '\\' . $class);
+        $res = $this->createFile($filename, $snapshot->produce());
 
         if (!$res) {
             $output->writeln("<error>Snapshot $filename already exists</error>");

--- a/src/Codeception/Command/GenerateSnapshot.php
+++ b/src/Codeception/Command/GenerateSnapshot.php
@@ -10,6 +10,7 @@ use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
+use function ucfirst;
 
 /**
  * Generates Snapshot.

--- a/src/Codeception/Command/GenerateSnapshot.php
+++ b/src/Codeception/Command/GenerateSnapshot.php
@@ -34,12 +34,12 @@ class GenerateSnapshot extends Command
         parent::configure();
     }
 
-    public function getDescription()
+    public function getDescription(): string
     {
         return 'Generates empty Snapshot class';
     }
 
-    public function execute(InputInterface $input, OutputInterface $output)
+    public function execute(InputInterface $input, OutputInterface $output): int
     {
         $suite = (string)$input->getArgument('suite');
         $class = $input->getArgument('snapshot');

--- a/src/Codeception/Command/GenerateStepObject.php
+++ b/src/Codeception/Command/GenerateStepObject.php
@@ -26,7 +26,7 @@ class GenerateStepObject extends Command
     use Shared\FileSystem;
     use Shared\Config;
 
-    protected function configure()
+    protected function configure(): void
     {
         $this->setDefinition([
             new InputArgument('suite', InputArgument::REQUIRED, 'Suite for StepObject'),

--- a/src/Codeception/Command/GenerateStepObject.php
+++ b/src/Codeception/Command/GenerateStepObject.php
@@ -23,8 +23,8 @@ use function ucfirst;
  */
 class GenerateStepObject extends Command
 {
-    use Shared\FileSystem;
-    use Shared\Config;
+    use Shared\FileSystemTrait;
+    use Shared\ConfigTrait;
 
     protected function configure(): void
     {

--- a/src/Codeception/Command/GenerateStepObject.php
+++ b/src/Codeception/Command/GenerateStepObject.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Codeception\Command;
 
 use Codeception\Configuration;
@@ -38,7 +41,7 @@ class GenerateStepObject extends Command
 
     public function execute(InputInterface $input, OutputInterface $output)
     {
-        $suite = $input->getArgument('suite');
+        $suite = (string)$input->getArgument('suite');
         $step = $input->getArgument('step');
         $config = $this->getSuiteConfig($suite);
 

--- a/src/Codeception/Command/GenerateStepObject.php
+++ b/src/Codeception/Command/GenerateStepObject.php
@@ -34,12 +34,12 @@ class GenerateStepObject extends Command
         ]);
     }
 
-    public function getDescription()
+    public function getDescription(): string
     {
         return 'Generates empty StepObject class';
     }
 
-    public function execute(InputInterface $input, OutputInterface $output)
+    public function execute(InputInterface $input, OutputInterface $output): int
     {
         $suite = (string)$input->getArgument('suite');
         $step = $input->getArgument('step');

--- a/src/Codeception/Command/GenerateStepObject.php
+++ b/src/Codeception/Command/GenerateStepObject.php
@@ -56,19 +56,19 @@ class GenerateStepObject extends Command
         $helper = $this->getHelper('question');
         $question = new Question("Add action to StepObject class (ENTER to exit): ");
 
-        $gen = new StepObjectGenerator($config, ucfirst($suite) . '\\' . $step);
+        $stepObject = new StepObjectGenerator($config, ucfirst($suite) . '\\' . $step);
 
         if (!$input->getOption('silent')) {
             do {
                 $question = new Question('Add action to StepObject class (ENTER to exit): ', null);
                 $action = $dialog->ask($input, $output, $question);
                 if ($action) {
-                    $gen->createAction($action);
+                    $stepObject->createAction($action);
                 }
             } while ($action);
         }
 
-        $res = $this->createFile($filename, $gen->produce());
+        $res = $this->createFile($filename, $stepObject->produce());
 
         if (!$res) {
             $output->writeln("<error>StepObject $filename already exists</error>");

--- a/src/Codeception/Command/GenerateStepObject.php
+++ b/src/Codeception/Command/GenerateStepObject.php
@@ -12,6 +12,7 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Question\Question;
+use function ucfirst;
 
 /**
  * Generates StepObject class. You will be asked for steps you want to implement.

--- a/src/Codeception/Command/GenerateSuite.php
+++ b/src/Codeception/Command/GenerateSuite.php
@@ -33,7 +33,7 @@ class GenerateSuite extends Command
     use Shared\Config;
     use Shared\Style;
 
-    protected function configure()
+    protected function configure(): void
     {
         $this->setDefinition([
             new InputArgument('suite', InputArgument::REQUIRED, 'suite to be generated'),

--- a/src/Codeception/Command/GenerateSuite.php
+++ b/src/Codeception/Command/GenerateSuite.php
@@ -135,7 +135,7 @@ EOF;
         return 0;
     }
 
-    private function containsInvalidCharacters($suite): bool
+    private function containsInvalidCharacters(string $suite): bool
     {
         return (bool) preg_match('#[^A-Za-z0-9_]#', $suite);
     }

--- a/src/Codeception/Command/GenerateSuite.php
+++ b/src/Codeception/Command/GenerateSuite.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Codeception\Command;
 
 use Codeception\Configuration;
@@ -42,7 +45,7 @@ class GenerateSuite extends Command
     public function execute(InputInterface $input, OutputInterface $output)
     {
         $this->addStyles($output);
-        $suite = $input->getArgument('suite');
+        $suite = (string)$input->getArgument('suite');
         $actor = $input->getArgument('actor');
 
         if ($this->containsInvalidCharacters($suite)) {

--- a/src/Codeception/Command/GenerateSuite.php
+++ b/src/Codeception/Command/GenerateSuite.php
@@ -6,7 +6,7 @@ namespace Codeception\Command;
 
 use Codeception\Configuration;
 use Codeception\Lib\Generator\Actor as ActorGenerator;
-use Codeception\Lib\Generator\Helper;
+use Codeception\Lib\Generator\Helper as HelperGenerator;
 use Codeception\Util\Template;
 use Exception;
 use Symfony\Component\Console\Command\Command;
@@ -85,14 +85,14 @@ class GenerateSuite extends Command
             "$helperName.php"
         ) . "$helperName.php";
 
-        $gen = new Helper($helperName, $config['namespace']);
+        $helper = new HelperGenerator($helperName, $config['namespace']);
         // generate helper
         $this->createFile(
             $file,
-            $gen->produce()
+            $helper->produce()
         );
 
-        $output->writeln("Helper <info>" . $gen->getHelperName() . "</info> was created in $file");
+        $output->writeln("Helper <info>" . $helper->getHelperName() . "</info> was created in $file");
 
         $yamlSuiteConfigTemplate = <<<EOF
 actor: {{actor}}
@@ -105,7 +105,7 @@ EOF;
             $dir . $suite . '.suite.yml',
             $yamlSuiteConfig = (new Template($yamlSuiteConfigTemplate))
                 ->place('actor', $actor)
-                ->place('helper', $gen->getHelperName())
+                ->place('helper', $helper->getHelperName())
                 ->produce()
         );
 
@@ -137,6 +137,6 @@ EOF;
 
     private function containsInvalidCharacters($suite): bool
     {
-        return preg_match('#[^A-Za-z0-9_]#', $suite) ? true : false;
+        return (bool) preg_match('#[^A-Za-z0-9_]#', $suite);
     }
 }

--- a/src/Codeception/Command/GenerateSuite.php
+++ b/src/Codeception/Command/GenerateSuite.php
@@ -8,6 +8,7 @@ use Codeception\Configuration;
 use Codeception\Lib\Generator\Actor as ActorGenerator;
 use Codeception\Lib\Generator\Helper;
 use Codeception\Util\Template;
+use Exception;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
@@ -60,7 +61,7 @@ class GenerateSuite extends Command
 
         $dir = Configuration::testsDir();
         if (file_exists($dir . $suite . '.suite.yml')) {
-            throw new \Exception("Suite configuration file '$suite.suite.yml' already exists.");
+            throw new Exception("Suite configuration file '$suite.suite.yml' already exists.");
         }
 
         $this->createDirectoryFor($dir . $suite);

--- a/src/Codeception/Command/GenerateSuite.php
+++ b/src/Codeception/Command/GenerateSuite.php
@@ -29,9 +29,9 @@ use function ucfirst;
  */
 class GenerateSuite extends Command
 {
-    use Shared\FileSystem;
-    use Shared\Config;
-    use Shared\Style;
+    use Shared\FileSystemTrait;
+    use Shared\ConfigTrait;
+    use Shared\StyleTrait;
 
     protected function configure(): void
     {

--- a/src/Codeception/Command/GenerateSuite.php
+++ b/src/Codeception/Command/GenerateSuite.php
@@ -14,6 +14,9 @@ use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Yaml\Yaml;
+use function file_exists;
+use function preg_match;
+use function ucfirst;
 
 /**
  * Create new test suite. Requires suite name and actor name

--- a/src/Codeception/Command/GenerateSuite.php
+++ b/src/Codeception/Command/GenerateSuite.php
@@ -5,12 +5,12 @@ declare(strict_types=1);
 namespace Codeception\Command;
 
 use Codeception\Configuration;
+use Codeception\Lib\Generator\Actor as ActorGenerator;
 use Codeception\Lib\Generator\Helper;
 use Codeception\Util\Template;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
-use Codeception\Lib\Generator\Actor as ActorGenerator;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Yaml\Yaml;
 
@@ -37,12 +37,12 @@ class GenerateSuite extends Command
         ]);
     }
 
-    public function getDescription()
+    public function getDescription(): string
     {
         return 'Generates new test suite';
     }
 
-    public function execute(InputInterface $input, OutputInterface $output)
+    public function execute(InputInterface $input, OutputInterface $output): int
     {
         $this->addStyles($output);
         $suite = (string)$input->getArgument('suite');
@@ -131,7 +131,7 @@ EOF;
         return 0;
     }
 
-    private function containsInvalidCharacters($suite)
+    private function containsInvalidCharacters($suite): bool
     {
         return preg_match('#[^A-Za-z0-9_]#', $suite) ? true : false;
     }

--- a/src/Codeception/Command/GenerateTest.php
+++ b/src/Codeception/Command/GenerateTest.php
@@ -32,12 +32,12 @@ class GenerateTest extends Command
         parent::configure();
     }
 
-    public function getDescription()
+    public function getDescription(): string
     {
         return 'Generates empty unit test file in suite';
     }
 
-    public function execute(InputInterface $input, OutputInterface $output)
+    public function execute(InputInterface $input, OutputInterface $output): int
     {
         $suite = $input->getArgument('suite');
         $class = $input->getArgument('class');

--- a/src/Codeception/Command/GenerateTest.php
+++ b/src/Codeception/Command/GenerateTest.php
@@ -50,9 +50,9 @@ class GenerateTest extends Command
         $filename = $this->completeSuffix($className, 'Test');
         $filename = $path . $filename;
 
-        $gen = new TestGenerator($config, $class);
+        $test = new TestGenerator($config, $class);
 
-        $res = $this->createFile($filename, $gen->produce());
+        $res = $this->createFile($filename, $test->produce());
 
         if (!$res) {
             $output->writeln("<error>Test $filename already exists</error>");

--- a/src/Codeception/Command/GenerateTest.php
+++ b/src/Codeception/Command/GenerateTest.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Codeception\Command;
 
 use Codeception\Lib\Generator\Test as TestGenerator;

--- a/src/Codeception/Command/GenerateTest.php
+++ b/src/Codeception/Command/GenerateTest.php
@@ -21,7 +21,7 @@ class GenerateTest extends Command
     use Shared\FileSystem;
     use Shared\Config;
 
-    protected function configure()
+    protected function configure(): void
     {
         $this->setDefinition(
             [

--- a/src/Codeception/Command/GenerateTest.php
+++ b/src/Codeception/Command/GenerateTest.php
@@ -18,8 +18,8 @@ use Symfony\Component\Console\Output\OutputInterface;
  */
 class GenerateTest extends Command
 {
-    use Shared\FileSystem;
-    use Shared\Config;
+    use Shared\FileSystemTrait;
+    use Shared\ConfigTrait;
 
     protected function configure(): void
     {

--- a/src/Codeception/Command/GherkinSnippets.php
+++ b/src/Codeception/Command/GherkinSnippets.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Codeception\Command;
 
-use Codeception\Lib\Generator\GherkinSnippets as SnippetsGenerator;
+use Codeception\Lib\Generator\GherkinSnippets as GherkinSnippetsGenerator;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
@@ -52,15 +52,16 @@ class GherkinSnippets extends Command
         $test = $input->getArgument('test');
         $config = $this->getSuiteConfig($suite);
 
-        $generator = new SnippetsGenerator($config, $test);
-        $snippets = $generator->getSnippets();
-        $features = $generator->getFeatures();
+        $generator = new GherkinSnippetsGenerator($config, $test);
 
+        $snippets = $generator->getSnippets();
         if (empty($snippets)) {
             $output->writeln("<notice> All Gherkin steps are defined. Exiting... </notice>");
             return 0;
         }
         $output->writeln("<comment> Snippets found in: </comment>");
+
+        $features = $generator->getFeatures();
         foreach ($features as $feature) {
             $output->writeln("<info>  - {$feature} </info>");
         }

--- a/src/Codeception/Command/GherkinSnippets.php
+++ b/src/Codeception/Command/GherkinSnippets.php
@@ -25,8 +25,8 @@ use function count;
  */
 class GherkinSnippets extends Command
 {
-    use Shared\Config;
-    use Shared\Style;
+    use Shared\ConfigTrait;
+    use Shared\StyleTrait;
 
     protected function configure(): void
     {

--- a/src/Codeception/Command/GherkinSnippets.php
+++ b/src/Codeception/Command/GherkinSnippets.php
@@ -28,7 +28,7 @@ class GherkinSnippets extends Command
     use Shared\Config;
     use Shared\Style;
 
-    protected function configure()
+    protected function configure(): void
     {
         $this->setDefinition(
             [

--- a/src/Codeception/Command/GherkinSnippets.php
+++ b/src/Codeception/Command/GherkinSnippets.php
@@ -39,12 +39,12 @@ class GherkinSnippets extends Command
         parent::configure();
     }
 
-    public function getDescription()
+    public function getDescription(): string
     {
         return 'Fetches empty steps from feature files of suite and prints code snippets for them';
     }
 
-    public function execute(InputInterface $input, OutputInterface $output)
+    public function execute(InputInterface $input, OutputInterface $output): int
     {
         $this->addStyles($output);
         $suite = $input->getArgument('suite');

--- a/src/Codeception/Command/GherkinSnippets.php
+++ b/src/Codeception/Command/GherkinSnippets.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Codeception\Command;
 
 use Codeception\Lib\Generator\GherkinSnippets as SnippetsGenerator;

--- a/src/Codeception/Command/GherkinSnippets.php
+++ b/src/Codeception/Command/GherkinSnippets.php
@@ -10,6 +10,7 @@ use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
+use function count;
 
 /**
  * Generates code snippets for matched feature files in a suite.

--- a/src/Codeception/Command/GherkinSteps.php
+++ b/src/Codeception/Command/GherkinSteps.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Codeception\Command;
 
-use Codeception\Test\Loader\Gherkin;
+use Codeception\Test\Loader\Gherkin as GherkinLoader;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Helper\Table;
 use Symfony\Component\Console\Input\InputArgument;
@@ -49,7 +49,7 @@ class GherkinSteps extends Command
         $config = $this->getSuiteConfig($suite);
         $config['describe_steps'] = true;
 
-        $loader = new Gherkin($config);
+        $loader = new GherkinLoader($config);
         $steps = $loader->getSteps();
 
         foreach ($steps as $name => $context) {

--- a/src/Codeception/Command/GherkinSteps.php
+++ b/src/Codeception/Command/GherkinSteps.php
@@ -36,12 +36,12 @@ class GherkinSteps extends Command
         parent::configure();
     }
 
-    public function getDescription()
+    public function getDescription(): string
     {
         return 'Prints all defined feature steps';
     }
 
-    public function execute(InputInterface $input, OutputInterface $output)
+    public function execute(InputInterface $input, OutputInterface $output): int
     {
         $this->addStyles($output);
         $suite = $input->getArgument('suite');

--- a/src/Codeception/Command/GherkinSteps.php
+++ b/src/Codeception/Command/GherkinSteps.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Codeception\Command;
 
 use Codeception\Test\Loader\Gherkin;

--- a/src/Codeception/Command/GherkinSteps.php
+++ b/src/Codeception/Command/GherkinSteps.php
@@ -26,7 +26,7 @@ class GherkinSteps extends Command
     use Shared\Config;
     use Shared\Style;
 
-    protected function configure()
+    protected function configure(): void
     {
         $this->setDefinition(
             [

--- a/src/Codeception/Command/GherkinSteps.php
+++ b/src/Codeception/Command/GherkinSteps.php
@@ -11,6 +11,7 @@ use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
+use function count;
 
 /**
  * Prints all steps from all Gherkin contexts for a specific suite

--- a/src/Codeception/Command/GherkinSteps.php
+++ b/src/Codeception/Command/GherkinSteps.php
@@ -23,8 +23,8 @@ use function count;
  */
 class GherkinSteps extends Command
 {
-    use Shared\Config;
-    use Shared\Style;
+    use Shared\ConfigTrait;
+    use Shared\StyleTrait;
 
     protected function configure(): void
     {

--- a/src/Codeception/Command/GherkinSteps.php
+++ b/src/Codeception/Command/GherkinSteps.php
@@ -52,7 +52,6 @@ class GherkinSteps extends Command
         $steps = $loader->getSteps();
 
         foreach ($steps as $name => $context) {
-            /** @var $table Table  **/
             $table = new Table($output);
             $table->setHeaders(['Step', 'Implementation']);
             $output->writeln("Steps from <bold>$name</bold> context:");

--- a/src/Codeception/Command/Init.php
+++ b/src/Codeception/Command/Init.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Codeception\Command;
 
 use Codeception\InitTemplate;
+use Exception;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
@@ -41,13 +42,13 @@ class Init extends Command
             $className = 'Codeception\Template\\' . ucfirst($template);
 
             if (!class_exists($className)) {
-                throw new \Exception("Template from a $className can't be loaded; Init can't be executed");
+                throw new Exception("Template from a $className can't be loaded; Init can't be executed");
             }
         }
 
         $initProcess = new $className($input, $output);
         if (!$initProcess instanceof InitTemplate) {
-            throw new \Exception("$className is not a valid template");
+            throw new Exception("$className is not a valid template");
         }
         if ($input->getOption('path')) {
             $initProcess->initDir($input->getOption('path'));

--- a/src/Codeception/Command/Init.php
+++ b/src/Codeception/Command/Init.php
@@ -26,12 +26,12 @@ class Init extends Command
         );
     }
 
-    public function getDescription()
+    public function getDescription(): string
     {
         return "Creates test suites by a template";
     }
 
-    public function execute(InputInterface $input, OutputInterface $output)
+    public function execute(InputInterface $input, OutputInterface $output): int
     {
         $template = (string)$input->getArgument('template');
 

--- a/src/Codeception/Command/Init.php
+++ b/src/Codeception/Command/Init.php
@@ -22,7 +22,7 @@ class Init extends Command
             [
                 new InputArgument('template', InputArgument::REQUIRED, 'Init template for the setup'),
                 new InputOption('path', null, InputOption::VALUE_REQUIRED, 'Change current directory', null),
-                new InputOption('namespace', null, InputOption::VALUE_OPTIONAL, 'Namespace to add for actor classes and helpers\'', null),
+                new InputOption('namespace', null, InputOption::VALUE_OPTIONAL, 'Namespace to add for actor classes and helpers', null),
 
             ]
         );
@@ -51,8 +51,8 @@ class Init extends Command
         if (!$initProcess instanceof InitTemplate) {
             throw new Exception("$className is not a valid template");
         }
-        if ($input->getOption('path')) {
-            $initProcess->initDir($input->getOption('path'));
+        if ($path = $input->getOption('path')) {
+            $initProcess->initDir($path);
         }
         $initProcess->setup();
         return 0;

--- a/src/Codeception/Command/Init.php
+++ b/src/Codeception/Command/Init.php
@@ -11,6 +11,8 @@ use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
+use function class_exists;
+use function ucfirst;
 
 class Init extends Command
 {

--- a/src/Codeception/Command/Init.php
+++ b/src/Codeception/Command/Init.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Codeception\Command;
 
 use Codeception\InitTemplate;
@@ -31,7 +33,7 @@ class Init extends Command
 
     public function execute(InputInterface $input, OutputInterface $output)
     {
-        $template = $input->getArgument('template');
+        $template = (string)$input->getArgument('template');
 
         if (class_exists($template)) {
             $className = $template;

--- a/src/Codeception/Command/Init.php
+++ b/src/Codeception/Command/Init.php
@@ -16,8 +16,7 @@ use function ucfirst;
 
 class Init extends Command
 {
-
-    protected function configure()
+    protected function configure(): void
     {
         $this->setDefinition(
             [

--- a/src/Codeception/Command/Run.php
+++ b/src/Codeception/Command/Run.php
@@ -9,10 +9,11 @@ use Codeception\Configuration;
 use Codeception\Exception\ConfigurationException;
 use Codeception\Exception\ParseException;
 use Exception;
-use PHPUnit\Runner\Version;
+use InvalidArgumentException;
+use PHPUnit\Runner\Version as PHPUnitVersion;
 use RuntimeException;
 use Symfony\Component\Console\Command\Command;
-use Symfony\Component\Console\Exception\InvalidArgumentException;
+use Symfony\Component\Console\Exception\InvalidArgumentException as SymfonyConsoleInvalidArgumentException;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
@@ -128,7 +129,7 @@ class Run extends Command
 
     /**
      * Sets Run arguments
-     * @throws InvalidArgumentException
+     * @throws SymfonyConsoleInvalidArgumentException
      */
     protected function configure()
     {
@@ -277,7 +278,7 @@ class Run extends Command
 
         if (!$this->options['silent']) {
             $this->output->writeln(
-                Codecept::versionString() . "\nPowered by " . Version::getVersionString()
+                Codecept::versionString() . "\nPowered by " . PHPUnitVersion::getVersionString()
             );
             $this->output->writeln(
                 "Running with seed: " . $this->options['seed'] . "\n"
@@ -366,7 +367,7 @@ class Run extends Command
                         try {
                             list(, $suite, $test) = $this->matchTestFromFilename($suite, $testsPath);
                             $isIncludeTest = true;
-                        } catch (\InvalidArgumentException $e) {
+                        } catch (InvalidArgumentException $e) {
                             // Incorrect include match, continue trying to find one
                             continue;
                         }
@@ -531,7 +532,7 @@ class Run extends Command
         $res = preg_match("~^$testsPath/(.*?)(?>/(.*))?$~", $filename, $matches);
 
         if (!$res) {
-            throw new \InvalidArgumentException("Test file can't be matched");
+            throw new InvalidArgumentException("Test file can't be matched");
         }
         if (!isset($matches[2])) {
             $matches[2] = null;

--- a/src/Codeception/Command/Run.php
+++ b/src/Codeception/Command/Run.php
@@ -215,7 +215,7 @@ class Run extends Command
                 InputOption::VALUE_OPTIONAL,
                 'Generate CodeCoverage PHPUnit report in path'
             ),
-            new InputOption('no-exit', '', InputOption::VALUE_NONE, 'Don\'t finish with exit code'),
+            new InputOption('no-exit', '', InputOption::VALUE_NONE, "Don't finish with exit code"),
             new InputOption(
                 'group',
                 'g',
@@ -248,7 +248,7 @@ class Run extends Command
                 InputOption::VALUE_REQUIRED,
                 'Define random seed for shuffle setting'
             ),
-            new InputOption('no-artifacts', '', InputOption::VALUE_NONE, 'Don\'t report about artifacts'),
+            new InputOption('no-artifacts', '', InputOption::VALUE_NONE, "Don't report about artifacts"),
         ]);
 
         parent::configure();
@@ -329,7 +329,7 @@ class Run extends Command
         if (!$this->options['seed']) {
             $userOptions['seed'] = rand();
         } else {
-            $userOptions['seed'] = intval($this->options['seed']);
+            $userOptions['seed'] = (int) $this->options['seed'];
         }
         if ($this->options['no-colors'] || !$userOptions['ansi']) {
             $userOptions['colors'] = false;
@@ -343,7 +343,7 @@ class Run extends Command
         if ($this->options['report']) {
             $userOptions['silent'] = true;
         }
-        if ($this->options['coverage-xml'] or $this->options['coverage-html'] or $this->options['coverage-text'] or $this->options['coverage-crap4j'] or $this->options['coverage-phpunit']) {
+        if ($this->options['coverage-xml'] || $this->options['coverage-html'] || $this->options['coverage-text'] || $this->options['coverage-crap4j'] || $this->options['coverage-phpunit']) {
             $this->options['coverage'] = true;
         }
         if (!$userOptions['ansi'] && $input->getOption('colors')) {
@@ -369,7 +369,7 @@ class Run extends Command
 
                 foreach ($config['include'] as $include) {
                     // Find if the suite begins with an include path
-                    if (strpos($suite, $include) === 0) {
+                    if (strpos($suite, (string) $include) === 0) {
                         // Use include config
                         $config = Configuration::config($projectDir.$include);
 
@@ -421,7 +421,7 @@ class Run extends Command
 
         $this->codecept = new Codecept($userOptions);
 
-        if ($suite and $test) {
+        if ($suite && $test) {
             $this->codecept->run($suite, $test, $config);
         }
 
@@ -430,10 +430,10 @@ class Run extends Command
             $suites = $suite ? explode(',', $suite) : Configuration::suites();
             $this->executed = $this->runSuites($suites, $this->options['skip']);
 
-            if (!empty($config['include']) and !$suite) {
-                $current_dir = Configuration::projectDir();
+            if (!empty($config['include']) && !$suite) {
+                $currentDir = Configuration::projectDir();
                 $suites += $config['include'];
-                $this->runIncludedSuites($config['include'], $current_dir);
+                $this->runIncludedSuites($config['include'], $currentDir);
             }
 
             if ($this->executed === 0) {
@@ -445,10 +445,8 @@ class Run extends Command
 
         $this->codecept->printResult();
 
-        if (!$input->getOption('no-exit')) {
-            if (!$this->codecept->getResult()->wasSuccessful()) {
-                exit(1);
-            }
+        if (!$input->getOption('no-exit') && !$this->codecept->getResult()->wasSuccessful()) {
+            exit(1);
         }
         return 0;
     }
@@ -483,7 +481,7 @@ class Run extends Command
         }
 
         // Run single test without included tests
-        if (! Configuration::isEmpty() && strpos($suite, $config['paths']['tests']) === 0) {
+        if (! Configuration::isEmpty() && strpos($suite, (string) $config['paths']['tests']) === 0) {
             return $this->matchTestFromFilename($suite, $config['paths']['tests']);
         }
     }
@@ -492,24 +490,24 @@ class Run extends Command
      * Runs included suites recursively
      *
      * @param array $suites
-     * @param string $parent_dir
+     * @param string $parentDir
      * @throws ConfigurationException
      */
-    protected function runIncludedSuites(array $suites, string $parent_dir)
+    protected function runIncludedSuites(array $suites, string $parentDir): void
     {
         foreach ($suites as $relativePath) {
-            $current_dir = rtrim($parent_dir, DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR . $relativePath;
-            $config = Configuration::config($current_dir);
+            $currentDir = rtrim($parentDir, DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR . $relativePath;
+            $config = Configuration::config($currentDir);
             $suites = Configuration::suites();
 
             $namespace = $this->currentNamespace();
             $this->output->writeln(
-                "\n<fg=white;bg=magenta>\n[$namespace]: tests from $current_dir\n</fg=white;bg=magenta>"
+                "\n<fg=white;bg=magenta>\n[$namespace]: tests from $currentDir\n</fg=white;bg=magenta>"
             );
 
             $this->executed += $this->runSuites($suites, $this->options['skip']);
             if (!empty($config['include'])) {
-                $this->runIncludedSuites($config['include'], $current_dir);
+                $this->runIncludedSuites($config['include'], $currentDir);
             }
         }
     }
@@ -539,7 +537,7 @@ class Run extends Command
                 continue;
             }
             $this->codecept->run($suite);
-            $executed++;
+            ++$executed;
         }
 
         return $executed;
@@ -563,14 +561,14 @@ class Run extends Command
 
     private function matchFilteredTestName(&$path): ?string
     {
-        $test_parts = explode(':', $path, 2);
-        if (count($test_parts) > 1) {
-            list($path, $filter) = $test_parts;
+        $testParts = explode(':', $path, 2);
+        if (count($testParts) > 1) {
+            list($path, $filter) = $testParts;
             // use carat to signify start of string like in normal regex
             // phpunit --filter matches against the fully qualified method name, so tests actually begin with :
-            $carat_pos = strpos($filter, '^');
-            if ($carat_pos !== false) {
-                $filter = substr_replace($filter, ':', $carat_pos, 1);
+            $caratPos = strpos($filter, '^');
+            if ($caratPos !== false) {
+                $filter = substr_replace($filter, ':', $caratPos, 1);
             }
             return $filter;
         }
@@ -618,7 +616,7 @@ class Run extends Command
         $values = [];
         $request = (string)$input;
         foreach ($options as $option => $defaultValue) {
-            if (strpos($request, "--$option")) {
+            if (strpos($request, sprintf('--%s', (string) $option))) {
                 $values[$option] = $input->getOption($option) ? $input->getOption($option) : $defaultValue;
             } else {
                 $values[$option] = false;

--- a/src/Codeception/Command/Run.php
+++ b/src/Codeception/Command/Run.php
@@ -451,10 +451,7 @@ class Run extends Command
         return 0;
     }
 
-    /**
-     * @return mixed|void
-     */
-    protected function matchSingleTest($suite, $config)
+    protected function matchSingleTest($suite, $config): ?array
     {
         // Workaround when codeception.yml is inside tests directory and tests path is set to "."
         // @see https://github.com/Codeception/Codeception/issues/4432
@@ -484,6 +481,8 @@ class Run extends Command
         if (! Configuration::isEmpty() && strpos($suite, (string) $config['paths']['tests']) === 0) {
             return $this->matchTestFromFilename($suite, $config['paths']['tests']);
         }
+
+        return null;
     }
 
     /**
@@ -559,7 +558,7 @@ class Run extends Command
         return $matches;
     }
 
-    private function matchFilteredTestName(&$path): ?string
+    private function matchFilteredTestName(string &$path): ?string
     {
         $testParts = explode(':', $path, 2);
         if (count($testParts) > 1) {
@@ -609,7 +608,7 @@ class Run extends Command
     /**
      * @param InputInterface $input
      * @param array $options
-     * @return array<int|string, mixed>
+     * @return array<string, bool>
      */
     protected function booleanOptions(InputInterface $input, $options = []): array
     {
@@ -617,7 +616,7 @@ class Run extends Command
         $request = (string)$input;
         foreach ($options as $option => $defaultValue) {
             if (strpos($request, sprintf('--%s', (string) $option))) {
-                $values[$option] = $input->getOption($option) ? $input->getOption($option) : $defaultValue;
+                $values[$option] = $input->getOption($option) ?: $defaultValue;
             } else {
                 $values[$option] = false;
             }

--- a/src/Codeception/Command/Run.php
+++ b/src/Codeception/Command/Run.php
@@ -144,12 +144,11 @@ class Run extends Command
      */
     protected $output;
 
-
     /**
      * Sets Run arguments
      * @throws SymfonyConsoleInvalidArgumentException
      */
-    protected function configure()
+    protected function configure(): void
     {
         $this->setDefinition([
             new InputArgument('suite', InputArgument::OPTIONAL, 'suite to be tested'),
@@ -454,6 +453,9 @@ class Run extends Command
         return 0;
     }
 
+    /**
+     * @return mixed|void
+     */
     protected function matchSingleTest($suite, $config)
     {
         // Workaround when codeception.yml is inside tests directory and tests path is set to "."
@@ -559,7 +561,7 @@ class Run extends Command
         return $matches;
     }
 
-    private function matchFilteredTestName(&$path)
+    private function matchFilteredTestName(&$path): ?string
     {
         $test_parts = explode(':', $path, 2);
         if (count($test_parts) > 1) {
@@ -576,6 +578,10 @@ class Run extends Command
         return null;
     }
 
+    /**
+     * @param InputInterface $input
+     * @return string[]
+     */
     protected function passedOptionKeys(InputInterface $input): array
     {
         $options = [];
@@ -602,6 +608,11 @@ class Run extends Command
         return $options;
     }
 
+    /**
+     * @param InputInterface $input
+     * @param array $options
+     * @return array<int|string, mixed>
+     */
     protected function booleanOptions(InputInterface $input, $options = []): array
     {
         $values = [];
@@ -621,7 +632,7 @@ class Run extends Command
      * @param string $ext
      * @throws Exception
      */
-    private function ensurePhpExtIsAvailable(string $ext)
+    private function ensurePhpExtIsAvailable(string $ext): void
     {
         if (!extension_loaded(strtolower($ext))) {
             throw new Exception(

--- a/src/Codeception/Command/Run.php
+++ b/src/Codeception/Command/Run.php
@@ -18,6 +18,24 @@ use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
+use function array_flip;
+use function array_intersect_key;
+use function array_merge;
+use function count;
+use function explode;
+use function extension_loaded;
+use function getcwd;
+use function implode;
+use function in_array;
+use function preg_match;
+use function preg_replace;
+use function rtrim;
+use function sprintf;
+use function str_replace;
+use function strpos;
+use function strtolower;
+use function substr;
+use function substr_replace;
 
 /**
  * Executes tests.

--- a/src/Codeception/Command/Run.php
+++ b/src/Codeception/Command/Run.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Codeception\Command;
 
 use Codeception\Codecept;

--- a/src/Codeception/Command/Run.php
+++ b/src/Codeception/Command/Run.php
@@ -123,7 +123,7 @@ use function substr_replace;
  */
 class Run extends Command
 {
-    use Shared\Config;
+    use Shared\ConfigTrait;
     /**
      * @var Codecept
      */

--- a/src/Codeception/Command/Run.php
+++ b/src/Codeception/Command/Run.php
@@ -525,7 +525,7 @@ class Run extends Command
         return $config['namespace'];
     }
 
-    protected function runSuites($suites, $skippedSuites = []): int
+    protected function runSuites(array $suites, array $skippedSuites = []): int
     {
         $executed = 0;
         foreach ($suites as $suite) {

--- a/src/Codeception/Command/Run.php
+++ b/src/Codeception/Command/Run.php
@@ -6,7 +6,13 @@ namespace Codeception\Command;
 
 use Codeception\Codecept;
 use Codeception\Configuration;
+use Codeception\Exception\ConfigurationException;
+use Codeception\Exception\ParseException;
+use Exception;
+use PHPUnit\Runner\Version;
+use RuntimeException;
 use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Exception\InvalidArgumentException;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
@@ -122,7 +128,7 @@ class Run extends Command
 
     /**
      * Sets Run arguments
-     * @throws \Symfony\Component\Console\Exception\InvalidArgumentException
+     * @throws InvalidArgumentException
      */
     protected function configure()
     {
@@ -241,7 +247,7 @@ class Run extends Command
      * @param InputInterface $input
      * @param OutputInterface $output
      * @return int|null|void
-     * @throws \RuntimeException
+     * @throws ConfigurationException|ParseException
      */
     public function execute(InputInterface $input, OutputInterface $output): int
     {
@@ -271,7 +277,7 @@ class Run extends Command
 
         if (!$this->options['silent']) {
             $this->output->writeln(
-                Codecept::versionString() . "\nPowered by " . \PHPUnit\Runner\Version::getVersionString()
+                Codecept::versionString() . "\nPowered by " . Version::getVersionString()
             );
             $this->output->writeln(
                 "Running with seed: " . $this->options['seed'] . "\n"
@@ -350,7 +356,7 @@ class Run extends Command
                         $config = Configuration::config($projectDir.$include);
 
                         if (!isset($config['paths']['tests'])) {
-                            throw new \RuntimeException(
+                            throw new RuntimeException(
                                 sprintf("Included '%s' has no tests path configured", $include)
                             );
                         }
@@ -413,7 +419,7 @@ class Run extends Command
             }
 
             if ($this->executed === 0) {
-                throw new \RuntimeException(
+                throw new RuntimeException(
                     sprintf("Suite '%s' could not be found", implode(', ', $suites))
                 );
             }
@@ -466,6 +472,7 @@ class Run extends Command
      *
      * @param array $suites
      * @param string $parent_dir
+     * @throws ConfigurationException
      */
     protected function runIncludedSuites(array $suites, string $parent_dir)
     {
@@ -491,7 +498,7 @@ class Run extends Command
     {
         $config = Configuration::config();
         if (!$config['namespace']) {
-            throw new \RuntimeException(
+            throw new RuntimeException(
                 "Can't include into runner suite without a namespace;\n"
                 . "Please add `namespace` section into included codeception.yml file"
             );
@@ -593,12 +600,12 @@ class Run extends Command
 
     /**
      * @param string $ext
-     * @throws \Exception
+     * @throws Exception
      */
     private function ensurePhpExtIsAvailable(string $ext)
     {
         if (!extension_loaded(strtolower($ext))) {
-            throw new \Exception(
+            throw new Exception(
                 "Codeception requires \"{$ext}\" extension installed to make tests run\n"
                 . "If you are not sure, how to install \"{$ext}\", please refer to StackOverflow\n\n"
                 . "Notice: PHP for Apache/Nginx and CLI can have different php.ini files.\n"

--- a/src/Codeception/Command/Run.php
+++ b/src/Codeception/Command/Run.php
@@ -6,7 +6,6 @@ namespace Codeception\Command;
 
 use Codeception\Codecept;
 use Codeception\Configuration;
-use Codeception\Util\PathResolver;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
@@ -231,7 +230,7 @@ class Run extends Command
         parent::configure();
     }
 
-    public function getDescription()
+    public function getDescription(): string
     {
         return 'Runs the test suites';
     }
@@ -239,12 +238,12 @@ class Run extends Command
     /**
      * Executes Run
      *
-     * @param \Symfony\Component\Console\Input\InputInterface $input
-     * @param \Symfony\Component\Console\Output\OutputInterface $output
+     * @param InputInterface $input
+     * @param OutputInterface $output
      * @return int|null|void
      * @throws \RuntimeException
      */
-    public function execute(InputInterface $input, OutputInterface $output)
+    public function execute(InputInterface $input, OutputInterface $output): int
     {
         $this->ensurePhpExtIsAvailable('CURL');
         $this->ensurePhpExtIsAvailable('mbstring');
@@ -468,7 +467,7 @@ class Run extends Command
      * @param array $suites
      * @param string $parent_dir
      */
-    protected function runIncludedSuites($suites, $parent_dir)
+    protected function runIncludedSuites(array $suites, string $parent_dir)
     {
         foreach ($suites as $relativePath) {
             $current_dir = rtrim($parent_dir, DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR . $relativePath;
@@ -501,7 +500,7 @@ class Run extends Command
         return $config['namespace'];
     }
 
-    protected function runSuites($suites, $skippedSuites = [])
+    protected function runSuites($suites, $skippedSuites = []): int
     {
         $executed = 0;
         foreach ($suites as $suite) {
@@ -551,7 +550,7 @@ class Run extends Command
         return null;
     }
 
-    protected function passedOptionKeys(InputInterface $input)
+    protected function passedOptionKeys(InputInterface $input): array
     {
         $options = [];
         $request = (string)$input;
@@ -577,7 +576,7 @@ class Run extends Command
         return $options;
     }
 
-    protected function booleanOptions(InputInterface $input, $options = [])
+    protected function booleanOptions(InputInterface $input, $options = []): array
     {
         $values = [];
         $request = (string)$input;
@@ -596,7 +595,7 @@ class Run extends Command
      * @param string $ext
      * @throws \Exception
      */
-    private function ensurePhpExtIsAvailable($ext)
+    private function ensurePhpExtIsAvailable(string $ext)
     {
         if (!extension_loaded(strtolower($ext))) {
             throw new \Exception(

--- a/src/Codeception/Command/SelfUpdate.php
+++ b/src/Codeception/Command/SelfUpdate.php
@@ -33,7 +33,7 @@ class SelfUpdate extends Command
     /**
      * @var string
      */
-    const PHAR_URL = 'https://codeception.com/';
+    const PHAR_URL = 'https://codeception.com/php73/';
 
     /**
      * Holds the current script filename.

--- a/src/Codeception/Command/SelfUpdate.php
+++ b/src/Codeception/Command/SelfUpdate.php
@@ -14,7 +14,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 use function sprintf;
 
 /**
- * Auto-updates phar archive from official site: 'http://codeception.com/codecept.phar' .
+ * Auto-updates phar archive from official site: 'https://codeception.com/codecept.phar' .
  *
  * * `php codecept.phar self-update`
  *
@@ -23,12 +23,17 @@ use function sprintf;
 class SelfUpdate extends Command
 {
     /**
-     * Class constants
+     * @var string
      */
     const NAME = 'Codeception';
+    /**
+     * @var string
+     */
     const GITHUB_REPO = 'Codeception/Codeception';
-    const PHAR_URL = 'http://codeception.com/';
-    const PHAR_URL_PHP56 = 'http://codeception.com/php56/';
+    /**
+     * @var string
+     */
+    const PHAR_URL = 'https://codeception.com/';
 
     /**
      * Holds the current script filename.
@@ -41,12 +46,7 @@ class SelfUpdate extends Command
      */
     protected function configure(): void
     {
-        if (isset($_SERVER['argv'][0])) {
-            $this->filename = $_SERVER['argv'][0];
-        } else {
-            $this->filename = Phar::running(false);
-        }
-
+        $this->filename = isset($_SERVER['argv'][0]) ? $_SERVER['argv'][0] : Phar::running(false);
         $this
             ->setAliases(array('selfupdate'))
             ->setDescription(
@@ -55,7 +55,6 @@ class SelfUpdate extends Command
                     $this->filename
                 )
             );
-
         parent::configure();
     }
 
@@ -69,17 +68,17 @@ class SelfUpdate extends Command
      */
     public function execute(InputInterface $input, OutputInterface $output): int
     {
-        $version = $this->getCurrentVersion();
+        $currentVersion = $this->getCurrentVersion();
 
         $output->writeln(
             sprintf(
                 '<info>%s</info> version <comment>%s</comment>',
                 self::NAME,
-                $version
+                $currentVersion
             )
         );
 
-        $url = $this->getPharUrl();
+        $url = self::PHAR_URL;
 
         $updater = new Updater(null, false);
         $updater->getStrategy()->setPharUrl($url . 'codecept.phar');
@@ -107,18 +106,5 @@ class SelfUpdate extends Command
         }
 
         return 0;
-    }
-
-    /**
-     * Returns base url of phar file for current PHP version
-     *
-     * @return string
-     */
-    protected function getPharUrl(): string
-    {
-        if (version_compare(PHP_VERSION, '7.2.0', '<')) {
-            return self::PHAR_URL_PHP56;
-        }
-        return self::PHAR_URL;
     }
 }

--- a/src/Codeception/Command/SelfUpdate.php
+++ b/src/Codeception/Command/SelfUpdate.php
@@ -5,7 +5,9 @@ declare(strict_types=1);
 namespace Codeception\Command;
 
 use Codeception\Codecept;
+use Exception;
 use Humbug\SelfUpdate\Updater;
+use Phar;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -41,7 +43,7 @@ class SelfUpdate extends Command
         if (isset($_SERVER['argv'][0])) {
             $this->filename = $_SERVER['argv'][0];
         } else {
-            $this->filename = \Phar::running(false);
+            $this->filename = Phar::running(false);
         }
 
         $this
@@ -96,7 +98,7 @@ class SelfUpdate extends Command
             } else {
                 $output->writeln('You are already using the latest version.');
             }
-        } catch (\Exception $e) {
+        } catch (Exception $e) {
             $output->writeln(
                 sprintf(
                     "<error>\n%s\n</error>",

--- a/src/Codeception/Command/SelfUpdate.php
+++ b/src/Codeception/Command/SelfUpdate.php
@@ -4,12 +4,11 @@ declare(strict_types=1);
 
 namespace Codeception\Command;
 
+use Codeception\Codecept;
 use Humbug\SelfUpdate\Updater;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
-use Symfony\Component\Console\Question\ConfirmationQuestion;
-use Codeception\Codecept;
 
 /**
  * Auto-updates phar archive from official site: 'http://codeception.com/codecept.phar' .
@@ -60,7 +59,7 @@ class SelfUpdate extends Command
     /**
      * @return string
      */
-    protected function getCurrentVersion()
+    protected function getCurrentVersion(): string
     {
         return Codecept::VERSION;
     }
@@ -68,7 +67,7 @@ class SelfUpdate extends Command
     /**
      * {@inheritdoc}
      */
-    public function execute(InputInterface $input, OutputInterface $output)
+    public function execute(InputInterface $input, OutputInterface $output): int
     {
         $version = $this->getCurrentVersion();
 
@@ -115,7 +114,7 @@ class SelfUpdate extends Command
      *
      * @return string
      */
-    protected function getPharUrl()
+    protected function getPharUrl(): string
     {
         if (version_compare(PHP_VERSION, '7.2.0', '<')) {
             return self::PHAR_URL_PHP56;

--- a/src/Codeception/Command/SelfUpdate.php
+++ b/src/Codeception/Command/SelfUpdate.php
@@ -11,6 +11,7 @@ use Phar;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
+use function sprintf;
 
 /**
  * Auto-updates phar archive from official site: 'http://codeception.com/codecept.phar' .

--- a/src/Codeception/Command/SelfUpdate.php
+++ b/src/Codeception/Command/SelfUpdate.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Codeception\Command;
 
 use Humbug\SelfUpdate\Updater;

--- a/src/Codeception/Command/SelfUpdate.php
+++ b/src/Codeception/Command/SelfUpdate.php
@@ -39,7 +39,7 @@ class SelfUpdate extends Command
     /**
      * {@inheritdoc}
      */
-    protected function configure()
+    protected function configure(): void
     {
         if (isset($_SERVER['argv'][0])) {
             $this->filename = $_SERVER['argv'][0];
@@ -59,9 +59,6 @@ class SelfUpdate extends Command
         parent::configure();
     }
 
-    /**
-     * @return string
-     */
     protected function getCurrentVersion(): string
     {
         return Codecept::VERSION;

--- a/src/Codeception/Command/Shared/Config.php
+++ b/src/Codeception/Command/Shared/Config.php
@@ -9,6 +9,14 @@ use InvalidArgumentException;
 use Symfony\Component\Console\Exception\InvalidOptionException;
 use Symfony\Component\Yaml\Exception\ParseException;
 use Symfony\Component\Yaml\Yaml;
+use function array_merge_recursive;
+use function array_pop;
+use function array_shift;
+use function class_exists;
+use function count;
+use function explode;
+use function str_repeat;
+use function ucfirst;
 
 trait Config
 {

--- a/src/Codeception/Command/Shared/Config.php
+++ b/src/Codeception/Command/Shared/Config.php
@@ -11,22 +11,22 @@ use Symfony\Component\Yaml\Yaml;
 
 trait Config
 {
-    protected function getSuiteConfig($suite)
+    protected function getSuiteConfig($suite): array
     {
         return Configuration::suiteSettings($suite, $this->getGlobalConfig());
     }
 
-    protected function getGlobalConfig($conf = null)
+    protected function getGlobalConfig($conf = null): ?array
     {
         return Configuration::config($conf);
     }
 
-    protected function getSuites($conf = null)
+    protected function getSuites($conf = null): array
     {
         return Configuration::suites();
     }
 
-    protected function overrideConfig($configOptions)
+    protected function overrideConfig($configOptions): ?array
     {
         $updatedConfig = [];
         foreach ($configOptions as $option) {
@@ -50,7 +50,7 @@ trait Config
         return Configuration::append($updatedConfig);
     }
 
-    protected function enableExtensions($extensions)
+    protected function enableExtensions($extensions): ?array
     {
         $config = ['extensions' => ['enabled' => []]];
         foreach ($extensions as $name) {

--- a/src/Codeception/Command/Shared/Config.php
+++ b/src/Codeception/Command/Shared/Config.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Codeception\Command\Shared;
 
 use Codeception\Configuration;
+use InvalidArgumentException;
 use Symfony\Component\Console\Exception\InvalidOptionException;
 use Symfony\Component\Yaml\Exception\ParseException;
 use Symfony\Component\Yaml\Yaml;
@@ -32,7 +33,7 @@ trait Config
         foreach ($configOptions as $option) {
             $keys = explode(': ', $option);
             if (count($keys) < 2) {
-                throw new \InvalidArgumentException('--config-option should have config passed as "key:value"');
+                throw new InvalidArgumentException('--config-option should have config passed as "key:value"');
             }
             $value = array_pop($keys);
             $yaml = '';

--- a/src/Codeception/Command/Shared/Config.php
+++ b/src/Codeception/Command/Shared/Config.php
@@ -25,7 +25,7 @@ trait Config
         return Configuration::suiteSettings($suite, $this->getGlobalConfig());
     }
 
-    protected function getGlobalConfig($conf = null): ?array
+    protected function getGlobalConfig($conf = null): array
     {
         return Configuration::config($conf);
     }
@@ -35,7 +35,7 @@ trait Config
         return Configuration::suites();
     }
 
-    protected function overrideConfig($configOptions): ?array
+    protected function overrideConfig($configOptions): array
     {
         $updatedConfig = [];
         foreach ($configOptions as $option) {
@@ -59,7 +59,7 @@ trait Config
         return Configuration::append($updatedConfig);
     }
 
-    protected function enableExtensions($extensions): ?array
+    protected function enableExtensions($extensions): array
     {
         $config = ['extensions' => ['enabled' => []]];
         foreach ($extensions as $name) {

--- a/src/Codeception/Command/Shared/Config.php
+++ b/src/Codeception/Command/Shared/Config.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Codeception\Command\Shared;
 
 use Codeception\Configuration;

--- a/src/Codeception/Command/Shared/ConfigTrait.php
+++ b/src/Codeception/Command/Shared/ConfigTrait.php
@@ -18,7 +18,7 @@ use function explode;
 use function str_repeat;
 use function ucfirst;
 
-trait Config
+trait ConfigTrait
 {
     protected function getSuiteConfig($suite): array
     {

--- a/src/Codeception/Command/Shared/FileSystem.php
+++ b/src/Codeception/Command/Shared/FileSystem.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Codeception\Command\Shared;
 
 use Codeception\Util\Shared\Namespaces;
@@ -43,7 +46,7 @@ trait FileSystem
         return preg_replace("~$suffix$~", '', $classname);
     }
 
-    protected function createFile($filename, $contents, $force = false, $flags = null)
+    protected function createFile($filename, $contents, $force = false, $flags = 0): bool
     {
         if (file_exists($filename) && !$force) {
             return false;

--- a/src/Codeception/Command/Shared/FileSystem.php
+++ b/src/Codeception/Command/Shared/FileSystem.php
@@ -19,7 +19,7 @@ trait FileSystem
 {
     use Namespaces;
 
-    protected function createDirectoryFor($basePath, $className = ''): string
+    protected function createDirectoryFor(string $basePath, string $className = ''): string
     {
         $basePath = rtrim($basePath, DIRECTORY_SEPARATOR);
         if ($className) {
@@ -34,7 +34,7 @@ trait FileSystem
         return $basePath;
     }
 
-    protected function completeSuffix($filename, $suffix): string
+    protected function completeSuffix(string $filename, string $suffix): string
     {
         if (strpos(strrev($filename), strrev($suffix)) === 0) {
             $filename .= '.php';
@@ -49,13 +49,13 @@ trait FileSystem
         return $filename;
     }
 
-    protected function removeSuffix($classname, $suffix)
+    protected function removeSuffix(string $classname, string $suffix): string
     {
         $classname = preg_replace('~\.php$~', '', $classname);
         return preg_replace("~$suffix$~", '', $classname);
     }
 
-    protected function createFile($filename, $contents, $force = false, $flags = 0): bool
+    protected function createFile(string $filename, $contents, bool $force = false, int $flags = 0): bool
     {
         if (file_exists($filename) && !$force) {
             return false;

--- a/src/Codeception/Command/Shared/FileSystem.php
+++ b/src/Codeception/Command/Shared/FileSystem.php
@@ -10,7 +10,7 @@ trait FileSystem
 {
     use Namespaces;
 
-    protected function createDirectoryFor($basePath, $className = '')
+    protected function createDirectoryFor($basePath, $className = ''): string
     {
         $basePath = rtrim($basePath, DIRECTORY_SEPARATOR);
         if ($className) {
@@ -25,7 +25,7 @@ trait FileSystem
         return $basePath;
     }
 
-    protected function completeSuffix($filename, $suffix)
+    protected function completeSuffix($filename, $suffix): string
     {
         if (strpos(strrev($filename), strrev($suffix)) === 0) {
             $filename .= '.php';

--- a/src/Codeception/Command/Shared/FileSystem.php
+++ b/src/Codeception/Command/Shared/FileSystem.php
@@ -5,6 +5,15 @@ declare(strict_types=1);
 namespace Codeception\Command\Shared;
 
 use Codeception\Util\Shared\Namespaces;
+use function file_exists;
+use function file_put_contents;
+use function mkdir;
+use function pathinfo;
+use function preg_replace;
+use function rtrim;
+use function str_replace;
+use function strpos;
+use function strrev;
 
 trait FileSystem
 {

--- a/src/Codeception/Command/Shared/FileSystem.php
+++ b/src/Codeception/Command/Shared/FileSystem.php
@@ -55,7 +55,7 @@ trait FileSystem
         return preg_replace("~$suffix$~", '', $classname);
     }
 
-    protected function createFile(string $filename, $contents, bool $force = false, int $flags = 0): bool
+    protected function createFile(string $filename, string $contents, bool $force = false, int $flags = 0): bool
     {
         if (file_exists($filename) && !$force) {
             return false;

--- a/src/Codeception/Command/Shared/FileSystemTrait.php
+++ b/src/Codeception/Command/Shared/FileSystemTrait.php
@@ -15,7 +15,7 @@ use function str_replace;
 use function strpos;
 use function strrev;
 
-trait FileSystem
+trait FileSystemTrait
 {
     use Namespaces;
 

--- a/src/Codeception/Command/Shared/Style.php
+++ b/src/Codeception/Command/Shared/Style.php
@@ -9,7 +9,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 trait Style
 {
-    public function addStyles(OutputInterface $output)
+    public function addStyles(OutputInterface $output): void
     {
         $output->getFormatter()->setStyle('notice', new OutputFormatterStyle('white', 'green', ['bold']));
         $output->getFormatter()->setStyle('bold', new OutputFormatterStyle(null, null, ['bold']));

--- a/src/Codeception/Command/Shared/Style.php
+++ b/src/Codeception/Command/Shared/Style.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Codeception\Command\Shared;
 
 use Symfony\Component\Console\Formatter\OutputFormatterStyle;

--- a/src/Codeception/Command/Shared/StyleTrait.php
+++ b/src/Codeception/Command/Shared/StyleTrait.php
@@ -7,7 +7,7 @@ namespace Codeception\Command\Shared;
 use Symfony\Component\Console\Formatter\OutputFormatterStyle;
 use Symfony\Component\Console\Output\OutputInterface;
 
-trait Style
+trait StyleTrait
 {
     public function addStyles(OutputInterface $output): void
     {

--- a/src/Codeception/InitTemplate.php
+++ b/src/Codeception/InitTemplate.php
@@ -2,8 +2,8 @@
 
 namespace Codeception;
 
-use Codeception\Command\Shared\FileSystem;
-use Codeception\Command\Shared\Style;
+use Codeception\Command\Shared\FileSystemTrait;
+use Codeception\Command\Shared\StyleTrait;
 use Codeception\Lib\ModuleContainer;
 use Symfony\Component\Console\Helper\QuestionHelper;
 use Symfony\Component\Console\Input\InputInterface;
@@ -33,8 +33,8 @@ use Symfony\Component\Console\Question\Question;
  */
 abstract class InitTemplate
 {
-    use FileSystem;
-    use Style;
+    use FileSystemTrait;
+    use StyleTrait;
 
     const GIT_IGNORE = '.gitignore';
 

--- a/tests/data/register_command/examples/MyCustomCommand.php
+++ b/tests/data/register_command/examples/MyCustomCommand.php
@@ -16,8 +16,8 @@ use \Symfony\Component\Console\Output\OutputInterface;
 class MyCustomCommand extends Command implements CustomCommandInterface
 {
 
-    use \Codeception\Command\Shared\FileSystem;
-    use \Codeception\Command\Shared\Config;
+    use \Codeception\Command\Shared\FileSystemTrait;
+    use \Codeception\Command\Shared\ConfigTrait;
 
     /**
      * returns the name of the command

--- a/tests/data/register_command/examples/YourCustomCommand.php
+++ b/tests/data/register_command/examples/YourCustomCommand.php
@@ -16,8 +16,8 @@ use \Symfony\Component\Console\Output\OutputInterface;
 class YourCustomCommand extends Command implements CustomCommandInterface
 {
 
-    use \Codeception\Command\Shared\FileSystem;
-    use \Codeception\Command\Shared\Config;
+    use \Codeception\Command\Shared\FileSystemTrait;
+    use \Codeception\Command\Shared\ConfigTrait;
 
     /**
      * returns the name of the command


### PR DESCRIPTION
- [x] Use strict types in `src/Codeception/Command`.
- [x] Add type hints to Commands.
- [x] Remove unnecessary qualifiers in `src/Codeception/Command`.
- [x] Add 'use function' statements for performance reasons.

**Added from feedback:**

- [x] Longer aliases for ambiguous class names.
- [x] Fix naming in `src/Codeception/Command`.
- [x] Rename `src/Codeception/Command/Shared` traits.