### PR TITLE
Update code standards in Subscribers

### DIFF
--- a/src/Codeception/Coverage/Subscriber/Printer.php
+++ b/src/Codeception/Coverage/Subscriber/Printer.php
@@ -10,7 +10,7 @@ use Codeception\Coverage\PhpCodeCoverageFactory;
 use Codeception\Event\PrintResultEvent;
 use Codeception\Events;
 use Codeception\Exception\ConfigurationException;
-use Codeception\Subscriber\Shared\StaticEvents;
+use Codeception\Subscriber\Shared\StaticEventsTrait;
 use PHPUnit\Runner\Version as PHPUnitVersion;
 use SebastianBergmann\CodeCoverage\CodeCoverage;
 use SebastianBergmann\CodeCoverage\Report\Clover as CloverReport;
@@ -29,7 +29,7 @@ use function strpos;
 
 class Printer implements EventSubscriberInterface
 {
-    use StaticEvents;
+    use StaticEventsTrait;
 
     /**
      * @var array<string, string>

--- a/src/Codeception/Coverage/SuiteSubscriber.php
+++ b/src/Codeception/Coverage/SuiteSubscriber.php
@@ -10,7 +10,7 @@ use Codeception\Exception\ConfigurationException;
 use Codeception\Exception\ModuleException;
 use Codeception\Lib\Interfaces\Remote as RemoteInterface;
 use Codeception\Stub;
-use Codeception\Subscriber\Shared\StaticEvents;
+use Codeception\Subscriber\Shared\StaticEventsTrait;
 use Exception;
 use PHPUnit\Framework\CodeCoverageException;
 use PHPUnit\Framework\TestResult;
@@ -23,7 +23,7 @@ use function method_exists;
 
 abstract class SuiteSubscriber implements EventSubscriberInterface
 {
-    use StaticEvents;
+    use StaticEventsTrait;
 
     /**
      * @var array

--- a/src/Codeception/Subscriber/AutoRebuild.php
+++ b/src/Codeception/Subscriber/AutoRebuild.php
@@ -26,7 +26,7 @@ class AutoRebuild implements EventSubscriberInterface
     /**
      * @var array<string, string>
      */
-    public static $events = [
+    protected static $events = [
         Events::SUITE_INIT => 'updateActor'
     ];
 

--- a/src/Codeception/Subscriber/AutoRebuild.php
+++ b/src/Codeception/Subscriber/AutoRebuild.php
@@ -69,7 +69,7 @@ class AutoRebuild implements EventSubscriberInterface
         }
     }
 
