### PR TITLE
Update code standards in Steps

### DIFF
--- a/src/Codeception/Step/Action.php
+++ b/src/Codeception/Step/Action.php
@@ -1,8 +1,11 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Codeception\Step;
 
-use Codeception\Step;
+use Codeception\Step as CodeceptionStep;
 
-class Action extends Step
+class Action extends CodeceptionStep
 {
 }

--- a/src/Codeception/Step/Argument/FormattedOutput.php
+++ b/src/Codeception/Step/Argument/FormattedOutput.php
@@ -9,15 +9,11 @@ interface FormattedOutput
 {
     /**
      * Returns the argument's value formatted for output.
-     *
-     * @return string
      */
-    public function getOutput();
+    public function getOutput(): string;
 
     /**
      * Returns the argument's literal value.
-     *
-     * @return string
      */
-    public function __toString();
+    public function __toString(): string;
 }

--- a/src/Codeception/Step/Argument/PasswordArgument.php
+++ b/src/Codeception/Step/Argument/PasswordArgument.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Codeception\Step\Argument;
 
 class PasswordArgument implements FormattedOutput
@@ -9,7 +11,7 @@ class PasswordArgument implements FormattedOutput
      */
     private $password;
 
-    public function __construct($password)
+    public function __construct(string $password)
     {
         $this->password = $password;
     }
@@ -17,7 +19,7 @@ class PasswordArgument implements FormattedOutput
     /**
      * {@inheritdoc}
      */
-    public function getOutput()
+    public function getOutput(): string
     {
         return '******';
     }
@@ -25,7 +27,7 @@ class PasswordArgument implements FormattedOutput
     /**
      * {@inheritdoc}
      */
-    public function __toString()
+    public function __toString(): string
     {
         return $this->password;
     }

--- a/src/Codeception/Step/Assertion.php
+++ b/src/Codeception/Step/Assertion.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Codeception\Step;
 
 use Codeception\Step as CodeceptionStep;

--- a/src/Codeception/Step/Comment.php
+++ b/src/Codeception/Step/Comment.php
@@ -1,37 +1,41 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Codeception\Step;
 
 use Codeception\Lib\ModuleContainer;
 use Codeception\Step as CodeceptionStep;
+use function mb_strcut;
 
 class Comment extends CodeceptionStep
 {
-    public function __toString()
+    public function __toString(): string
     {
         return (string) $this->getAction();
     }
 
-    public function toString($maxLength)
+    public function toString($maxLength): string
     {
-        return mb_strcut($this->__toString(), 0, $maxLength, 'utf-8');
+        return mb_strcut((string) $this, 0, $maxLength, 'utf-8');
     }
 
-    public function getHtml($highlightColor = '#732E81')
+    public function getHtml($highlightColor = '#732E81'): string
     {
         return '<strong>' . $this->getAction() . '</strong>';
     }
 
-    public function getPhpCode($maxLength)
+    public function getPhpCode($maxLength): string
     {
         return '// ' . $this->getAction();
     }
 
-    public function run(ModuleContainer $container = null)
+    public function run(ModuleContainer $container = null): void
     {
         // don't do anything, let's rest
     }
 
-    public function getPrefix()
+    public function getPrefix(): string
     {
         return '';
     }

--- a/src/Codeception/Step/Condition.php
+++ b/src/Codeception/Step/Condition.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Codeception\Step;
 
 use Codeception\Step as CodeceptionStep;

--- a/src/Codeception/Step/ConditionalAssertion.php
+++ b/src/Codeception/Step/ConditionalAssertion.php
@@ -24,23 +24,23 @@ class ConditionalAssertion extends Assertion implements GeneratedStep
         }
     }
 
-    public function getAction(): ?string
+    public function getAction(): string
     {
         $action = 'can' . ucfirst($this->action);
-        return preg_replace('/^canDont/', 'cant', $action);
+        return (string)preg_replace('/^canDont/', 'cant', $action);
     }
 
-    public function getHumanizedAction()
+    public function getHumanizedAction(): string
     {
         return $this->humanize($this->action . ' ' . $this->getHumanizedArguments());
     }
 
-    public static function getTemplate(Template $template)
+    public static function getTemplate(Template $template): ?Template
     {
         $action = $template->getVar('action');
 
         if ((0 !== strpos($action, 'see')) && (0 !== strpos($action, 'dontSee'))) {
-            return '';
+            return null;
         }
 
         $conditionalDoc = "* [!] Conditional Assertion: Test won't be stopped on fail\n     " . $template->getVar('doc');
@@ -57,7 +57,7 @@ class ConditionalAssertion extends Assertion implements GeneratedStep
             ->place('step', 'ConditionalAssertion');
     }
 
-    public function match($name): bool
+    public function match(string $name): bool
     {
         return 0 === strpos($name, 'see') || 0 === strpos($name, 'dontSee');
     }

--- a/src/Codeception/Step/ConditionalAssertion.php
+++ b/src/Codeception/Step/ConditionalAssertion.php
@@ -1,26 +1,33 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Codeception\Step;
 
 use Codeception\Exception\ConditionalAssertionFailed;
 use Codeception\Lib\ModuleContainer;
 use Codeception\Util\Template;
