### PR TITLE
Show origin of warning in error message

### DIFF
--- a/src/Codeception/Subscriber/ErrorHandler.php
+++ b/src/Codeception/Subscriber/ErrorHandler.php
@@ -80,7 +80,8 @@ class ErrorHandler implements EventSubscriberInterface
             return false;
         }
 
-        throw new \PHPUnit\Framework\Exception($errstr, $errno);
+        $relativePath = codecept_relative_path($errfile);
+        throw new \PHPUnit\Framework\Exception("$errstr at $relativePath:$errline", $errno);
     }
 
     public function shutdownHandler()

--- a/tests/unit/Codeception/Subscriber/ErrorHandlerTest.php
+++ b/tests/unit/Codeception/Subscriber/ErrorHandlerTest.php
@@ -5,8 +5,20 @@ use Codeception\Lib\Notification;
 use Codeception\Subscriber\ErrorHandler;
 use Codeception\Suite;
 
-class ErrorHandlerTest extends \PHPUnit\Framework\TestCase
+class ErrorHandlerTest extends \Codeception\PHPUnit\TestCase
 {
+    private $originalErrorLevel;
+
+    public function _setUp()
+    {
+        $this->originalErrorLevel = error_reporting();
+    }
+
+    public function _tearDown()
+    {
+        // Deprecation message test changes error_level
+        error_reporting($this->originalErrorLevel);
+    }
 
     public function testDeprecationMessagesRespectErrorLevelSetting()
     {
@@ -22,5 +34,17 @@ class ErrorHandlerTest extends \PHPUnit\Framework\TestCase
         $errorHandler->errorHandler(E_USER_DEPRECATED, 'deprecated message', __FILE__, __LINE__, []);
 
         $this->assertEquals([], Notification::all(), 'Deprecation message was added to notifications');
+    }
+
+    public function testShowsLocationOfWarning()
+    {
+        if (PHP_MAJOR_VERSION === 5) {
+            $this->expectException(\PHPUnit_Framework_Exception::class);
+        } else {
+            $this->expectException(\PHPUnit\Framework\Exception::class);
+        }
+        $SEP = DIRECTORY_SEPARATOR;
+        $this->expectExceptionMessage("Undefined variable: file at tests{$SEP}unit{$SEP}Codeception{$SEP}Subscriber{$SEP}ErrorHandlerTest.php:48");
+        trigger_error('Undefined variable: file', E_USER_WARNING);
     }
 }


### PR DESCRIPTION
Fixes #6090

Codeception ErrorHandler wasn't very useful for investigating notices and warning, because it didn't show where the warning happened.

```
In ErrorHandler.php line 83:
                                     
  [PHPUnit\Framework\Exception (8)]  
  Undefined variable: file           
                                     

Exception trace:
  at /var/www/p2pr/vendor/codeception/codeception/src/Codeception/Subscriber/ErrorHandler.php:83
 Codeception\Subscriber\ErrorHandler->errorHandler() at /var/www/p2pr/vendor/codeception/module-symfony/
```

After applying this change, error message will tell the file and line of code where the warning originated.

```
[PHPUnit\Framework\Exception] Undefined variable: a at tests/unit/Codeception/Subscriber/ErrorHandlerTest.php:29
```