### PR TITLE
Update code standards in Utils

### DIFF
--- a/src/Codeception/Util/ActionSequence.php
+++ b/src/Codeception/Util/ActionSequence.php
@@ -22,34 +22,34 @@ use function str_replace;
  * ActionSequence::build()->click('do')->click('undo');
  * ```
  *
- * @method $this see[optional]
- * @method $this dontSee[optional]
- * @method $this seeElement[optional]
- * @method $this dontSeeElement[optional]
- * @method $this click[optional]
- * @method $this wait[optional]
- * @method $this waitForElementChange[optional]
- * @method $this waitForElement[optional]
- * @method $this waitForElementVisible[optional]
- * @method $this waitForElementNotVisible[optional]
- * @method $this waitForText[optional]
- * @method $this submitForm[optional]
- * @method $this seeLink[optional]
- * @method $this dontSeeLink[optional]
- * @method $this seeCheckboxIsChecked[optional]
- * @method $this dontSeeCheckboxIsChecked[optional]
- * @method $this seeInField[optional]
- * @method $this dontSeeInField[optional]
- * @method $this seeInFormFields[optional]
- * @method $this dontSeeInFormFields[optional]
- * @method $this selectOption[optional]
- * @method $this checkOption[optional]
- * @method $this uncheckOption[optional]
- * @method $this fillField[optional]
- * @method $this attachFile[optional]
- * @method $this seeNumberOfElements[optional]
- * @method $this seeOptionIsSelected[optional]
- * @method $this dontSeeOptionIsSelected[optional]
+ * @method $this see($text, $selector = null)
+ * @method $this dontSee($text, $selector = null)
+ * @method $this seeElement($selector, $attributes = [])
+ * @method $this dontSeeElement($selector, $attributes = [])
+ * @method $this click($link, $context = null)
+ * @method $this wait($timeout)
+ * @method $this waitForElementChange($element, \Closure $callback, $timeout = 30)
+ * @method $this waitForElement($element, $timeout = 10)
+ * @method $this waitForElementVisible($element, $timeout = 10)
+ * @method $this waitForElementNotVisible($element, $timeout = 10)
+ * @method $this waitForText($text, $timeout = 10, $selector = null)
+ * @method $this submitForm($selector, array $params, $button = null)
+ * @method $this seeLink($text, $url = null)
+ * @method $this dontSeeLink($text, $url = null)
+ * @method $this seeCheckboxIsChecked($checkbox)
+ * @method $this dontSeeCheckboxIsChecked($checkbox)
+ * @method $this seeInField($field, $value)
+ * @method $this dontSeeInField($field, $value)
+ * @method $this seeInFormFields($formSelector, array $params)
+ * @method $this dontSeeInFormFields($formSelector, array $params)
+ * @method $this selectOption($select, $option)
+ * @method $this checkOption($option)
+ * @method $this uncheckOption($option)
+ * @method $this fillField($field, $value)
+ * @method $this attachFile($field, $filename)
+ * @method $this seeNumberOfElements($selector, $expected)
+ * @method $this seeOptionIsSelected($selector, $optionText)
+ * @method $this dontSeeOptionIsSelected($selector, $optionText)
  */
 class ActionSequence
 {
@@ -66,13 +66,13 @@ class ActionSequence
         return new self;
     }
 
-    public function __call(string $action, $arguments): self
+    public function __call(string $action, array $arguments): self
     {
         $this->addAction($action, $arguments);
         return $this;
     }
 
-    protected function addAction($action, $arguments): void
+    protected function addAction(string $action, $arguments): void
     {
         if (!is_array($arguments)) {
             $arguments = [$arguments];

--- a/src/Codeception/Util/ActionSequence.php
+++ b/src/Codeception/Util/ActionSequence.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Codeception\Util;
 
 use Codeception\Step\Action;

--- a/src/Codeception/Util/ActionSequence.php
+++ b/src/Codeception/Util/ActionSequence.php
@@ -11,7 +11,6 @@ use function codecept_debug;
 use function get_class;
 use function implode;
 use function is_array;
-use function sprintf;
 use function str_replace;
 
 /**
@@ -23,34 +22,34 @@ use function str_replace;
  * ActionSequence::build()->click('do')->click('undo');
  * ```
  *