+use PHPUnit\Framework\AssertionFailedError;
+use function preg_replace;
+use function str_replace;
+use function strpos;
+use function ucfirst;
 
 class ConditionalAssertion extends Assertion implements GeneratedStep
 {
-    public function run(ModuleContainer $container = null)
+    public function run(ModuleContainer $container = null): void
     {
         try {
             parent::run($container);
-        } catch (\PHPUnit\Framework\AssertionFailedError $e) {
+        } catch (AssertionFailedError $e) {
             throw new ConditionalAssertionFailed($e->getMessage(), $e->getCode(), $e);
         }
     }
 
-    public function getAction()
+    public function getAction(): ?string
     {
         $action = 'can' . ucfirst($this->action);
-        $action = preg_replace('/^canDont/', 'cant', $action);
-        return $action;
+        return preg_replace('/^canDont/', 'cant', $action);
     }
 
     public function getHumanizedAction()
@@ -50,7 +57,7 @@ class ConditionalAssertion extends Assertion implements GeneratedStep
             ->place('step', 'ConditionalAssertion');
     }
 
-    public function match($name)
+    public function match($name): bool
     {
         return 0 === strpos($name, 'see') || 0 === strpos($name, 'dontSee');
     }

--- a/src/Codeception/Step/Executor.php
+++ b/src/Codeception/Step/Executor.php
@@ -1,15 +1,21 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Codeception\Step;
 
