### PR TITLE
Update code standards in Coverage and Event

### DIFF
--- a/src/Codeception/Coverage/Filter.php
+++ b/src/Codeception/Coverage/Filter.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Codeception\Coverage;
 
 use Codeception\Configuration;

--- a/src/Codeception/Coverage/Filter.php
+++ b/src/Codeception/Coverage/Filter.php
@@ -137,7 +137,7 @@ class Filter
         return $this;
     }
 
-    protected function matchWildcardPattern($pattern): Finder
+    protected function matchWildcardPattern(string $pattern): Finder
     {
         $finder = Finder::create();
         $fileOrDir = str_replace('\\', '/', $pattern);

--- a/src/Codeception/Coverage/Filter.php
+++ b/src/Codeception/Coverage/Filter.php
@@ -10,11 +10,19 @@ use Codeception\Exception\ModuleException;
 use SebastianBergmann\CodeCoverage\CodeCoverage;
 use Symfony\Component\Finder\Exception\DirectoryNotFoundException;
 use Symfony\Component\Finder\Finder;
+use function array_pop;
+use function count;
+use function explode;
+use function implode;
+use function is_array;
+use function method_exists;
+use function str_replace;
+use function strpos;
 
 class Filter
 {
     /**
-     * @var CodeCoverage
+     * @var CodeCoverage|null
      */
     protected $phpCodeCoverage = null;
 
@@ -24,7 +32,7 @@ class Filter
     protected static $c3;
 
     /**
-     * @var \SebastianBergmann\CodeCoverage\Filter
+     * @var \SebastianBergmann\CodeCoverage\Filter|null
      */
     protected $filter = null;
 
@@ -34,29 +42,23 @@ class Filter
         $this->filter = $this->phpCodeCoverage->filter();
     }
 
-    /**
-     * @param CodeCoverage $phpCoverage
-     * @return Filter
-     */
-    public static function setup(CodeCoverage $phpCoverage)
+    public static function setup(CodeCoverage $phpCoverage): self
     {
         self::$c3 = new self($phpCoverage);
         return self::$c3;
     }
 
-    /**
-     * @return null|CodeCoverage
-     */
-    public function getPhpCodeCoverage()
+    public function getPhpCodeCoverage(): ?CodeCoverage
     {
         return $this->phpCodeCoverage;
     }
 
     /**
-     * @param $config
+     * @param array $config
      * @return Filter
+     * @throws ConfigurationException
      */
-    public function whiteList($config)
+    public function whiteList(array $config): self
     {
         $filter = $this->filter;
         if (!isset($config['coverage'])) {
@@ -88,7 +90,7 @@ class Filter
                         $filter->addFileToWhitelist($file);
                     } else {
                         //php-code-coverage 9+
-                        $filter->includeFile($file);
+                        $filter->includeFile((string) $file);
                     }
                 }
             }
@@ -122,10 +124,11 @@ class Filter
     }
 
     /**
-     * @param $config
+     * @param array $config
      * @return Filter
+     * @throws ModuleException
      */