- * @method $this see([optional])
- * @method $this dontSee([optional])
- * @method $this seeElement([optional])
- * @method $this dontSeeElement([optional])
- * @method $this click([optional])
- * @method $this wait([optional])
- * @method $this waitForElementChange([optional])
- * @method $this waitForElement([optional])
- * @method $this waitForElementVisible([optional])
- * @method $this waitForElementNotVisible([optional])
- * @method $this waitForText([optional])
- * @method $this submitForm([optional])
- * @method $this seeLink([optional])
- * @method $this dontSeeLink([optional])
- * @method $this seeCheckboxIsChecked([optional])
- * @method $this dontSeeCheckboxIsChecked([optional])
- * @method $this seeInField([optional])
- * @method $this dontSeeInField([optional])
- * @method $this seeInFormFields([optional])
- * @method $this dontSeeInFormFields([optional])
- * @method $this selectOption([optional])
- * @method $this checkOption([optional])
- * @method $this uncheckOption([optional])
- * @method $this fillField([optional])
- * @method $this attachFile([optional])
- * @method $this seeNumberOfElements([optional])
- * @method $this seeOptionIsSelected([optional])
- * @method $this dontSeeOptionIsSelected([optional])
+ * @method $this see[optional]
+ * @method $this dontSee[optional]
+ * @method $this seeElement[optional]
+ * @method $this dontSeeElement[optional]
+ * @method $this click[optional]
+ * @method $this wait[optional]
+ * @method $this waitForElementChange[optional]
+ * @method $this waitForElement[optional]
+ * @method $this waitForElementVisible[optional]
+ * @method $this waitForElementNotVisible[optional]
+ * @method $this waitForText[optional]
+ * @method $this submitForm[optional]
+ * @method $this seeLink[optional]
+ * @method $this dontSeeLink[optional]
+ * @method $this seeCheckboxIsChecked[optional]
+ * @method $this dontSeeCheckboxIsChecked[optional]
+ * @method $this seeInField[optional]
+ * @method $this dontSeeInField[optional]
+ * @method $this seeInFormFields[optional]
+ * @method $this dontSeeInFormFields[optional]
+ * @method $this selectOption[optional]
+ * @method $this checkOption[optional]
+ * @method $this uncheckOption[optional]
+ * @method $this fillField[optional]
+ * @method $this attachFile[optional]
+ * @method $this seeNumberOfElements[optional]
+ * @method $this seeOptionIsSelected[optional]
+ * @method $this dontSeeOptionIsSelected[optional]
  */
 class ActionSequence
 {
@@ -62,12 +61,12 @@ class ActionSequence
     /**
      * Creates an instance
      */
-    public static function build(): ActionSequence
+    public static function build(): self
     {
         return new self;
     }
 
-    public function __call($action, $arguments): self
+    public function __call(string $action, $arguments): self
     {
         $this->addAction($action, $arguments);
         return $this;
@@ -84,8 +83,6 @@ class ActionSequence
     /**
      * Creates action sequence from associative array,
      * where key is action, and value is action arguments
-     *
-     * @param array $actions
      */
     public function fromArray(array $actions): self
     {

--- a/src/Codeception/Util/ActionSequence.php
+++ b/src/Codeception/Util/ActionSequence.php
@@ -5,6 +5,14 @@ declare(strict_types=1);
 namespace Codeception\Util;
 
 use Codeception\Step\Action;
+use Exception;
+use function call_user_func_array;
+use function codecept_debug;
+use function get_class;
+use function implode;
+use function is_array;
+use function sprintf;
+use function str_replace;
 
 /**
  * Class for defining an array actions to be executed inside `performOn` of WebDriver

--- a/src/Codeception/Util/ActionSequence.php
+++ b/src/Codeception/Util/ActionSequence.php
@@ -54,24 +54,26 @@ use function str_replace;
  */
 class ActionSequence
 {
+    /**
+     * @var Action[]
+     */
     protected $actions = [];
 
     /**
      * Creates an instance
-     * @return ActionSequence
      */
-    public static function build()
+    public static function build(): ActionSequence
     {
         return new self;
     }
 
-    public function __call($action, $arguments)
+    public function __call($action, $arguments): self
     {
         $this->addAction($action, $arguments);
         return $this;
     }
 
-    protected function addAction($action, $arguments)
+    protected function addAction($action, $arguments): void
     {
         if (!is_array($arguments)) {
             $arguments = [$arguments];
@@ -84,9 +86,8 @@ class ActionSequence
      * where key is action, and value is action arguments
      *
      * @param array $actions
-     * @return $this
      */
-    public function fromArray(array $actions)
+    public function fromArray(array $actions): self
     {
         foreach ($actions as $action => $arguments) {
             $this->addAction($action, $arguments);
@@ -96,9 +97,10 @@ class ActionSequence
 
     /**
      * Returns a list of logged actions as associative array
-     * @return array
+     *
+     * @return Action[]
      */
-    public function toArray()
+    public function getActions(): array
     {
         return $this->actions;
     }
@@ -108,27 +110,26 @@ class ActionSequence
      *
      * @param $context
      */
-    public function run($context)
+    public function run($context): void
     {
         foreach ($this->actions as $step) {
-            /** @var $step Action  **/
-            codecept_debug("- $step");
+            codecept_debug("- {$step}");
             try {
                 call_user_func_array([$context, $step->getAction()], $step->getArguments());
-            } catch (\Exception $e) {
-                $class = get_class($e); // rethrow exception for a specific action
-                throw new $class($e->getMessage() . "\nat $step");
+            } catch (Exception $exception) {
+                $class = get_class($exception); // rethrow exception for a specific action
+                throw new $class($exception->getMessage() . "\nat {$step}");
             }
         }
     }
 
-    public function __toString()
+    public function __toString(): string
     {
         $actionsLog = [];
 
         foreach ($this->actions as $step) {
             $args = str_replace('"', "'", $step->getArgumentsAsString(20));
-            $actionsLog[] = $step->getAction() . ": $args";
+            $actionsLog[] = $step->getAction() . ": {$args}";
         }
 
         return implode(', ', $actionsLog);

--- a/src/Codeception/Util/Annotation.php
+++ b/src/Codeception/Util/Annotation.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Codeception\Util;
 
 use ReflectionClass;
+use ReflectionMethod;
 use function get_class;
 use function in_array;
 use function is_object;
@@ -34,7 +35,7 @@ class Annotation
      */
     protected $reflectedClass;
     /**
-     * @var ReflectionClass|\ReflectionMethod
+     * @var ReflectionClass|ReflectionMethod
      */
     protected $currentReflectedItem;
 
@@ -49,6 +50,8 @@ class Annotation
      * Annotation::forClass('MyTestCase')->method('testData')->fetch('depends');
      * Annotation::forClass('MyTestCase')->method('testData')->fetchAll('depends');
      * ```
+     * @param object|string $class
+     * @return static
      */
     public static function forClass($class): Annotation
     {
@@ -64,24 +67,19 @@ class Annotation
     }
 
     /**
-     * @param $class
-     * @param $method
-     *
-     * @return $this
+     * @param object|string $class
+     * @param string $method
+     * @return Annotation
      */
-    public static function forMethod($class, $method): self
+    public static function forMethod($class, string $method): self
     {
         return self::forClass($class)->method($method);
     }
 
     /**
      * Parses raw comment for annotations
-     *
-     * @param $docblock
-     * @param $annotation
-     * @return array
      */
-    public static function fetchAnnotationsFromDocblock($annotation, $docblock)
+    public static function fetchAnnotationsFromDocblock(string $annotation, string $docblock): array
     {
         if (preg_match_all(sprintf(self::$regex, $annotation), $docblock, $matched)) {
             return $matched[1];
@@ -91,11 +89,8 @@ class Annotation
 
     /**
      * Fetches all available annotations
-     *
-     * @param $docblock
-     * @return array
      */
-    public static function fetchAllAnnotationsFromDocblock($docblock): array
+    public static function fetchAllAnnotationsFromDocblock(string $docblock): array
     {
         $annotations = [];
         if (!preg_match_all(sprintf(self::$regex, '(\w+)'), (string)$docblock, $matched)) {
@@ -117,17 +112,13 @@ class Annotation
         $this->reflectedClass = $reflectionClass;
     }
 
-    public function method($method): self
+    public function method(string $method): self
     {
         $this->currentReflectedItem = $this->reflectedClass->getMethod($method);
         return $this;
     }
 
-    /**
-     * @param $annotation
-     * @return mixed|null
-     */
-    public function fetch($annotation)
+    public function fetch(string $annotation): ?string
     {
         $docBlock = (string) $this->currentReflectedItem->getDocComment();
         if (preg_match(sprintf(self::$regex, $annotation), $docBlock, $matched)) {
@@ -136,7 +127,7 @@ class Annotation
         return null;
     }
 
-    public function fetchAll($annotation): array
+    public function fetchAll(string $annotation): array
     {
         $docBlock = (string) $this->currentReflectedItem->getDocComment();
         if (preg_match_all(sprintf(self::$regex, $annotation), $docBlock, $matched)) {
@@ -155,10 +146,10 @@ class Annotation
      * Either JSON or Doctrine-annotation style allowed
      * Returns null if not a valid array data
      *
-     * @param $annotation
+     * @param string $annotation
      * @return array|mixed|string
      */
-    public static function arrayValue($annotation)
+    public static function arrayValue(string $annotation)
     {
         $annotation = trim($annotation);
         $openingBrace = substr($annotation, 0, 1);

--- a/src/Codeception/Util/Annotation.php
+++ b/src/Codeception/Util/Annotation.php
@@ -4,6 +4,17 @@ declare(strict_types=1);
 
 namespace Codeception\Util;
 
+use ReflectionClass;
+use function get_class;
+use function in_array;
+use function is_object;
+use function json_decode;
+use function preg_match;
+use function preg_match_all;
+use function sprintf;
+use function substr;
+use function trim;
+
 /**
  * Simple annotation parser. Take only key-value annotations for methods or class.
  */

--- a/src/Codeception/Util/Annotation.php
+++ b/src/Codeception/Util/Annotation.php
@@ -145,11 +145,8 @@ class Annotation
      * Returns an associative array value of annotation
      * Either JSON or Doctrine-annotation style allowed
      * Returns null if not a valid array data
-     *
-     * @param string $annotation
-     * @return array|mixed|string
      */
-    public static function arrayValue(string $annotation)
+    public static function arrayValue(string $annotation): ?array
     {
         $annotation = trim($annotation);
         $openingBrace = substr($annotation, 0, 1);

--- a/src/Codeception/Util/Annotation.php
+++ b/src/Codeception/Util/Annotation.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Codeception\Util;
 
 /**

--- a/src/Codeception/Util/ArrayContainsComparator.php
+++ b/src/Codeception/Util/ArrayContainsComparator.php
@@ -4,6 +4,14 @@ declare(strict_types=1);
 
 namespace Codeception\Util;
 
+use function array_intersect;
+use function array_keys;
+use function count;
+use function is_array;
+use function is_numeric;
+use function min;
+use function range;
+
 class ArrayContainsComparator
 {
     /**

--- a/src/Codeception/Util/ArrayContainsComparator.php
+++ b/src/Codeception/Util/ArrayContainsComparator.php
@@ -19,20 +19,17 @@ class ArrayContainsComparator
      */
     protected $haystack = [];
 
-    public function __construct($haystack)
+    public function __construct(array $haystack)
     {
         $this->haystack = $haystack;
     }
 
-    /**
-     * @return array
-     */
-    public function getHaystack()
+    public function getHaystack(): array
     {
         return $this->haystack;
     }
 
-    public function containsArray(array $needle)
+    public function containsArray(array $needle): bool
     {
         return $needle == $this->arrayIntersectRecursive($needle, $this->haystack);
     }
@@ -61,22 +58,13 @@ class ArrayContainsComparator
 
     /**
      * This array has sequential keys?
-     *
-     * @param array $array
-     *
-     * @return bool
      */
-    private function arrayIsSequential(array $array)
+    private function arrayIsSequential(array $array): bool
     {
         return array_keys($array) === range(0, count($array) - 1);
     }
 
-    /**
-     * @param array $arr1
-     * @param array $arr2
-     * @return array
-     */
-    private function sequentialArrayIntersect(array $arr1, array $arr2)
+    private function sequentialArrayIntersect(array $arr1, array $arr2): array
     {
         $ret = [];
 
@@ -144,7 +132,7 @@ class ArrayContainsComparator
         return $ret;
     }
 
-    private function isEqualValue($val1, $val2)
+    private function isEqualValue($val1, $val2): bool
     {
         if (is_numeric($val1)) {
             $val1 = (string) $val1;

--- a/src/Codeception/Util/ArrayContainsComparator.php
+++ b/src/Codeception/Util/ArrayContainsComparator.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Codeception\Util;
 
 class ArrayContainsComparator

--- a/src/Codeception/Util/Autoload.php
+++ b/src/Codeception/Util/Autoload.php
@@ -17,6 +17,9 @@ use function trim;
  */
 class Autoload
 {
+    /**
+     * @var bool
+     */
     protected static $registered = false;
     /**
      * An associative array where the key is a namespace prefix and the value
@@ -43,16 +46,14 @@ class Autoload
      * Autoload::addNamespace('', '/path/to/pageobjects');
      *
      * Autoload::addNamespace('app\Codeception', '/path/to/controllers');
-     * ?>
      * ```
      *
      * @param string $prefix The namespace prefix.
-     * @param string $base_dir A base directory for class files in the namespace.
+     * @param string $baseDir A base directory for class files in the namespace.
      * @param bool $prepend If true, prepend the base directory to the stack instead of appending it;
      *                      this causes it to be searched first rather than last.
-     * @return void
      */
-    public static function addNamespace($prefix, $base_dir, $prepend = false)
+    public static function addNamespace(string $prefix, string $baseDir, bool $prepend = false): void
     {
         if (!self::$registered) {
             spl_autoload_register([__CLASS__, 'load']);
@@ -63,19 +64,19 @@ class Autoload
         $prefix = trim($prefix, '\\') . '\\';
 
         // normalize the base directory with a trailing separator
-        $base_dir = rtrim($base_dir, '/') . DIRECTORY_SEPARATOR;
-        $base_dir = rtrim($base_dir, DIRECTORY_SEPARATOR) . '/';
+        $baseDir = rtrim($baseDir, '/') . DIRECTORY_SEPARATOR;
+        $baseDir = rtrim($baseDir, DIRECTORY_SEPARATOR) . '/';
 
         // initialize the namespace prefix array
-        if (isset(self::$map[$prefix]) === false) {
+        if (!isset(self::$map[$prefix])) {
             self::$map[$prefix] = [];
         }
 
         // retain the base directory for the namespace prefix
         if ($prepend) {
-            array_unshift(self::$map[$prefix], $base_dir);
+            array_unshift(self::$map[$prefix], $baseDir);
         } else {
-            self::$map[$prefix][] = $base_dir;
+            self::$map[$prefix][] = $baseDir;
         }
     }
 
@@ -124,18 +125,18 @@ class Autoload
      * Load the mapped file for a namespace prefix and relative class.
      *
      * @param string $prefix The namespace prefix.
-     * @param string $relative_class The relative class name.
-     * @return mixed Boolean false if no mapped file can be loaded, or the name of the mapped file that was loaded.
+     * @param string $relativeClass The relative class name.
+     * @return bool|string Boolean false if no mapped file can be loaded, or the name of the mapped file that was loaded.
      */
-    protected static function loadMappedFile($prefix, $relative_class)
+    protected static function loadMappedFile(string $prefix, string $relativeClass)
     {
         if (!isset(self::$map[$prefix])) {
             return false;
         }
 
-        foreach (self::$map[$prefix] as $base_dir) {
-            $file = $base_dir
-                . str_replace('\\', '/', $relative_class)
+        foreach (self::$map[$prefix] as $baseDir) {
+            $file = $baseDir
+                . str_replace('\\', '/', $relativeClass)
                 . '.php';
 
             // 'static' is for testing purposes
@@ -147,7 +148,7 @@ class Autoload
         return false;
     }
 
-    protected static function requireFile($file)
+    protected static function requireFile($file): bool
     {
         if (file_exists($file)) {
             require_once $file;

--- a/src/Codeception/Util/Autoload.php
+++ b/src/Codeception/Util/Autoload.php
@@ -4,6 +4,13 @@ declare(strict_types=1);
 
 namespace Codeception\Util;
 
+use function array_unshift;
+use function file_exists;
+use function rtrim;
+use function spl_autoload_register;
+use function str_replace;
+use function trim;
+
 /**
  * Autoloader, which is fully compatible with PSR-4,
  * and can be used to autoload your `Helper`, `Page`, and `Step` classes.

--- a/src/Codeception/Util/Autoload.php
+++ b/src/Codeception/Util/Autoload.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Codeception\Util;
 
 /**

--- a/src/Codeception/Util/Debug.php
+++ b/src/Codeception/Util/Debug.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Codeception\Util;
 
 use Codeception\Lib\Console\Output;

--- a/src/Codeception/Util/Debug.php
+++ b/src/Codeception/Util/Debug.php
@@ -20,7 +20,7 @@ class Debug
      */
     protected static $output = null;
 
-    public static function setOutput(Output $output)
+    public static function setOutput(Output $output): void
     {
         self::$output = $output;
     }
@@ -30,7 +30,7 @@ class Debug
      *
      * @param $message
      */
-    public static function debug($message)
+    public static function debug($message): void
     {
         if (!self::$output) {
             return;
@@ -38,7 +38,7 @@ class Debug
         self::$output->debug($message);
     }
 
-    public static function isEnabled()
+    public static function isEnabled(): bool
     {
         return (bool) self::$output;
     }

--- a/src/Codeception/Util/Debug.php
+++ b/src/Codeception/Util/Debug.php
@@ -8,7 +8,6 @@ use Codeception\Lib\Console\Output;
 use Symfony\Component\Console\Helper\QuestionHelper;
 use Symfony\Component\Console\Input\ArgvInput;
 use Symfony\Component\Console\Question\ConfirmationQuestion;
-use Symfony\Component\Console\Question\Question;
 
 /**
  * This class is used only when Codeception is executed in `--debug` mode.

--- a/src/Codeception/Util/FileSystem.php
+++ b/src/Codeception/Util/FileSystem.php
@@ -12,19 +12,18 @@ use function unlink;
 
 /**
  * Set of functions to work with Filesystem
- *
  */
 class FileSystem
 {
     /**
      * @param $path
      */
-    public static function doEmptyDir($path)
+    public static function doEmptyDir($path): void
     {
-        /** @var $iterator \RecursiveIteratorIterator|\SplFileObject[] */
-        $iterator = new \RecursiveIteratorIterator(
-            new \RecursiveDirectoryIterator($path),
-            \RecursiveIteratorIterator::CHILD_FIRST
+        /** @var $iterator RecursiveIteratorIterator|\SplFileObject[] */
+        $iterator = new RecursiveIteratorIterator(
+            new RecursiveDirectoryIterator($path),
+            RecursiveIteratorIterator::CHILD_FIRST
         );
 
         foreach ($iterator as $path) {
@@ -41,11 +40,7 @@ class FileSystem
         }
     }
 
-    /**
-     * @param $dir
-     * @return bool
-     */
-    public static function deleteDir($dir)
+    public static function deleteDir($dir): bool
     {
         if (!file_exists($dir)) {
             return true;
@@ -77,10 +72,6 @@ class FileSystem
         return @rmdir($dir);
     }
 
-    /**
-     * @param $src
-     * @param $dst
-     */
     public static function copyDir($src, $dst)
     {
         $dir = opendir($src);

--- a/src/Codeception/Util/FileSystem.php
+++ b/src/Codeception/Util/FileSystem.php
@@ -4,6 +4,12 @@ declare(strict_types=1);
 
 namespace Codeception\Util;
 
+use RecursiveDirectoryIterator;
+use RecursiveIteratorIterator;
+use function basename;
+use function rmdir;
+use function unlink;
+
 /**
  * Set of functions to work with Filesystem
  *

--- a/src/Codeception/Util/FileSystem.php
+++ b/src/Codeception/Util/FileSystem.php
@@ -17,7 +17,6 @@ class FileSystem
 {
     public static function doEmptyDir(string $path): void
     {
-        /** @var $iterator RecursiveIteratorIterator|\SplFileObject[] */
         $iterator = new RecursiveIteratorIterator(
             new RecursiveDirectoryIterator($path),
             RecursiveIteratorIterator::CHILD_FIRST

--- a/src/Codeception/Util/FileSystem.php
+++ b/src/Codeception/Util/FileSystem.php
@@ -15,10 +15,7 @@ use function unlink;
  */
 class FileSystem
 {
-    /**
-     * @param $path
-     */
-    public static function doEmptyDir($path): void
+    public static function doEmptyDir(string $path): void
     {
         /** @var $iterator RecursiveIteratorIterator|\SplFileObject[] */
         $iterator = new RecursiveIteratorIterator(
@@ -40,7 +37,7 @@ class FileSystem
         }
     }
 
-    public static function deleteDir($dir): bool
+    public static function deleteDir(string $dir): bool
     {
         if (!file_exists($dir)) {
             return true;
@@ -72,7 +69,7 @@ class FileSystem
         return @rmdir($dir);
     }
 
-    public static function copyDir($src, $dst)
+    public static function copyDir(string $src, string $dst): void
     {
         $dir = opendir($src);
         @mkdir($dst);

--- a/src/Codeception/Util/FileSystem.php
+++ b/src/Codeception/Util/FileSystem.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Codeception\Util;
 
 /**

--- a/src/Codeception/Util/Fixtures.php
+++ b/src/Codeception/Util/Fixtures.php
@@ -23,7 +23,7 @@ class Fixtures
 {
     protected static $fixtures = [];
 
-    public static function add($name, $data)
+    public static function add($name, $data): void
     {
         self::$fixtures[$name] = $data;
     }
@@ -31,13 +31,13 @@ class Fixtures
     public static function get($name)
     {
         if (!self::exists($name)) {
-            throw new \RuntimeException("$name not found in fixtures");
+            throw new RuntimeException("{$name} not found in fixtures");
         }
 
         return self::$fixtures[$name];
     }
 
-    public static function cleanup($name = null)
+    public static function cleanup($name = null): void
     {
         if (self::exists($name)) {
             unset(self::$fixtures[$name]);
@@ -47,7 +47,7 @@ class Fixtures
         self::$fixtures = [];
     }
 
-    public static function exists($name)
+    public static function exists($name): bool
     {
         return isset(self::$fixtures[$name]);
     }

--- a/src/Codeception/Util/Fixtures.php
+++ b/src/Codeception/Util/Fixtures.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Codeception\Util;
 
+use RuntimeException;
+
 /**
  * Really basic class to store data in global array and use it in Cests/Tests.
  *

--- a/src/Codeception/Util/Fixtures.php
+++ b/src/Codeception/Util/Fixtures.php
@@ -14,21 +14,18 @@ use RuntimeException;
  * Fixtures::add('user1', ['name' => 'davert']);
  * Fixtures::get('user1');
  * Fixtures::exists('user1');
- *
- * ?>
  * ```
- *
  */
 class Fixtures
 {
     protected static $fixtures = [];
 
-    public static function add($name, $data): void
+    public static function add(string $name, $data): void
     {
         self::$fixtures[$name] = $data;
     }
 
-    public static function get($name)
+    public static function get(string $name)
     {
         if (!self::exists($name)) {
             throw new RuntimeException("{$name} not found in fixtures");
@@ -37,7 +34,7 @@ class Fixtures
         return self::$fixtures[$name];
     }
 
-    public static function cleanup($name = null): void
+    public static function cleanup(string $name = ''): void
     {
         if (self::exists($name)) {
             unset(self::$fixtures[$name]);
@@ -47,7 +44,7 @@ class Fixtures
         self::$fixtures = [];
     }
 
-    public static function exists($name): bool
+    public static function exists(string $name): bool
     {
         return isset(self::$fixtures[$name]);
     }

--- a/src/Codeception/Util/Fixtures.php
+++ b/src/Codeception/Util/Fixtures.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Codeception\Util;
 
 /**

--- a/src/Codeception/Util/Locator.php
+++ b/src/Codeception/Util/Locator.php
@@ -335,7 +335,7 @@ class Locator
     /**
      * Transforms strict locator, \Facebook\WebDriver\WebDriverBy into a string representation
      *
-     * @param string|array $selector
+     * @param string|array|WebDriverBy $selector
      * @return string
      */
     public static function humanReadableString($selector): string

--- a/src/Codeception/Util/Locator.php
+++ b/src/Codeception/Util/Locator.php
@@ -56,11 +56,11 @@ class Locator
      * As a result the Locator will produce a mixed XPath value that will be used in fillField action.
      *
      * @static
-     * @param $selector1
-     * @param $selector2
+     * @param string $selector1
+     * @param string $selector2
      * @throws Exception
      */
-    public static function combine($selector1, $selector2): string
+    public static function combine(string $selector1, string $selector2): string
     {
         $selectors = func_get_args();
         foreach ($selectors as $k => $v) {

--- a/src/Codeception/Util/Locator.php
+++ b/src/Codeception/Util/Locator.php
@@ -4,10 +4,26 @@ declare(strict_types=1);
 
 namespace Codeception\Util;
 
+use DOMDocument;
+use DOMXPath;
+use Exception;
 use Facebook\WebDriver\WebDriverBy;
+use InvalidArgumentException;
 use Symfony\Component\CssSelector\CssSelectorConverter;
 use Symfony\Component\CssSelector\Exception\ParseException;
 use Symfony\Component\CssSelector\XPath\Translator;
+use function abs;
+use function class_exists;
+use function func_get_args;
+use function implode;
+use function is_array;
+use function is_int;
+use function is_string;
+use function key;
+use function preg_match;
+use function sprintf;
+use function strpos;
+use function strtolower;
 
 /**
  * Set of useful functions for using CSS and XPath locators.

--- a/src/Codeception/Util/Locator.php
+++ b/src/Codeception/Util/Locator.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Codeception\Util;
 
 use Facebook\WebDriver\WebDriverBy;

--- a/src/Codeception/Util/Locator.php
+++ b/src/Codeception/Util/Locator.php
@@ -41,7 +41,6 @@ class Locator
      * use \Codeception\Util\Locator;
      *
      * $I->see('Title', Locator::combine('h1','h2','h3'));
-     * ?>
      * ```
      *
      * This will search for `Title` text in either `h1`, `h2`, or `h3` tag.
@@ -52,16 +51,13 @@ class Locator
      * use \Codeception\Util\Locator;
      *
      * $I->fillField(Locator::combine('form input[type=text]','//form/textarea[2]'), 'qwerty');
-     * ?>
      * ```
      *
      * As a result the Locator will produce a mixed XPath value that will be used in fillField action.
      *
      * @static
-     *
      * @param $selector1
      * @param $selector2
-     *
      * @throws Exception
      */
     public static function combine($selector1, $selector2): string
@@ -84,14 +80,10 @@ class Locator
      * use \Codeception\Util\Locator;
      *
      * $I->see('Log In', Locator::href('/login.php'));
-     * ?>
      * ```
-     *
      * @static
-     *
-     * @param $url
      */
-    public static function href($url): string
+    public static function href(string $url): string
     {
         return sprintf('//a[@href=normalize-space(%s)]', Translator::getXpathLiteral($url));
     }
@@ -108,14 +100,10 @@ class Locator
      * $I->fillField(Locator::tabIndex(1), 'davert');
      * $I->fillField(Locator::tabIndex(2) , 'qwerty');
      * $I->click('Login');
-     * ?>
      * ```
-     *
      * @static
-     *
-     * @param $index
      */
-    public static function tabIndex($index): string
+    public static function tabIndex(int $index): string
     {
         return sprintf('//*[@tabindex = normalize-space(%d)]', $index);
     }
@@ -129,11 +117,8 @@ class Locator
      *
      * $I->seeElement(Locator::option('Male'), '#select-gender');
      * ```
-     *
-     * @param $value
-     *
      */
-    public static function option($value): string
+    public static function option(string $value): string
     {
         return sprintf('//option[.=normalize-space("%s")]', $value);
     }
@@ -160,13 +145,9 @@ class Locator
      *
      * $I->seeElement(Locator::find('img', ['title' => 'diagram']));
      * ```
-     *
      * @static
-     *
-     * @param $element
-     * @param $attributes
      */
-    public static function find($element, array $attributes): string
+    public static function find(string $element, array $attributes): string
     {
         $operands = [];
         foreach ($attributes as $attribute => $value) {
@@ -188,10 +169,8 @@ class Locator
      * Locator::isCSS('body') => true
      * Locator::isCSS('//body/p/user') => false
      * ```
-     *
-     * @param $selector
      */
-    public static function isCSS($selector): bool
+    public static function isCSS(string $selector): bool
     {
         try {
             (new CssSelectorConverter())->toXPath($selector);
@@ -210,10 +189,8 @@ class Locator
      * Locator::isXPath('body') => false
      * Locator::isXPath('//body/p/user') => true
      * ```
-     *
-     * @param $locator
      */
-    public static function isXPath($locator): bool
+    public static function isXPath(string $locator): bool
     {
         $domDocument = new DOMDocument('1.0', 'UTF-8');
         $domxPath = new DOMXPath($domDocument);
@@ -221,7 +198,7 @@ class Locator
     }
 
     /**
-     * @param $locator
+     * @param array|WebDriverBy|string $locator
      */
     public static function isPrecise($locator): bool
     {
@@ -249,11 +226,8 @@ class Locator
      * Locator::isID('body') => false
      * Locator::isID('//body/p/user') => false
      * ```
-     *
-     * @param $id
-     *
      */
-    public static function isID($id): bool
+    public static function isID(string $id): bool
     {
         return (bool)preg_match('~^#[\w\.\-\[\]\=\^\~\:]+$~', $id);
     }
@@ -267,10 +241,8 @@ class Locator
      * Locator::isClass('body') => false
      * Locator::isClass('//body/p/user') => false
      * ```
-     *
-     * @param $class
      */
-    public static function isClass($class): bool
+    public static function isClass(string $class): bool
     {
         return (bool)preg_match('~^\.[\w\.\-\[\]\=\^\~\:]+$~', $class);
     }
@@ -286,12 +258,8 @@ class Locator
      * Locator::contains('label', 'Name'); // label containing name
      * Locator::contains('div[@contenteditable=true]', 'hello world');
      * ```
-     *
-     * @param $element
-     * @param $text
-     *
      */
-    public static function contains($element, $text): string
+    public static function contains(string $element, string $text): string
     {
         $text = Translator::getXpathLiteral($text);
         return sprintf('%s[%s]', self::toXPath($element), "contains(., {$text})");
@@ -314,8 +282,7 @@ class Locator
      *
      * @param string $element CSS or XPath locator
      * @param int|string $position xPath index
-     *
-     * @return mixed
+     * @return string
      */
     public static function elementAt(string $element, $position): string
     {
@@ -342,12 +309,8 @@ class Locator
      *
      * Locator::firstElement('//table/tr');
      * ```
-     *
-     * @param $element
-     *
-     * @return mixed
      */
-    public static function firstElement($element)
+    public static function firstElement(string $element): string
     {
         return self::elementAt($element, 1);
     }
@@ -363,20 +326,17 @@ class Locator
      *
      * Locator::lastElement('//table/tr');
      * ```
-     *
-     * @param $element
-     *
-     * @return mixed
      */
-    public static function lastElement($element)
+    public static function lastElement(string $element): string
     {
         return self::elementAt($element, 'last()');
     }
 
     /**
-     * Transforms strict locator, \Facebook\WebDriver\WebDriverBy into a string represenation
+     * Transforms strict locator, \Facebook\WebDriver\WebDriverBy into a string representation
      *
-     * @param $selector
+     * @param string|array $selector
+     * @return string
      */
     public static function humanReadableString($selector): string
     {

--- a/src/Codeception/Util/Maybe.php
+++ b/src/Codeception/Util/Maybe.php
@@ -34,10 +34,19 @@ use function range;
  * ?>
  * ```
  */
-class Maybe implements \ArrayAccess, \Iterator, \JsonSerializable
+class Maybe implements ArrayAccess, Iterator, JsonSerializable
 {
+    /**
+     * @var int
+     */
     protected $position = 0;
+    /**
+     * @var null|object
+     */
     protected $val = null;
+    /**
+     * @var null
+     */
     protected $assocArray = null;
 
     public function __construct($val = null)
@@ -49,7 +58,7 @@ class Maybe implements \ArrayAccess, \Iterator, \JsonSerializable
         $this->position = 0;
     }
 
-    private function isAssocArray($arr)
+    private function isAssocArray($arr): bool
     {
         return array_keys($arr) !== range(0, count($arr) - 1);
     }
@@ -70,7 +79,7 @@ class Maybe implements \ArrayAccess, \Iterator, \JsonSerializable
         return $this->val;
     }
 
-    public function __get($key)
+    public function __get($key): Maybe
     {
         if ($this->val === null) {
             return new Maybe();
@@ -116,40 +125,38 @@ class Maybe implements \ArrayAccess, \Iterator, \JsonSerializable
 
     public function __unset($key)
     {
-        if (is_object($this->val)) {
-            if (isset($this->val->{$key}) || property_exists($this->val, $key)) {
-                unset($this->val->{$key});
-                return;
-            }
+        if (is_object($this->val) && (isset($this->val->{$key}) || property_exists($this->val, $key))) {
+            unset($this->val->{$key});
+            return;
         }
     }
 
-    public function offsetExists($offset)
+    public function offsetExists($offset): bool
     {
-        if (is_array($this->val) || ($this->val instanceof \ArrayAccess)) {
+        if (is_array($this->val) || ($this->val instanceof ArrayAccess)) {
             return isset($this->val[$offset]);
         }
         return false;
     }
 
-    public function offsetGet($offset)
+    public function offsetGet($offset): Maybe
     {
-        if (is_array($this->val) || ($this->val instanceof \ArrayAccess)) {
+        if (is_array($this->val) || $this->val instanceof ArrayAccess) {
             return $this->val[$offset];
         }
         return new Maybe();
     }
 
-    public function offsetSet($offset, $value)
+    public function offsetSet($offset, $value): void
     {
-        if (is_array($this->val) || ($this->val instanceof \ArrayAccess)) {
+        if (is_array($this->val) || ($this->val instanceof ArrayAccess)) {
             $this->val[$offset] = $value;
         }
     }
 
-    public function offsetUnset($offset)
+    public function offsetUnset($offset): void
     {
-        if (is_array($this->val) || ($this->val instanceof \ArrayAccess)) {
+        if (is_array($this->val) || ($this->val instanceof ArrayAccess)) {
             unset($this->val[$offset]);
         }
     }
@@ -172,7 +179,7 @@ class Maybe implements \ArrayAccess, \Iterator, \JsonSerializable
      * (PHP 5 &gt;= 5.0.0)<br/>
      * Return the current element
      * @link http://php.net/manual/en/iterator.current.php
-     * @return mixed Can return any type.
+     * @return null|mixed Can return any type.
      */
     public function current()
     {
@@ -193,7 +200,7 @@ class Maybe implements \ArrayAccess, \Iterator, \JsonSerializable
      * @link http://php.net/manual/en/iterator.next.php
      * @return void Any returned value is ignored.
      */
-    public function next()
+    public function next(): void
     {
         ++$this->position;
     }
@@ -202,7 +209,7 @@ class Maybe implements \ArrayAccess, \Iterator, \JsonSerializable
      * (PHP 5 &gt;= 5.0.0)<br/>
      * Return the key of the current element
      * @link http://php.net/manual/en/iterator.key.php
-     * @return mixed scalar on success, or null on failure.
+     * @return mixed|int|string scalar on success, or null on failure.
      */
     public function key()
     {
@@ -221,7 +228,7 @@ class Maybe implements \ArrayAccess, \Iterator, \JsonSerializable
      * @return boolean The return value will be casted to boolean and then evaluated.
      * Returns true on success or false on failure.
      */
-    public function valid()
+    public function valid(): ?bool
     {
         if (!is_array($this->val)) {
             return null;
@@ -240,7 +247,7 @@ class Maybe implements \ArrayAccess, \Iterator, \JsonSerializable
      * @link http://php.net/manual/en/iterator.rewind.php
      * @return void Any returned value is ignored.
      */
-    public function rewind()
+    public function rewind(): void
     {
         if (is_array($this->val)) {
             $this->assocArray = $this->isAssocArray($this->val);

--- a/src/Codeception/Util/Maybe.php
+++ b/src/Codeception/Util/Maybe.php
@@ -4,6 +4,19 @@ declare(strict_types=1);
 
 namespace Codeception\Util;
 
+use ArrayAccess;
+use Iterator;
+use JsonSerializable;
+use function array_keys;
+use function call_user_func_array;
+use function count;
+use function is_array;
+use function is_object;
+use function is_scalar;
+use function method_exists;
+use function property_exists;
+use function range;
+
 /**
  * Class to represent any type of content.
  * This class can act as an object, array, or string.

--- a/src/Codeception/Util/Maybe.php
+++ b/src/Codeception/Util/Maybe.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Codeception\Util;
 
 /**

--- a/src/Codeception/Util/Maybe.php
+++ b/src/Codeception/Util/Maybe.php
@@ -49,7 +49,7 @@ class Maybe implements ArrayAccess, Iterator, JsonSerializable
      */
     protected $assocArray = null;
 
-    public function __construct($val = null)
+    public function __construct(?array $val = null)
     {
         $this->val = $val;
         if (is_array($this->val)) {
@@ -58,28 +58,21 @@ class Maybe implements ArrayAccess, Iterator, JsonSerializable
         $this->position = 0;
     }
 
-    private function isAssocArray($arr): bool
+    private function isAssocArray(array $arr): bool
     {
         return array_keys($arr) !== range(0, count($arr) - 1);
     }
 
-    public function __toString()
+    public function __toString(): string
     {
         if ($this->val === null) {
-            return "?";
-        }
-        if (is_scalar($this->val)) {
-            return (string)$this->val;
+            return '?';
         }
 
-        if (is_object($this->val) && method_exists($this->val, '__toString')) {
-            return $this->val->__toString();
-        }
-
-        return $this->val;
+        return (string)$this->val;
     }
 
-    public function __get($key): Maybe
+    public function __get(string $key): Maybe
     {
         if ($this->val === null) {
             return new Maybe();
@@ -94,7 +87,7 @@ class Maybe implements ArrayAccess, Iterator, JsonSerializable
         return $this->val->key;
     }
 
-    public function __set($key, $val)
+    public function __set(string $key, $val)
     {
         if ($this->val === null) {
             return;
@@ -108,7 +101,7 @@ class Maybe implements ArrayAccess, Iterator, JsonSerializable
         $this->val->key = $val;
     }
 
-    public function __call($method, $args)
+    public function __call(string $method, array $args)
     {
         if ($this->val === null) {
             return new Maybe();
@@ -123,7 +116,7 @@ class Maybe implements ArrayAccess, Iterator, JsonSerializable
         }
     }
 
-    public function __unset($key)
+    public function __unset(string $key)
     {
         if (is_object($this->val) && (isset($this->val->{$key}) || property_exists($this->val, $key))) {
             unset($this->val->{$key});
@@ -209,7 +202,7 @@ class Maybe implements ArrayAccess, Iterator, JsonSerializable
      * (PHP 5 &gt;= 5.0.0)<br/>
      * Return the key of the current element
      * @link http://php.net/manual/en/iterator.key.php
-     * @return mixed|int|string scalar on success, or null on failure.
+     * @return int|string|null scalar on success, or null on failure.
      */
     public function key()
     {

--- a/src/Codeception/Util/PathResolver.php
+++ b/src/Codeception/Util/PathResolver.php
@@ -25,12 +25,11 @@ class PathResolver
      * @param string $path
      * @param string $projDir
      * @param string $dirSep
-     * @return string
      */
-    public static function getRelativeDir($path, $projDir, $dirSep = DIRECTORY_SEPARATOR)
+    public static function getRelativeDir(string $path, string $projDir, string $dirSep = DIRECTORY_SEPARATOR): string
     {
         // ensure $projDir ends with a trailing $dirSep
-        $projDir = preg_replace('/'.preg_quote($dirSep, '/').'*$/', $dirSep, $projDir);
+        $projDir = preg_replace('/'. preg_quote($dirSep, '/').'*$/', $dirSep, $projDir);
         // if $path is a within $projDir
         if (self::fsCaseStrCmp(substr($path, 0, strlen($projDir)), $projDir, $dirSep) == 0) {
             // simply chop it off the front
@@ -60,19 +59,19 @@ class PathResolver
         $relProjDirParts = array_filter(explode($dirSep, substr($projDir, strlen($projDirAbsPrefix['wholePrefix']))), 'strlen');
         // While there are any, peel off any common parent directories
         // from the beginning of the $projDir and $path
-        while ((count($relPathParts) > 0) && (count($relProjDirParts) > 0) &&
+        while (($relPathParts !== []) && ($relProjDirParts !== []) &&
             (self::fsCaseStrCmp($relPathParts[0], $relProjDirParts[0], $dirSep) == 0)
         ) {
             array_shift($relPathParts);
             array_shift($relProjDirParts);
         }
-        if (count($relProjDirParts) > 0) {
+        if ($relProjDirParts !== []) {
             // prefix $relPath with '..' for all remaining unmatched $projDir
             // subdirectories
             $relPathParts = array_merge(array_fill(0, count($relProjDirParts), '..'), $relPathParts);
         }
         // only append a trailing seperator if one is already present
-        $trailingSep = preg_match('/'.preg_quote($dirSep, '/').'$/', $path) ? $dirSep : '';
+        $trailingSep = preg_match('/'. preg_quote($dirSep, '/').'$/', $path) ? $dirSep : '';
         // convert array of dir paths back into a string path
         return implode($dirSep, $relPathParts).$trailingSep;
     }
@@ -85,7 +84,7 @@ class PathResolver
      * @param string $dirSep
      * @return int -1 / 0 / 1 for < / = / > respectively
      */
-    private static function fsCaseStrCmp($str1, $str2, $dirSep = DIRECTORY_SEPARATOR)
+    private static function fsCaseStrCmp(string $str1, string $str2, string $dirSep = DIRECTORY_SEPARATOR): int
     {
         $cmpFn = self::isWindows($dirSep) ? 'strcasecmp' : 'strcmp';
         return $cmpFn($str1, $str2);
@@ -110,16 +109,16 @@ class PathResolver
      *
      * @param string $path
      * @param string $dirSep
-     * @return string
+     * @return array<string, mixed>
      */
-    private static function getPathAbsolutenessPrefix($path, $dirSep = DIRECTORY_SEPARATOR)
+    private static function getPathAbsolutenessPrefix(string $path, string $dirSep = DIRECTORY_SEPARATOR): array
     {
         $devLetterPrefixPattern = '';
         if (self::isWindows($dirSep)) {
             $devLetterPrefixPattern = '([A-Za-z]:|)';
         }
         $matches = [];
-        if (!preg_match('/^'.$devLetterPrefixPattern.preg_quote($dirSep, '/').'?/', $path, $matches)) {
+        if (!preg_match('/^'.$devLetterPrefixPattern. preg_quote($dirSep, '/').'?/', $path, $matches)) {
             // This should match, even if it matches 0 characters
             throw new ConfigurationException("INTERNAL ERROR: This must be a regex problem.");
         }
@@ -132,14 +131,13 @@ class PathResolver
      * Are we in a Windows style filesystem?
      *
      * @param string $dirSep
-     * @return bool
      */
-    private static function isWindows($dirSep = DIRECTORY_SEPARATOR)
+    private static function isWindows(string $dirSep = DIRECTORY_SEPARATOR): bool
     {
         return ($dirSep == '\\');
     }
 
-    public static function isPathAbsolute($path)
+    public static function isPathAbsolute($path): bool
     {
         if (DIRECTORY_SEPARATOR === '/') {
             return substr($path, 0, 1) === DIRECTORY_SEPARATOR;

--- a/src/Codeception/Util/PathResolver.php
+++ b/src/Codeception/Util/PathResolver.php
@@ -22,9 +22,6 @@ class PathResolver
 {
     /**
      * Returns path to a given directory relative to $projDir.
-     * @param string $path
-     * @param string $projDir
-     * @param string $dirSep
      */
     public static function getRelativeDir(string $path, string $projDir, string $dirSep = DIRECTORY_SEPARATOR): string
     {
@@ -109,7 +106,7 @@ class PathResolver
      *
      * @param string $path
      * @param string $dirSep
-     * @return array<string, mixed>
+     * @return array<string, string>
      */
     private static function getPathAbsolutenessPrefix(string $path, string $dirSep = DIRECTORY_SEPARATOR): array
     {
@@ -129,15 +126,13 @@ class PathResolver
 
     /**
      * Are we in a Windows style filesystem?
-     *
-     * @param string $dirSep
      */
     private static function isWindows(string $dirSep = DIRECTORY_SEPARATOR): bool
     {
         return ($dirSep == '\\');
     }
 
-    public static function isPathAbsolute($path): bool
+    public static function isPathAbsolute(string $path): bool
     {
         if (DIRECTORY_SEPARATOR === '/') {
             return substr($path, 0, 1) === DIRECTORY_SEPARATOR;

--- a/src/Codeception/Util/PathResolver.php
+++ b/src/Codeception/Util/PathResolver.php
@@ -5,6 +5,18 @@ declare(strict_types=1);
 namespace Codeception\Util;
 
 use Codeception\Exception\ConfigurationException;
+use function array_fill;
+use function array_filter;
+use function array_merge;
+use function array_shift;
+use function count;
+use function explode;
+use function implode;
+use function preg_match;
+use function preg_quote;
+use function preg_replace;
+use function strlen;
+use function substr;
 
 class PathResolver
 {

--- a/src/Codeception/Util/PathResolver.php
+++ b/src/Codeception/Util/PathResolver.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Codeception\Util;
 
 use Codeception\Exception\ConfigurationException;

--- a/src/Codeception/Util/ReflectionHelper.php
+++ b/src/Codeception/Util/ReflectionHelper.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Codeception\Util;
 
 use ReflectionException;

--- a/src/Codeception/Util/ReflectionHelper.php
+++ b/src/Codeception/Util/ReflectionHelper.php
@@ -35,13 +35,10 @@ class ReflectionHelper
     /**
      * Read a private property of an object.
      *
-     * @param object $object
-     * @param string $property
-     * @param string|null $class
      * @return mixed
      * @throws ReflectionException
      */
-    public static function readPrivateProperty($object, $property, $class = null)
+    public static function readPrivateProperty(object $object, string $property, ?string $class = null)
     {
         if (is_null($class)) {
             $class = $object;
@@ -56,14 +53,10 @@ class ReflectionHelper
     /**
      * Invoke a private method of an object.
      *
-     * @param object $object
-     * @param string $method
-     * @param array $args
-     * @param string|null $class
      * @return mixed
      * @throws ReflectionException
      */
-    public static function invokePrivateMethod($object, $method, $args = [], $class = null)
+    public static function invokePrivateMethod(object $object, string $method, array $args = [], ?string $class = null)
     {
         if (is_null($class)) {
             $class = $object;
@@ -83,7 +76,7 @@ class ReflectionHelper
      * @param $object
      * @return mixed
      */
-    public static function getClassShortName($object)
+    public static function getClassShortName($object): string
     {
         $path = explode('\\', get_class($object));
         return array_pop($path);
@@ -91,18 +84,15 @@ class ReflectionHelper
 
     /**
      * Adapted from https://github.com/Behat/Behat/pull/1313
-     *
-     * @param ReflectionParameter $parameter
-     * @return string|null
      */
-    public static function getClassFromParameter(ReflectionParameter $parameter)
+    public static function getClassFromParameter(ReflectionParameter $parameter): ?string
     {
         if (PHP_VERSION_ID < 70100) {
             $class = $parameter->getClass();
             if ($class !== null) {
                 return $class->name;
             }
-            return $class;
+            return null;
         }
 
         $type = $parameter->getType();
@@ -110,10 +100,11 @@ class ReflectionHelper
             return null;
         }
         $typeString = $type->getName();
-
         if ($typeString === 'self') {
             return $parameter->getDeclaringClass()->getName();
-        } elseif ($typeString === 'parent') {
+        }
+
+        if ($typeString === 'parent') {
             return $parameter->getDeclaringClass()->getParentClass()->getName();
         }
 
@@ -127,15 +118,15 @@ class ReflectionHelper
      *
      * @return string
      */
-    public static function getDefaultValue(ReflectionParameter $param)
+    public static function getDefaultValue(ReflectionParameter $parameter)
     {
-        if ($param->isDefaultValueAvailable()) {
-            if (method_exists($param, 'isDefaultValueConstant') && $param->isDefaultValueConstant()) {
-                $constName = $param->getDefaultValueConstantName();
+        if ($parameter->isDefaultValueAvailable()) {
+            if (method_exists($parameter, 'isDefaultValueConstant') && $parameter->isDefaultValueConstant()) {
+                $constName = $parameter->getDefaultValueConstantName();
                 if (false !== strpos($constName, '::')) {
                     list($class, $const) = explode('::', $constName);
                     if (in_array($class, ['self', 'static'])) {
-                        $constName = '\\' . $param->getDeclaringClass()->getName() . '::' . $const;
+                        $constName = '\\' . $parameter->getDeclaringClass()->getName() . '::' . $const;
                     } elseif (substr($class, 0, 1) !== '\\') {
                         $constName = '\\' . $constName;
                     }
@@ -144,7 +135,7 @@ class ReflectionHelper
                 return $constName;
             }
 
-            return self::phpEncodeValue($param->getDefaultValue());
+            return self::phpEncodeValue($parameter->getDefaultValue());
         }
 
         // Default to 'null' for PHP versions < 7.1.
@@ -152,8 +143,7 @@ class ReflectionHelper
             return 'null';
         }
 
-        $type = $param->getType();
-
+        $type = $parameter->getType();
         // Default to 'null' if explicitly allowed or there is no specific type hint.
         if (!$type || $type->allowsNull() || !$type->isBuiltin()) {
             return 'null';
@@ -184,7 +174,7 @@ class ReflectionHelper
      *
      * @param mixed $value
      *
-     * @return string
+     * @return string|bool
      */
     public static function phpEncodeValue($value)
     {
@@ -204,15 +194,14 @@ class ReflectionHelper
      *
      * @param array $array
      *
-     * @return string
      */
-    public static function phpEncodeArray(array $array)
+    public static function phpEncodeArray(array $array): string
     {
         $isPlainArray = function (array $value) {
-            return ((count($value) === 0)
+            return (($value === [])
                 || (
                     (array_keys($value) === range(0, count($value) - 1))
-                    && (0 === count(array_filter(array_keys($value), 'is_string'))))
+                    && ([] === array_filter(array_keys($value), 'is_string')))
             );
         };
 

--- a/src/Codeception/Util/ReflectionHelper.php
+++ b/src/Codeception/Util/ReflectionHelper.php
@@ -72,29 +72,15 @@ class ReflectionHelper
      * Returns class name without namespace
      *
      * (does not use reflection actually)
-     *
-     * @param $object
-     * @return mixed
      */
-    public static function getClassShortName($object): string
+    public static function getClassShortName(object $object): string
     {
         $path = explode('\\', get_class($object));
         return array_pop($path);
     }
 
-    /**
-     * Adapted from https://github.com/Behat/Behat/pull/1313
-     */
     public static function getClassFromParameter(ReflectionParameter $parameter): ?string
     {
-        if (PHP_VERSION_ID < 70100) {
-            $class = $parameter->getClass();
-            if ($class !== null) {
-                return $class->name;
-            }
-            return null;
-        }
-
         $type = $parameter->getType();
         if ($type === null || $type->isBuiltin()) {
             return null;
@@ -113,12 +99,8 @@ class ReflectionHelper
 
     /**
      * Infer default parameter from the reflection object and format it as PHP (code) string
-     *
-     * @param ReflectionParameter $param
-     *
-     * @return string
      */
-    public static function getDefaultValue(ReflectionParameter $parameter)
+    public static function getDefaultValue(ReflectionParameter $parameter): string
     {
         if ($parameter->isDefaultValueAvailable()) {
             if (method_exists($parameter, 'isDefaultValueConstant') && $parameter->isDefaultValueConstant()) {
@@ -136,11 +118,6 @@ class ReflectionHelper
             }
 
             return self::phpEncodeValue($parameter->getDefaultValue());
-        }
-
-        // Default to 'null' for PHP versions < 7.1.
-        if (PHP_VERSION_ID < 70100) {
-            return 'null';
         }
 
         $type = $parameter->getType();
@@ -191,9 +168,6 @@ class ReflectionHelper
 
     /**
      * Recursively PHP encode an array
-     *
-     * @param array $array
-     *
      */
     public static function phpEncodeArray(array $array): string
     {

--- a/src/Codeception/Util/ReflectionHelper.php
+++ b/src/Codeception/Util/ReflectionHelper.php
@@ -5,9 +5,27 @@ declare(strict_types=1);
 namespace Codeception\Util;
 
 use ReflectionException;
+use ReflectionMethod;
 use ReflectionParameter;
 use ReflectionProperty;
-use ReflectionMethod;
+use function array_filter;
+use function array_keys;
+use function array_map;
+use function array_pop;
+use function count;
+use function explode;
+use function get_class;
+use function implode;
+use function in_array;
+use function is_array;
+use function is_null;
+use function is_string;
+use function json_encode;
+use function method_exists;
+use function range;
+use function strpos;
+use function substr;
+use function var_export;
 
 /**
  * This class contains helper methods to help with common Reflection tasks.

--- a/src/Codeception/Util/ReflectionHelper.php
+++ b/src/Codeception/Util/ReflectionHelper.php
@@ -150,17 +150,16 @@ class ReflectionHelper
      * PHP encode value
      *
      * @param mixed $value
-     *
-     * @return string|bool
+     * @return string
      */
-    public static function phpEncodeValue($value)
+    public static function phpEncodeValue($value): string
     {
         if (is_array($value)) {
             return self::phpEncodeArray($value);
         }
 
         if (is_string($value)) {
-            return json_encode($value);
+            return json_encode($value, JSON_THROW_ON_ERROR);
         }
 
         return var_export($value, true);

--- a/src/Codeception/Util/ReflectionPropertyAccessor.php
+++ b/src/Codeception/Util/ReflectionPropertyAccessor.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Codeception\Util;
 
 use InvalidArgumentException;

--- a/src/Codeception/Util/ReflectionPropertyAccessor.php
+++ b/src/Codeception/Util/ReflectionPropertyAccessor.php
@@ -16,12 +16,10 @@ use function is_object;
 class ReflectionPropertyAccessor
 {
     /**
-     * @param object $obj
-     * @param string $field
      * @return mixed
      * @throws ReflectionException
      */
-    public function getProperty($obj, $field)
+    public function getProperty(object $obj, string $field)
     {
         if (!$obj || !is_object($obj)) {
             throw new InvalidArgumentException('Cannot get property "' . $field . '" of "' . gettype($obj) . '", expecting object');
@@ -40,19 +38,15 @@ class ReflectionPropertyAccessor
     }
 
     /**
-     * @param object|null $obj
-     * @param string $class
-     * @param array $data
-     * @return object|null
      * @throws ReflectionException
      */
-    private function setPropertiesForClass($obj, $class, array $data)
+    private function setPropertiesForClass(?object $obj, string $class, array $data): ?object
     {
-        $reflectedEntity = new ReflectionClass($class);
+        $reflectionClass = new ReflectionClass($class);
 
-        if (!$obj) {
+        if ($obj === null) {
             $constructorParameters = [];
-            $constructor = $reflectedEntity->getConstructor();
+            $constructor = $reflectionClass->getConstructor();
             if (null !== $constructor) {
                 foreach ($constructor->getParameters() as $parameter) {
                     if ($parameter->isOptional()) {
@@ -67,10 +61,10 @@ class ReflectionPropertyAccessor
                 }
             }
 
-            $obj = $reflectedEntity->newInstance(...$constructorParameters);
+            $obj = $reflectionClass->newInstance(...$constructorParameters);
         }
 
-        foreach ($reflectedEntity->getProperties() as $property) {
+        foreach ($reflectionClass->getProperties() as $property) {
             if (isset($data[$property->name])) {
                 $property->setAccessible(true);
                 $property->setValue($obj, $data[$property->name]);
@@ -80,11 +74,9 @@ class ReflectionPropertyAccessor
     }
 
     /**
-     * @param object|null $obj
-     * @param array $data
      * @throws ReflectionException
      */
-    public function setProperties($obj, array $data)
+    public function setProperties(?object $obj, array $data): void
     {
         if (!$obj || !is_object($obj)) {
             throw new InvalidArgumentException('Cannot set properties for "' . gettype($obj) . '", expecting object');
@@ -97,12 +89,9 @@ class ReflectionPropertyAccessor
     }
 
     /**
-     * @param string $class
-     * @param array $data
-     * @return object
      * @throws ReflectionException
      */
-    public function createWithProperties($class, array $data)
+    public function createWithProperties(string $class, array $data): ?object
     {
         $obj = null;
         do {

--- a/src/Codeception/Util/ReflectionPropertyAccessor.php
+++ b/src/Codeception/Util/ReflectionPropertyAccessor.php
@@ -7,6 +7,7 @@ namespace Codeception\Util;
 use InvalidArgumentException;
 use ReflectionClass;
 use ReflectionException;
+use function array_key_exists;
 use function get_class;
 use function get_parent_class;
 use function gettype;

--- a/src/Codeception/Util/Shared/Namespaces.php
+++ b/src/Codeception/Util/Shared/Namespaces.php
@@ -4,6 +4,15 @@ declare(strict_types=1);
 
 namespace Codeception\Util\Shared;
 
+use function array_filter;
+use function array_pop;
+use function array_shift;
+use function count;
+use function explode;
+use function implode;
+use function ltrim;
+use function str_replace;
+
 trait Namespaces
 {
     protected function breakParts($class)

--- a/src/Codeception/Util/Shared/Namespaces.php
+++ b/src/Codeception/Util/Shared/Namespaces.php
@@ -7,7 +7,6 @@ namespace Codeception\Util\Shared;
 use function array_filter;
 use function array_pop;
 use function array_shift;
-use function count;
 use function explode;
 use function implode;
 use function ltrim;
@@ -15,11 +14,11 @@ use function str_replace;
 
 trait Namespaces
 {
-    protected function breakParts($class)
+    protected function breakParts(string $class)
     {
         $class      = str_replace('/', '\\', $class);
         $namespaces = explode('\\', $class);
-        if (count($namespaces) > 0) {
+        if (!empty($namespaces)) {
             $namespaces[0] = ltrim($namespaces[0], '\\');
         }
         if (!$namespaces[0]) {
@@ -28,19 +27,19 @@ trait Namespaces
         return $namespaces;
     }
 
-    protected function getShortClassName($class): string
+    protected function getShortClassName(string $class): string
     {
         $namespaces = $this->breakParts($class);
         return array_pop($namespaces);
     }
 
-    protected function getNamespaceString($class): string
+    protected function getNamespaceString(string $class): string
     {
         $namespaces = $this->getNamespaces($class);
         return implode('\\', $namespaces);
     }
 
-    protected function getNamespaceHeader($class): string
+    protected function getNamespaceHeader(string $class): string
     {
         $str = $this->getNamespaceString($class);
         if (!$str) {
@@ -49,7 +48,7 @@ trait Namespaces
         return "namespace {$str};\n";
     }
 
-    protected function getNamespaces($class)
+    protected function getNamespaces(string $class)
     {
         $namespaces = $this->breakParts($class);
         array_pop($namespaces);

--- a/src/Codeception/Util/Shared/Namespaces.php
+++ b/src/Codeception/Util/Shared/Namespaces.php
@@ -19,7 +19,7 @@ trait Namespaces
     {
         $class      = str_replace('/', '\\', $class);
         $namespaces = explode('\\', $class);
-        if (count($namespaces)) {
+        if (count($namespaces) > 0) {
             $namespaces[0] = ltrim($namespaces[0], '\\');
         }
         if (!$namespaces[0]) {
@@ -28,32 +28,31 @@ trait Namespaces
         return $namespaces;
     }
 
-    protected function getShortClassName($class)
+    protected function getShortClassName($class): string
     {
         $namespaces = $this->breakParts($class);
         return array_pop($namespaces);
     }
 
-    protected function getNamespaceString($class)
+    protected function getNamespaceString($class): string
     {
         $namespaces = $this->getNamespaces($class);
         return implode('\\', $namespaces);
     }
 
-    protected function getNamespaceHeader($class)
+    protected function getNamespaceHeader($class): string
     {
         $str = $this->getNamespaceString($class);
         if (!$str) {
             return "";
         }
-        return "namespace $str;\n";
+        return "namespace {$str};\n";
     }
 
     protected function getNamespaces($class)
     {
         $namespaces = $this->breakParts($class);
         array_pop($namespaces);
-        $namespaces = array_filter($namespaces, 'strlen');
-        return $namespaces;
+        return array_filter($namespaces, 'strlen');
     }
 }

--- a/src/Codeception/Util/Shared/Namespaces.php
+++ b/src/Codeception/Util/Shared/Namespaces.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Codeception\Util\Shared;
 
 trait Namespaces

--- a/src/Codeception/Util/Soap.php
+++ b/src/Codeception/Util/Soap.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Codeception\Util;
 
 /**

--- a/src/Codeception/Util/Soap.php
+++ b/src/Codeception/Util/Soap.php
@@ -13,12 +13,12 @@ namespace Codeception\Util;
  */
 class Soap extends Xml
 {
-    public static function request()
+    public static function request(): XmlBuilder
     {
         return new XmlBuilder();
     }
 
-    public static function response()
+    public static function response(): XmlBuilder
     {
         return new XmlBuilder();
     }

--- a/src/Codeception/Util/Template.php
+++ b/src/Codeception/Util/Template.php
@@ -21,12 +21,7 @@ class Template
     protected $placeholderStart;
     protected $placeholderEnd;
 
-    /**
-     * Takes a template string
-     *
-     * @param $template
-     */
-    public function __construct($template, string $placeholderStart = '{{', string $placeholderEnd = '}}')
+    public function __construct(string $template, string $placeholderStart = '{{', string $placeholderEnd = '}}')
     {
         $this->template         = $template;
         $this->placeholderStart = $placeholderStart;
@@ -36,7 +31,7 @@ class Template
     /**
      * Replaces {{var}} string with provided value
      */
-    public function place($var, $val): self
+    public function place(string $var, $val): self
     {
         $this->vars[$var] = $val;
         return $this;
@@ -52,22 +47,18 @@ class Template
         $this->vars = $vars;
     }
 
-    /**
-     * @return mixed|void
-     */
-    public function getVar($name)
+    public function getVar(string $name)
     {
         if (isset($this->vars[$name])) {
             return $this->vars[$name];
         }
+        return null;
     }
 
     /**
      * Fills up template string with placed variables.
-     *
-     * @return mixed
      */
-    public function produce()
+    public function produce(): string
     {
         $result = $this->template;
         $regex = sprintf('~%s([\w\.]+)%s~m', $this->placeholderStart, $this->placeholderEnd);

--- a/src/Codeception/Util/Template.php
+++ b/src/Codeception/Util/Template.php
@@ -4,6 +4,13 @@ declare(strict_types=1);
 
 namespace Codeception\Util;
 
+use function array_key_exists;
+use function explode;
+use function is_array;
+use function preg_match_all;
+use function sprintf;
+use function str_replace;
+
 /**
  * Basic template engine used for generating initial Cept/Cest/Test files.
  */

--- a/src/Codeception/Util/Template.php
+++ b/src/Codeception/Util/Template.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Codeception\Util;
 
 /**

--- a/src/Codeception/Util/Template.php
+++ b/src/Codeception/Util/Template.php
@@ -26,7 +26,7 @@ class Template
      *
      * @param $template
      */
-    public function __construct($template, $placeholderStart = '{{', $placeholderEnd = '}}')
+    public function __construct($template, string $placeholderStart = '{{', string $placeholderEnd = '}}')
     {
         $this->template         = $template;
         $this->placeholderStart = $placeholderStart;
@@ -35,12 +35,8 @@ class Template
 
     /**
      * Replaces {{var}} string with provided value
-     *
-     * @param $var
-     * @param $val
-     * @return $this
      */
-    public function place($var, $val)
+    public function place($var, $val): self
     {
         $this->vars[$var] = $val;
         return $this;
@@ -51,11 +47,14 @@ class Template
      *
      * @param array $vars
      */
-    public function setVars(array $vars)
+    public function setVars(array $vars): void
     {
         $this->vars = $vars;
     }
 
+    /**
+     * @return mixed|void
+     */
     public function getVar($name)
     {
         if (isset($this->vars[$name])) {

--- a/src/Codeception/Util/Uri.php
+++ b/src/Codeception/Util/Uri.php
@@ -5,6 +5,13 @@ declare(strict_types=1);
 namespace Codeception\Util;
 
 use GuzzleHttp\Psr7\Uri as Psr7Uri;
+use InvalidArgumentException;
+use function dirname;
+use function ltrim;
+use function parse_url;
+use function preg_match;
+use function rtrim;
+use function strpos;
 
 class Uri
 {

--- a/src/Codeception/Util/Uri.php
+++ b/src/Codeception/Util/Uri.php
@@ -24,9 +24,9 @@ class Uri
      *
      * @param string $baseUri the base URL
      * @param string $uri the URL to merge
-     * @return array the merged array
+     * @return string the merged array
      */
-    public static function mergeUrls($baseUri, $uri)
+    public static function mergeUrls(string $baseUri, string $uri): string
     {
         $base = new Psr7Uri($baseUri);
         $parts = parse_url($uri);
@@ -36,12 +36,12 @@ class Uri
         if ($parts === false) {
             $parts = parse_url($base.$uri);
         }
-        
+
         if ($parts === false) {
-            throw new \InvalidArgumentException("Invalid URI $uri");
+            throw new InvalidArgumentException("Invalid URI {$uri}");
         }
 
-        if (isset($parts['host']) and isset($parts['scheme'])) {
+        if (isset($parts['host']) && isset($parts['scheme'])) {
             // if this is an absolute url, replace with it
             return $uri;
         }
@@ -56,7 +56,7 @@ class Uri
             $path = $parts['path'];
             $basePath = $base->getPath();
             if ((strpos($path, '/') !== 0) && !empty($path)) {
-                if ($basePath) {
+                if ($basePath !== '') {
                     // if it ends with a slash, relative paths are below it
                     if (preg_match('~/$~', $basePath)) {
                         $path = $basePath . $path;
@@ -86,10 +86,8 @@ class Uri
 
     /**
      * Retrieve /path?query#fragment part of URL
-     * @param $url
-     * @return string
      */
-    public static function retrieveUri($url)
+    public static function retrieveUri(string $url): string
     {
         $uri = new Psr7Uri($url);
         return (string)(new Psr7Uri())
@@ -98,11 +96,11 @@ class Uri
             ->withFragment($uri->getFragment());
     }
 
-    public static function retrieveHost($url)
+    public static function retrieveHost($url): string
     {
         $urlParts = parse_url($url);
-        if (!isset($urlParts['host']) or !isset($urlParts['scheme'])) {
-            throw new \InvalidArgumentException("Wrong URL passes, host and scheme not set");
+        if (!isset($urlParts['host']) || !isset($urlParts['scheme'])) {
+            throw new InvalidArgumentException("Wrong URL passes, host and scheme not set");
         }
         $host = $urlParts['scheme'] . '://' . $urlParts['host'];
         if (isset($urlParts['port'])) {
@@ -111,7 +109,7 @@ class Uri
         return $host;
     }
 
-    public static function appendPath($url, $path)
+    public static function appendPath($url, $path): string
     {
         $uri = new Psr7Uri($url);
         $cutUrl = (string)$uri->withQuery('')->withFragment('');

--- a/src/Codeception/Util/Uri.php
+++ b/src/Codeception/Util/Uri.php
@@ -96,7 +96,7 @@ class Uri
             ->withFragment($uri->getFragment());
     }
 
-    public static function retrieveHost($url): string
+    public static function retrieveHost(string $url): string
     {
         $urlParts = parse_url($url);
         if (!isset($urlParts['host']) || !isset($urlParts['scheme'])) {
@@ -109,7 +109,7 @@ class Uri
         return $host;
     }
 
-    public static function appendPath($url, $path): string
+    public static function appendPath(string $url, string $path): string
     {
         $uri = new Psr7Uri($url);
         $cutUrl = (string)$uri->withQuery('')->withFragment('');

--- a/src/Codeception/Util/Uri.php
+++ b/src/Codeception/Util/Uri.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Codeception\Util;
 
 use GuzzleHttp\Psr7\Uri as Psr7Uri;

--- a/src/Codeception/Util/Xml.php
+++ b/src/Codeception/Util/Xml.php
@@ -4,6 +4,10 @@ declare(strict_types=1);
 
 namespace Codeception\Util;
 
+use DOMDocument;
+use DOMNode;
+use function is_array;
+
 class Xml
 {
     /**

--- a/src/Codeception/Util/Xml.php
+++ b/src/Codeception/Util/Xml.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Codeception\Util;
 
 class Xml

--- a/src/Codeception/Util/Xml.php
+++ b/src/Codeception/Util/Xml.php
@@ -13,19 +13,18 @@ class Xml
     /**
      * @static
      *
-     * @param \DOMDocument $xml
-     * @param \DOMNode $node
+     * @param DOMDocument $xml
+     * @param DOMNode $domNode
      * @param array $array
-     *
-     * @return \DOMDocument
+     * @return DOMDocument
      */
-    public static function arrayToXml(\DOMDocument $xml, \DOMNode $node, $array = [])
+    public static function arrayToXml(DOMDocument $xml, DOMNode $domNode, array $array = []): DOMDocument
     {
         foreach ($array as $el => $val) {
             if (is_array($val)) {
-                self::arrayToXml($xml, $node->$el, $val);
+                self::arrayToXml($xml, $domNode->$el, $val);
             } else {
-                $node->appendChild($xml->createElement($el, $val));
+                $domNode->appendChild($xml->createElement($el, $val));
             }
         }
         return $xml;
@@ -34,21 +33,20 @@ class Xml
     /**
      * @static
      *
-     * @param $xml
-     *
-     * @return \DOMDocument|\DOMNode
+     * @param XmlBuilder|DOMDocument $xml
+     * @return DOMDocument|DOMNode
      */
     public static function toXml($xml)
     {
         if ($xml instanceof XmlBuilder) {
             return $xml->getDom();
         }
-        if ($xml instanceof \DOMDocument) {
+        if ($xml instanceof DOMDocument) {
             return $xml;
         }
-        $dom = new \DOMDocument();
+        $dom = new DOMDocument();
         $dom->preserveWhiteSpace = false;
-        if ($xml instanceof \DOMNode) {
+        if ($xml instanceof DOMNode) {
             $xml = $dom->importNode($xml, true);
             $dom->appendChild($xml);
             return $dom;
@@ -63,7 +61,7 @@ class Xml
         return $dom;
     }
 
-    public static function build()
+    public static function build(): XmlBuilder
     {
         return new XmlBuilder();
     }

--- a/src/Codeception/Util/Xml.php
+++ b/src/Codeception/Util/Xml.php
@@ -34,9 +34,9 @@ class Xml
      * @static
      *
      * @param XmlBuilder|DOMDocument $xml
-     * @return DOMDocument|DOMNode
+     * @return DOMDocument
      */
-    public static function toXml($xml)
+    public static function toXml($xml): DOMDocument
     {
         if ($xml instanceof XmlBuilder) {
             return $xml->getDom();

--- a/src/Codeception/Util/XmlBuilder.php
+++ b/src/Codeception/Util/XmlBuilder.php
@@ -4,6 +4,10 @@ declare(strict_types=1);
 
 namespace Codeception\Util;
 
+use DOMDocument;
+use DOMElement;
+use Exception;
+
 /**
  * That's a pretty simple yet powerful class to build XML structures in jQuery-like style.
  * With no XML line actually written!

--- a/src/Codeception/Util/XmlBuilder.php
+++ b/src/Codeception/Util/XmlBuilder.php
@@ -149,7 +149,7 @@ class XmlBuilder
         return $this;
     }
 
-    public function __toString()
+    public function __toString(): string
     {
         return $this->dom->saveXML();
     }

--- a/src/Codeception/Util/XmlBuilder.php
+++ b/src/Codeception/Util/XmlBuilder.php
@@ -13,7 +13,6 @@ use Exception;
  * With no XML line actually written!
  * Uses DOM extension to manipulate XML data.
  *
- *
  * ```php
  * <?php
  * $xml = new \Codeception\Util\XmlBuilder();
@@ -69,25 +68,24 @@ use Exception;
  *  * `$xml->getDom` - get a DOMDocument object
  *  * `$xml->__toString` - get a string representation of XML.
  *
- * [Source code](https://github.com/Codeception/Codeception/blob/4.0/src/Codeception/Util/XmlBuilder.php)
+ * [Source code](https://github.com/Codeception/Codeception/blob/5.0/src/Codeception/Util/XmlBuilder.php)
  */
 class XmlBuilder
 {
     /**
      * @var DOMDocument
      */
-    protected $__dom__;
+    protected $dom;
 
     /**
      * @var DOMElement
      */
-    protected $__currentNode__;
-
+    protected $currentNode;
 
     public function __construct()
     {
-        $this->__dom__ = new DOMDocument();
-        $this->__currentNode__ = $this->__dom__;
+        $this->dom = new DOMDocument();
+        $this->currentNode = $this->dom;
     }
 
     /**
@@ -95,15 +93,15 @@ class XmlBuilder
      */
     public function __get(string $tag): XmlBuilder
     {
-        $domElement = $this->__dom__->createElement($tag);
-        $this->__currentNode__->appendChild($domElement);
-        $this->__currentNode__ = $domElement;
+        $domElement = $this->dom->createElement($tag);
+        $this->currentNode->appendChild($domElement);
+        $this->currentNode = $domElement;
         return $this;
     }
 
     public function val($val): self
     {
-        $this->__currentNode__->nodeValue = $val;
+        $this->currentNode->nodeValue = $val;
     }
 
     /**
@@ -111,7 +109,7 @@ class XmlBuilder
      */
     public function attr(string $attr, string $val): self
     {
-        $this->__currentNode__->setAttribute($attr, $val);
+        $this->currentNode->setAttribute($attr, $val);
         return $this;
     }
 
@@ -120,25 +118,25 @@ class XmlBuilder
      */
     public function parent(): self
     {
-        $this->__currentNode__ = $this->__currentNode__->parentNode;
+        $this->currentNode = $this->currentNode->parentNode;
         return $this;
     }
 
     /**
      * Traverses to parent with $name
      *
-     * @param $tag
+     * @param string $tag
      * @return XmlBuilder
      * @throws Exception
      */
-    public function parents($tag): self
+    public function parents(string $tag): self
     {
-        $traverseNode = $this->__currentNode__;
+        $traverseNode = $this->currentNode;
         $elFound = false;
         while ($traverseNode->parentNode) {
             $traverseNode = $traverseNode->parentNode;
             if ($traverseNode->tagName == $tag) {
-                $this->__currentNode__ = $traverseNode;
+                $this->currentNode = $traverseNode;
                 $elFound = true;
                 break;
             }
@@ -153,11 +151,11 @@ class XmlBuilder
 
     public function __toString()
     {
-        return $this->__dom__->saveXML();
+        return $this->dom->saveXML();
     }
 
     public function getDom(): DOMDocument
     {
-        return $this->__dom__;
+        return $this->dom;
     }
 }

--- a/src/Codeception/Util/XmlBuilder.php
+++ b/src/Codeception/Util/XmlBuilder.php
@@ -74,57 +74,42 @@ use Exception;
 class XmlBuilder
 {
     /**
-     * @var \DOMDocument
+     * @var DOMDocument
      */
     protected $__dom__;
 
     /**
-     * @var \DOMElement
+     * @var DOMElement
      */
     protected $__currentNode__;
 
 
     public function __construct()
     {
-        $this->__dom__ = new \DOMDocument();
+        $this->__dom__ = new DOMDocument();
         $this->__currentNode__ = $this->__dom__;
     }
 
     /**
      * Appends child node
-     *
-     * @param $tag
-     *
-     * @return XmlBuilder
      */
-    public function __get($tag)
+    public function __get(string $tag): XmlBuilder
     {
-        $node = $this->__dom__->createElement($tag);
-        $this->__currentNode__->appendChild($node);
-        $this->__currentNode__ = $node;
+        $domElement = $this->__dom__->createElement($tag);
+        $this->__currentNode__->appendChild($domElement);
+        $this->__currentNode__ = $domElement;
         return $this;
     }
 
-    /**
-     * @param $val
-     *
-     * @return XmlBuilder
-     */
-    public function val($val)
+    public function val($val): self
     {
         $this->__currentNode__->nodeValue = $val;
-        return $this;
     }
 
     /**
      * Sets attribute for current node
-     *
-     * @param $attr
-     * @param $val
-     *
-     * @return XmlBuilder
      */
-    public function attr($attr, $val)
+    public function attr(string $attr, string $val): self
     {
         $this->__currentNode__->setAttribute($attr, $val);
         return $this;
@@ -132,10 +117,8 @@ class XmlBuilder
 
     /**
      * Traverses to parent
-     *
-     * @return XmlBuilder
      */
-    public function parent()
+    public function parent(): self
     {
         $this->__currentNode__ = $this->__currentNode__->parentNode;
         return $this;
@@ -145,11 +128,10 @@ class XmlBuilder
      * Traverses to parent with $name
      *
      * @param $tag
-     *
      * @return XmlBuilder
-     * @throws \Exception
+     * @throws Exception
      */
-    public function parents($tag)
+    public function parents($tag): self
     {
         $traverseNode = $this->__currentNode__;
         $elFound = false;
@@ -163,7 +145,7 @@ class XmlBuilder
         }
 
         if (!$elFound) {
-            throw new \Exception("Parent $tag not found in XML");
+            throw new Exception("Parent {$tag} not found in XML");
         }
 
         return $this;
@@ -174,10 +156,7 @@ class XmlBuilder
         return $this->__dom__->saveXML();
     }
 
-    /**
-     * @return \DOMDocument
-     */
-    public function getDom()
+    public function getDom(): DOMDocument
     {
         return $this->__dom__;
     }

--- a/src/Codeception/Util/XmlBuilder.php
+++ b/src/Codeception/Util/XmlBuilder.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Codeception\Util;
 
 /**

--- a/src/Codeception/Util/XmlStructure.php
+++ b/src/Codeception/Util/XmlStructure.php
@@ -15,54 +15,43 @@ use Symfony\Component\CssSelector\CssSelectorConverter;
 class XmlStructure
 {
     /**
-     * @var \DOMDocument|\DOMNode
+     * @var DOMDocument|DOMNode
      */
     protected $xml;
-    
+
     public function __construct($xml)
     {
-        $this->xml = XmlUtils::toXml($xml);
+        $this->xml = SoapXmlUtil::toXml($xml);
     }
 
-    public function matchesXpath($xpath)
+    public function matchesXpath($xpath): bool
     {
-        $path = new \DOMXPath($this->xml);
-        $res = $path->query($xpath);
+        $domXpath = new DOMXPath($this->xml);
+        $res = $domXpath->query($xpath);
         if ($res === false) {
             throw new MalformedLocatorException($xpath);
         }
         return $res->length > 0;
     }
 
-    /**
-     * @param $cssOrXPath
-     * @return \DOMElement
-     */
-    public function matchElement($cssOrXPath)
+    public function matchElement(string $cssOrXPath): ?DOMNode
     {
-        $xpath = new \DOMXpath($this->xml);
-        try {
-            $selector = (new CssSelectorConverter())->toXPath($cssOrXPath);
-            $els = $xpath->query($selector);
-            if ($els) {
-                return $els->item(0);
-            }
-        } catch (ParseException $e) {
+        $domXpath = new DOMXpath($this->xml);
+        $selector = (new CssSelectorConverter())->toXPath($cssOrXPath);
+        $els = $domXpath->query($selector);
+        if ($els) {
+            return $els->item(0);
         }
-        $els = $xpath->query($cssOrXPath);
-        if ($els->length) {
+        $els = $domXpath->query($cssOrXPath);
+        if ($els->length !== 0) {
             return $els->item(0);
         }
         throw new ElementNotFound($cssOrXPath);
     }
-    /**
 
-     * @param $xml
-     * @return bool
-     */
-    public function matchXmlStructure($xml)
+    public function matchXmlStructure($xml): bool
     {
-        $xml = XmlUtils::toXml($xml);
+        $xml = SoapXmlUtil::toXml($xml);
         $root = $xml->firstChild;
         $els = $this->xml->getElementsByTagName($root->nodeName);
         if (empty($els)) {
@@ -76,7 +65,7 @@ class XmlStructure
         return $matches;
     }
 
-    protected function matchForNode($schema, $xml)
+    protected function matchForNode($schema, $xml): bool
     {
         foreach ($schema->childNodes as $node1) {
             $matched = false;

--- a/src/Codeception/Util/XmlStructure.php
+++ b/src/Codeception/Util/XmlStructure.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Codeception\Util;
 
 use Codeception\Exception\ElementNotFound;

--- a/src/Codeception/Util/XmlStructure.php
+++ b/src/Codeception/Util/XmlStructure.php
@@ -24,7 +24,7 @@ class XmlStructure
         $this->xml = SoapXmlUtil::toXml($xml);
     }
 
-    public function matchesXpath($xpath): bool
+    public function matchesXpath(string $xpath): bool
     {
         $domXpath = new DOMXPath($this->xml);
         $res = $domXpath->query($xpath);

--- a/src/Codeception/Util/XmlStructure.php
+++ b/src/Codeception/Util/XmlStructure.php
@@ -6,9 +6,11 @@ namespace Codeception\Util;
 
 use Codeception\Exception\ElementNotFound;
 use Codeception\Exception\MalformedLocatorException;
+use Codeception\Util\Soap as SoapXmlUtil;
+use DOMDocument;
+use DOMNode;
+use DOMXPath;
 use Symfony\Component\CssSelector\CssSelectorConverter;
-use Symfony\Component\CssSelector\Exception\ParseException;
-use Codeception\Util\Soap as XmlUtils;
 
 class XmlStructure
 {

--- a/tests/unit/Codeception/Util/MockAutoload.php
+++ b/tests/unit/Codeception/Util/MockAutoload.php
@@ -11,7 +11,7 @@ class MockAutoload extends Autoload
         self::$files = $files;
     }
 
-    protected static function requireFile($file)
+    protected static function requireFile($file): bool
     {
         return in_array($file, self::$files);
     }


### PR DESCRIPTION
- Use strict types in `src/Codeception/Util`.
- Add some type hints to Utils.
- Add 'use function' statements for performance reasons.
- Fix naming in `src/Codeception/Util`.