### PR TITLE
Fix GroupManager::normalizeFilePath

### DIFF
--- a/src/Codeception/Lib/GroupManager.php
+++ b/src/Codeception/Lib/GroupManager.php
@@ -107,7 +107,7 @@ class GroupManager
                 return sprintf('%s:%s', realpath($fullPath), $pathParts[2]);
             }
 
-            $this->checkIfFileExists($file);
+            $this->checkIfFileExists($file, $group);
             return realpath($file);
         } elseif (strpos($file, ':') === false) {
             $dirtyPath = Configuration::projectDir() . $file;


### PR DESCRIPTION
* Fix GroupManager::normalizeFilePath changes with GroupManager::checkIfFileExists argument change in 0e110ef96 (merged in v4.1.15). A line was missed in the change and caused errors.
* Fix #6099 