### PR TITLE
[5.0] Update code standards in Exceptions

### DIFF
--- a/src/Codeception/Exception/ConditionalAssertionFailed.php
+++ b/src/Codeception/Exception/ConditionalAssertionFailed.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Codeception\Exception;
 
 class ConditionalAssertionFailed extends \PHPUnit\Framework\AssertionFailedError

--- a/src/Codeception/Exception/ConditionalAssertionFailed.php
+++ b/src/Codeception/Exception/ConditionalAssertionFailed.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Codeception\Exception;
 
-class ConditionalAssertionFailed extends \PHPUnit\Framework\AssertionFailedError
+use PHPUnit\Framework\AssertionFailedError;
+
+class ConditionalAssertionFailed extends AssertionFailedError
 {
 }

--- a/src/Codeception/Exception/ConfigurationException.php
+++ b/src/Codeception/Exception/ConfigurationException.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Codeception\Exception;
 
 class ConfigurationException extends \Exception

--- a/src/Codeception/Exception/ConfigurationException.php
+++ b/src/Codeception/Exception/ConfigurationException.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Codeception\Exception;
 
-class ConfigurationException extends \Exception
+use Exception;
+
+class ConfigurationException extends Exception
 {
 }

--- a/src/Codeception/Exception/ContentNotFound.php
+++ b/src/Codeception/Exception/ContentNotFound.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Codeception\Exception;
 
 class ContentNotFound extends \PHPUnit\Framework\AssertionFailedError

--- a/src/Codeception/Exception/ContentNotFound.php
+++ b/src/Codeception/Exception/ContentNotFound.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Codeception\Exception;
 
-class ContentNotFound extends \PHPUnit\Framework\AssertionFailedError
+use PHPUnit\Framework\AssertionFailedError;
+
+class ContentNotFound extends AssertionFailedError
 {
 }

--- a/src/Codeception/Exception/ElementNotFound.php
+++ b/src/Codeception/Exception/ElementNotFound.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Codeception\Exception;
 
 use Codeception\Util\Locator;

--- a/src/Codeception/Exception/ElementNotFound.php
+++ b/src/Codeception/Exception/ElementNotFound.php
@@ -5,8 +5,11 @@ declare(strict_types=1);
 namespace Codeception\Exception;
 
 use Codeception\Util\Locator;
+use PHPUnit\Framework\AssertionFailedError;
+use function is_string;
+use function strpos;
 
