### PR TITLE
suggestion on missing modules

### DIFF
--- a/src/Codeception/Lib/ModuleContainer.php
+++ b/src/Codeception/Lib/ModuleContainer.php
@@ -289,7 +289,7 @@ class ModuleContainer
     public function throwMissingModuleExceptionWithSuggestion($className, $moduleName)
     {
         $suggestedModuleNameInfo = $this->getModuleSuggestion($moduleName);
-        throw new ModuleException($className, "Module $moduleName couldn't be connected$suggestedModuleNameInfo");
+        throw new ModuleException($className, "Module $moduleName couldn't be connected" . $suggestedModuleNameInfo);
     }
 
     protected function getModuleSuggestion($missingModuleName)

--- a/src/Codeception/Lib/ModuleContainer.php
+++ b/src/Codeception/Lib/ModuleContainer.php
@@ -22,6 +22,11 @@ class ModuleContainer
      */
     const MODULE_NAMESPACE = '\\Codeception\\Module\\';
 
+    /**
+     * @var integer
+     */
+    const MAXIMUM_LEVENSHTEIN_DISTANCE = 5;
+
     public static $packages = [
         'AMQP' => 'codeception/module-amqp',
         'Apc' => 'codeception/module-apc',
@@ -275,10 +280,35 @@ class ModuleContainer
     public function getModule($moduleName)
     {
         if (!$this->hasModule($moduleName)) {
-            throw new ModuleException(__CLASS__, "Module $moduleName couldn't be connected");
+            $this->throwMissingModuleExceptionWithSuggestion(__CLASS__, $moduleName);
         }
 
         return $this->modules[$moduleName];
+    }
+
+    public function throwMissingModuleExceptionWithSuggestion($className, $moduleName)
+    {
+        $suggestedModuleNameInfo = $this->getModuleSuggestion($moduleName);
+        throw new ModuleException($className, "Module $moduleName couldn't be connected$suggestedModuleNameInfo");
+    }
+
+    protected function getModuleSuggestion($missingModuleName)
+    {
+        $shortestLevenshteinDistance = null;
+        $suggestedModuleName = null;
+        foreach ($this->modules as $moduleName => $module) {
+            $levenshteinDistance = levenshtein($missingModuleName, $moduleName);
+            if ($shortestLevenshteinDistance === null || $levenshteinDistance <= $shortestLevenshteinDistance) {
+                $shortestLevenshteinDistance = $levenshteinDistance;
+                $suggestedModuleName = $moduleName;
+            }
+        }
+
+        if ($suggestedModuleName !== null && $shortestLevenshteinDistance <= self::MAXIMUM_LEVENSHTEIN_DISTANCE) {
+            return " (did you mean '$suggestedModuleName'?)";
+        }
+
+        return '';
     }
 
     /**

--- a/src/Codeception/Module.php
+++ b/src/Codeception/Module.php
@@ -337,7 +337,7 @@ abstract class Module
     protected function getModule($name)
     {
         if (!$this->hasModule($name)) {
-            throw new Exception\ModuleException(__CLASS__, "Module $name couldn't be connected");
+            $this->moduleContainer->throwMissingModuleExceptionWithSuggestion(__CLASS__, $name);
         }
         return $this->moduleContainer->getModule($name);
     }

--- a/tests/unit/Codeception/Lib/ModuleContainerTest.php
+++ b/tests/unit/Codeception/Lib/ModuleContainerTest.php
@@ -388,17 +388,11 @@ class ModuleContainerTest extends Unit
         ]];
         $this->moduleContainer = new ModuleContainer(Stub::make('Codeception\Lib\Di'), $config);
         $this->moduleContainer->create('Codeception\Lib\HelperModule');
-
-//        $message = "couldn't be connected (did you mean '$correctModule'?)";
-        $message = "Codeception\Module: Module $wrongModule couldn't be connected (did you mean '$correctModule'?)";
-//        $expectedException = new ModuleException($wrongModule, $message);
-
+        
+        $message = "Codeception\Lib\ModuleContainer: Module $wrongModule couldn't be connected (did you mean '$correctModule'?)";
         $this->expectException('\Codeception\Exception\ModuleException');
         $this->expectExceptionMessage($message);
         $this->moduleContainer->getModule($wrongModule);
-//        $this->tester->expectException($expectedException, function($wrongModule) {
-//            $this->moduleContainer->hasModule($wrongModule);
-//        });
     }
 }
 

--- a/tests/unit/Codeception/Lib/ModuleContainerTest.php
+++ b/tests/unit/Codeception/Lib/ModuleContainerTest.php
@@ -1,6 +1,7 @@
 <?php
 namespace Codeception\Lib;
 
+use Codeception\Exception\ModuleException;
 use Codeception\Lib\Interfaces\ConflictsWithModule;
 use Codeception\Lib\Interfaces\DependsOnModule;
 use Codeception\Test\Unit;
@@ -375,6 +376,24 @@ class ModuleContainerTest extends Unit
         $this->moduleContainer = new ModuleContainer(Stub::make('Codeception\Lib\Di'), $config);
         $this->moduleContainer->create('Codeception\Lib\HelperModule');
         $this->moduleContainer->hasModule('Codeception\Lib\HelperModule');
+    }
+
+    public function testSuggestMissingModule()
+    {
+        $correctModule = 'Codeception\Lib\HelperModule';
+        $wrongModule = 'Codeception\Lib\Helpamodule';
+
+        $config = ['modules' => [
+            'enabled' => [$correctModule],
+        ]];
+        $this->moduleContainer = new ModuleContainer(Stub::make('Codeception\Lib\Di'), $config);
+        $this->moduleContainer->create('Codeception\Lib\HelperModule');
+
+        $message = "couldn't be connected (did you mean '$correctModule'?)";
+        $expectedException = new ModuleException($wrongModule, $message);
+        $this->tester->expectException($expectedException, function($wrongModule) {
+            $this->moduleContainer->hasModule($wrongModule);
+        });
     }
 }
 

--- a/tests/unit/Codeception/Lib/ModuleContainerTest.php
+++ b/tests/unit/Codeception/Lib/ModuleContainerTest.php
@@ -389,11 +389,16 @@ class ModuleContainerTest extends Unit
         $this->moduleContainer = new ModuleContainer(Stub::make('Codeception\Lib\Di'), $config);
         $this->moduleContainer->create('Codeception\Lib\HelperModule');
 
-        $message = "couldn't be connected (did you mean '$correctModule'?)";
-        $expectedException = new ModuleException($wrongModule, $message);
-        $this->tester->expectException($expectedException, function($wrongModule) {
-            $this->moduleContainer->hasModule($wrongModule);
-        });
+//        $message = "couldn't be connected (did you mean '$correctModule'?)";
+        $message = "Codeception\Module: Module $wrongModule couldn't be connected (did you mean '$correctModule'?)";
+//        $expectedException = new ModuleException($wrongModule, $message);
+
+        $this->expectException('\Codeception\Exception\ModuleException');
+        $this->expectExceptionMessage($message);
+        $this->moduleContainer->hasModule($wrongModule);
+//        $this->tester->expectException($expectedException, function($wrongModule) {
+//            $this->moduleContainer->hasModule($wrongModule);
+//        });
     }
 }
 

--- a/tests/unit/Codeception/Lib/ModuleContainerTest.php
+++ b/tests/unit/Codeception/Lib/ModuleContainerTest.php
@@ -395,7 +395,7 @@ class ModuleContainerTest extends Unit
 
         $this->expectException('\Codeception\Exception\ModuleException');
         $this->expectExceptionMessage($message);
-        $this->moduleContainer->hasModule($wrongModule);
+        $this->moduleContainer->getModule($wrongModule);
 //        $this->tester->expectException($expectedException, function($wrongModule) {
 //            $this->moduleContainer->hasModule($wrongModule);
 //        });


### PR DESCRIPTION
had the problem that i wasn't able to connect to a module, which i included in the config. took quite a while to debug. it was a simple diff in the case `LockPick ` vs `Lockpick`

so i added some code to add a  suggestion which module could be meant to the error message. 

```
[ModuleException] Codeception\Module: Module \C33s\Codeception\Module\LockPick couldn't be connected 
```
vs
```
[ModuleException] Codeception\Module: Module \C33s\Codeception\Module\LockPick couldn't be connected (did you mean '\C33s\Codeception\Module\Lockpick'?)
```

have not adapted any tests yet, wanted to wait for comments if you would merge this before.