### PR TITLE
Fix `run suite` when suite name matches directory

### DIFF
--- a/src/Codeception/Command/Run.php
+++ b/src/Codeception/Command/Run.php
@@ -538,6 +538,10 @@ class Run extends Command
 
     protected function matchTestFromFilename($filename, $testsPath)
     {
+        if ($filename === $testsPath) {
+            //codecept run tests
+            return ['','',null];
+        }
         $testsPath = str_replace(['//', '\/', '\\'], '/', $testsPath);
         $filename = str_replace(['//', '\/', '\\'], '/', $filename);
         $res = preg_match("~^$testsPath/(.*?)(?>/(.*))?$~", $filename, $matches);

--- a/src/Codeception/Command/Run.php
+++ b/src/Codeception/Command/Run.php
@@ -538,19 +538,31 @@ class Run extends Command
 
     protected function matchTestFromFilename($filename, $testsPath)
     {
-        if ($filename === $testsPath) {
-            //codecept run tests
-            return ['','',null];
+        $filter = '';
+        if (strpos($filename, ':') !== false) {
+            list($filename, $filter) = explode(':', $filename, 2);
+            if ($filter) {
+                $filter = ':' . $filter;
+            }
         }
+
         $testsPath = str_replace(['//', '\/', '\\'], '/', $testsPath);
         $filename = str_replace(['//', '\/', '\\'], '/', $filename);
+
+        if (rtrim($filename, '/') === $testsPath) {
+            //codecept run tests
+            return ['', '', $filter];
+        }
         $res = preg_match("~^$testsPath/(.*?)(?>/(.*))?$~", $filename, $matches);
 
         if (!$res) {
             throw new \InvalidArgumentException("Test file can't be matched");
         }
         if (!isset($matches[2])) {
-            $matches[2] = null;
+            $matches[2] = '';
+        }
+        if ($filter) {
+            $matches[2] .= $filter;
         }
 
         return $matches;

--- a/src/Codeception/Command/Run.php
+++ b/src/Codeception/Command/Run.php
@@ -540,7 +540,14 @@ class Run extends Command
     {
         $filter = '';
         if (strpos($filename, ':') !== false) {
-            list($filename, $filter) = explode(':', $filename, 2);
+            if ((PHP_OS === 'Windows' || PHP_OS === 'WINNT') && $filename[1] === ':') {
+                // match C:\...
+                list($drive, $path, $filter) = explode(':', $filename, 3);
+                $filename = $drive . ':' . $path;
+            } else {
+                list($filename, $filter) = explode(':', $filename, 2);
+            }
+
             if ($filter) {
                 $filter = ':' . $filter;
             }

--- a/src/Codeception/Command/Run.php
+++ b/src/Codeception/Command/Run.php
@@ -470,7 +470,8 @@ class Run extends Command
                     list($file) = explode(':', $suite, -1);
                 }
                 $realPath = $cwd . DIRECTORY_SEPARATOR . $file;
-                if (file_exists($realPath) || is_dir($realPath)) {
+                if (file_exists($realPath) && strpos($realPath, $realTestDir) === 0) {
+                    //only match test if file is in tests directory
                     return $this->matchTestFromFilename(
                         $cwd . DIRECTORY_SEPARATOR . $suite,
                         $realTestDir

--- a/src/Codeception/Command/Run.php
+++ b/src/Codeception/Command/Run.php
@@ -385,10 +385,10 @@ class Run extends Command
         }
 
         if ($test) {
-            $filter = $this->matchFilteredTestName($test);
-            $userOptions['filter'] = $filter;
+            $userOptions['filter'] = $this->matchFilteredTestName($test);
+        } elseif ($suite) {
+            $userOptions['filter'] = $this->matchFilteredTestName($suite);
         }
-
         if (!$this->options['silent'] && $config['settings']['shuffle']) {
             $this->output->writeln(
                 "[Seed] <info>" . $userOptions['seed'] . "</info>"

--- a/tests/cli/RunCest.php
+++ b/tests/cli/RunCest.php
@@ -25,6 +25,16 @@ class RunCest
     }
 
     /**
+     * https://github.com/Codeception/Codeception/issues/6103
+     */
+    public function runSuiteWhenNameMatchesExistingDirectory(\CliGuy $I)
+    {
+        $I->amInPath(codecept_data_dir('dir_matches_suite'));
+        $I->executeCommand('run api');
+        $I->seeInShellOutput('SuccessCest');
+    }
+
+    /**
      * @group reports
      * @group core
      *

--- a/tests/cli/RunCest.php
+++ b/tests/cli/RunCest.php
@@ -34,6 +34,13 @@ class RunCest
         $I->seeInShellOutput('SuccessCest');
     }
 
+    public function runTestsDoesntFail(\CliGuy $I)
+    {
+        $I->amInPath(codecept_data_dir('dir_matches_suite'));
+        $I->executeCommand('run tests');
+        $I->seeInShellOutput('SuccessCest');
+    }
+
     /**
      * @group reports
      * @group core

--- a/tests/cli/RunCest.php
+++ b/tests/cli/RunCest.php
@@ -41,6 +41,13 @@ class RunCest
         $I->seeInShellOutput('SuccessCest');
     }
 
+    public function filterTestsWithoutSpecifyingSuite(\CliGuy $I)
+    {
+        $I->amInPath(codecept_data_dir('dir_matches_suite'));
+        $I->executeCommand('run :^Success');
+        $I->seeInShellOutput('SuccessCest');
+    }
+
     /**
      * @group reports
      * @group core

--- a/tests/cli/RunCest.php
+++ b/tests/cli/RunCest.php
@@ -41,6 +41,16 @@ class RunCest
         $I->seeInShellOutput('SuccessCest');
     }
 
+    public function runTestsWithFilterDoesntFail(\CliGuy $I)
+    {
+        $I->amInPath(codecept_data_dir('dir_matches_suite'));
+        $I->executeCommand('run tests:^Success');
+        $I->seeInShellOutput('SuccessCest');
+
+        $I->executeCommand('run tests/:^Success');
+        $I->seeInShellOutput('SuccessCest');
+    }
+
     public function filterTestsWithoutSpecifyingSuite(\CliGuy $I)
     {
         $I->amInPath(codecept_data_dir('dir_matches_suite'));

--- a/tests/cli/RunCest.php
+++ b/tests/cli/RunCest.php
@@ -44,17 +44,17 @@ class RunCest
     public function runTestsWithFilterDoesntFail(\CliGuy $I)
     {
         $I->amInPath(codecept_data_dir('dir_matches_suite'));
-        $I->executeCommand('run tests:^Success');
+        $I->executeCommand('run tests:^success');
         $I->seeInShellOutput('SuccessCest');
 
-        $I->executeCommand('run tests/:^Success');
+        $I->executeCommand('run tests/:^success');
         $I->seeInShellOutput('SuccessCest');
     }
 
     public function filterTestsWithoutSpecifyingSuite(\CliGuy $I)
     {
         $I->amInPath(codecept_data_dir('dir_matches_suite'));
-        $I->executeCommand('run :^Success');
+        $I->executeCommand('run :^success');
         $I->seeInShellOutput('SuccessCest');
     }
 

--- a/tests/data/dir_matches_suite/codeception.yml
+++ b/tests/data/dir_matches_suite/codeception.yml
@@ -1,0 +1,8 @@
+actor: Tester
+paths:
+    tests: tests
+    log: tests/_output
+    data: tests/_data
+    support: tests/_support
+settings:
+    memory_limit: 1024M

--- a/tests/data/dir_matches_suite/tests/_output/.gitignore
+++ b/tests/data/dir_matches_suite/tests/_output/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/tests/data/dir_matches_suite/tests/_support/ApiTester.php
+++ b/tests/data/dir_matches_suite/tests/_support/ApiTester.php
@@ -1,0 +1,25 @@
+<?php
+
+
+/**
+ * Inherited Methods
+ * @method void wantToTest($text)
+ * @method void wantTo($text)
+ * @method void execute($callable)
+ * @method void expectTo($prediction)
+ * @method void expect($prediction)
+ * @method void amGoingTo($argumentation)
+ * @method void am($role)
+ * @method void lookForwardTo($achieveValue)
+ * @method void comment($description)
+ *
+ * @SuppressWarnings(PHPMD)
+*/
+class ApiTester extends \Codeception\Actor
+{
+    use _generated\ApiTesterActions;
+
+   /**
+    * Define custom actions here
+    */
+}

--- a/tests/data/dir_matches_suite/tests/_support/_generated/.gitignore
+++ b/tests/data/dir_matches_suite/tests/_support/_generated/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/tests/data/dir_matches_suite/tests/api.suite.yml
+++ b/tests/data/dir_matches_suite/tests/api.suite.yml
@@ -1,0 +1,4 @@
+class_name: ApiTester
+modules:
+    enabled:
+        - Asserts

--- a/tests/data/dir_matches_suite/tests/api/SuccessCest.php
+++ b/tests/data/dir_matches_suite/tests/api/SuccessCest.php
@@ -1,0 +1,11 @@
+<?php
+
+
+class SuccessCest
+{
+
+    public function successful(ApiTester $I)
+    {
+        $I->assertTrue(true);
+    }
+}


### PR DESCRIPTION
Original purpose of this change was to make `codecept run api` work when there is `api/` directory in project root and api suite in tests.

I looked into related issues and made the following commands work too:
`codecept run tests`
`codecept run ^*LoginWithWrongPassword$`
`codecept run tests:^*LoginWithWrongPassword$`
`codecept run tests/:^*LoginWithWrongPassword$`

Closes #6103
Closes #5278