-    public function blackList($config)
+    public function blackList(array $config): self
     {
         if (isset($config['coverage']['blacklist'])) {
             throw new ModuleException($this, 'The blacklist functionality has been removed from PHPUnit 5,'
@@ -134,29 +137,26 @@ class Filter
         return $this;
     }
 
-    protected function matchWildcardPattern($pattern)
+    protected function matchWildcardPattern($pattern): Finder
     {
         $finder = Finder::create();
         $fileOrDir = str_replace('\\', '/', $pattern);
         $parts = explode('/', $fileOrDir);
         $file = array_pop($parts);
         $finder->name($file);
-        if (count($parts)) {
-            $last_path = array_pop($parts);
-            if ($last_path === '*') {
+        if (count($parts) > 0) {
+            $lastPath = array_pop($parts);
+            if ($lastPath === '*') {
                 $finder->in(Configuration::projectDir() . implode('/', $parts));
             } else {
-                $finder->in(Configuration::projectDir() . implode('/', $parts) . '/' . $last_path);
+                $finder->in(Configuration::projectDir() . implode('/', $parts) . '/' . $lastPath);
             }
         }
         $finder->ignoreVCS(true)->files();
         return $finder;
     }
 
-    /**
-     * @return \SebastianBergmann\CodeCoverage\Filter
-     */
-    public function getFilter()
+    public function getFilter(): \SebastianBergmann\CodeCoverage\Filter
     {
         return $this->filter;
     }

--- a/src/Codeception/Coverage/PhpCodeCoverageFactory.php
+++ b/src/Codeception/Coverage/PhpCodeCoverageFactory.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Codeception\Coverage;
 
 use SebastianBergmann\CodeCoverage\CodeCoverage;

--- a/src/Codeception/Coverage/PhpCodeCoverageFactory.php
+++ b/src/Codeception/Coverage/PhpCodeCoverageFactory.php
@@ -7,10 +7,11 @@ namespace Codeception\Coverage;
 use SebastianBergmann\CodeCoverage\CodeCoverage;
 use SebastianBergmann\CodeCoverage\Driver\Driver;
 use SebastianBergmann\CodeCoverage\Filter as CodeCoverageFilter;
+use function method_exists;
 
 class PhpCodeCoverageFactory
 {
-    public static function build()
+    public static function build(): CodeCoverage
     {
         if (method_exists(Driver::class, 'forLineCoverage')) {
             //php-code-coverage 9+

--- a/src/Codeception/Coverage/Subscriber/Local.php
+++ b/src/Codeception/Coverage/Subscriber/Local.php
@@ -15,6 +15,9 @@ use Codeception\Lib\Interfaces\Remote;
  */
 class Local extends SuiteSubscriber
 {
+    /**
+     * @var array<string, string>
+     */
     public static $events = [
         Events::SUITE_BEFORE => 'beforeSuite',
         Events::SUITE_AFTER  => 'afterSuite',
@@ -25,26 +28,26 @@ class Local extends SuiteSubscriber
      */
     protected $module;
 
-    protected function isEnabled()
+    protected function isEnabled(): bool
     {
-        return $this->module === null and $this->settings['enabled'];
+        return $this->module === null && $this->settings['enabled'];
     }
 
-    public function beforeSuite(SuiteEvent $e)
+    public function beforeSuite(SuiteEvent $event): void
     {
-        $this->applySettings($e->getSettings());
-        $this->module = $this->getServerConnectionModule($e->getSuite()->getModules());
+        $this->applySettings($event->getSettings());
+        $this->module = $this->getServerConnectionModule($event->getSuite()->getModules());
         if (!$this->isEnabled()) {
             return;
         }
-        $this->applyFilter($e->getResult());
+        $this->applyFilter($event->getResult());
     }
 
-    public function afterSuite(SuiteEvent $e)
+    public function afterSuite(SuiteEvent $event): void
     {
         if (!$this->isEnabled()) {
             return;
         }
-        $this->mergeToPrint($e->getResult()->getCodeCoverage());
+        $this->mergeToPrint($event->getResult()->getCodeCoverage());
     }
 }

--- a/src/Codeception/Coverage/Subscriber/Local.php
+++ b/src/Codeception/Coverage/Subscriber/Local.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Codeception\Coverage\Subscriber;
 
 use Codeception\Coverage\SuiteSubscriber;

--- a/src/Codeception/Coverage/Subscriber/LocalServer.php
+++ b/src/Codeception/Coverage/Subscriber/LocalServer.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Codeception\Coverage\Subscriber;
 
 use Codeception\Configuration;

--- a/src/Codeception/Coverage/Subscriber/LocalServer.php
+++ b/src/Codeception/Coverage/Subscriber/LocalServer.php
@@ -178,9 +178,6 @@ class LocalServer extends SuiteSubscriber
 
     /**
      * Allows Translating Remote Paths To Local (IE: When Using Docker)
-     *
-     * @param CodeCoverage $coverage
-     * @return $this
      */
     protected function preProcessCoverage(CodeCoverage $coverage): self
     {

--- a/src/Codeception/Coverage/Subscriber/Printer.php
+++ b/src/Codeception/Coverage/Subscriber/Printer.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Codeception\Coverage\Subscriber;
 
 use Codeception\Configuration;

--- a/src/Codeception/Coverage/Subscriber/Printer.php
+++ b/src/Codeception/Coverage/Subscriber/Printer.php
@@ -11,30 +11,62 @@ use Codeception\Event\PrintResultEvent;
 use Codeception\Events;
 use Codeception\Exception\ConfigurationException;
 use Codeception\Subscriber\Shared\StaticEvents;
+use PHPUnit\Runner\Version as PHPUnitVersion;
+use SebastianBergmann\CodeCoverage\CodeCoverage;
+use SebastianBergmann\CodeCoverage\Report\Clover as CloverReport;
+use SebastianBergmann\CodeCoverage\Report\Cobertura as CoberturaReport;
+use SebastianBergmann\CodeCoverage\Report\Crap4j as Crap4jReport;
+use SebastianBergmann\CodeCoverage\Report\Html\Facade as HtmlFacadeReport;
+use SebastianBergmann\CodeCoverage\Report\PHP as PhpReport;
+use SebastianBergmann\CodeCoverage\Report\Text as TextReport;
+use SebastianBergmann\CodeCoverage\Report\Xml\Facade as XmlFacadeReport;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use function array_merge;
+use function class_exists;
+use function file_put_contents;
+use function sprintf;
+use function strpos;
 
 class Printer implements EventSubscriberInterface
 {
     use StaticEvents;
 
+    /**
+     * @var array<string, string>
+     */
     public static $events = [
         Events::RESULT_PRINT_AFTER => 'printResult'
     ];
 
+    /**
+     * @var array
+     */
     protected $settings = [
         'enabled'           => true,
-        'low_limit'         => '35',
-        'high_limit'        => '70',
+        'low_limit'         => 35,
+        'high_limit'        => 70,
         'show_uncovered'    => false,
         'show_only_summary' => false
     ];
 
+    /**
+     * @var CodeCoverage
+     */
     public static $coverage;
+    /**
+     * @var array
+     */
     protected $options;
+    /**
+     * @var string
+     */
     protected $logDir;
+    /**
+     * @var array
+     */
     protected $destination = [];
 
-    public function __construct($options)
+    public function __construct(array $options)
     {
         $this->options = $options;
         $this->logDir = Configuration::outputDir();
@@ -44,12 +76,11 @@ class Printer implements EventSubscriberInterface
 
         // Apply filter
         $filter = new Filter(self::$coverage);
-        $filter
-            ->whiteList(Configuration::config())
-            ->blackList(Configuration::config());
+        $filter->whiteList(Configuration::config());
+        $filter->blackList(Configuration::config());
     }
 
-    protected function absolutePath($path)
+    protected function absolutePath(string $path): string
     {
         if ((strpos($path, '/') === 0) || (strpos($path, ':') === 1)) { // absolute path
             return $path;
@@ -57,9 +88,9 @@ class Printer implements EventSubscriberInterface
         return $this->logDir . $path;
     }
 
-    public function printResult(PrintResultEvent $e)
+    public function printResult(PrintResultEvent $event): void
     {
-        $printer = $e->getPrinter();
+        $printer = $event->getPrinter();
         if (!$this->settings['enabled']) {
             $printer->write("\nCodeCoverage is disabled in `codeception.yml` config\n");
             return;
@@ -97,9 +128,9 @@ class Printer implements EventSubscriberInterface
         }
     }
 
-    protected function printConsole(\PHPUnit\Util\Printer $printer)
+    protected function printConsole(\PHPUnit\Util\Printer $printer): void
     {
-        $writer = new \SebastianBergmann\CodeCoverage\Report\Text(
+        $writer = new TextReport(
             $this->settings['low_limit'],
             $this->settings['high_limit'],
             $this->settings['show_uncovered'],
@@ -108,35 +139,35 @@ class Printer implements EventSubscriberInterface
         $printer->write($writer->process(self::$coverage, $this->options['colors']));
     }
 
-    protected function printHtml()
+    protected function printHtml(): void
     {
-        $writer = new \SebastianBergmann\CodeCoverage\Report\Html\Facade(
+        $writer = new HtmlFacadeReport(
             $this->settings['low_limit'],
             $this->settings['high_limit'],
             sprintf(
                 ', <a href="http://codeception.com">Codeception</a> and <a href="http://phpunit.de/">PHPUnit %s</a>',
-                \PHPUnit\Runner\Version::id()
+                PHPUnitVersion::id()
             )
         );
 
         $writer->process(self::$coverage, $this->absolutePath($this->options['coverage-html']));
     }
 
-    protected function printXml()
+    protected function printXml(): void
     {
-        $writer = new \SebastianBergmann\CodeCoverage\Report\Clover();
+        $writer = new CloverReport();
         $writer->process(self::$coverage, $this->absolutePath($this->options['coverage-xml']));
     }
 
-    protected function printPHP()
+    protected function printPHP(): void
     {
-        $writer = new \SebastianBergmann\CodeCoverage\Report\PHP;
+        $writer = new PhpReport();
         $writer->process(self::$coverage, $this->absolutePath($this->options['coverage']));
     }
 
-    protected function printText()
+    protected function printText(): void
     {
-        $writer = new \SebastianBergmann\CodeCoverage\Report\Text(
+        $writer = new TextReport(
             $this->settings['low_limit'],
             $this->settings['high_limit'],
             $this->settings['show_uncovered'],
@@ -148,24 +179,24 @@ class Printer implements EventSubscriberInterface
         );
     }
 
-    protected function printCrap4j()
+    protected function printCrap4j(): void
     {
-        $writer = new \SebastianBergmann\CodeCoverage\Report\Crap4j;
+        $writer = new Crap4jReport();
         $writer->process(self::$coverage, $this->absolutePath($this->options['coverage-crap4j']));
     }
 
-    protected function printCobertura()
+    protected function printCobertura(): void
     {
-        if (!class_exists(\SebastianBergmann\CodeCoverage\Report\Cobertura::class)) {
+        if (!class_exists(CoberturaReport::class)) {
             throw new ConfigurationException("Cobertura report requires php-code-coverage >= 9.2");
         }
-        $writer = new \SebastianBergmann\CodeCoverage\Report\Cobertura;
+        $writer = new CoberturaReport();
         $writer->process(self::$coverage, $this->absolutePath($this->options['coverage-cobertura']));
     }
 
-    protected function printPHPUnit()
+    protected function printPHPUnit(): void
     {
-        $writer = new \SebastianBergmann\CodeCoverage\Report\Xml\Facade(\PHPUnit\Runner\Version::id());
+        $writer = new XmlFacadeReport(PHPUnitVersion::id());
         $writer->process(self::$coverage, $this->absolutePath($this->options['coverage-phpunit']));
     }
 }

--- a/src/Codeception/Coverage/Subscriber/RemoteServer.php
+++ b/src/Codeception/Coverage/Subscriber/RemoteServer.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Codeception\Coverage\Subscriber;
 
 use Codeception\Configuration;

--- a/src/Codeception/Coverage/Subscriber/RemoteServer.php
+++ b/src/Codeception/Coverage/Subscriber/RemoteServer.php
@@ -7,6 +7,14 @@ namespace Codeception\Coverage\Subscriber;
 use Codeception\Configuration;
 use Codeception\Event\SuiteEvent;
 use Codeception\Util\FileSystem;
+use PharData;
+use function file_put_contents;
+use function is_dir;
+use function mkdir;
+use function strtr;
+use function sys_get_temp_dir;
+use function tempnam;
+use function unlink;
 
 /**
  * When collecting code coverage on remote server
@@ -17,18 +25,18 @@ use Codeception\Util\FileSystem;
  */
 class RemoteServer extends LocalServer
 {
-    public function isEnabled()
+    public function isEnabled(): bool
     {
-        return $this->module and $this->settings['remote'] and $this->settings['enabled'];
+        return $this->module && $this->settings['remote'] && $this->settings['enabled'];
     }
 
-    public function afterSuite(SuiteEvent $e)
+    public function afterSuite(SuiteEvent $event): void
     {
         if (!$this->isEnabled()) {
             return;
         }
 
-        $suite = strtr($e->getSuite()->getName(), ['\\' => '.']);
+        $suite = strtr($event->getSuite()->getName(), ['\\' => '.']);
         if ($this->options['coverage-xml']) {
             $this->retrieveAndPrintXml($suite);
         }
@@ -46,7 +54,7 @@ class RemoteServer extends LocalServer
         }
     }
 
-    protected function retrieveAndPrintHtml($suite)
+    protected function retrieveAndPrintHtml(string $suite): void
     {
         $tempFile = tempnam(sys_get_temp_dir(), 'C3') . '.tar';
         file_put_contents($tempFile, $this->c3Request('html'));
@@ -58,31 +66,31 @@ class RemoteServer extends LocalServer
             mkdir($destDir, 0777, true);
         }
 
-        $phar = new \PharData($tempFile);
-        $phar->extractTo($destDir);
+        $pharData = new PharData($tempFile);
+        $pharData->extractTo($destDir);
 
         unlink($tempFile);
     }
 
-    protected function retrieveAndPrintXml($suite)
+    protected function retrieveAndPrintXml(string $suite): void
     {
         $destFile = Configuration::outputDir() . $suite . '.remote.coverage.xml';
         file_put_contents($destFile, $this->c3Request('clover'));
     }
 
-    protected function retrieveAndPrintCrap4j($suite)
+    protected function retrieveAndPrintCrap4j(string $suite): void
     {
         $destFile = Configuration::outputDir() . $suite . '.remote.crap4j.xml';
         file_put_contents($destFile, $this->c3Request('crap4j'));
     }
 
-    protected function retrieveAndPrintCobertura($suite)
+    protected function retrieveAndPrintCobertura(string $suite): void
     {
         $destFile = Configuration::outputDir() . $suite . '.remote.cobertura.xml';
         file_put_contents($destFile, $this->c3Request('cobertura'));
     }
 
-    protected function retrieveAndPrintPHPUnit($suite)
+    protected function retrieveAndPrintPHPUnit(string $suite): void
     {
         $tempFile = tempnam(sys_get_temp_dir(), 'C3') . '.tar';
         file_put_contents($tempFile, $this->c3Request('phpunit'));
@@ -94,8 +102,8 @@ class RemoteServer extends LocalServer
             mkdir($destDir, 0777, true);
         }
 
-        $phar = new \PharData($tempFile);
-        $phar->extractTo($destDir);
+        $pharData = new PharData($tempFile);
+        $pharData->extractTo($destDir);
 
         unlink($tempFile);
     }

--- a/src/Codeception/Coverage/SuiteSubscriber.php
+++ b/src/Codeception/Coverage/SuiteSubscriber.php
@@ -52,7 +52,7 @@ abstract class SuiteSubscriber implements EventSubscriberInterface
      */
     protected $modules = [];
     /**
-     * @var CodeCoverage
+     * @var CodeCoverage|null
      */
     protected $coverage;
     /**

--- a/src/Codeception/Coverage/SuiteSubscriber.php
+++ b/src/Codeception/Coverage/SuiteSubscriber.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Codeception\Coverage;
 
 use Codeception\Configuration;

--- a/src/Codeception/Coverage/SuiteSubscriber.php
+++ b/src/Codeception/Coverage/SuiteSubscriber.php
@@ -6,18 +6,28 @@ namespace Codeception\Coverage;
 
 use Codeception\Configuration;
 use Codeception\Coverage\Subscriber\Printer;
-use Codeception\Lib\Interfaces\Remote;
+use Codeception\Exception\ConfigurationException;
+use Codeception\Exception\ModuleException;
+use Codeception\Lib\Interfaces\Remote as RemoteInterface;
 use Codeception\Stub;
 use Codeception\Subscriber\Shared\StaticEvents;
+use Exception;
 use PHPUnit\Framework\CodeCoverageException;
+use PHPUnit\Framework\TestResult;
 use SebastianBergmann\CodeCoverage\CodeCoverage;
+use SebastianBergmann\CodeCoverage\Driver\Driver as CodeCoverageDriver;
 use SebastianBergmann\CodeCoverage\Filter as CodeCoverageFilter;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use function array_keys;
+use function method_exists;
 
 abstract class SuiteSubscriber implements EventSubscriberInterface
 {
     use StaticEvents;
 
+    /**
+     * @var array
+     */
     protected $defaultSettings = [
         'enabled'        => false,
         'remote'         => false,
@@ -29,31 +39,62 @@ abstract class SuiteSubscriber implements EventSubscriberInterface
         'work_dir'       => null,
         'cookie_domain'  => null,
     ];
-
+    /**
+     * @var array
+     */
     protected $settings = [];
+    /**
+     * @var array
+     */
     protected $filters = [];
+    /**
+     * @var array
+     */
     protected $modules = [];
-
+    /**
+     * @var CodeCoverage
+     */
     protected $coverage;
+    /**
+     * @var string
+     */
     protected $logDir;
+    /**
+     * @var array
+     */
     protected $options;
+    /**
+     * @var array
+     */
     public static $events = [];
 
     abstract protected function isEnabled();
 
-    public function __construct($options = [])
+    /**
+     * SuiteSubscriber constructor.
+     *
+     * @param array $options
+     * @throws ConfigurationException
+     */
+    public function __construct(array $options = [])
     {
         $this->options = $options;
         $this->logDir = Configuration::outputDir();
     }
 
-    protected function applySettings($settings)
+    /**
+     * @param array $settings
+     * @throws Exception
+     */
+    protected function applySettings(array $settings): void
     {
         try {
             $this->coverage = PhpCodeCoverageFactory::build();
         } catch (CodeCoverageException $e) {
-            throw new \Exception(
-                'XDebug is required to collect CodeCoverage. Please install xdebug extension and enable it in php.ini'
+            throw new Exception(
+                'XDebug is required to collect CodeCoverage. Please install xdebug extension and enable it in php.ini',
+                $e->getCode(),
+                $e
             );
         }
 
@@ -80,21 +121,25 @@ abstract class SuiteSubscriber implements EventSubscriberInterface
 
     /**
      * @param array $modules
-     * @return \Codeception\Lib\Interfaces\Remote|null
+     * @return RemoteInterface|null
      */
-    protected function getServerConnectionModule(array $modules)
+    protected function getServerConnectionModule(array $modules): ?RemoteInterface
     {
         foreach ($modules as $module) {
-            if ($module instanceof Remote) {
+            if ($module instanceof RemoteInterface) {
                 return $module;
             }
         }
         return null;
     }
 
-    public function applyFilter(\PHPUnit\Framework\TestResult $result)
+    /**
+     * @param TestResult $result
+     * @throws ConfigurationException|ModuleException|Exception
+     */
+    public function applyFilter(TestResult $result): void
     {
-        $driver = Stub::makeEmpty('SebastianBergmann\CodeCoverage\Driver\Driver');
+        $driver = Stub::makeEmpty(CodeCoverageDriver::class);
         $result->setCodeCoverage(new CodeCoverage($driver, new CodeCoverageFilter()));
 
         Filter::setup($this->coverage)
@@ -104,7 +149,7 @@ abstract class SuiteSubscriber implements EventSubscriberInterface
         $result->setCodeCoverage($this->coverage);
     }
 
-    protected function mergeToPrint($coverage)
+    protected function mergeToPrint(CodeCoverage $coverage): void
     {
         Printer::$coverage->merge($coverage);
     }

--- a/src/Codeception/Event/FailEvent.php
+++ b/src/Codeception/Event/FailEvent.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Codeception\Event;
 
 class FailEvent extends TestEvent

--- a/src/Codeception/Event/FailEvent.php
+++ b/src/Codeception/Event/FailEvent.php
@@ -4,10 +4,13 @@ declare(strict_types=1);
 
 namespace Codeception\Event;
 
+use Exception;
+use PHPUnit\Framework\Test as PHPUnitTest;
+
 class FailEvent extends TestEvent
 {
     /**
-     * @var \Exception
+     * @var Exception
      */
     protected $fail;
 
@@ -16,19 +19,19 @@ class FailEvent extends TestEvent
      */
     protected $count;
 
-    public function __construct(\PHPUnit\Framework\Test $test, $time, $e, $count = 0)
+    public function __construct(PHPUnitTest $test, ?float $time, Exception $e, int $count = 0)
     {
         parent::__construct($test, $time);
         $this->fail = $e;
         $this->count = $count;
     }
 
-    public function getCount()
+    public function getCount(): int
     {
         return $this->count;
     }
 
-    public function getFail()
+    public function getFail(): Exception
     {
         return $this->fail;
     }

--- a/src/Codeception/Event/PrintResultEvent.php
+++ b/src/Codeception/Event/PrintResultEvent.php
@@ -4,38 +4,34 @@ declare(strict_types=1);
 
 namespace Codeception\Event;
 
+use PHPUnit\Framework\TestResult;
+use PHPUnit\Util\Printer;
 use Symfony\Contracts\EventDispatcher\Event;
 
 class PrintResultEvent extends Event
 {
     /**
-     * @var \PHPUnit\Framework\TestResult
+     * @var TestResult
      */
     protected $result;
 
     /**
-     * @var \PHPUnit\Util\Printer
+     * @var Printer
      */
     protected $printer;
 
-    public function __construct(\PHPUnit\Framework\TestResult $result, \PHPUnit\Util\Printer $printer)
+    public function __construct(TestResult $testResult, Printer $printer)
     {
-        $this->result = $result;
+        $this->result = $testResult;
         $this->printer = $printer;
     }
 
-    /**
-     * @return \PHPUnit\Util\Printer
-     */
-    public function getPrinter()
+    public function getPrinter(): Printer
     {
         return $this->printer;
     }
 
-    /**
-     * @return \PHPUnit\Framework\TestResult
-     */
-    public function getResult()
+    public function getResult(): TestResult
     {
         return $this->result;
     }

--- a/src/Codeception/Event/PrintResultEvent.php
+++ b/src/Codeception/Event/PrintResultEvent.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Codeception\Event;
 
 use Symfony\Contracts\EventDispatcher\Event;

--- a/src/Codeception/Event/StepEvent.php
+++ b/src/Codeception/Event/StepEvent.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Codeception\Event;
 
 use Codeception\Step;

--- a/src/Codeception/Event/StepEvent.php
+++ b/src/Codeception/Event/StepEvent.php
@@ -26,15 +26,12 @@ class StepEvent extends Event
         $this->step = $step;
     }
 
-    public function getStep()
+    public function getStep(): Step
     {
         return $this->step;
     }
 
-    /**
-     * @return TestInterface
-     */
-    public function getTest()
+    public function getTest(): TestInterface
     {
         return $this->test;
     }

--- a/src/Codeception/Event/SuiteEvent.php
+++ b/src/Codeception/Event/SuiteEvent.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Codeception\Event;
 
+use Codeception\Suite;
 use PHPUnit\Framework\TestResult;
 use PHPUnit\Framework\TestSuite;
 use Symfony\Contracts\EventDispatcher\Event;
@@ -35,7 +36,10 @@ class SuiteEvent extends Event
         $this->settings = $settings;
     }
 
-    public function getSuite(): TestSuite
+    /**
+     * @return Suite|TestSuite
+     */
+    public function getSuite()
     {
         return $this->suite;
     }
@@ -45,7 +49,7 @@ class SuiteEvent extends Event
         return $this->result;
     }
 
-    public function getSettings(): array
+    public function getSettings(): ?array
     {
         return $this->settings;
     }

--- a/src/Codeception/Event/SuiteEvent.php
+++ b/src/Codeception/Event/SuiteEvent.php
@@ -4,53 +4,48 @@ declare(strict_types=1);
 
 namespace Codeception\Event;
 
-use Codeception\Suite;
+use PHPUnit\Framework\TestResult;
+use PHPUnit\Framework\TestSuite;
 use Symfony\Contracts\EventDispatcher\Event;
 
 class SuiteEvent extends Event
 {
     /**
-     * @var \PHPUnit\Framework\TestSuite
+     * @var TestSuite
      */
     protected $suite;
 
     /**
-     * @var \PHPUnit\Framework\TestResult
+     * @var TestResult
      */
     protected $result;
 
     /**
      * @var array
      */
-    protected $settings;
+    protected $settings = [];
 
     public function __construct(
-        \PHPUnit\Framework\TestSuite $suite,
-        \PHPUnit\Framework\TestResult $result = null,
-        $settings = []
+        TestSuite $testSuite,
+        TestResult $testResult = null,
+        array $settings = []
     ) {
-        $this->suite = $suite;
-        $this->result = $result;
+        $this->suite = $testSuite;
+        $this->result = $testResult;
         $this->settings = $settings;
     }
 
-    /**
-     * @return Suite
-     */
-    public function getSuite()
+    public function getSuite(): TestSuite
     {
         return $this->suite;
     }
 
-    /**
-     * @return \PHPUnit\Framework\TestResult
-     */
-    public function getResult()
+    public function getResult(): TestResult
     {
         return $this->result;
     }
 
-    public function getSettings()
+    public function getSettings(): array
     {
         return $this->settings;
     }

--- a/src/Codeception/Event/SuiteEvent.php
+++ b/src/Codeception/Event/SuiteEvent.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Codeception\Event;
 
 use Codeception\Suite;

--- a/src/Codeception/Event/TestEvent.php
+++ b/src/Codeception/Event/TestEvent.php
@@ -4,12 +4,13 @@ declare(strict_types=1);
 
 namespace Codeception\Event;
 
+use PHPUnit\Framework\Test as PHPUnitTest;
 use Symfony\Contracts\EventDispatcher\Event;
 
 class TestEvent extends Event
 {
     /**
-     * @var \PHPUnit\Framework\Test
+     * @var PHPUnitTest
      */
     protected $test;
 
@@ -18,16 +19,13 @@ class TestEvent extends Event
      */
     protected $time;
 
-    public function __construct(\PHPUnit\Framework\Test $test, $time = 0)
+    public function __construct(PHPUnitTest $test, ?float $time = 0)
     {
         $this->test = $test;
         $this->time = $time;
     }
 
-    /**
-     * @return float
-     */
-    public function getTime()
+    public function getTime(): float
     {
         return $this->time;
     }

--- a/src/Codeception/Event/TestEvent.php
+++ b/src/Codeception/Event/TestEvent.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Codeception\Event;
 
 use Symfony\Contracts\EventDispatcher\Event;


### PR DESCRIPTION
- Use strict types in `src/Codeception/Coverage` and `src/Codeception/Event`.
- Add type hints to Coverage Subscribers and Events.
- Add 'use function' statements for performance reasons.
- Longer aliases for ambiguous class names.
- Fix naming in `src/Codeception/Coverage` and `src/Codeception/Event`.