-class ElementNotFound extends \PHPUnit\Framework\AssertionFailedError
+class ElementNotFound extends AssertionFailedError
 {
     public function __construct($selector, $message = null)
     {

--- a/src/Codeception/Exception/ElementNotFound.php
+++ b/src/Codeception/Exception/ElementNotFound.php
@@ -11,11 +11,11 @@ use function strpos;
 
 class ElementNotFound extends AssertionFailedError
 {
-    public function __construct($selector, $message = null)
+    public function __construct($selector, string $message = '')
     {
         if (!is_string($selector) || strpos($selector, "'") === false) {
             $selector = Locator::humanReadableString($selector);
         }
-        parent::__construct($message . " element with $selector was not found.");
+        parent::__construct("{$message} element with {$selector} was not found.");
     }
 }

--- a/src/Codeception/Exception/ExtensionException.php
+++ b/src/Codeception/Exception/ExtensionException.php
@@ -4,7 +4,11 @@ declare(strict_types=1);
 
 namespace Codeception\Exception;
 
-class ExtensionException extends \Exception
+use Exception;
+use function get_class;
+use function is_object;
+
+class ExtensionException extends Exception
 {
     public function __construct($extension, $message, \Exception $previous = null)
     {

--- a/src/Codeception/Exception/ExtensionException.php
+++ b/src/Codeception/Exception/ExtensionException.php
@@ -10,7 +10,14 @@ use function is_object;
 
 class ExtensionException extends Exception
 {
-    public function __construct($extension, $message, \Exception $previous = null)
+    /**
+     * ExtensionException constructor.
+     *
+     * @param object|string $extension
+     * @param string $message
+     * @param Exception|null $previous
+     */
+    public function __construct($extension, string $message, Exception $previous = null)
     {
         parent::__construct($message, $previous);
         if (is_object($extension)) {

--- a/src/Codeception/Exception/ExtensionException.php
+++ b/src/Codeception/Exception/ExtensionException.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Codeception\Exception;
 
 class ExtensionException extends \Exception

--- a/src/Codeception/Exception/InjectionException.php
+++ b/src/Codeception/Exception/InjectionException.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Codeception\Exception;
 
-class InjectionException extends \Exception
+use Exception;
+
+class InjectionException extends Exception
 {
 }

--- a/src/Codeception/Exception/InjectionException.php
+++ b/src/Codeception/Exception/InjectionException.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Codeception\Exception;
 
 class InjectionException extends \Exception

--- a/src/Codeception/Exception/MalformedLocatorException.php
+++ b/src/Codeception/Exception/MalformedLocatorException.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Codeception\Exception;
 
+use function ucfirst;
+
 class MalformedLocatorException extends TestRuntimeException
 {
     public function __construct($locator, $type = "CSS or XPath")

--- a/src/Codeception/Exception/MalformedLocatorException.php
+++ b/src/Codeception/Exception/MalformedLocatorException.php
@@ -8,8 +8,8 @@ use function ucfirst;
 
 class MalformedLocatorException extends TestRuntimeException
 {
-    public function __construct($locator, $type = "CSS or XPath")
+    public function __construct(string $locator, string $type = 'CSS or XPath')
     {
-        parent::__construct(ucfirst($type) . " locator is malformed: $locator");
+        parent::__construct(ucfirst($type) . " locator is malformed: {$locator}");
     }
 }

--- a/src/Codeception/Exception/MalformedLocatorException.php
+++ b/src/Codeception/Exception/MalformedLocatorException.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Codeception\Exception;
 
 class MalformedLocatorException extends TestRuntimeException

--- a/src/Codeception/Exception/ModuleConfigException.php
+++ b/src/Codeception/Exception/ModuleConfigException.php
@@ -12,7 +12,14 @@ use function str_replace;
 
 class ModuleConfigException extends Exception
 {
-    public function __construct($module, $message, \Exception $previous = null)
+    /**
+     * ModuleConfigException constructor.
+     *
+     * @param object|string $module
+     * @param string $message
+     * @param Exception|null $previous
+     */
+    public function __construct($module, string $message, Exception $previous = null)
     {
         if (is_object($module)) {
             $module = get_class($module);

--- a/src/Codeception/Exception/ModuleConfigException.php
+++ b/src/Codeception/Exception/ModuleConfigException.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Codeception\Exception;
 
 class ModuleConfigException extends \Exception

--- a/src/Codeception/Exception/ModuleConfigException.php
+++ b/src/Codeception/Exception/ModuleConfigException.php
@@ -4,7 +4,13 @@ declare(strict_types=1);
 
 namespace Codeception\Exception;
 
-class ModuleConfigException extends \Exception
+use Exception;
+use function get_class;
+use function is_object;
+use function ltrim;
+use function str_replace;
+
+class ModuleConfigException extends Exception
 {
     public function __construct($module, $message, \Exception $previous = null)
     {

--- a/src/Codeception/Exception/ModuleConflictException.php
+++ b/src/Codeception/Exception/ModuleConflictException.php
@@ -12,7 +12,14 @@ use function str_replace;
 
 class ModuleConflictException extends Exception
 {
-    public function __construct($module, $conflicted, $additional = '')
+    /**
+     * ModuleConflictException constructor.
+     *
+     * @param object|string $module
+     * @param object|string $conflicted
+     * @param string $additional
+     */
+    public function __construct($module, $conflicted, string $additional = '')
     {
         if (is_object($module)) {
             $module = get_class($module);
@@ -22,7 +29,7 @@ class ModuleConflictException extends Exception
         }
         $module = ltrim(str_replace('Codeception\Module\\', '', $module), '\\');
         $conflicted = ltrim(str_replace('Codeception\Module\\', '', $conflicted), '\\');
-        $this->message = "$module module conflicts with $conflicted\n\n--\n"
+        $this->message = "{$module} module conflicts with {$conflicted}\n\n--\n"
             . "This usually happens when you enable two modules with the same actions but with different backends.\n"
             . "For instance, you can't run PhpBrowser, WebDriver, Laravel5 modules in one suite,\n"
             . "as they implement similar methods but use different drivers to execute them.\n"

--- a/src/Codeception/Exception/ModuleConflictException.php
+++ b/src/Codeception/Exception/ModuleConflictException.php
@@ -4,7 +4,13 @@ declare(strict_types=1);
 
 namespace Codeception\Exception;
 
-class ModuleConflictException extends \Exception
+use Exception;
+use function get_class;
+use function is_object;
+use function ltrim;
+use function str_replace;
+
+class ModuleConflictException extends Exception
 {
     public function __construct($module, $conflicted, $additional = '')
     {

--- a/src/Codeception/Exception/ModuleConflictException.php
+++ b/src/Codeception/Exception/ModuleConflictException.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Codeception\Exception;
 
 class ModuleConflictException extends \Exception

--- a/src/Codeception/Exception/ModuleException.php
+++ b/src/Codeception/Exception/ModuleException.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Codeception\Exception;
 
 class ModuleException extends \Exception

--- a/src/Codeception/Exception/ModuleException.php
+++ b/src/Codeception/Exception/ModuleException.php
@@ -4,7 +4,13 @@ declare(strict_types=1);
 
 namespace Codeception\Exception;
 
-class ModuleException extends \Exception
+use Exception;
+use function get_class;
+use function is_object;
+use function ltrim;
+use function str_replace;
+
+class ModuleException extends Exception
 {
     protected $module;
 

--- a/src/Codeception/Exception/ModuleException.php
+++ b/src/Codeception/Exception/ModuleException.php
@@ -12,9 +12,18 @@ use function str_replace;
 
 class ModuleException extends Exception
 {
+    /**
+     * @var string
+     */
     protected $module;
 
-    public function __construct($module, $message)
+    /**
+     * ModuleException constructor.
+     *
+     * @param object|string $module
+     * @param string $message
+     */
+    public function __construct($module, string $message)
     {
         if (is_object($module)) {
             $module = get_class($module);

--- a/src/Codeception/Exception/ModuleRequireException.php
+++ b/src/Codeception/Exception/ModuleRequireException.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Codeception\Exception;
 
 class ModuleRequireException extends \Exception

--- a/src/Codeception/Exception/ModuleRequireException.php
+++ b/src/Codeception/Exception/ModuleRequireException.php
@@ -12,13 +12,19 @@ use function str_replace;
 
 class ModuleRequireException extends Exception
 {
-    public function __construct($module, $message)
+    /**
+     * ModuleRequireException constructor.
+     *
+     * @param object|string $module
+     * @param string $message
+     */
+    public function __construct($module, string $message)
     {
         if (is_object($module)) {
             $module = get_class($module);
         }
         $module = str_replace('Codeception\\Module\\', '', ltrim($module, '\\'));
         parent::__construct($message);
-        $this->message = "[$module] module requirements not met --\n \n" . $this->message;
+        $this->message = "[{$module}] module requirements not met --\n \n" . $this->message;
     }
 }

--- a/src/Codeception/Exception/ModuleRequireException.php
+++ b/src/Codeception/Exception/ModuleRequireException.php
@@ -4,7 +4,13 @@ declare(strict_types=1);
 
 namespace Codeception\Exception;
 
-class ModuleRequireException extends \Exception
+use Exception;
+use function get_class;
+use function is_object;
+use function ltrim;
+use function str_replace;
+
+class ModuleRequireException extends Exception
 {
     public function __construct($module, $message)
     {

--- a/src/Codeception/Exception/ParseException.php
+++ b/src/Codeception/Exception/ParseException.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Codeception\Exception;
 
 class ParseException extends \Exception

--- a/src/Codeception/Exception/ParseException.php
+++ b/src/Codeception/Exception/ParseException.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Codeception\Exception;
 
-class ParseException extends \Exception
+use Exception;
+
+class ParseException extends Exception
 {
 }

--- a/src/Codeception/Exception/RemoteException.php
+++ b/src/Codeception/Exception/RemoteException.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace Codeception\Exception;
 
-class RemoteException extends \Exception
+use Exception;
+
+class RemoteException extends Exception
 {
     public function __construct($message)
     {

--- a/src/Codeception/Exception/RemoteException.php
+++ b/src/Codeception/Exception/RemoteException.php
@@ -8,7 +8,7 @@ use Exception;
 
 class RemoteException extends Exception
 {
-    public function __construct($message)
+    public function __construct(string $message)
     {
         parent::__construct($message);
         $this->message = "Remote Application Error:\n" . $this->message;

--- a/src/Codeception/Exception/RemoteException.php
+++ b/src/Codeception/Exception/RemoteException.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Codeception\Exception;
 
 class RemoteException extends \Exception

--- a/src/Codeception/Exception/TestParseException.php
+++ b/src/Codeception/Exception/TestParseException.php
@@ -8,15 +8,15 @@ use Exception;
 
 class TestParseException extends Exception
 {
-    public function __construct($fileName, $errors = null, $line = null)
+    public function __construct(string $fileName, string $errors = null, string $line = null)
     {
         if ($line) {
-            $this->message = "Couldn't parse test '$fileName' on line $line";
+            $this->message = "Couldn't parse test '{$fileName}' on line {$line}";
         } else {
-            $this->message = "Couldn't parse test '$fileName'";
+            $this->message = "Couldn't parse test '{$fileName}'";
         }
         if ($errors) {
-            $this->message .= "\n$errors";
+            $this->message .= "\n{$errors}";
         }
     }
 }

--- a/src/Codeception/Exception/TestParseException.php
+++ b/src/Codeception/Exception/TestParseException.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace Codeception\Exception;
 
-class TestParseException extends \Exception
+use Exception;
+
+class TestParseException extends Exception
 {
     public function __construct($fileName, $errors = null, $line = null)
     {

--- a/src/Codeception/Exception/TestParseException.php
+++ b/src/Codeception/Exception/TestParseException.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Codeception\Exception;
 
 class TestParseException extends \Exception

--- a/src/Codeception/Exception/TestRuntimeException.php
+++ b/src/Codeception/Exception/TestRuntimeException.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Codeception\Exception;
 
-class TestRuntimeException extends \RuntimeException
+use RuntimeException;
+
+class TestRuntimeException extends RuntimeException
 {
 }

--- a/src/Codeception/Exception/TestRuntimeException.php
+++ b/src/Codeception/Exception/TestRuntimeException.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Codeception\Exception;
 
 class TestRuntimeException extends \RuntimeException


### PR DESCRIPTION
- Use strict types in `src/Codeception/Exception`.
- Add type hints to Exceptions.
- Add 'use function' statements for performance reasons.