### PR TITLE
Update "running with seed" in the CLI report

### DIFF
--- a/src/Codeception/Command/Run.php
+++ b/src/Codeception/Command/Run.php
@@ -274,7 +274,7 @@ class Run extends Command
 
             if ($this->options['seed']) {
                 $this->output->writeln(
-                    "Running with seed: " . $this->options['seed'] . "\n"
+                    "Running with seed: <info>" . $this->options['seed'] . "</info>\n"
                 );
             }
         }

--- a/src/Codeception/Command/Run.php
+++ b/src/Codeception/Command/Run.php
@@ -271,9 +271,12 @@ class Run extends Command
             $this->output->writeln(
                 Codecept::versionString() . "\nPowered by " . \PHPUnit\Runner\Version::getVersionString()
             );
-            $this->output->writeln(
-                "Running with seed: " . $this->options['seed'] . "\n"
-            );
+
+            if ($this->options['seed']) {
+                $this->output->writeln(
+                    "Running with seed: " . $this->options['seed'] . "\n"
+                );
+            }
         }
         if ($this->options['debug']) {
             $this->output->setVerbosity(OutputInterface::VERBOSITY_VERY_VERBOSE);


### PR DESCRIPTION

### codecept run

`Running with seed:` removed :white_check_mark:

Before | After
------------ | -------------
<img width="716" alt="Capture d’écran 2021-01-13 à 18 44 55" src="https://user-images.githubusercontent.com/1255561/104489754-4854af00-55d0-11eb-9c3f-77875425770a.png"> | <img width="710" alt="Capture d’écran 2021-01-13 à 18 49 12" src="https://user-images.githubusercontent.com/1255561/104489928-805bf200-55d0-11eb-8c5e-9e9baea614c3.png">



### codecept run -o "settings: shuffle: true"

`Running with seed:` removed :white_check_mark:

Before | After
------------ | -------------
<img width="715" alt="Capture d’écran 2021-01-13 à 18 45 16" src="https://user-images.githubusercontent.com/1255561/104489748-47bc1880-55d0-11eb-889d-8a982ef401cd.png"> | <img width="713" alt="Capture d’écran 2021-01-13 à 18 49 24" src="https://user-images.githubusercontent.com/1255561/104489927-7f2ac500-55d0-11eb-98f7-739cbfa86137.png">



### codecept run --seed 105623729

color added :white_check_mark:


Before | After
------------ | -------------
<img width="714" alt="Capture d’écran 2021-01-13 à 18 45 41" src="https://user-images.githubusercontent.com/1255561/104489744-45f25500-55d0-11eb-847c-7fd33bda4060.png"> | <img width="714" alt="Capture d’écran 2021-01-13 à 19 06 27" src="https://user-images.githubusercontent.com/1255561/104491450-8ce14a00-55d2-11eb-80b4-21410602b40b.png">