+use Closure;
 use Codeception\Step as CodeceptionStep;
 use Codeception\Lib\ModuleContainer;
 
 class Executor extends CodeceptionStep
 {
+    /**
+     * @var Closure|null
+     */
+    protected $callable;
 
-    protected $callable = null;
-
-    public function __construct(\Closure $callable, $arguments = [])
+    public function __construct(Closure $callable, array $arguments = [])
     {
         parent::__construct('execute callable function', []);
 

--- a/src/Codeception/Step/Executor.php
+++ b/src/Codeception/Step/Executor.php
@@ -11,7 +11,7 @@ use Codeception\Lib\ModuleContainer;
 class Executor extends CodeceptionStep
 {
     /**
-     * @var Closure|null
+     * @var Closure
      */
     protected $callable;
 

--- a/src/Codeception/Step/GeneratedStep.php
+++ b/src/Codeception/Step/GeneratedStep.php
@@ -6,5 +6,5 @@ use Codeception\Util\Template;
 
 interface GeneratedStep
 {
-    public static function getTemplate(Template $template);
+    public static function getTemplate(Template $template): ?Template;
 }

--- a/src/Codeception/Step/GeneratedStep.php
+++ b/src/Codeception/Step/GeneratedStep.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Codeception\Step;
 
 use Codeception\Util\Template;

--- a/src/Codeception/Step/Incomplete.php
+++ b/src/Codeception/Step/Incomplete.php
@@ -1,17 +1,21 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Codeception\Step;
 
 use Codeception\Step as CodeceptionStep;
 use Codeception\Lib\ModuleContainer;
+use PHPUnit\Framework\IncompleteTestError;
 
 class Incomplete extends CodeceptionStep
 {
-    public function run(ModuleContainer $container = null)
+    public function run(ModuleContainer $container = null): void
     {
-        throw new \PHPUnit\Framework\IncompleteTestError($this->getAction());
+        throw new IncompleteTestError($this->getAction());
     }
 
-    public function __toString()
+    public function __toString(): string
     {
         return $this->getAction();
     }

--- a/src/Codeception/Step/Meta.php
+++ b/src/Codeception/Step/Meta.php
@@ -1,27 +1,35 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Codeception\Step;
 
 use Codeception\Lib\ModuleContainer;
 use Codeception\Step as CodeceptionStep;
+use function array_pop;
+use function end;
+use function is_string;
+use function str_replace;
+use function strpos;
 
 class Meta extends CodeceptionStep
 {
-    public function run(ModuleContainer $container = null)
+    public function run(ModuleContainer $container = null): void
     {
     }
 
-    public function setTraceInfo($file, $line)
+    public function setTraceInfo($file, $line): void
     {
         $this->file = $file;
         $this->line = $line;
     }
 
-    public function setPrefix($actor)
+    public function setPrefix($actor): void
     {
         $this->prefix = $actor;
     }
 
-    public function getArgumentsAsString($maxLength = 200)
+    public function getArgumentsAsString($maxLength = 200): string
     {
         $argumentBackup = $this->arguments;
         $lastArgAsString = '';
@@ -35,7 +43,7 @@ class Meta extends CodeceptionStep
         return $result;
     }
 
-    public function setFailed($failed)
+    public function setFailed($failed): void
     {
         $this->failed = $failed;
     }

--- a/src/Codeception/Step/Meta.php
+++ b/src/Codeception/Step/Meta.php
@@ -18,18 +18,18 @@ class Meta extends CodeceptionStep
     {
     }
 
-    public function setTraceInfo($file, $line): void
+    public function setTraceInfo(string $file, int $line): void
     {
         $this->file = $file;
         $this->line = $line;
     }
 
-    public function setPrefix($actor): void
+    public function setPrefix(string $actor): void
     {
         $this->prefix = $actor;
     }
 
-    public function getArgumentsAsString($maxLength = 200): string
+    public function getArgumentsAsString($maxLength = self::DEFAULT_MAX_LENGTH): string
     {
         $argumentBackup = $this->arguments;
         $lastArgAsString = '';
@@ -43,7 +43,7 @@ class Meta extends CodeceptionStep
         return $result;
     }
 
-    public function setFailed($failed): void
+    public function setFailed(bool $failed): void
     {
         $this->failed = $failed;
     }

--- a/src/Codeception/Step/Retry.php
+++ b/src/Codeception/Step/Retry.php
@@ -1,15 +1,24 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Codeception\Step;
 
 use Codeception\Lib\ModuleContainer;
 use Codeception\Util\Template;
+use Exception;
+use function codecept_debug;
+use function strpos;
+use function ucfirst;
+use function usleep;
 
 class Retry extends Assertion implements GeneratedStep
 {
-
+    /**
+     * @var string
+     */
     protected static $methodTemplate = <<<EOF
-    
+
     /**
      * [!] Method is generated.
      * 
@@ -45,12 +54,12 @@ EOF;
             try {
                 $this->isTry = $retry < $this->retryNum;
                 return parent::run($container);
-            } catch (\Exception $e) {
-                $retry++;
+            } catch (Exception $e) {
+                ++$retry;
                 if (!$this->isTry) {
                     throw $e;
                 }
-                codecept_debug("Retrying #$retry in ${interval}ms");
+                codecept_debug("Retrying #{$retry} in ${interval}ms");
                 usleep($interval * 1000);
                 $interval *= 2;
             }

--- a/src/Codeception/Step/Retry.php
+++ b/src/Codeception/Step/Retry.php
@@ -66,16 +66,16 @@ EOF;
         }
     }
 
-    public static function getTemplate(Template $template)
+    public static function getTemplate(Template $template): ?Template
     {
         $action = $template->getVar('action');
 
         if ((strpos($action, 'have') === 0) || (strpos($action, 'am') === 0)) {
-            return; // dont retry conditions
+            return null; // dont retry conditions
         }
 
         if (strpos($action, 'wait') === 0) {
-            return; // dont retry waiters
+            return null; // dont retry waiters
         }
 
         $doc = "* Executes $action and retries on failure.";

--- a/src/Codeception/Step/Skip.php
+++ b/src/Codeception/Step/Skip.php
@@ -1,17 +1,21 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Codeception\Step;
 
 use Codeception\Step as CodeceptionStep;
 use Codeception\Lib\ModuleContainer;
+use PHPUnit\Framework\SkippedTestError;
 
 class Skip extends CodeceptionStep
 {
-    public function run(ModuleContainer $container = null)
+    public function run(ModuleContainer $container = null): void
     {
-        throw new \PHPUnit\Framework\SkippedTestError($this->getAction());
+        throw new SkippedTestError($this->getAction());
     }
 
-    public function __toString()
+    public function __toString(): string
     {
         return $this->getAction();
     }

--- a/src/Codeception/Step/TryTo.php
+++ b/src/Codeception/Step/TryTo.php
@@ -25,20 +25,20 @@ class TryTo extends Assertion implements GeneratedStep
         return true;
     }
 
-    public static function getTemplate(Template $template)
+    public static function getTemplate(Template $template): ?Template
     {
         $action = $template->getVar('action');
 
         if ((strpos($action, 'have') === 0) || (strpos($action, 'am') === 0)) {
-            return; // dont try on conditions
+            return null; // dont try on conditions
         }
 
         if (strpos($action, 'wait') === 0) {
-            return; // dont try on waiters
+            return null; // dont try on waiters
         }
 
         if (strpos($action, 'grab') === 0) {
-            return; // dont on grabbers
+            return null; // dont on grabbers
         }
 
         $conditionalDoc = "* [!] Test won't be stopped on fail. Error won't be logged \n     " . $template->getVar('doc');

--- a/src/Codeception/Step/TryTo.php
+++ b/src/Codeception/Step/TryTo.php
@@ -1,18 +1,24 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Codeception\Step;
 
 use Codeception\Lib\ModuleContainer;
 use Codeception\Util\Template;
+use Exception;
+use function codecept_debug;
+use function strpos;
+use function ucfirst;
 
 class TryTo extends Assertion implements GeneratedStep
 {
-    public function run(ModuleContainer $container = null)
+    public function run(ModuleContainer $container = null): bool
     {
         $this->isTry = true;
         try {
             parent::run($container);
-        } catch (\Exception $e) {
+        } catch (Exception $e) {
             codecept_debug("Failed to perform: {$e->getMessage()}, skipping...");
             return false;
         }


### PR DESCRIPTION
- Use strict types in `src/Codeception/Step`.
- Add some type hints to Steps.
- Add 'use function' statements for performance reasons.