-    protected function generateActorActions($actorActionsFile, $settings): void
+    protected function generateActorActions(string $actorActionsFile, array $settings): void
     {
         if (!file_exists(Configuration::supportDir() . '_generated')) {
             @mkdir(Configuration::supportDir() . '_generated');

--- a/src/Codeception/Subscriber/AutoRebuild.php
+++ b/src/Codeception/Subscriber/AutoRebuild.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Codeception\Subscriber;
 
 use Codeception\Configuration;

--- a/src/Codeception/Subscriber/AutoRebuild.php
+++ b/src/Codeception/Subscriber/AutoRebuild.php
@@ -6,24 +6,36 @@ use Codeception\Event\SuiteEvent;
 use Codeception\Events;
 use Codeception\Lib\Generator\Actions;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use function codecept_debug;
+use function fclose;
+use function fgets;
+use function file_exists;
+use function file_put_contents;
+use function fopen;
+use function is_writable;
+use function mkdir;
+use function preg_match;
 
 class AutoRebuild implements EventSubscriberInterface
 {
     use Shared\StaticEvents;
 
+    /**
+     * @var array<string, string>
+     */
     public static $events = [
         Events::SUITE_INIT => 'updateActor'
     ];
 
-    public function updateActor(SuiteEvent $e)
+    public function updateActor(SuiteEvent $event): void
     {
-        $settings = $e->getSettings();
+        $settings = $event->getSettings();
         if (!$settings['actor']) {
             codecept_debug('actor is empty');
             return; // no actor
         }
 
-        $modules = $e->getSuite()->getModules();
+        $modules = $event->getSuite()->getModules();
 
         $actorActionsFile = Configuration::supportDir() . '_generated' . DIRECTORY_SEPARATOR
             . $settings['actor'] . 'Actions.php';
@@ -33,10 +45,10 @@ class AutoRebuild implements EventSubscriberInterface
             $this->generateActorActions($actorActionsFile, $settings);
             return;
         }
-        
+
         // load actor class to see hash
         $handle = @fopen($actorActionsFile, "r");
-        if ($handle and is_writable($actorActionsFile)) {
+        if ($handle && is_writable($actorActionsFile)) {
             $line = @fgets($handle);
             if (preg_match('~\[STAMP\] ([a-f0-9]*)~', $line, $matches)) {
                 $hash = $matches[1];
@@ -54,7 +66,7 @@ class AutoRebuild implements EventSubscriberInterface
         }
     }
 
-    protected function generateActorActions($actorActionsFile, $settings)
+    protected function generateActorActions($actorActionsFile, $settings): void
     {
         if (!file_exists(Configuration::supportDir() . '_generated')) {
             @mkdir(Configuration::supportDir() . '_generated');

--- a/src/Codeception/Subscriber/AutoRebuild.php
+++ b/src/Codeception/Subscriber/AutoRebuild.php
@@ -21,7 +21,7 @@ use function preg_match;
 
 class AutoRebuild implements EventSubscriberInterface
 {
-    use Shared\StaticEvents;
+    use Shared\StaticEventsTrait;
 
     /**
      * @var array<string, string>

--- a/src/Codeception/Subscriber/BeforeAfterTest.php
+++ b/src/Codeception/Subscriber/BeforeAfterTest.php
@@ -59,7 +59,7 @@ class BeforeAfterTest implements EventSubscriberInterface
         $this->runHooks('afterClass');
     }
 
-    protected function runHooks($hookName): void
+    protected function runHooks(string $hookName): void
     {
         foreach ($this->hooks as $className => $hook) {
             foreach ($hook[$hookName] as $method) {

--- a/src/Codeception/Subscriber/BeforeAfterTest.php
+++ b/src/Codeception/Subscriber/BeforeAfterTest.php
@@ -22,7 +22,7 @@ class BeforeAfterTest implements EventSubscriberInterface
     /**
      * @var array<string, string|int[]|string[]>
      */
-    public static $events = [
+    protected static $events = [
         Events::SUITE_BEFORE => 'beforeClass',
         Events::SUITE_AFTER  => ['afterClass', 100]
     ];

--- a/src/Codeception/Subscriber/BeforeAfterTest.php
+++ b/src/Codeception/Subscriber/BeforeAfterTest.php
@@ -16,7 +16,7 @@ use function strstr;
 
 class BeforeAfterTest implements EventSubscriberInterface
 {
-    use Shared\StaticEvents;
+    use Shared\StaticEventsTrait;
 
     /**
      * @var array<string, string|int[]|string[]>

--- a/src/Codeception/Subscriber/BeforeAfterTest.php
+++ b/src/Codeception/Subscriber/BeforeAfterTest.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Codeception\Subscriber;
 
 use Codeception\Event\SuiteEvent;

--- a/src/Codeception/Subscriber/BeforeAfterTest.php
+++ b/src/Codeception/Subscriber/BeforeAfterTest.php
@@ -6,8 +6,9 @@ namespace Codeception\Subscriber;
 
 use Codeception\Event\SuiteEvent;
 use Codeception\Events;
-use PHPUnit\Framework\Test;
-use Rector\Core\Tests\Issues\Issue4191\DoNotDuplicateComment\Fixture\a;
+use PHPUnit\Framework\Test as PHPUnitTest;
+use PHPUnit\Framework\TestSuite\DataProvider;
+use PHPUnit\Util\Test as TestUtil;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use function call_user_func;
 use function get_class;
@@ -42,14 +43,14 @@ class BeforeAfterTest implements EventSubscriberInterface
     public function beforeClass(SuiteEvent $event): void
     {
         foreach ($event->getSuite()->tests() as $test) {
-            /** @var Test test **/
-            if ($test instanceof \PHPUnit\Framework\TestSuite\DataProvider) {
+            /** @var PHPUnitTest test **/
+            if ($test instanceof DataProvider) {
                 $potentialTestClass = strstr($test->getName(), '::', true);
-                $this->hooks[$potentialTestClass] = \PHPUnit\Util\Test::getHookMethods($potentialTestClass);
+                $this->hooks[$potentialTestClass] = TestUtil::getHookMethods($potentialTestClass);
             }
 
             $testClass = get_class($test);
-            $this->hooks[$testClass] = \PHPUnit\Util\Test::getHookMethods($testClass);
+            $this->hooks[$testClass] = TestUtil::getHookMethods($testClass);
         }
         $this->runHooks('beforeClass');
     }

--- a/src/Codeception/Subscriber/Bootstrap.php
+++ b/src/Codeception/Subscriber/Bootstrap.php
@@ -11,13 +11,16 @@ class Bootstrap implements EventSubscriberInterface
 {
     use Shared\StaticEvents;
 
+    /**
+     * @var array<string, string>
+     */
     public static $events = [
         Events::SUITE_INIT => 'loadBootstrap',
     ];
 
-    public function loadBootstrap(SuiteEvent $e)
+    public function loadBootstrap(SuiteEvent $event): void
     {
-        $settings = $e->getSettings();
+        $settings = $event->getSettings();
 
         if (!isset($settings['bootstrap'])) {
             return;

--- a/src/Codeception/Subscriber/Bootstrap.php
+++ b/src/Codeception/Subscriber/Bootstrap.php
@@ -16,7 +16,7 @@ class Bootstrap implements EventSubscriberInterface
     /**
      * @var array<string, string>
      */
-    public static $events = [
+    protected static $events = [
         Events::SUITE_INIT => 'loadBootstrap',
     ];
 

--- a/src/Codeception/Subscriber/Bootstrap.php
+++ b/src/Codeception/Subscriber/Bootstrap.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Codeception\Subscriber;
 
 use Codeception\Configuration;

--- a/src/Codeception/Subscriber/Bootstrap.php
+++ b/src/Codeception/Subscriber/Bootstrap.php
@@ -7,7 +7,6 @@ namespace Codeception\Subscriber;
 use Codeception\Configuration;
 use Codeception\Event\SuiteEvent;
 use Codeception\Events;
-use Codeception\Exception\ConfigurationException;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
 class Bootstrap implements EventSubscriberInterface

--- a/src/Codeception/Subscriber/Bootstrap.php
+++ b/src/Codeception/Subscriber/Bootstrap.php
@@ -12,7 +12,7 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
 class Bootstrap implements EventSubscriberInterface
 {
-    use Shared\StaticEvents;
+    use Shared\StaticEventsTrait;
 
     /**
      * @var array<string, string>

--- a/src/Codeception/Subscriber/Console.php
+++ b/src/Codeception/Subscriber/Console.php
@@ -62,7 +62,7 @@ class Console implements EventSubscriberInterface
     /**
      * @var array<string, string>
      */
-    public static $events = [
+    protected static $events = [
         Events::SUITE_BEFORE       => 'beforeSuite',
         Events::SUITE_AFTER        => 'afterSuite',
         Events::TEST_START         => 'startTest',
@@ -121,7 +121,7 @@ class Console implements EventSubscriberInterface
      */
     protected $traceLength = 5;
     /**
-     * @var int|null|string|bool
+     * @var int
      */
     protected $width;
 
@@ -627,10 +627,7 @@ class Console implements EventSubscriberInterface
         $this->output->writeln("");
     }
 
-    /**
-     * @return int|string|bool
-     */
-    public function detectWidth()
+    public function detectWidth(): int
     {
         $this->width = 60;
         if (!$this->isWin()
@@ -640,7 +637,7 @@ class Console implements EventSubscriberInterface
         ) {
             // try to get terminal width from ENV variable (bash), see also https://github.com/Codeception/Codeception/issues/3788
             if (getenv('COLUMNS')) {
-                $this->width = getenv('COLUMNS');
+                $this->width = (int) getenv('COLUMNS');
             } else {
                 $this->width = (int) (`command -v tput >> /dev/null 2>&1 && tput cols`) - 2;
             }

--- a/src/Codeception/Subscriber/Console.php
+++ b/src/Codeception/Subscriber/Console.php
@@ -165,7 +165,7 @@ class Console implements EventSubscriberInterface
      */
     protected $messageFactory;
 
-    public function __construct($options)
+    public function __construct(array $options)
     {
         $this->prepareOptions($options);
         $this->output = new Output($options);
@@ -273,9 +273,6 @@ class Console implements EventSubscriberInterface
         $this->failedStep[] = $step;
     }
 
-    /**
-     * @param PrintResultEvent $event
-     */
     public function afterResult(PrintResultEvent $event): void
     {
         $result = $event->getResult();
@@ -462,35 +459,35 @@ class Console implements EventSubscriberInterface
         }
     }
 
-    public function printException($e, $cause = null): void
+    public function printException($exception, string $cause = null): void
     {
-        if ($e instanceof \PHPUnit\Framework\SkippedTestError || $e instanceof \PHPUnit\Framework_IncompleteTestError) {
-            if ($e->getMessage() !== '') {
-                $this->message(OutputFormatter::escape($e->getMessage()))->prepend("\n")->writeln();
+        if ($exception instanceof \PHPUnit\Framework\SkippedTestError || $exception instanceof \PHPUnit\Framework_IncompleteTestError) {
+            if ($exception->getMessage() !== '') {
+                $this->message(OutputFormatter::escape($exception->getMessage()))->prepend("\n")->writeln();
             }
 
             return;
         }
 
-        $class = $e instanceof \PHPUnit\Framework\ExceptionWrapper
-            ? $e->getClassname()
-            : get_class($e);
+        $class = $exception instanceof \PHPUnit\Framework\ExceptionWrapper
+            ? $exception->getClassname()
+            : get_class($exception);
 
         if (strpos($class, 'Codeception\Exception') === 0) {
             $class = substr($class, strlen('Codeception\Exception\\'));
         }
 
         $this->output->writeln('');
-        $message = $this->message(OutputFormatter::escape($e->getMessage()));
+        $message = $this->message(OutputFormatter::escape($exception->getMessage()));
 
-        if ($e instanceof \PHPUnit\Framework\ExpectationFailedException) {
-            $comparisonFailure = $e->getComparisonFailure();
+        if ($exception instanceof \PHPUnit\Framework\ExpectationFailedException) {
+            $comparisonFailure = $exception->getComparisonFailure();
             if ($comparisonFailure !== null) {
                 $message->append($this->messageFactory->prepareComparisonFailureMessage($comparisonFailure));
             }
         }
 
-        $isFailure = $e instanceof \PHPUnit\Framework\AssertionFailedError
+        $isFailure = $exception instanceof \PHPUnit\Framework\AssertionFailedError
             || $class === \PHPUnit\Framework\ExpectationFailedException::class
             || $class === \PHPUnit\Framework\AssertionFailedError::class;
 
@@ -713,7 +710,7 @@ class Console implements EventSubscriberInterface
         }
     }
 
-    private function prepareOptions($options): void
+    private function prepareOptions(array $options): void
     {
         $this->options = array_merge($this->options, $options);
         $this->debug = $this->options['debug'] || $this->options['verbosity'] >= OutputInterface::VERBOSITY_VERY_VERBOSE;

--- a/src/Codeception/Subscriber/Console.php
+++ b/src/Codeception/Subscriber/Console.php
@@ -13,21 +13,45 @@ use Codeception\Lib\Console\Output;
 use Codeception\Lib\Notification;
 use Codeception\Step;
 use Codeception\Step\Comment;
+use Codeception\Step\ConditionalAssertion;
 use Codeception\Suite;
 use Codeception\Test\Descriptor;
 use Codeception\Test\Interfaces\ScenarioDriven;
 use Codeception\TestInterface;
 use Codeception\Util\Debug;
+use PHPUnit\Framework\SelfDescribing;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Formatter\OutputFormatter;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use function array_count_values;
+use function array_map;
+use function array_merge;
+use function array_reverse;
+use function array_shift;
+use function codecept_output_dir;
+use function codecept_relative_path;
+use function count;
+use function exec;
+use function get_class;
+use function getenv;
+use function implode;
+use function number_format;
+use function preg_match;
+use function preg_replace;
+use function round;
+use function sprintf;
+use function strlen;
+use function strpos;
+use function strtoupper;
+use function substr;
+use function ucfirst;
 
 class Console implements EventSubscriberInterface
 {
     use Shared\StaticEvents;
 
     /**
-     * @var string[]
+     * @var array<string, string>
      */
     public static $events = [
         Events::SUITE_BEFORE       => 'beforeSuite',
@@ -54,27 +78,72 @@ class Console implements EventSubscriberInterface
     /**
      * @var Message
      */
-    protected $message = null;
+    protected $message;
+    /**
+     * @var bool
+     */
     protected $steps = true;
+    /**
+     * @var bool
+     */
     protected $debug = false;
+    /**
+     * @var bool
+     */
     protected $ansi = true;
+    /**
+     * @var bool
+     */
     protected $silent = false;
+    /**
+     * @var bool
+     */
     protected $lastTestFailed = false;
-    protected $printedTest = null;
+    /**
+     * @var TestInterface|null
+     */
+    protected $printedTest;
+    /**
+     * @var bool
+     */
     protected $rawStackTrace = false;
+    /**
+     * @var int
+     */
     protected $traceLength = 5;
+    /**
+     * @var int|null|string|bool
+     */
     protected $width;
 
     /**
      * @var OutputInterface
      */
     protected $output;
+    /**
+     * @var ConditionalAssertion[]
+     */
     protected $conditionalFails = [];
+    /**
+     * @var Step[]
+     */
     protected $failedStep = [];
+    /**
+     * @var string[]
+     */
     protected $reports = [];
+    /**
+     * @var string
+     */
     protected $namespace = '';
+    /**
+     * @var array<string, string>
+     */
     protected $chars = ['success' => '+', 'fail' => 'x', 'of' => ':'];
 
+    /**
+     * @var array<string, int|bool|null>
+     */
     protected $options = [
         'debug'         => false,
         'ansi'          => false,
@@ -122,21 +191,21 @@ class Console implements EventSubscriberInterface
     }
 
     // triggered for scenario based tests: cept, cest
-    public function beforeSuite(SuiteEvent $e)
+    public function beforeSuite(SuiteEvent $event): void
     {
         $this->namespace = "";
-        $settings = $e->getSettings();
+        $settings = $event->getSettings();
         if (isset($settings['namespace'])) {
             $this->namespace = $settings['namespace'];
         }
         $this->message("%s Tests (%d) ")
-            ->with(ucfirst($e->getSuite()->getName()), $e->getSuite()->count())
+            ->with(ucfirst($event->getSuite()->getName()), $event->getSuite()->count())
             ->style('bold')
             ->width($this->width, '-')
             ->prepend("\n")
             ->writeln();
 
-        if ($e->getSuite() instanceof Suite) {
+        if ($event->getSuite() instanceof Suite) {
             $message = $this->message(
                 implode(
                     ', ',
@@ -144,7 +213,7 @@ class Console implements EventSubscriberInterface
                         function ($module) {
                             return $module->_getName();
                         },
-                        $e->getSuite()->getModules()
+                        $event->getSuite()->getModules()
                     )
                 )
             );
@@ -154,18 +223,18 @@ class Console implements EventSubscriberInterface
                 ->writeln(OutputInterface::VERBOSITY_VERBOSE);
         }
 
-        $this->message('')->width($this->width, '-')->writeln(OutputInterface::VERBOSITY_VERBOSE);
+        $this->message()->width($this->width, '-')->writeln(OutputInterface::VERBOSITY_VERBOSE);
     }
 
     // triggered for all tests
-    public function startTest(TestEvent $e)
+    public function startTest(TestEvent $event): void
     {
         $this->conditionalFails = [];
-        $test = $e->getTest();
+        $test = $event->getTest();
         $this->printedTest = $test;
         $this->message = null;
 
-        if (!$this->output->isInteractive() and !$this->isDetailed($test)) {
+        if (!$this->output->isInteractive() && !$this->isDetailed($test)) {
             return;
         }
         $this->writeCurrentTest($test);
@@ -188,13 +257,13 @@ class Console implements EventSubscriberInterface
         }
     }
 
-    public function afterStep(StepEvent $e)
+    public function afterStep(StepEvent $event): void
     {
-        $step = $e->getStep();
+        $step = $event->getStep();
         if (!$step->hasFailed()) {
             return;
         }
-        if ($step instanceof Step\ConditionalAssertion) {
+        if ($step instanceof ConditionalAssertion) {
             $this->conditionalFails[] = $step;
             return;
         }
@@ -204,10 +273,10 @@ class Console implements EventSubscriberInterface
     /**
      * @param PrintResultEvent $event
      */
-    public function afterResult(PrintResultEvent $event)
+    public function afterResult(PrintResultEvent $event): void
     {
         $result = $event->getResult();
-        if ($result->skippedCount() + $result->notImplementedCount() > 0 and $this->options['verbosity'] < OutputInterface::VERBOSITY_VERBOSE) {
+        if ($result->skippedCount() + $result->notImplementedCount() > 0 && $this->options['verbosity'] < OutputInterface::VERBOSITY_VERBOSE) {
             $this->output->writeln("run with `-v` to get more info about skipped or incomplete tests");
         }
         foreach ($this->reports as $message) {
@@ -215,95 +284,98 @@ class Console implements EventSubscriberInterface
         }
     }
 
-    private function absolutePath($path)
+    private function absolutePath(string $path): string
     {
-        if ((strpos($path, '/') === 0) or (strpos($path, ':') === 1)) { // absolute path
+        if (strpos($path, '/') === 0 || strpos($path, ':') === 1) { // absolute path
             return $path;
         }
 
         return codecept_output_dir() . $path;
     }
 
-    public function testSuccess(TestEvent $e)
+    public function testSuccess(TestEvent $event): void
     {
-        if ($this->isDetailed($e->getTest())) {
+        if ($this->isDetailed($event->getTest())) {
             $this->message('PASSED')->center(' ')->style('ok')->append("\n")->writeln();
 
             return;
         }
-        $this->writelnFinishedTest($e, $this->message($this->chars['success'])->style('ok'));
+        $this->writelnFinishedTest($event, $this->message($this->chars['success'])->style('ok'));
     }
 
-    public function endTest(TestEvent $e)
+    public function endTest(TestEvent $event): void
     {
         $this->metaStep = null;
         $this->printedTest = null;
     }
 
-    public function testWarning(TestEvent $e)
+    public function testWarning(TestEvent $event): void
     {
-        if ($this->isDetailed($e->getTest())) {
+        if ($this->isDetailed($event->getTest())) {
             $this->message('WARNING')->center(' ')->style('pending')->append("\n")->writeln();
 
             return;
         }
-        $this->writelnFinishedTest($e, $this->message('W')->style('pending'));
+        $this->writelnFinishedTest($event, $this->message('W')->style('pending'));
     }
 
-    public function testFail(FailEvent $e)
+    public function testFail(FailEvent $event): void
     {
-        if ($this->isDetailed($e->getTest())) {
+        if ($this->isDetailed($event->getTest())) {
             $this->message('FAIL')->center(' ')->style('fail')->append("\n")->writeln();
 
             return;
         }
-        $this->writelnFinishedTest($e, $this->message($this->chars['fail'])->style('fail'));
+        $this->writelnFinishedTest($event, $this->message($this->chars['fail'])->style('fail'));
     }
 
-    public function testError(FailEvent $e)
+    public function testError(FailEvent $event): void
     {
-        if ($this->isDetailed($e->getTest())) {
+        if ($this->isDetailed($event->getTest())) {
             $this->message('ERROR')->center(' ')->style('fail')->append("\n")->writeln();
 
             return;
         }
-        $this->writelnFinishedTest($e, $this->message('E')->style('fail'));
+        $this->writelnFinishedTest($event, $this->message('E')->style('fail'));
     }
 
-    public function testSkipped(FailEvent $e)
+    public function testSkipped(FailEvent $event): void
     {
-        if ($this->isDetailed($e->getTest())) {
-            $msg = $e->getFail()->getMessage();
-            $this->message('SKIPPED')->append($msg ? ": $msg" : '')->center(' ')->style('pending')->writeln();
+        if ($this->isDetailed($event->getTest())) {
+            $msg = $event->getFail()->getMessage();
+            $this->message('SKIPPED')->append($msg !== '' ? ": {$msg}" : '')->center(' ')->style('pending')->writeln();
 
             return;
         }
-        $this->writelnFinishedTest($e, $this->message('S')->style('pending'));
+        $this->writelnFinishedTest($event, $this->message('S')->style('pending'));
     }
 
-    public function testIncomplete(FailEvent $e)
+    public function testIncomplete(FailEvent $event): void
     {
-        if ($this->isDetailed($e->getTest())) {
-            $msg = $e->getFail()->getMessage();
-            $this->message('INCOMPLETE')->append($msg ? ": $msg" : '')->center(' ')->style('pending')->writeln();
+        if ($this->isDetailed($event->getTest())) {
+            $msg = $event->getFail()->getMessage();
+            $this->message('INCOMPLETE')->append($msg !== '' ? ": {$msg}" : '')->center(' ')->style('pending')->writeln();
 
             return;
         }
-        $this->writelnFinishedTest($e, $this->message('I')->style('pending'));
+        $this->writelnFinishedTest($event, $this->message('I')->style('pending'));
     }
 
-    protected function isDetailed($test)
+    protected function isDetailed($test): bool
     {
-        return $test instanceof ScenarioDriven && $this->steps;
+        if (!$test instanceof ScenarioDriven) {
+            return false;
+        }
+        return (bool) $this->steps;
     }
 
-    public function beforeStep(StepEvent $e)
+    public function beforeStep(StepEvent $event): void
     {
-        if (!$this->steps or !$e->getTest() instanceof ScenarioDriven) {
+        if (!$this->steps || !$event->getTest() instanceof ScenarioDriven) {
             return;
         }
-        $metaStep = $e->getStep()->getMetaStep();
-        if ($metaStep and $this->metaStep != $metaStep) {
+        $metaStep = $event->getStep()->getMetaStep();
+        if ($metaStep && $this->metaStep != $metaStep) {
             $this->message(' ' . $metaStep->getPrefix())
                 ->style('bold')
                 ->append($metaStep->__toString())
@@ -311,12 +383,12 @@ class Console implements EventSubscriberInterface
         }
         $this->metaStep = $metaStep;
 
-        $this->printStep($e->getStep());
+        $this->printStep($event->getStep());
     }
 
-    private function printStep(Step $step)
+    private function printStep(Step $step): void
     {
-        if ($step instanceof Comment and $step->__toString() == '') {
+        if ($step instanceof Comment && $step->__toString() == '') {
             return; // don't print empty comments
         }
         $msg = $this->message(' ');
@@ -336,7 +408,7 @@ class Console implements EventSubscriberInterface
         $msg->writeln();
     }
 
-    public function afterSuite(SuiteEvent $e)
+    public function afterSuite(SuiteEvent $event): void
     {
         $this->message()->width($this->width, '-')->writeln();
         $messages = Notification::all();
@@ -348,12 +420,12 @@ class Console implements EventSubscriberInterface
         }
     }
 
-    public function printFail(FailEvent $e)
+    public function printFail(FailEvent $event): void
     {
-        $failedTest = $e->getTest();
-        $fail = $e->getFail();
+        $failedTest = $event->getTest();
+        $fail = $event->getFail();
 
-        $this->output->write($e->getCount() . ") ");
+        $this->output->write($event->getCount() . ") ");
         $this->writeCurrentTest($failedTest, false);
         $this->output->writeln('');
         $this->message("<error> Test </error> ")
@@ -370,27 +442,27 @@ class Console implements EventSubscriberInterface
         $this->printExceptionTrace($fail);
     }
 
-    public function printReports(TestInterface $failedTest)
+    public function printReports(TestInterface $failedTest): void
     {
         if ($this->options['no-artifacts']) {
             return;
         }
         $reports = $failedTest->getMetadata()->getReports();
-        if (count($reports)) {
+        if (!empty($reports)) {
             $this->output->writeln('<comment>Artifacts:</comment>');
             $this->output->writeln('');
         }
 
         foreach ($reports as $type => $report) {
             $type = ucfirst($type);
-            $this->output->writeln("$type: <debug>$report</debug>");
+            $this->output->writeln("{$type}: <debug>{$report}</debug>");
         }
     }
 
-    public function printException($e, $cause = null)
+    public function printException($e, $cause = null): void
     {
-        if ($e instanceof \PHPUnit\Framework\SkippedTestError or $e instanceof \PHPUnit\Framework_IncompleteTestError) {
-            if ($e->getMessage()) {
+        if ($e instanceof \PHPUnit\Framework\SkippedTestError || $e instanceof \PHPUnit\Framework_IncompleteTestError) {
+            if ($e->getMessage() !== '') {
                 $this->message(OutputFormatter::escape($e->getMessage()))->prepend("\n")->writeln();
             }
 
@@ -410,28 +482,28 @@ class Console implements EventSubscriberInterface
 
         if ($e instanceof \PHPUnit\Framework\ExpectationFailedException) {
             $comparisonFailure = $e->getComparisonFailure();
-            if ($comparisonFailure) {
+            if ($comparisonFailure !== null) {
                 $message->append($this->messageFactory->prepareComparisonFailureMessage($comparisonFailure));
             }
         }
 
         $isFailure = $e instanceof \PHPUnit\Framework\AssertionFailedError
-            || $class === 'PHPUnit\Framework\ExpectationFailedException'
-            || $class === 'PHPUnit\Framework\AssertionFailedError';
+            || $class === \PHPUnit\Framework\ExpectationFailedException::class
+            || $class === \PHPUnit\Framework\AssertionFailedError::class;
 
         if (!$isFailure) {
-            $message->prepend("[$class] ")->block('error');
+            $message->prepend("[{$class}] ")->block('error');
         }
 
         if ($isFailure && $cause) {
             $cause = OutputFormatter::escape(ucfirst($cause));
-            $message->prepend("<error> Step </error> $cause\n<error> Fail </error> ");
+            $message->prepend("<error> Step </error> {$cause}\n<error> Fail </error> ");
         }
 
         $message->writeln();
     }
 
-    public function printScenarioFail(ScenarioDriven $failedTest, $fail)
+    public function printScenarioFail(ScenarioDriven $failedTest, $fail): void
     {
         if ($this->conditionalFails) {
             $failedStep = (string) array_shift($this->conditionalFails);
@@ -457,28 +529,28 @@ class Console implements EventSubscriberInterface
         }
     }
 
-    public function printExceptionTrace($e)
+    public function printExceptionTrace($exception): void
     {
         static $limit = 10;
 
-        if ($e instanceof \PHPUnit\Framework\SkippedTestError or $e instanceof \PHPUnit\Framework_IncompleteTestError) {
+        if ($exception instanceof \PHPUnit\Framework\SkippedTestError || $exception instanceof \PHPUnit\Framework_IncompleteTestError) {
             return;
         }
 
         if ($this->rawStackTrace) {
-            $this->message(OutputFormatter::escape(\PHPUnit\Util\Filter::getFilteredStacktrace($e, true, false)))->writeln();
+            $this->message(OutputFormatter::escape(\PHPUnit\Util\Filter::getFilteredStacktrace($exception, true, false)))->writeln();
 
             return;
         }
 
-        $trace = \PHPUnit\Util\Filter::getFilteredStacktrace($e, false);
+        $trace = \PHPUnit\Util\Filter::getFilteredStacktrace($exception, false);
 
         $i = 0;
         foreach ($trace as $step) {
             if ($i >= $limit) {
                 break;
             }
-            $i++;
+            ++$i;
 
             $message = $this->message($i)->prepend('#')->width(4);
 
@@ -496,22 +568,19 @@ class Console implements EventSubscriberInterface
             $message->writeln();
         }
 
-        $prev = $e->getPrevious();
+        $prev = $exception->getPrevious();
         if ($prev) {
             $this->printExceptionTrace($prev);
         }
     }
 
-
-    /**
-     * @param $failedTest
-     */
-    public function printScenarioTrace(ScenarioDriven $failedTest)
+    public function printScenarioTrace(ScenarioDriven $failedTest): void
     {
         $trace = array_reverse($failedTest->getScenario()->getSteps());
-        $length = $stepNumber = count($trace);
+        $length = count($trace);
+        $stepNumber = $length;
 
-        if (!$length) {
+        if ($length === 0) {
             return;
         }
 
@@ -537,11 +606,11 @@ class Console implements EventSubscriberInterface
             }
 
             $line = $step->getLine();
-            if ($line and (!$step instanceof Comment)) {
-                $message->append(" at <info>$line</info>");
+            if ($line && !$step instanceof Comment) {
+                $message->append(" at <info>{$line}</info>");
             }
 
-            $stepNumber--;
+            --$stepNumber;
             $message->writeln();
             if (($length - $stepNumber - 1) >= $this->traceLength) {
                 break;
@@ -550,11 +619,14 @@ class Console implements EventSubscriberInterface
         $this->output->writeln("");
     }
 
+    /**
+     * @return int|string|bool
+     */
     public function detectWidth()
     {
         $this->width = 60;
         if (!$this->isWin()
-            && (php_sapi_name() === "cli")
+            && (PHP_SAPI === "cli")
             && (getenv('TERM'))
             && (getenv('TERM') != 'unknown')
         ) {
@@ -564,7 +636,7 @@ class Console implements EventSubscriberInterface
             } else {
                 $this->width = (int) (`command -v tput >> /dev/null 2>&1 && tput cols`) - 2;
             }
-        } elseif ($this->isWin() && (php_sapi_name() === "cli")) {
+        } elseif ($this->isWin() && (PHP_SAPI === "cli")) {
             exec('mode con', $output);
             if (isset($output[4])) {
                 preg_match('/^ +.* +(\d+)$/', $output[4], $matches);
@@ -576,18 +648,14 @@ class Console implements EventSubscriberInterface
         return $this->width;
     }
 
-    private function isWin()
+    private function isWin(): bool
     {
         return strtoupper(substr(PHP_OS, 0, 3)) === 'WIN';
     }
 
-    /**
-     * @param \PHPUnit\Framework\SelfDescribing $test
-     * @param bool                              $inProgress
-     */
-    protected function writeCurrentTest(\PHPUnit\Framework\SelfDescribing $test, $inProgress = true)
+    protected function writeCurrentTest(SelfDescribing $test, bool $inProgress = true): void
     {
-        $prefix = ($this->output->isInteractive() and !$this->isDetailed($test) and $inProgress) ? '- ' : '';
+        $prefix = ($this->output->isInteractive() && !$this->isDetailed($test) && $inProgress) ? '- ' : '';
 
         $testString = Descriptor::getTestAsString($test);
         $testString = preg_replace('~^([^:]+):\s~', "<focus>$1{$this->chars['of']}</focus> ", $testString);
@@ -598,7 +666,7 @@ class Console implements EventSubscriberInterface
             ->write();
     }
 
-    protected function writelnFinishedTest(TestEvent $event, Message $result)
+    protected function writelnFinishedTest(TestEvent $event, Message $result): void
     {
         $test = $event->getTest();
         if ($this->isDetailed($test)) {
@@ -615,31 +683,24 @@ class Console implements EventSubscriberInterface
         $numFails = count($this->conditionalFails);
         if ($numFails == 1) {
             $conditionalFailsMessage = "[F]";
-        } elseif ($numFails) {
+        } elseif ($numFails !== 0) {
             $conditionalFailsMessage = "{$numFails}x[F]";
         }
-        $conditionalFailsMessage = "<error>$conditionalFailsMessage</error> ";
+        $conditionalFailsMessage = "<error>{$conditionalFailsMessage}</error> ";
         $this->message($conditionalFailsMessage)->write();
         $this->writeTimeInformation($event);
         $this->output->writeln('');
     }
 
-    /**
-     * @param $string
-     * @return Message
-     */
-    private function message($string = '')
+    private function message(string $string = ''): Message
     {
         return $this->messageFactory->message($string);
     }
 
-    /**
-     * @param TestEvent $event
-     */
-    protected function writeTimeInformation(TestEvent $event)
+    protected function writeTimeInformation(TestEvent $event): void
     {
         $time = $event->getTime();
-        if ($time) {
+        if ($time !== 0.0) {
             $this
                 ->message(number_format(round($time, 2), 2))
                 ->prepend('(')
@@ -649,10 +710,7 @@ class Console implements EventSubscriberInterface
         }
     }
 
-    /**
-     * @param $options
-     */
-    private function prepareOptions($options)
+    private function prepareOptions($options): void
     {
         $this->options = array_merge($this->options, $options);
         $this->debug = $this->options['debug'] || $this->options['verbosity'] >= OutputInterface::VERBOSITY_VERY_VERBOSE;

--- a/src/Codeception/Subscriber/Console.php
+++ b/src/Codeception/Subscriber/Console.php
@@ -51,7 +51,7 @@ use function ucfirst;
 
 class Console implements EventSubscriberInterface
 {
-    use Shared\StaticEvents;
+    use Shared\StaticEventsTrait;
 
     /**
      * @var array<string, string>

--- a/src/Codeception/Subscriber/Console.php
+++ b/src/Codeception/Subscriber/Console.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Codeception\Subscriber;
 
 use Codeception\Event\FailEvent;
@@ -181,7 +184,7 @@ class Console implements EventSubscriberInterface
             if (!$this->options[$report]) {
                 continue;
             }
-            $path = $this->absolutePath($this->options[$report]);
+            $path = $this->absolutePath((string)$this->options[$report]);
             $this->reports[] = sprintf(
                 "- <bold>%s</bold> report generated in <comment>file://%s</comment>",
                 strtoupper($report),
@@ -552,7 +555,7 @@ class Console implements EventSubscriberInterface
             }
             ++$i;
 
-            $message = $this->message($i)->prepend('#')->width(4);
+            $message = $this->message((string)$i)->prepend('#')->width(4);
 
             if (!isset($step['file'])) {
                 foreach (['class', 'type', 'function'] as $info) {
@@ -595,9 +598,9 @@ class Console implements EventSubscriberInterface
             }
 
             $message = $this
-                ->message($stepNumber)
+                ->message((string)$stepNumber)
                 ->prepend(' ')
-                ->width(strlen($length))
+                ->width(strlen((string)$length))
                 ->append(". ");
             $message->append(OutputFormatter::escape($step->getPhpCode($this->width - $message->getLength())));
 

--- a/src/Codeception/Subscriber/Dependencies.php
+++ b/src/Codeception/Subscriber/Dependencies.php
@@ -20,7 +20,7 @@ class Dependencies implements EventSubscriberInterface
     /**
      * @var array<string, string>
      */
-    static $events = [
+    protected static $events = [
         Events::TEST_START => 'testStart',
         Events::TEST_SUCCESS => 'testSuccess'
     ];

--- a/src/Codeception/Subscriber/Dependencies.php
+++ b/src/Codeception/Subscriber/Dependencies.php
@@ -7,19 +7,26 @@ use Codeception\Test\Interfaces\Dependent;
 use Codeception\TestInterface;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Codeception\Events;
+use function in_array;
 
 class Dependencies implements EventSubscriberInterface
 {
     use Shared\StaticEvents;
 
+    /**
+     * @var array<string, string>
+     */
     static $events = [
         Events::TEST_START => 'testStart',
         Events::TEST_SUCCESS => 'testSuccess'
     ];
 
+    /**
+     * @var string[]
+     */
     protected $successfulTests = [];
 
-    public function testStart(TestEvent $event)
+    public function testStart(TestEvent $event): void
     {
         $test = $event->getTest();
         if (!$test instanceof Dependent) {
@@ -29,13 +36,13 @@ class Dependencies implements EventSubscriberInterface
         $testSignatures = $test->fetchDependencies();
         foreach ($testSignatures as $signature) {
             if (!in_array($signature, $this->successfulTests)) {
-                $test->getMetadata()->setSkip("This test depends on $signature to pass");
+                $test->getMetadata()->setSkip("This test depends on {$signature} to pass");
                 return;
             }
         }
     }
 
-    public function testSuccess(TestEvent $event)
+    public function testSuccess(TestEvent $event): void
     {
         $test = $event->getTest();
         if (!$test instanceof TestInterface) {

--- a/src/Codeception/Subscriber/Dependencies.php
+++ b/src/Codeception/Subscriber/Dependencies.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Codeception\Subscriber;
 
 use Codeception\Event\TestEvent;

--- a/src/Codeception/Subscriber/Dependencies.php
+++ b/src/Codeception/Subscriber/Dependencies.php
@@ -14,7 +14,7 @@ use function in_array;
 
 class Dependencies implements EventSubscriberInterface
 {
-    use Shared\StaticEvents;
+    use Shared\StaticEventsTrait;
 
     /**
      * @var array<string, string>

--- a/src/Codeception/Subscriber/Dependencies.php
+++ b/src/Codeception/Subscriber/Dependencies.php
@@ -5,11 +5,12 @@ declare(strict_types=1);
 namespace Codeception\Subscriber;
 
 use Codeception\Event\TestEvent;
+use Codeception\Events;
 use Codeception\Test\Descriptor;
 use Codeception\Test\Interfaces\Dependent;
 use Codeception\TestInterface;
+use PHPUnit\Framework\SelfDescribing;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
-use Codeception\Events;
 use function in_array;
 
 class Dependencies implements EventSubscriberInterface
@@ -47,6 +48,7 @@ class Dependencies implements EventSubscriberInterface
 
     public function testSuccess(TestEvent $event): void
     {
+        /** @var SelfDescribing $test */
         $test = $event->getTest();
         if (!$test instanceof TestInterface) {
             return;

--- a/src/Codeception/Subscriber/ErrorHandler.php
+++ b/src/Codeception/Subscriber/ErrorHandler.php
@@ -94,23 +94,23 @@ class ErrorHandler implements EventSubscriberInterface
         $this->initialized = true;
     }
 
-    public function errorHandler($errno, $errstr, $errfile, $errline, $context = [])
+    public function errorHandler(int $errNum, string $errMsg, string $errFile, string $errLine, array $context = []): bool
     {
-        if (E_USER_DEPRECATED === $errno) {
-            $this->handleDeprecationError($errno, $errstr, $errfile, $errline, $context);
-            return;
+        if (E_USER_DEPRECATED === $errNum) {
+            $this->handleDeprecationError($errNum, $errMsg, $errFile, $errLine, $context);
+            return true;
         }
 
-        if ((error_reporting() & $errno) === 0) {
+        if ((error_reporting() & $errNum) === 0) {
             // This error code is not included in error_reporting
             return false;
         }
 
-        if (strpos($errstr, 'Cannot modify header information') !== false) {
+        if (strpos($errMsg, 'Cannot modify header information') !== false) {
             return false;
         }
 
-        throw new \PHPUnit\Framework\Exception($errstr, $errno);
+        throw new \PHPUnit\Framework\Exception($errMsg, $errNum);
     }
 
     public function shutdownHandler(): void
@@ -169,7 +169,7 @@ class ErrorHandler implements EventSubscriberInterface
         }
     }
 
-    private function handleDeprecationError($type, $message, $file, $line, $context): void
+    private function handleDeprecationError(int $type, string $message, string $file, string $line, array $context): void
     {
         if (($this->errorLevel & $type) === 0) {
             return;

--- a/src/Codeception/Subscriber/ErrorHandler.php
+++ b/src/Codeception/Subscriber/ErrorHandler.php
@@ -7,6 +7,8 @@ namespace Codeception\Subscriber;
 use Codeception\Event\SuiteEvent;
 use Codeception\Events;
 use Codeception\Lib\Notification;
+use PHPUnit\Framework\Exception as PHPUnitException;
+use Symfony\Bridge\PhpUnit\DeprecationErrorHandler as SymfonyDeprecationErrorHandler;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use function call_user_func;
 use function class_exists;
@@ -110,7 +112,7 @@ class ErrorHandler implements EventSubscriberInterface
             return false;
         }
 
-        throw new \PHPUnit\Framework\Exception($errMsg, $errNum);
+        throw new PHPUnitException($errMsg, $errNum);
     }
 
     public function shutdownHandler(): void
@@ -165,7 +167,7 @@ class ErrorHandler implements EventSubscriberInterface
             }
 
             $this->deprecationsInstalled = true;
-            \Symfony\Bridge\PhpUnit\DeprecationErrorHandler::register(getenv('SYMFONY_DEPRECATIONS_HELPER'));
+            SymfonyDeprecationErrorHandler::register(getenv('SYMFONY_DEPRECATIONS_HELPER'));
         }
     }
 

--- a/src/Codeception/Subscriber/ErrorHandler.php
+++ b/src/Codeception/Subscriber/ErrorHandler.php
@@ -25,7 +25,7 @@ use function strpos;
 
 class ErrorHandler implements EventSubscriberInterface
 {
-    use Shared\StaticEvents;
+    use Shared\StaticEventsTrait;
 
     /**
      * @var array<string, string>

--- a/src/Codeception/Subscriber/ErrorHandler.php
+++ b/src/Codeception/Subscriber/ErrorHandler.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Codeception\Subscriber;
 
 use Codeception\Event\SuiteEvent;

--- a/src/Codeception/Subscriber/ErrorHandler.php
+++ b/src/Codeception/Subscriber/ErrorHandler.php
@@ -32,7 +32,7 @@ class ErrorHandler implements EventSubscriberInterface
     /**
      * @var array<string, string>
      */
-    public static $events = [
+    protected static $events = [
         Events::SUITE_BEFORE => 'handle',
         Events::SUITE_AFTER  => 'onFinish'
     ];

--- a/src/Codeception/Subscriber/ExtensionLoader.php
+++ b/src/Codeception/Subscriber/ExtensionLoader.php
@@ -23,7 +23,7 @@ class ExtensionLoader implements EventSubscriberInterface
     /**
      * @var array<string, string>
      */
-    public static $events = [
+    protected static $events = [
         Events::MODULE_INIT => 'registerSuiteExtensions',
         Events::SUITE_AFTER  => 'stopSuiteExtensions'
     ];

--- a/src/Codeception/Subscriber/ExtensionLoader.php
+++ b/src/Codeception/Subscriber/ExtensionLoader.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Codeception\Subscriber;
 
 use Codeception\Configuration;

--- a/src/Codeception/Subscriber/ExtensionLoader.php
+++ b/src/Codeception/Subscriber/ExtensionLoader.php
@@ -18,7 +18,7 @@ use function reset;
 
 class ExtensionLoader implements EventSubscriberInterface
 {
-    use Shared\StaticEvents;
+    use Shared\StaticEventsTrait;
 
     /**
      * @var array<string, string>

--- a/src/Codeception/Subscriber/ExtensionLoader.php
+++ b/src/Codeception/Subscriber/ExtensionLoader.php
@@ -59,7 +59,7 @@ class ExtensionLoader implements EventSubscriberInterface
         $this->config = Configuration::config();
     }
 
-    public function bootGlobalExtensions($options): void
+    public function bootGlobalExtensions(array $options): void
     {
         $this->options = $options;
         $this->globalExtensions = $this->bootExtensions($this->config);
@@ -97,10 +97,11 @@ class ExtensionLoader implements EventSubscriberInterface
     }
 
     /**
+     * @param array $config
      * @return array<class-string, EventSubscriberInterface>
      * @throws ConfigurationException
      */
-    protected function bootExtensions($config): array
+    protected function bootExtensions(array $config): array
     {
         $extensions = [];
 
@@ -127,7 +128,7 @@ class ExtensionLoader implements EventSubscriberInterface
         return $extensions;
     }
 
-    private function getExtensionConfig($extension, $config)
+    private function getExtensionConfig(string $extension, array $config): array
     {
         $extensionConfig = isset($config['extensions']['config'][$extension])
             ? $config['extensions']['config'][$extension]

--- a/src/Codeception/Subscriber/FailFast.php
+++ b/src/Codeception/Subscriber/FailFast.php
@@ -10,7 +10,7 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
 class FailFast implements EventSubscriberInterface
 {
-    use Shared\StaticEvents;
+    use Shared\StaticEventsTrait;
 
     /**
      * @var array<string, string>

--- a/src/Codeception/Subscriber/FailFast.php
+++ b/src/Codeception/Subscriber/FailFast.php
@@ -15,7 +15,7 @@ class FailFast implements EventSubscriberInterface
     /**
      * @var array<string, string>
      */
-    public static $events = [
+    protected static $events = [
         Events::SUITE_BEFORE => 'stopOnFail',
     ];
 

--- a/src/Codeception/Subscriber/FailFast.php
+++ b/src/Codeception/Subscriber/FailFast.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Codeception\Subscriber;
 
 use Codeception\Event\SuiteEvent;

--- a/src/Codeception/Subscriber/FailFast.php
+++ b/src/Codeception/Subscriber/FailFast.php
@@ -9,13 +9,16 @@ class FailFast implements EventSubscriberInterface
 {
     use Shared\StaticEvents;
 
+    /**
+     * @var array<string, string>
+     */
     public static $events = [
         Events::SUITE_BEFORE => 'stopOnFail',
     ];
 
-    public function stopOnFail(SuiteEvent $e)
+    public function stopOnFail(SuiteEvent $event): void
     {
-        $e->getResult()->stopOnError(true);
-        $e->getResult()->stopOnFailure(true);
+        $event->getResult()->stopOnError(true);
+        $event->getResult()->stopOnFailure(true);
     }
 }

--- a/src/Codeception/Subscriber/GracefulTermination.php
+++ b/src/Codeception/Subscriber/GracefulTermination.php
@@ -1,5 +1,8 @@
 <?php
-declare (ticks = 1);
+
+declare(strict_types=1);
+declare(ticks=1);
+
 namespace Codeception\Subscriber;
 
 use Codeception\Event\SuiteEvent;

--- a/src/Codeception/Subscriber/GracefulTermination.php
+++ b/src/Codeception/Subscriber/GracefulTermination.php
@@ -4,11 +4,21 @@ namespace Codeception\Subscriber;
 
 use Codeception\Event\SuiteEvent;
 use Codeception\Events;
+use RuntimeException;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use function function_exists;
+use function pcntl_async_signals;
+use function pcntl_signal;
 
 class GracefulTermination implements EventSubscriberInterface
 {
+    /**
+     * @var string
+     */
     const SIGNAL_FUNC = 'pcntl_signal';
+    /**
+     * @var string
+     */
     const ASYNC_SIGNAL_HANDLING_FUNC = 'pcntl_async_signals';
 
     /**
@@ -16,7 +26,7 @@ class GracefulTermination implements EventSubscriberInterface
      */
     protected $suiteEvent;
 
-    public function handleSuite(SuiteEvent $event)
+    public function handleSuite(SuiteEvent $event): void
     {
         if (PHP_MAJOR_VERSION === 7 && PHP_MINOR_VERSION === 0) {
             // skip for PHP 7.0: https://github.com/Codeception/Codeception/issues/3607
@@ -26,25 +36,32 @@ class GracefulTermination implements EventSubscriberInterface
             pcntl_async_signals(true);
         }
         if (function_exists(self::SIGNAL_FUNC)) {
-            pcntl_signal(SIGTERM, [$this, 'terminate']);
-            pcntl_signal(SIGINT, [$this, 'terminate']);
+            pcntl_signal(SIGTERM, function () {
+                $this->terminate();
+            });
+            pcntl_signal(SIGINT, function () {
+                $this->terminate();
+            });
         }
 
         $this->suiteEvent = $event;
     }
 
-    public function terminate()
+    public function terminate(): void
     {
         if ($this->suiteEvent) {
             $this->suiteEvent->getResult()->stopOnError(true);
             $this->suiteEvent->getResult()->stopOnFailure(true);
         }
-        throw new \RuntimeException(
+        throw new RuntimeException(
             "\n\n---------------------------\nTESTS EXECUTION TERMINATED\n---------------------------\n"
         );
     }
 
-    public static function getSubscribedEvents()
+    /**
+     * @return array<string, string>
+     */
+    public static function getSubscribedEvents(): array
     {
         if (!function_exists(self::SIGNAL_FUNC)) {
             return [];

--- a/src/Codeception/Subscriber/Module.php
+++ b/src/Codeception/Subscriber/Module.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Codeception\Subscriber;
 
 use Codeception\Event\FailEvent;

--- a/src/Codeception/Subscriber/Module.php
+++ b/src/Codeception/Subscriber/Module.php
@@ -16,7 +16,7 @@ use function array_reverse;
 
 class Module implements EventSubscriberInterface
 {
-    use Shared\StaticEvents;
+    use Shared\StaticEventsTrait;
 
     /**
      * @var array<string, string>

--- a/src/Codeception/Subscriber/Module.php
+++ b/src/Codeception/Subscriber/Module.php
@@ -9,11 +9,15 @@ use Codeception\Events;
 use Codeception\Suite;
 use Codeception\TestInterface;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use function array_reverse;
 
 class Module implements EventSubscriberInterface
 {
     use Shared\StaticEvents;
 
+    /**
+     * @var array<string, string>
+     */
     public static $events = [
         Events::TEST_BEFORE  => 'before',
         Events::TEST_AFTER   => 'after',
@@ -36,26 +40,26 @@ class Module implements EventSubscriberInterface
         $this->modules = $modules;
     }
 
-    public function beforeSuite(SuiteEvent $e)
+    public function beforeSuite(SuiteEvent $event): void
     {
-        $suite = $e->getSuite();
+        $suite = $event->getSuite();
         if (!$suite instanceof Suite) {
             return;
         }
         $this->modules = $suite->getModules();
         foreach ($this->modules as $module) {
-            $module->_beforeSuite($e->getSettings());
+            $module->_beforeSuite($event->getSettings());
         }
     }
 
-    public function afterSuite()
+    public function afterSuite(): void
     {
         foreach (array_reverse($this->modules) as $module) {
             $module->_afterSuite();
         }
     }
 
-    public function before(TestEvent $event)
+    public function before(TestEvent $event): void
     {
         if (!$event->getTest() instanceof TestInterface) {
             return;
@@ -66,38 +70,38 @@ class Module implements EventSubscriberInterface
         }
     }
 
-    public function after(TestEvent $e)
+    public function after(TestEvent $event): void
     {
-        if (!$e->getTest() instanceof TestInterface) {
+        if (!$event->getTest() instanceof TestInterface) {
             return;
         }
         foreach (array_reverse($this->modules) as $module) {
-            $module->_after($e->getTest());
+            $module->_after($event->getTest());
             $module->_resetConfig();
         }
     }
 
-    public function failed(FailEvent $e)
+    public function failed(FailEvent $event): void
     {
-        if (!$e->getTest() instanceof TestInterface) {
+        if (!$event->getTest() instanceof TestInterface) {
             return;
         }
         foreach (array_reverse($this->modules) as $module) {
-            $module->_failed($e->getTest(), $e->getFail());
+            $module->_failed($event->getTest(), $event->getFail());
         }
     }
 
-    public function beforeStep(StepEvent $e)
+    public function beforeStep(StepEvent $event): void
     {
         foreach ($this->modules as $module) {
-            $module->_beforeStep($e->getStep(), $e->getTest());
+            $module->_beforeStep($event->getStep(), $event->getTest());
         }
     }
 
-    public function afterStep(StepEvent $e)
+    public function afterStep(StepEvent $event): void
     {
         foreach (array_reverse($this->modules) as $module) {
-            $module->_afterStep($e->getStep(), $e->getTest());
+            $module->_afterStep($event->getStep(), $event->getTest());
         }
     }
 }

--- a/src/Codeception/Subscriber/Module.php
+++ b/src/Codeception/Subscriber/Module.php
@@ -97,14 +97,14 @@ class Module implements EventSubscriberInterface
     public function beforeStep(StepEvent $event): void
     {
         foreach ($this->modules as $module) {
-            $module->_beforeStep($event->getStep(), $event->getTest());
+            $module->_beforeStep($event->getStep());
         }
     }
 
     public function afterStep(StepEvent $event): void
     {
         foreach (array_reverse($this->modules) as $module) {
-            $module->_afterStep($event->getStep(), $event->getTest());
+            $module->_afterStep($event->getStep());
         }
     }
 }

--- a/src/Codeception/Subscriber/Module.php
+++ b/src/Codeception/Subscriber/Module.php
@@ -21,7 +21,7 @@ class Module implements EventSubscriberInterface
     /**
      * @var array<string, string>
      */
-    public static $events = [
+    protected static $events = [
         Events::TEST_BEFORE  => 'before',
         Events::TEST_AFTER   => 'after',
         Events::STEP_BEFORE  => 'beforeStep',

--- a/src/Codeception/Subscriber/PrepareTest.php
+++ b/src/Codeception/Subscriber/PrepareTest.php
@@ -13,7 +13,7 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
 class PrepareTest implements EventSubscriberInterface
 {
-    use Shared\StaticEvents;
+    use Shared\StaticEventsTrait;
 
     /**
      * @var array<string, string>

--- a/src/Codeception/Subscriber/PrepareTest.php
+++ b/src/Codeception/Subscriber/PrepareTest.php
@@ -13,13 +13,19 @@ class PrepareTest implements EventSubscriberInterface
 {
     use Shared\StaticEvents;
 
+    /**
+     * @var array<string, string>
+     */
     public static $events = [
         Events::TEST_BEFORE => 'prepare',
     ];
 
+    /**
+     * @var array
+     */
     protected $modules = [];
 
-    public function prepare(TestEvent $event)
+    public function prepare(TestEvent $event): void
     {
         $test = $event->getTest();
         /** @var $di Di  **/
@@ -32,7 +38,7 @@ class PrepareTest implements EventSubscriberInterface
 
         foreach ($prepareMethods as $method) {
 
-            /** @var $module \Codeception\Module  **/
+            /** @var \Codeception\Module $module **/
             if ($test instanceof Cest) {
                 $di->injectDependencies($test->getTestClass(), $method);
             }

--- a/src/Codeception/Subscriber/PrepareTest.php
+++ b/src/Codeception/Subscriber/PrepareTest.php
@@ -18,7 +18,7 @@ class PrepareTest implements EventSubscriberInterface
     /**
      * @var array<string, string>
      */
-    public static $events = [
+    protected static $events = [
         Events::TEST_BEFORE => 'prepare',
     ];
 

--- a/src/Codeception/Subscriber/PrepareTest.php
+++ b/src/Codeception/Subscriber/PrepareTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Codeception\Subscriber;
 
 use Codeception\Event\TestEvent;

--- a/src/Codeception/Subscriber/Shared/StaticEvents.php
+++ b/src/Codeception/Subscriber/Shared/StaticEvents.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Codeception\Subscriber\Shared;
 
 trait StaticEvents

--- a/src/Codeception/Subscriber/Shared/StaticEvents.php
+++ b/src/Codeception/Subscriber/Shared/StaticEvents.php
@@ -3,7 +3,7 @@ namespace Codeception\Subscriber\Shared;
 
 trait StaticEvents
 {
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents(): array
     {
         return static::$events;
     }

--- a/src/Codeception/Subscriber/Shared/StaticEventsTrait.php
+++ b/src/Codeception/Subscriber/Shared/StaticEventsTrait.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Codeception\Subscriber\Shared;
 
-trait StaticEvents
+trait StaticEventsTrait
 {
     public static function getSubscribedEvents(): array
     {


### PR DESCRIPTION
- [x] Use strict types in `src/Codeception/Subscriber`.
- [x] Add type hints to Subscribers.
- [x] Remove unnecessary qualifiers in `src/Codeception/Subscriber`.
- [x] Add 'use function' statements for performance reasons.
- [x] Longer aliases for ambiguous class names.
- [x] Fix naming in `src/Codeception/Subscriber`.
- [x] Rename `src/Codeception/Subscriber/Shared/StaticEvent` trait.