### PR TITLE
Update code standards in src/Codeception/Test

### DIFF
--- a/src/Codeception/Event/FailEvent.php
+++ b/src/Codeception/Event/FailEvent.php
@@ -4,13 +4,13 @@ declare(strict_types=1);
 
 namespace Codeception\Event;
 
-use Exception;
 use PHPUnit\Framework\Test as PHPUnitTest;
+use Throwable;
 
 class FailEvent extends TestEvent
 {
     /**
-     * @var Exception
+     * @var Throwable
      */
     protected $fail;
 
@@ -19,7 +19,7 @@ class FailEvent extends TestEvent
      */
     protected $count;
 
-    public function __construct(PHPUnitTest $test, ?float $time, Exception $e, int $count = 0)
+    public function __construct(PHPUnitTest $test, ?float $time, Throwable $e, int $count = 0)
     {
         parent::__construct($test, $time);
         $this->fail = $e;
@@ -31,7 +31,7 @@ class FailEvent extends TestEvent
         return $this->count;
     }
 
-    public function getFail(): Exception
+    public function getFail(): Throwable
     {
         return $this->fail;
     }

--- a/src/Codeception/Test/Cept.php
+++ b/src/Codeception/Test/Cept.php
@@ -7,6 +7,7 @@ namespace Codeception\Test;
 use Codeception\Exception\TestParseException;
 use Codeception\Lib\Console\Message;
 use Codeception\Lib\Parser;
+use Exception;
 use ParseError;
 use function basename;
 use function file_get_contents;
@@ -59,12 +60,13 @@ class Cept extends Test implements Interfaces\Plain, Interfaces\ScenarioDriven, 
         return $this->getSignature() . ': ' . Message::ucfirst($this->getFeature());
     }
 
-    /**
-     * @return string|false
-     */
-    public function getSourceCode()
+    public function getSourceCode(): string
     {
-        return file_get_contents($this->getFileName());
+        $fileName = $this->getFileName();
+        if (!$sourceCode = file_get_contents($fileName)) {
+            throw new Exception("Could not get content of file {$fileName}, please check its permissions.");
+        }
+        return $sourceCode;
     }
 
     public function getReportFields(): array

--- a/src/Codeception/Test/Cept.php
+++ b/src/Codeception/Test/Cept.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Codeception\Test;
 
 use Codeception\Exception\TestParseException;

--- a/src/Codeception/Test/Cept.php
+++ b/src/Codeception/Test/Cept.php
@@ -2,8 +2,11 @@
 namespace Codeception\Test;
 
 use Codeception\Exception\TestParseException;
-use Codeception\Lib\Parser;
 use Codeception\Lib\Console\Message;
+use Codeception\Lib\Parser;
+use ParseError;
+use function basename;
+use function file_get_contents;
 
 /**
  * Executes tests delivered in Cept format.
@@ -28,24 +31,22 @@ class Cept extends Test implements Interfaces\Plain, Interfaces\ScenarioDriven, 
         $this->parser = new Parser($this->getScenario(), $this->getMetadata());
     }
 
-    public function preload()
+    public function preload(): void
     {
         $this->getParser()->prepareToRun($this->getSourceCode());
     }
 
-    public function test()
+    public function test(): void
     {
-        $scenario = $this->getScenario();
         $testFile = $this->getMetadata()->getFilename();
-        /** @noinspection PhpIncludeInspection */
         try {
             require $testFile;
-        } catch (\ParseError $e) {
-            throw new TestParseException($testFile, $e->getMessage(), $e->getLine());
+        } catch (ParseError $error) {
+            throw new TestParseException($testFile, $error->getMessage(), $error->getLine());
         }
     }
 
-    public function getSignature()
+    public function getSignature(): string
     {
         return $this->getMetadata()->getName() . 'Cept';
     }
@@ -55,12 +56,15 @@ class Cept extends Test implements Interfaces\Plain, Interfaces\ScenarioDriven, 
         return $this->getSignature() . ': ' . Message::ucfirst($this->getFeature());
     }
 
+    /**
+     * @return string|false
+     */
     public function getSourceCode()
     {
         return file_get_contents($this->getFileName());
     }
 
-    public function getReportFields()
+    public function getReportFields(): array
     {
         return [
             'name' => basename($this->getFileName(), 'Cept.php'),
@@ -69,15 +73,12 @@ class Cept extends Test implements Interfaces\Plain, Interfaces\ScenarioDriven, 
         ];
     }
 
-    /**
-     * @return Parser
-     */
-    protected function getParser()
+    protected function getParser(): Parser
     {
         return $this->parser;
     }
 
-    public function fetchDependencies()
+    public function fetchDependencies(): array
     {
         return $this->getMetadata()->getDependencies();
     }

--- a/src/Codeception/Test/Cest.php
+++ b/src/Codeception/Test/Cest.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Codeception\Test;
 
 use Codeception\Example;

--- a/src/Codeception/Test/Cest.php
+++ b/src/Codeception/Test/Cest.php
@@ -7,6 +7,20 @@ use Codeception\Lib\Parser;
 use Codeception\Step\Comment;
 use Codeception\Util\Annotation;
 use Codeception\Util\ReflectionHelper;
+use Exception;
+use LogicException;
+use ReflectionMethod;
+use function array_slice;
+use function file;
+use function get_class;
+use function implode;
+use function is_callable;
+use function method_exists;
+use function preg_replace;
+use function sprintf;
+use function strpos;
+use function strtolower;
+use function trim;
 
 /**
  * Executes tests delivered in Cest format.
@@ -39,7 +53,7 @@ class Cest extends Test implements
         $this->parser = new Parser($this->getScenario(), $this->getMetadata());
     }
 
-    public function preload()
+    public function preload(): void
     {
         $this->scenario->setFeature($this->getSpecFromMethod());
         $code = $this->getSourceCode();
@@ -54,25 +68,24 @@ class Cest extends Test implements
         }
     }
 
-    public function getSourceCode()
+    public function getSourceCode(): string
     {
-        $method = new \ReflectionMethod($this->testClassInstance, $this->testMethod);
-        $start_line = $method->getStartLine() - 1; // it's actually - 1, otherwise you wont get the function() block
-        $end_line = $method->getEndLine();
+        $method = new ReflectionMethod($this->testClassInstance, $this->testMethod);
+        $startLine = $method->getStartLine() - 1; // it's actually - 1, otherwise you wont get the function() block
+        $endLine = $method->getEndLine();
         $source = file($method->getFileName());
-        return implode("", array_slice($source, $start_line, $end_line - $start_line));
+        return implode("", array_slice($source, $startLine, $endLine - $startLine));
     }
 
-    public function getSpecFromMethod()
+    public function getSpecFromMethod(): string
     {
         $text = $this->testMethod;
         $text = preg_replace('/([A-Z]+)([A-Z][a-z])/', '\\1 \\2', $text);
         $text = preg_replace('/([a-z\d])([A-Z])/', '\\1 \\2', $text);
-        $text = strtolower($text);
-        return $text;
+        return strtolower($text);
     }
 
-    public function test()
+    public function test(): void
     {
         $actorClass = $this->getMetadata()->getCurrent('actor');
         $I = new $actorClass($this->getScenario());
@@ -82,23 +95,23 @@ class Cest extends Test implements
             $this->executeTestMethod($I);
             $this->executeAfterMethods($this->testMethod, $I);
             $this->executeHook($I, 'passed');
-        } catch (\Exception $e) {
+        } catch (Exception $exception) {
             $this->executeHook($I, 'failed');
             // fails and errors are now handled by Codeception\PHPUnit\Listener
-            throw $e;
+            throw $exception;
         } finally {
             $this->executeHook($I, 'after');
         }
     }
 
-    protected function executeHook($I, $hook)
+    protected function executeHook($I, string $hook): void
     {
-        if (is_callable([$this->testClassInstance, "_$hook"])) {
-            $this->invoke("_$hook", [$I, $this->scenario]);
+        if (is_callable([$this->testClassInstance, "_{$hook}"])) {
+            $this->invoke("_{$hook}", [$I, $this->scenario]);
         }
     }
 
-    protected function executeBeforeMethods($testMethod, $I)
+    protected function executeBeforeMethods($testMethod, $I): void
     {
         $annotations = \PHPUnit\Util\Test::parseTestMethodAnnotations(get_class($this->testClassInstance), $testMethod);
         if (!empty($annotations['method']['before'])) {
@@ -107,7 +120,7 @@ class Cest extends Test implements
             }
         }
     }
-    protected function executeAfterMethods($testMethod, $I)
+    protected function executeAfterMethods($testMethod, $I): void
     {
         $annotations = \PHPUnit\Util\Test::parseTestMethodAnnotations(get_class($this->testClassInstance), $testMethod);
         if (!empty($annotations['method']['after'])) {
@@ -117,7 +130,7 @@ class Cest extends Test implements
         }
     }
 
-    protected function executeContextMethod($context, $I)
+    protected function executeContextMethod(string $context, $I): void
     {
         if (method_exists($this->testClassInstance, $context)) {
             $this->executeBeforeMethods($context, $I);
@@ -125,22 +138,22 @@ class Cest extends Test implements
             $this->executeAfterMethods($context, $I);
             return;
         }
-        throw new \LogicException(
-            "Method $context defined in annotation but does not exist in " . get_class($this->testClassInstance)
+        throw new LogicException(
+            "Method {$context} defined in annotation but does not exist in " . get_class($this->testClassInstance)
         );
     }
 
-    protected function invoke($methodName, array $context)
+    protected function invoke($methodName, array $context): void
     {
         foreach ($context as $class) {
             $this->getMetadata()->getService('di')->set($class);
         }
         $this->getMetadata()->getService('di')->injectDependencies($this->testClassInstance, $methodName, $context);
     }
-    protected function executeTestMethod($I)
+    protected function executeTestMethod($I): void
     {
         if (!method_exists($this->testClassInstance, $this->testMethod)) {
-            throw new \Exception("Method {$this->testMethod} can't be found in tested class");
+            throw new Exception("Method {$this->testMethod} can't be found in tested class");
         }
 
         if ($this->getMetadata()->getCurrent('example')) {
@@ -155,7 +168,7 @@ class Cest extends Test implements
         return sprintf('%s: %s', ReflectionHelper::getClassShortName($this->getTestClass()), Message::ucfirst($this->getFeature()));
     }
 
-    public function getSignature()
+    public function getSignature(): string
     {
         return get_class($this->getTestClass()) . ":" . $this->getTestMethod();
     }
@@ -170,10 +183,7 @@ class Cest extends Test implements
         return $this->testMethod;
     }
 
-    /**
-     * @return array
-     */
-    public function getReportFields()
+    public function getReportFields(): array
     {
         return [
             'file'    => $this->getFileName(),
@@ -183,16 +193,16 @@ class Cest extends Test implements
         ];
     }
 
-    protected function getParser()
+    protected function getParser(): Parser
     {
         return $this->parser;
     }
 
-    public function fetchDependencies()
+    public function fetchDependencies(): array
     {
         $names = [];
         foreach ($this->getMetadata()->getDependencies() as $required) {
-            if ((strpos($required, ':') === false) and method_exists($this->getTestClass(), $required)) {
+            if (strpos($required, ':') === false && method_exists($this->getTestClass(), $required)) {
                 $required = get_class($this->getTestClass()) . ":$required";
             }
             $names[] = $required;
@@ -208,7 +218,7 @@ class Cest extends Test implements
         return \PHPUnit\Util\Test::getLinesToBeCovered($class, $method);
     }
 
-    public function getLinesToBeUsed()
+    public function getLinesToBeUsed(): array
     {
         $class  = get_class($this->getTestClass());
         $method = $this->getTestMethod();

--- a/src/Codeception/Test/Descriptor.php
+++ b/src/Codeception/Test/Descriptor.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Codeception\Test;
 
 use Codeception\Test\Interfaces\Descriptive;

--- a/src/Codeception/Test/Descriptor.php
+++ b/src/Codeception/Test/Descriptor.php
@@ -4,21 +4,32 @@ namespace Codeception\Test;
 use Codeception\Test\Interfaces\Descriptive;
 use Codeception\Test\Interfaces\Plain;
 use Codeception\Util\ReflectionHelper;
+use PHPUnit\Framework\SelfDescribing;
+use PHPUnit\Framework\TestCase;
+use ReflectionClass;
+use function codecept_relative_path;
+use function get_class;
+use function json_encode;
+use function method_exists;
+use function preg_replace;
+use function realpath;
+use function sha1;
+use function str_replace;
+use function strtolower;
+use function substr;
+use function ucfirst;
 
 class Descriptor
 {
     /**
      * Provides a test name which can be located by
-     *
-     * @param \PHPUnit\Framework\SelfDescribing $testCase
-     * @return string
      */
-    public static function getTestSignature(\PHPUnit\Framework\SelfDescribing $testCase)
+    public static function getTestSignature(SelfDescribing $testCase): string
     {
         if ($testCase instanceof Descriptive) {
             return $testCase->getSignature();
         }
-        if ($testCase instanceof \PHPUnit\Framework\TestCase) {
+        if ($testCase instanceof TestCase) {
             return get_class($testCase) . ':' . $testCase->getName(false);
         }
         return $testCase->toString();
@@ -26,11 +37,8 @@ class Descriptor
 
     /**
      * Provides a test name which is unique for individual iterations of tests using examples
-     *
-     * @param \PHPUnit\Framework\SelfDescribing $testCase
-     * @return string
      */
-    public static function getTestSignatureUnique(\PHPUnit\Framework\SelfDescribing $testCase)
+    public static function getTestSignatureUnique(SelfDescribing $testCase): string
     {
         $env     = '';
         $example = '';
@@ -44,15 +52,16 @@ class Descriptor
         if (method_exists($testCase, 'getMetaData')
             && !empty($testCase->getMetadata()->getCurrent('example'))
         ) {
-            $example = ':' . substr(sha1(json_encode($testCase->getMetadata()->getCurrent('example'))), 0, 7);
+            $currentExample = json_encode($testCase->getMetadata()->getCurrent('example'), JSON_THROW_ON_ERROR);
+            $example = ':' . substr(sha1($currentExample), 0, 7);
         }
 
         return self::getTestSignature($testCase) . $env . $example;
     }
 
-    public static function getTestAsString(\PHPUnit\Framework\SelfDescribing $testCase)
+    public static function getTestAsString(SelfDescribing $testCase): string
     {
-        if ($testCase instanceof \PHPUnit\Framework\TestCase) {
+        if ($testCase instanceof TestCase) {
             $text = self::getTestCaseNameAsString($testCase->getName());
             return ReflectionHelper::getClassShortName($testCase) . ': ' . $text;
         }
@@ -60,40 +69,31 @@ class Descriptor
         return $testCase->toString();
     }
 
-  /**
-   * @param string $testCaseName
-   * @return string
-   */
-    public static function getTestCaseNameAsString($testCaseName)
+    public static function getTestCaseNameAsString(string $testCaseName): string
     {
         $text = $testCaseName;
         $text = preg_replace('/([A-Z]+)([A-Z][a-z])/', '\\1 \\2', $text);
         $text = preg_replace('/([a-z\d])([A-Z])/', '\\1 \\2', $text);
         $text = preg_replace('/^test /', '', $text);
         $text = ucfirst(strtolower($text));
-        $text = str_replace(['::', 'with data set'], [':', '|'], $text);
-        return $text;
+        return str_replace(['::', 'with data set'], [':', '|'], $text);
     }
 
     /**
      * Provides a test file name relative to Codeception root
      *
-     * @param \PHPUnit\Framework\SelfDescribing $testCase
-     * @return mixed
+     * @param SelfDescribing $testCase
+     * @return string|false
      */
-    public static function getTestFileName(\PHPUnit\Framework\SelfDescribing $testCase)
+    public static function getTestFileName(SelfDescribing $testCase)
     {
         if ($testCase instanceof Descriptive) {
             return codecept_relative_path(realpath($testCase->getFileName()));
         }
-        return (new \ReflectionClass($testCase))->getFileName();
+        return (new ReflectionClass($testCase))->getFileName();
     }
 
-    /**
-     * @param \PHPUnit\Framework\SelfDescribing $testCase
-     * @return mixed|string
-     */
-    public static function getTestFullName(\PHPUnit\Framework\SelfDescribing $testCase)
+    public static function getTestFullName(SelfDescribing $testCase): string
     {
         if ($testCase instanceof Plain) {
             return self::getTestFileName($testCase);
@@ -102,7 +102,7 @@ class Descriptor
             $signature = $testCase->getSignature(); // cut everything before ":" from signature
             return self::getTestFileName($testCase) . ':' . preg_replace('~^(.*?):~', '', $signature);
         }
-        if ($testCase instanceof \PHPUnit\Framework\TestCase) {
+        if ($testCase instanceof TestCase) {
             return self::getTestFileName($testCase) . ':' . $testCase->getName(false);
         }
         return self::getTestFileName($testCase) . ':' . $testCase->toString();
@@ -110,11 +110,8 @@ class Descriptor
 
     /**
      * Provides a test data set index
-     *
-     * @param \PHPUnit\Framework\SelfDescribing $testCase
-     * @return int|null
      */
-    public static function getTestDataSetIndex(\PHPUnit\Framework\SelfDescribing $testCase)
+    public static function getTestDataSetIndex(SelfDescribing $testCase): ?int
     {
         if ($testCase instanceof Descriptive) {
             return $testCase->getMetadata()->getIndex();

--- a/src/Codeception/Test/Descriptor.php
+++ b/src/Codeception/Test/Descriptor.php
@@ -84,11 +84,8 @@ class Descriptor
 
     /**
      * Provides a test file name relative to Codeception root
-     *
-     * @param SelfDescribing $testCase
-     * @return string|false
      */
-    public static function getTestFileName(SelfDescribing $testCase)
+    public static function getTestFileName(SelfDescribing $testCase): string
     {
         if ($testCase instanceof Descriptive) {
             return codecept_relative_path(realpath($testCase->getFileName()));

--- a/src/Codeception/Test/Feature/AssertionCounter.php
+++ b/src/Codeception/Test/Feature/AssertionCounter.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Codeception\Test\Feature;
 
 use PHPUnit\Framework\Assert;

--- a/src/Codeception/Test/Feature/AssertionCounter.php
+++ b/src/Codeception/Test/Feature/AssertionCounter.php
@@ -1,30 +1,36 @@
 <?php
 namespace Codeception\Test\Feature;
 
+use PHPUnit\Framework\Assert;
+
 trait AssertionCounter
 {
+    /**
+     * @var int
+     */
     protected $numAssertions = 0;
 
-    public function getNumAssertions()
+    public function getNumAssertions(): int
     {
         return $this->numAssertions;
     }
+
     /**
      * This method is not covered by the backward compatibility promise
      * for PHPUnit, but is nice to have for extensions.
      */
-    public function addToAssertionCount($count)
+    public function addToAssertionCount(int $count): void
     {
         $this->numAssertions += $count;
     }
 
-    protected function assertionCounterStart()
+    protected function assertionCounterStart(): void
     {
-        \PHPUnit\Framework\Assert::resetCount();
+        Assert::resetCount();
     }
 
-    protected function assertionCounterEnd()
+    protected function assertionCounterEnd(): void
     {
-        $this->numAssertions = \PHPUnit\Framework\Assert::getCount();
+        $this->numAssertions = Assert::getCount();
     }
 }

--- a/src/Codeception/Test/Feature/CodeCoverage.php
+++ b/src/Codeception/Test/Feature/CodeCoverage.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Codeception\Test\Feature;
 
 use Codeception\Test\Descriptor;

--- a/src/Codeception/Test/Feature/CodeCoverage.php
+++ b/src/Codeception/Test/Feature/CodeCoverage.php
@@ -3,15 +3,15 @@ namespace Codeception\Test\Feature;
 
 use Codeception\Test\Descriptor;
 use Codeception\Test\Interfaces\StrictCoverage;
+use Codeception\Test\Test as CodeceptTest;
+use PHP_CodeCoverage_Exception;
+use PHPUnit\Framework\TestResult;
 
 trait CodeCoverage
 {
-    /**
-     * @return \PHPUnit\Framework\TestResult
-     */
-    abstract public function getTestResultObject();
+    abstract public function getTestResultObject(): TestResult;
 
-    public function codeCoverageStart()
+    public function codeCoverageStart(): void
     {
         $codeCoverage = $this->getTestResultObject()->getCodeCoverage();
         if (!$codeCoverage) {
@@ -20,7 +20,7 @@ trait CodeCoverage
         $codeCoverage->start(Descriptor::getTestSignature($this));
     }
 
-    public function codeCoverageEnd($status, $time)
+    public function codeCoverageEnd(string $status, float $time): void
     {
         $codeCoverage = $this->getTestResultObject()->getCodeCoverage();
         if (!$codeCoverage) {
@@ -37,9 +37,9 @@ trait CodeCoverage
 
         try {
             $codeCoverage->stop(true, $linesToBeCovered, $linesToBeUsed);
-        } catch (\PHP_CodeCoverage_Exception $cce) {
-            if ($status === \Codeception\Test\Test::STATUS_OK) {
-                $this->getTestResultObject()->addError($this, $cce, $time);
+        } catch (PHP_CodeCoverage_Exception $exception) {
+            if ($status === CodeceptTest::STATUS_OK) {
+                $this->getTestResultObject()->addError($this, $exception, $time);
             }
         }
     }

--- a/src/Codeception/Test/Feature/ErrorLogger.php
+++ b/src/Codeception/Test/Feature/ErrorLogger.php
@@ -1,25 +1,24 @@
 <?php
 namespace Codeception\Test\Feature;
 
-use Codeception\Test\Test as CodeceptionTest;
+use Codeception\Test\Test as CodeceptTest;
+use PHPUnit\Framework\TestResult;
+use Throwable;
 
 trait ErrorLogger
 {
-    /**
-     * @return \PHPUnit\Framework\TestResult
-     */
-    abstract public function getTestResultObject();
+    abstract public function getTestResultObject(): TestResult;
 
-    public function errorLoggerEnd($status, $time, $exception = null)
+    public function errorLoggerEnd(string $status, float $time, Throwable $exception = null): void
     {
         if (!$exception) {
             return;
         }
 
-        if ($status === CodeceptionTest::STATUS_ERROR) {
+        if ($status === CodeceptTest::STATUS_ERROR) {
              $this->getTestResultObject()->addError($this, $exception, $time);
         }
-        if ($status === CodeceptionTest::STATUS_FAIL) {
+        if ($status === CodeceptTest::STATUS_FAIL) {
             $this->getTestResultObject()->addFailure($this, $exception, $time);
         }
     }

--- a/src/Codeception/Test/Feature/ErrorLogger.php
+++ b/src/Codeception/Test/Feature/ErrorLogger.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Codeception\Test\Feature;
 
 use Codeception\Test\Test as CodeceptTest;

--- a/src/Codeception/Test/Feature/IgnoreIfMetadataBlocked.php
+++ b/src/Codeception/Test/Feature/IgnoreIfMetadataBlocked.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Codeception\Test\Feature;
 
 use Codeception\Test\Metadata;

--- a/src/Codeception/Test/Feature/IgnoreIfMetadataBlocked.php
+++ b/src/Codeception/Test/Feature/IgnoreIfMetadataBlocked.php
@@ -2,22 +2,19 @@
 namespace Codeception\Test\Feature;
 
 use Codeception\Test\Metadata;
+use PHPUnit\Framework\IncompleteTestError;
+use PHPUnit\Framework\SkippedTestError;
+use PHPUnit\Framework\TestResult;
 
 trait IgnoreIfMetadataBlocked
 {
-    /**
-     * @return Metadata
-     */
-    abstract public function getMetadata();
+    abstract public function getMetadata(): Metadata;
 
-    abstract protected function ignore($ignored);
+    abstract protected function ignore(bool $ignored);
 
-    /**
-     * @return \PHPUnit\Framework\TestResult
-     */
-    abstract protected function getTestResultObject();
+    abstract protected function getTestResultObject(): TestResult;
 
-    protected function ignoreIfMetadataBlockedStart()
+    protected function ignoreIfMetadataBlockedStart(): void
     {
         if (!$this->getMetadata()->isBlocked()) {
             return;
@@ -26,11 +23,13 @@ trait IgnoreIfMetadataBlocked
         $this->ignore(true);
 
         if ($this->getMetadata()->getSkip() !== null) {
-            $this->getTestResultObject()->addFailure($this, new \PHPUnit\Framework\SkippedTestError((string)$this->getMetadata()->getSkip()), 0);
+            $skippedTestError = new SkippedTestError((string)$this->getMetadata()->getSkip());
+            $this->getTestResultObject()->addFailure($this, $skippedTestError, 0);
             return;
         }
         if ($this->getMetadata()->getIncomplete() !== null) {
-            $this->getTestResultObject()->addFailure($this, new \PHPUnit\Framework\IncompleteTestError((string)$this->getMetadata()->getIncomplete()), 0);
+            $incompleteTestError = new IncompleteTestError((string)$this->getMetadata()->getIncomplete());
+            $this->getTestResultObject()->addFailure($this, $incompleteTestError, 0);
             return;
         }
     }

--- a/src/Codeception/Test/Feature/IgnoreIfMetadataBlocked.php
+++ b/src/Codeception/Test/Feature/IgnoreIfMetadataBlocked.php
@@ -13,7 +13,7 @@ trait IgnoreIfMetadataBlocked
 {
     abstract public function getMetadata(): Metadata;
 
-    abstract protected function ignore(bool $ignored);
+    abstract protected function ignore(bool $ignored): void;
 
     abstract protected function getTestResultObject(): TestResult;
 

--- a/src/Codeception/Test/Feature/MetadataCollector.php
+++ b/src/Codeception/Test/Feature/MetadataCollector.php
@@ -10,12 +10,12 @@ trait MetadataCollector
      */
     private $metadata;
 
-    protected function setMetadata(Metadata $metadata)
+    protected function setMetadata(Metadata $metadata): void
     {
         $this->metadata = $metadata;
     }
 
-    public function getMetadata()
+    public function getMetadata(): Metadata
     {
         return $this->metadata;
     }

--- a/src/Codeception/Test/Feature/MetadataCollector.php
+++ b/src/Codeception/Test/Feature/MetadataCollector.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Codeception\Test\Feature;
 
 use Codeception\Test\Metadata;

--- a/src/Codeception/Test/Feature/MetadataCollector.php
+++ b/src/Codeception/Test/Feature/MetadataCollector.php
@@ -28,7 +28,7 @@ trait MetadataCollector
         return $this->getMetadata()->getName();
     }
 
-    public function getFileName()
+    public function getFileName(): string
     {
         return $this->getMetadata()->getFilename();
     }

--- a/src/Codeception/Test/Feature/ScenarioLoader.php
+++ b/src/Codeception/Test/Feature/ScenarioLoader.php
@@ -27,7 +27,7 @@ trait ScenarioLoader
         return $this->scenario;
     }
 
-    public function getFeature()
+    public function getFeature(): string
     {
         return $this->getScenario()->getFeature();
     }
@@ -44,5 +44,5 @@ trait ScenarioLoader
     }
 
     abstract protected function getParser(): Parser;
-    abstract public function getSourceCode();
+    abstract public function getSourceCode(): string;
 }

--- a/src/Codeception/Test/Feature/ScenarioLoader.php
+++ b/src/Codeception/Test/Feature/ScenarioLoader.php
@@ -12,20 +12,14 @@ trait ScenarioLoader
      */
     private $scenario;
 
-    /**
-     * @return Metadata
-     */
-    abstract public function getMetadata();
+    abstract public function getMetadata(): Metadata;
 
-    protected function createScenario()
+    protected function createScenario(): void
     {
         $this->scenario = new Scenario($this);
     }
 
-    /**
-     * @return Scenario
-     */
-    public function getScenario()
+    public function getScenario(): Scenario
     {
         return $this->scenario;
     }
@@ -35,7 +29,7 @@ trait ScenarioLoader
         return $this->getScenario()->getFeature();
     }
 
-    public function getScenarioText($format = 'text')
+    public function getScenarioText(string $format = 'text'): string
     {
         $code = $this->getSourceCode();
         $this->getParser()->parseFeature($code);
@@ -46,9 +40,6 @@ trait ScenarioLoader
         return $this->getScenario()->getText();
     }
 
-    /**
-     * @return Parser
-     */
-    abstract protected function getParser();
+    abstract protected function getParser(): Parser;
     abstract public function getSourceCode();
 }

--- a/src/Codeception/Test/Feature/ScenarioLoader.php
+++ b/src/Codeception/Test/Feature/ScenarioLoader.php
@@ -27,7 +27,7 @@ trait ScenarioLoader
         return $this->scenario;
     }
 
-    public function getFeature(): string
+    public function getFeature(): ?string
     {
         return $this->getScenario()->getFeature();
     }

--- a/src/Codeception/Test/Feature/ScenarioLoader.php
+++ b/src/Codeception/Test/Feature/ScenarioLoader.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Codeception\Test\Feature;
 
 use Codeception\Lib\Parser;

--- a/src/Codeception/Test/Gherkin.php
+++ b/src/Codeception/Test/Gherkin.php
@@ -216,12 +216,12 @@ class Gherkin extends Test implements ScenarioDriven, Reported
         return $this->getFeature() . ': ' . $this->getScenarioTitle();
     }
 
-    public function getFeature(): string
+    public function getFeature(): ?string
     {
         return $this->getMetadata()->getFeature();
     }
 
-    public function getScenarioTitle()
+    public function getScenarioTitle(): string
     {
         return $this->getMetadata()->getName();
     }

--- a/src/Codeception/Test/Gherkin.php
+++ b/src/Codeception/Test/Gherkin.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Codeception\Test;
 
 use Behat\Gherkin\Node\FeatureNode;
@@ -48,7 +51,7 @@ class Gherkin extends Test implements ScenarioDriven, Reported
      */
     protected $scenario;
 
-    public function __construct(FeatureNode $featureNode, ScenarioInterface $scenarioNode, $steps = [])
+    public function __construct(FeatureNode $featureNode, ScenarioInterface $scenarioNode, array $steps = [])
     {
         $this->featureNode = $featureNode;
         $this->scenarioNode = $scenarioNode;

--- a/src/Codeception/Test/Gherkin.php
+++ b/src/Codeception/Test/Gherkin.php
@@ -16,6 +16,7 @@ use Codeception\Step\Comment;
 use Codeception\Step\Meta;
 use Codeception\Test\Interfaces\Reported;
 use Codeception\Test\Interfaces\ScenarioDriven;
+use Exception;
 use function array_merge;
 use function array_pop;
 use function array_shift;
@@ -215,7 +216,7 @@ class Gherkin extends Test implements ScenarioDriven, Reported
         return $this->getFeature() . ': ' . $this->getScenarioTitle();
     }
 
-    public function getFeature()
+    public function getFeature(): string
     {
         return $this->getMetadata()->getFeature();
     }
@@ -230,17 +231,18 @@ class Gherkin extends Test implements ScenarioDriven, Reported
         return $this->scenario;
     }
 
-    /**
-     * @param string $format
-     * @return string|false
-     */
-    public function getScenarioText(string $format = 'text')
+    public function getScenarioText(string $format = 'text'): string
     {
-        return file_get_contents($this->getFileName());
+        $fileName = $this->getFileName();
+        if (!$scenarioText = file_get_contents($fileName)) {
+            throw new Exception("Could not get scenario {$fileName}, please check its permissions.");
+        }
+        return $scenarioText;
     }
 
-    public function getSourceCode(): void
+    public function getSourceCode(): string
     {
+        return '';
     }
 
     public function getScenarioNode(): ScenarioNode

--- a/src/Codeception/Test/Interfaces/Dependent.php
+++ b/src/Codeception/Test/Interfaces/Dependent.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Codeception\Test\Interfaces;
 
 interface Dependent

--- a/src/Codeception/Test/Interfaces/Descriptive.php
+++ b/src/Codeception/Test/Interfaces/Descriptive.php
@@ -1,7 +1,9 @@
 <?php
 namespace Codeception\Test\Interfaces;
 
-interface Descriptive extends \PHPUnit\Framework\SelfDescribing
+use PHPUnit\Framework\SelfDescribing;
+
+interface Descriptive extends SelfDescribing
 {
     public function getFileName();
 

--- a/src/Codeception/Test/Interfaces/Descriptive.php
+++ b/src/Codeception/Test/Interfaces/Descriptive.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Codeception\Test\Interfaces;
 
 use PHPUnit\Framework\SelfDescribing;

--- a/src/Codeception/Test/Interfaces/Descriptive.php
+++ b/src/Codeception/Test/Interfaces/Descriptive.php
@@ -6,7 +6,7 @@ use PHPUnit\Framework\SelfDescribing;
 
 interface Descriptive extends SelfDescribing
 {
-    public function getFileName();
+    public function getFileName(): string;
 
-    public function getSignature();
+    public function getSignature(): string;
 }

--- a/src/Codeception/Test/Interfaces/Plain.php
+++ b/src/Codeception/Test/Interfaces/Plain.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Codeception\Test\Interfaces;
 
 /**

--- a/src/Codeception/Test/Interfaces/Reported.php
+++ b/src/Codeception/Test/Interfaces/Reported.php
@@ -5,8 +5,6 @@ interface Reported
 {
     /**
      * Field values for XML/JSON/TAP reports
-     *
-     * @return array
      */
-    public function getReportFields();
+    public function getReportFields(): array;
 }

--- a/src/Codeception/Test/Interfaces/Reported.php
+++ b/src/Codeception/Test/Interfaces/Reported.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Codeception\Test\Interfaces;
 
 interface Reported

--- a/src/Codeception/Test/Interfaces/ScenarioDriven.php
+++ b/src/Codeception/Test/Interfaces/ScenarioDriven.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Codeception\Test\Interfaces;
 
 use Codeception\Scenario;

--- a/src/Codeception/Test/Interfaces/ScenarioDriven.php
+++ b/src/Codeception/Test/Interfaces/ScenarioDriven.php
@@ -6,13 +6,13 @@ use Codeception\Scenario;
 
 interface ScenarioDriven
 {
-    public function getFeature();
+    public function getFeature(): string;
 
     public function getScenario(): Scenario;
 
-    public function getScenarioText(string $format = 'text');
+    public function getScenarioText(string $format = 'text'): string;
 
-    public function preload();
+    public function preload(): void;
 
-    public function getSourceCode();
+    public function getSourceCode(): string;
 }

--- a/src/Codeception/Test/Interfaces/ScenarioDriven.php
+++ b/src/Codeception/Test/Interfaces/ScenarioDriven.php
@@ -1,16 +1,15 @@
 <?php
 namespace Codeception\Test\Interfaces;
 
+use Codeception\Scenario;
+
 interface ScenarioDriven
 {
     public function getFeature();
 
-    /**
-     * @return \Codeception\Scenario
-     */
-    public function getScenario();
+    public function getScenario(): Scenario;
 
-    public function getScenarioText($format = 'text');
+    public function getScenarioText(string $format = 'text');
 
     public function preload();
 

--- a/src/Codeception/Test/Interfaces/ScenarioDriven.php
+++ b/src/Codeception/Test/Interfaces/ScenarioDriven.php
@@ -6,7 +6,7 @@ use Codeception\Scenario;
 
 interface ScenarioDriven
 {
-    public function getFeature(): string;
+    public function getFeature(): ?string;
 
     public function getScenario(): Scenario;
 

--- a/src/Codeception/Test/Loader.php
+++ b/src/Codeception/Test/Loader.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Codeception\Test;
 
 use Codeception\Test\Loader\Cept as CeptLoader;

--- a/src/Codeception/Test/Loader.php
+++ b/src/Codeception/Test/Loader.php
@@ -7,6 +7,7 @@ namespace Codeception\Test;
 use Codeception\Test\Loader\Cept as CeptLoader;
 use Codeception\Test\Loader\Cest as CestLoader;
 use Codeception\Test\Loader\Gherkin as GherkinLoader;
+use Codeception\Test\Loader\LoaderInterface;
 use Codeception\Test\Loader\Unit as UnitLoader;
 use Exception;
 use Symfony\Component\Finder\Finder;
@@ -50,13 +51,16 @@ use function substr;
 class Loader
 {
     /**
-     * @var Cept[]|Cest[]|Gherkin[]|Unit[]
+     * @var LoaderInterface[]
      */
     protected $formats = [];
     /**
      * @var array
      */
     protected $tests = [];
+    /**
+     * @var string
+     */
     protected $path;
 
     public function __construct(array $suiteSettings)

--- a/src/Codeception/Test/Loader/Cept.php
+++ b/src/Codeception/Test/Loader/Cept.php
@@ -1,27 +1,33 @@
 <?php
 namespace Codeception\Test\Loader;
 
-use Codeception\Lib\Parser;
 use Codeception\Test\Cept as CeptFormat;
+use function basename;
 
 class Cept implements LoaderInterface
 {
+    /**
+     * @var CeptFormat[]
+     */
     protected $tests = [];
 
-    public function getPattern()
+    public function getPattern(): string
     {
         return '~Cept\.php$~';
     }
 
-    function loadTests($file)
+    function loadTests(string $filename): void
     {
-        $name = basename($file, 'Cept.php');
+        $name = basename($filename, 'Cept.php');
 
-        $cept = new CeptFormat($name, $file);
+        $cept = new CeptFormat($name, $filename);
         $this->tests[] = $cept;
     }
 
-    public function getTests()
+    /**
+     * @return CeptFormat[]
+     */
+    public function getTests(): array
     {
         return $this->tests;
     }

--- a/src/Codeception/Test/Loader/Cept.php
+++ b/src/Codeception/Test/Loader/Cept.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Codeception\Test\Loader;
 
 use Codeception\Test\Cept as CeptFormat;
@@ -16,7 +19,7 @@ class Cept implements LoaderInterface
         return '~Cept\.php$~';
     }
 
-    function loadTests(string $filename): void
+    public function loadTests(string $filename): void
     {
         $name = basename($filename, 'Cept.php');
 

--- a/src/Codeception/Test/Loader/Cest.php
+++ b/src/Codeception/Test/Loader/Cest.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Codeception\Test\Loader;
 
 use Codeception\Exception\TestParseException;

--- a/src/Codeception/Test/Loader/Gherkin.php
+++ b/src/Codeception/Test/Loader/Gherkin.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Codeception\Test\Loader;
 
 use Behat\Gherkin\Filter\RoleFilter;

--- a/src/Codeception/Test/Loader/Gherkin.php
+++ b/src/Codeception/Test/Loader/Gherkin.php
@@ -14,9 +14,29 @@ use Codeception\Exception\ParseException;
 use Codeception\Exception\TestParseException;
 use Codeception\Test\Gherkin as GherkinFormat;
 use Codeception\Util\Annotation;
+use ReflectionClass;
+use function array_keys;
+use function array_map;
+use function array_merge;
+use function class_exists;
+use function dirname;
+use function file_get_contents;
+use function get_class_methods;
+use function glob;
+use function implode;
+use function preg_match;
+use function preg_quote;
+use function preg_replace;
+use function rtrim;
+use function sprintf;
+use function str_replace;
+use function strpos;
 
 class Gherkin implements LoaderInterface
 {
+    /**
+     * @var array
+     */
     protected static $defaultSettings = [
         'namespace' => '',
         'actor' => '',
@@ -29,6 +49,9 @@ class Gherkin implements LoaderInterface
         ]
     ];
 
+    /**
+     * @var GherkinFormat[]
+     */
     protected $tests = [];
 
     /**
@@ -36,8 +59,14 @@ class Gherkin implements LoaderInterface
      */
     protected $parser;
 
+    /**
+     * @var array
+     */
     protected $settings = [];
 
+    /**
+     * @var array
+     */
     protected $steps = [];
 
     public function __construct($settings = [])
@@ -46,7 +75,7 @@ class Gherkin implements LoaderInterface
         if (!class_exists('Behat\Gherkin\Keywords\ArrayKeywords')) {
             throw new TestParseException('Feature file can only be parsed with Behat\Gherkin library. Please install `behat/gherkin` with Composer');
         }
-        $gherkin = new \ReflectionClass('Behat\Gherkin\Gherkin');
+        $gherkin = new ReflectionClass(\Behat\Gherkin\Gherkin::class);
         $gherkinClassPath = dirname($gherkin->getFileName());
         $i18n = require $gherkinClassPath . '/../../../i18n.php';
         $keywords = new GherkinKeywords($i18n);
@@ -55,15 +84,15 @@ class Gherkin implements LoaderInterface
         $this->fetchGherkinSteps();
     }
 
-    protected function fetchGherkinSteps()
+    protected function fetchGherkinSteps(): void
     {
         $contexts = $this->settings['gherkin']['contexts'];
 
         foreach ($contexts['tag'] as $tag => $tagContexts) {
-            $this->addSteps($tagContexts, "tag:$tag");
+            $this->addSteps($tagContexts, "tag:{$tag}");
         }
         foreach ($contexts['role'] as $role => $roleContexts) {
-            $this->addSteps($roleContexts, "role:$role");
+            $this->addSteps($roleContexts, "role:{$role}");
         }
 
         if (empty($this->steps) && empty($contexts['default']) && $this->settings['actor']) { // if no context is set, actor to be a context
@@ -88,13 +117,13 @@ class Gherkin implements LoaderInterface
                 return $namespace . $path;
             }, $files);
 
-            $this->addSteps($dynamicContexts, 'default');
+            $this->addSteps($dynamicContexts);
         }
 
         $this->addSteps($contexts['default']);
     }
 
-    protected function addSteps(array $contexts, $group = 'default')
+    protected function addSteps(array $contexts, string $group = 'default'): void
     {
         if (!isset($this->steps[$group])) {
             $this->steps[$group] = [];
@@ -102,7 +131,7 @@ class Gherkin implements LoaderInterface
 
         foreach ($contexts as $context) {
             $methods = get_class_methods($context);
-            if (!$methods) {
+            if ($methods === []) {
                 continue;
             }
             foreach ($methods as $method) {
@@ -122,7 +151,7 @@ class Gherkin implements LoaderInterface
         }
     }
 
-    public function makePlaceholderPattern($pattern)
+    public function makePlaceholderPattern(string $pattern): string
     {
         if (isset($this->settings['describe_steps'])) {
             return $pattern;
@@ -141,27 +170,27 @@ class Gherkin implements LoaderInterface
 
             // params converting from :param to match 11 and "aaa" and "aaa\"aaa"
             $pattern = preg_replace('~"?\\\:(\w+)"?~', $replacePattern, $pattern);
-            $pattern = "/^$pattern$/u";
+            $pattern = "/^{$pattern}$/u";
             // validating this pattern is slow, so we skip it now
         }
         return $pattern;
     }
 
-    private function validatePattern($pattern)
+    private function validatePattern($pattern): void
     {
         if (strpos($pattern, '/') !== 0) {
             return; // not a user-regex but a string with placeholder
         }
         if (@preg_match($pattern, ' ') === false) {
-            throw new ParseException("Loading Gherkin step with regex\n \n$pattern\n \nfailed. This regular expression is invalid.");
+            throw new ParseException("Loading Gherkin step with regex\n \n{$pattern}\n \nfailed. This regular expression is invalid.");
         }
     }
 
-    public function loadTests($filename)
+    public function loadTests(string $filename): void
     {
         $featureNode = $this->parser->parse(file_get_contents($filename), $filename);
 
-        if (!$featureNode) {
+        if ($featureNode === null) {
             return;
         }
 
@@ -170,16 +199,16 @@ class Gherkin implements LoaderInterface
             $steps = $this->steps['default']; // load default context
 
             foreach (array_merge($scenarioNode->getTags(), $featureNode->getTags()) as $tag) { // load tag contexts
-                if (isset($this->steps["tag:$tag"])) {
-                    $steps = array_merge($steps, $this->steps["tag:$tag"]);
+                if (isset($this->steps["tag:{$tag}"])) {
+                    $steps = array_merge($steps, $this->steps["tag:{$tag}"]);
                 }
             }
 
             $roles = $this->settings['gherkin']['contexts']['role']; // load role contexts
-            foreach ($roles as $role => $context) {
+            foreach (array_keys($roles) as $role) {
                 $filter = new RoleFilter($role);
                 if ($filter->isFeatureMatch($featureNode)) {
-                    $steps = array_merge($steps, $this->steps["role:$role"]);
+                    $steps = array_merge($steps, $this->steps["role:{$role}"]);
                     break;
                 }
             }
@@ -188,7 +217,13 @@ class Gherkin implements LoaderInterface
                 foreach ($scenarioNode->getExamples() as $example) {
                     /** @var $example ExampleNode  **/
                     $params = implode(', ', $example->getTokens());
-                    $exampleNode = new ScenarioNode($scenarioNode->getTitle() . " | $params", $scenarioNode->getTags(), $example->getSteps(), $example->getKeyword(), $example->getLine());
+                    $exampleNode = new ScenarioNode(
+                        $scenarioNode->getTitle() . " | {$params}",
+                        $scenarioNode->getTags(),
+                        $example->getSteps(),
+                        $example->getKeyword(),
+                        $example->getLine()
+                    );
                     $this->tests[] = new GherkinFormat($featureNode, $exampleNode, $steps);
                 }
                 continue;
@@ -197,20 +232,20 @@ class Gherkin implements LoaderInterface
         }
     }
 
-    public function getTests()
+    /**
+     * @return GherkinFormat[]
+     */
+    public function getTests(): array
     {
         return $this->tests;
     }
 
-    public function getPattern()
+    public function getPattern(): string
     {
         return '~\.feature$~';
     }
 
-    /**
-     * @return array
-     */
-    public function getSteps()
+    public function getSteps(): array
     {
         return $this->steps;
     }

--- a/src/Codeception/Test/Loader/LoaderInterface.php
+++ b/src/Codeception/Test/Loader/LoaderInterface.php
@@ -4,9 +4,9 @@ namespace Codeception\Test\Loader;
 
 interface LoaderInterface
 {
-    public function loadTests(string $filename);
+    public function loadTests(string $filename): void;
 
-    public function getTests();
+    public function getTests(): array;
 
-    public function getPattern();
+    public function getPattern(): string;
 }

--- a/src/Codeception/Test/Loader/LoaderInterface.php
+++ b/src/Codeception/Test/Loader/LoaderInterface.php
@@ -3,7 +3,7 @@ namespace Codeception\Test\Loader;
 
 interface LoaderInterface
 {
-    public function loadTests($filename);
+    public function loadTests(string $filename);
 
     public function getTests();
 

--- a/src/Codeception/Test/Loader/LoaderInterface.php
+++ b/src/Codeception/Test/Loader/LoaderInterface.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Codeception\Test\Loader;
 
 interface LoaderInterface

--- a/src/Codeception/Test/Loader/Unit.php
+++ b/src/Codeception/Test/Loader/Unit.php
@@ -9,7 +9,7 @@ use Codeception\Test\Descriptor;
 use Codeception\Test\Unit as UnitFormat;
 use Codeception\Util\Annotation;
 use PHPUnit\Framework\DataProviderTestSuite;
-use PHPUnit\Framework\Test;
+use PHPUnit\Framework\Test as PHPUnitTest;
 use PHPUnit\Framework\TestBuilder;
 use ReflectionClass;
 use ReflectionMethod;
@@ -71,7 +71,7 @@ class Unit implements LoaderInterface
         return $test;
     }
 
-    protected function enhancePhpunitTest(Test $test): void
+    protected function enhancePhpunitTest(PHPUnitTest $test): void
     {
         $className = get_class($test);
         $methodName = $test->getName(false);

--- a/src/Codeception/Test/Loader/Unit.php
+++ b/src/Codeception/Test/Loader/Unit.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Codeception\Test\Loader;
 
 use Codeception\Lib\Parser;
@@ -75,7 +78,8 @@ class Unit implements LoaderInterface
         $dependencies = \PHPUnit\Util\Test::getDependencies($className, $methodName);
         $test->setDependencies($dependencies);
         if ($test instanceof UnitFormat) {
-            $test->getMetadata()->setParamsFromAnnotations(Annotation::forMethod($test, $methodName)->raw());
+            $annotations = Annotation::forMethod($test, $methodName)->raw();
+            $test->getMetadata()->setParamsFromAnnotations($annotations);
             $test->getMetadata()->setFilename(Descriptor::getTestFileName($test));
         }
     }

--- a/src/Codeception/Test/Loader/Unit.php
+++ b/src/Codeception/Test/Loader/Unit.php
@@ -5,28 +5,37 @@ use Codeception\Lib\Parser;
 use Codeception\Test\Descriptor;
 use Codeception\Test\Unit as UnitFormat;
 use Codeception\Util\Annotation;
+use PHPUnit\Framework\DataProviderTestSuite;
+use PHPUnit\Framework\Test;
+use PHPUnit\Framework\TestBuilder;
+use ReflectionClass;
+use ReflectionMethod;
+use function get_class;
 
 class Unit implements LoaderInterface
 {
+    /**
+     * @var array
+     */
     protected $tests = [];
 
-    public function getPattern()
+    public function getPattern(): string
     {
         return '~Test\.php$~';
     }
 
-    public function loadTests($path)
+    public function loadTests(string $filename): void
     {
-        Parser::load($path);
-        $testClasses = Parser::getClassesFromFile($path);
+        Parser::load($filename);
+        $testClasses = Parser::getClassesFromFile($filename);
 
         foreach ($testClasses as $testClass) {
-            $reflected = new \ReflectionClass($testClass);
+            $reflected = new ReflectionClass($testClass);
             if (!$reflected->isInstantiable()) {
                 continue;
             }
 
-            foreach ($reflected->getMethods(\ReflectionMethod::IS_PUBLIC) as $method) {
+            foreach ($reflected->getMethods(ReflectionMethod::IS_PUBLIC) as $method) {
                 $test = $this->createTestFromPhpUnitMethod($reflected, $method);
                 if (!$test) {
                     continue;
@@ -36,19 +45,19 @@ class Unit implements LoaderInterface
         }
     }
 
-    public function getTests()
+    public function getTests(): array
     {
         return $this->tests;
     }
 
-    protected function createTestFromPhpUnitMethod(\ReflectionClass $class, \ReflectionMethod $method)
+    protected function createTestFromPhpUnitMethod(ReflectionClass $class, ReflectionMethod $method)
     {
         if (!\PHPUnit\Util\Test::isTestMethod($method)) {
-            return;
+            return null;
         }
-        $test = (new \PHPUnit\Framework\TestBuilder)->build($class, $method->name);
+        $test = (new TestBuilder)->build($class, $method->name);
 
-        if ($test instanceof \PHPUnit\Framework\DataProviderTestSuite) {
+        if ($test instanceof DataProviderTestSuite) {
             foreach ($test->tests() as $t) {
                 $this->enhancePhpunitTest($t);
             }
@@ -59,7 +68,7 @@ class Unit implements LoaderInterface
         return $test;
     }
 
-    protected function enhancePhpunitTest(\PHPUnit\Framework\Test $test)
+    protected function enhancePhpunitTest(Test $test): void
     {
         $className = get_class($test);
         $methodName = $test->getName(false);

--- a/src/Codeception/Test/Metadata.php
+++ b/src/Codeception/Test/Metadata.php
@@ -3,6 +3,9 @@ namespace Codeception\Test;
 
 use Codeception\Exception\InjectionException;
 use Codeception\Util\Annotation;
+use function array_merge;
+use function array_merge_recursive;
+use function array_unique;
 
 class Metadata
 {
@@ -11,6 +14,9 @@ class Metadata
     protected $feature;
     protected $index;
 
+    /**
+     * @var array
+     */
     protected $params = [
         'env' => [],
         'group' => [],
@@ -19,71 +25,59 @@ class Metadata
         'incomplete' => null
     ];
 
+    /**
+     * @var array
+     */
     protected $current = [];
+    /**
+     * @var array
+     */
     protected $services = [];
+    /**
+     * @var array
+     */
     protected $reports = [];
 
-    /**
-     * @return mixed
-     */
     public function getEnv()
     {
         return $this->params['env'];
     }
 
-    /**
-     * @return array
-     */
-    public function getGroups()
+    public function getGroups(): array
     {
         return array_unique($this->params['group']);
     }
 
-    /**
-     * @param mixed $groups
-     */
-    public function setGroups($groups)
+    public function setGroups($groups): void
     {
         $this->params['group'] = array_merge($this->params['group'], $groups);
     }
 
-    /**
-     * @return mixed
-     */
     public function getSkip()
     {
         return $this->params['skip'];
     }
 
-    /**
-     * @param mixed $skip
-     */
-    public function setSkip($skip)
+    public function setSkip($skip): void
     {
         $this->params['skip'] = $skip;
     }
 
-    /**
-     * @return mixed
-     */
     public function getIncomplete()
     {
         return $this->params['incomplete'];
     }
 
-    /**
-     * @param mixed $incomplete
-     */
-    public function setIncomplete($incomplete)
+    public function setIncomplete($incomplete): void
     {
         $this->params['incomplete'] = $incomplete;
     }
 
     /**
      * @param string|null $key
-     * @return mixed
+     * @return string|array|null
      */
-    public function getCurrent($key = null)
+    public function getCurrent(?string $key = null)
     {
         if ($key) {
             if (isset($this->current[$key])) {
@@ -98,123 +92,83 @@ class Metadata
         return $this->current;
     }
 
-    public function setCurrent(array $currents)
+    public function setCurrent(array $currents): void
     {
         $this->current = array_merge($this->current, $currents);
     }
 
-    /**
-     * @return mixed
-     */
     public function getName()
     {
         return $this->name;
     }
 
-    /**
-     * @param mixed $name
-     */
-    public function setName($name)
+    public function setName($name): void
     {
         $this->name = $name;
     }
 
-    /**
-     * @return mixed
-     */
     public function getFilename()
     {
         return $this->filename;
     }
 
-    /**
-     * @param mixed $index
-     */
-    public function setIndex($index)
+    public function setIndex($index): void
     {
         $this->index = $index;
     }
 
-    /**
-     * @return mixed
-     */
     public function getIndex()
     {
         return $this->index;
     }
 
-    /**
-     * @param mixed $filename
-     */
-    public function setFilename($filename)
+    public function setFilename($filename): void
     {
         $this->filename = $filename;
     }
 
-    /**
-     * @return array
-     */
-    public function getDependencies()
+    public function getDependencies(): array
     {
         return $this->params['depends'];
     }
 
-    public function isBlocked()
+    public function isBlocked(): bool
     {
         return $this->getSkip() !== null || $this->getIncomplete() !== null;
     }
 
-    /**
-     * @return mixed
-     */
     public function getFeature()
     {
         return $this->feature;
     }
 
-    /**
-     * @param mixed $feature
-     */
-    public function setFeature($feature)
+    public function setFeature($feature): void
     {
         $this->feature = $feature;
     }
 
-    /**
-     * @param $service
-     * @return array
-     * @throws InjectionException
-     */
-    public function getService($service)
+    public function getService($service): object
     {
         if (!isset($this->services[$service])) {
-            throw new InjectionException("Service $service is not defined and can't be accessed from a test");
+            throw new InjectionException("Service {$service} is not defined and can't be accessed from a test");
         }
         return $this->services[$service];
     }
 
-    /**
-     * @param array $services
-     */
-    public function setServices($services)
+    public function setServices(array $services): void
     {
         $this->services = $services;
     }
 
     /**
      * Returns all test reports
-     * @return array
      */
-    public function getReports()
+    public function getReports(): array
     {
         return $this->reports;
     }
 
-    /**
-     * @param $type
-     * @param $report
-     */
-    public function addReport($type, $report)
+    public function addReport($type, $report): void
     {
         $this->reports[$type] = $report;
     }
@@ -222,11 +176,8 @@ class Metadata
     /**
      * Returns test params like: env, group, skip, incomplete, etc
      * Can return by annotation or return all if no key passed
-     *
-     * @param null $key
-     * @return array|mixed|null
      */
-    public function getParam($key = null)
+    public function getParam($key = null): ?array
     {
         if ($key) {
             if (isset($this->params[$key])) {
@@ -238,10 +189,7 @@ class Metadata
         return $this->params;
     }
 
-    /**
-     * @param mixed $annotations
-     */
-    public function setParamsFromAnnotations($annotations)
+    public function setParamsFromAnnotations($annotations): void
     {
         $params = Annotation::fetchAllAnnotationsFromDocblock($annotations);
         $this->params = array_merge_recursive($this->params, $params);
@@ -252,10 +200,7 @@ class Metadata
         }
     }
 
-    /**
-     * @param $params
-     */
-    public function setParams($params)
+    public function setParams($params): void
     {
         $this->params = array_merge_recursive($this->params, $params);
     }

--- a/src/Codeception/Test/Metadata.php
+++ b/src/Codeception/Test/Metadata.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Codeception\Test;
 
 use Codeception\Exception\InjectionException;
@@ -168,7 +171,7 @@ class Metadata
         return $this->reports;
     }
 
-    public function addReport($type, $report): void
+    public function addReport(string $type, $report): void
     {
         $this->reports[$type] = $report;
     }
@@ -177,7 +180,7 @@ class Metadata
      * Returns test params like: env, group, skip, incomplete, etc
      * Can return by annotation or return all if no key passed
      */
-    public function getParam($key = null): ?array
+    public function getParam(string $key = null): ?array
     {
         if ($key) {
             if (isset($this->params[$key])) {
@@ -191,7 +194,7 @@ class Metadata
 
     public function setParamsFromAnnotations($annotations): void
     {
-        $params = Annotation::fetchAllAnnotationsFromDocblock($annotations);
+        $params = Annotation::fetchAllAnnotationsFromDocblock((string)$annotations);
         $this->params = array_merge_recursive($this->params, $params);
 
         // set singular value for some params
@@ -200,7 +203,7 @@ class Metadata
         }
     }
 
-    public function setParams($params): void
+    public function setParams(array $params): void
     {
         $this->params = array_merge_recursive($this->params, $params);
     }

--- a/src/Codeception/Test/Metadata.php
+++ b/src/Codeception/Test/Metadata.php
@@ -13,7 +13,13 @@ use function array_unique;
 class Metadata
 {
     protected $name;
+    /**
+     * @var string
+     */
     protected $filename;
+    /**
+     * @var string|null
+     */
     protected $feature;
     protected $index;
 
@@ -41,7 +47,7 @@ class Metadata
      */
     protected $reports = [];
 
-    public function getEnv()
+    public function getEnv(): array
     {
         return $this->params['env'];
     }
@@ -51,34 +57,37 @@ class Metadata
         return array_unique($this->params['group']);
     }
 
-    public function setGroups($groups): void
+    /**
+     * @param string[] $groups
+     */
+    public function setGroups(array $groups): void
     {
         $this->params['group'] = array_merge($this->params['group'], $groups);
     }
 
-    public function getSkip()
+    public function getSkip(): ?string
     {
         return $this->params['skip'];
     }
 
-    public function setSkip($skip): void
+    public function setSkip(string $skip): void
     {
         $this->params['skip'] = $skip;
     }
 
-    public function getIncomplete()
+    public function getIncomplete(): ?string
     {
         return $this->params['incomplete'];
     }
 
-    public function setIncomplete($incomplete): void
+    public function setIncomplete(string $incomplete): void
     {
         $this->params['incomplete'] = $incomplete;
     }
 
     /**
      * @param string|null $key
-     * @return string|array|null
+     * @return mixed
      */
     public function getCurrent(?string $key = null)
     {
@@ -100,17 +109,17 @@ class Metadata
         $this->current = array_merge($this->current, $currents);
     }
 
-    public function getName()
+    public function getName(): string
     {
         return $this->name;
     }
 
-    public function setName($name): void
+    public function setName(string $name): void
     {
         $this->name = $name;
     }
 
-    public function getFilename()
+    public function getFilename(): string
     {
         return $this->filename;
     }
@@ -125,7 +134,7 @@ class Metadata
         return $this->index;
     }
 
-    public function setFilename($filename): void
+    public function setFilename(string $filename): void
     {
         $this->filename = $filename;
     }
@@ -140,17 +149,17 @@ class Metadata
         return $this->getSkip() !== null || $this->getIncomplete() !== null;
     }
 
-    public function getFeature()
+    public function getFeature(): ?string
     {
         return $this->feature;
     }
 
-    public function setFeature($feature): void
+    public function setFeature(?string $feature): void
     {
         $this->feature = $feature;
     }
 
-    public function getService($service): object
+    public function getService(string $service): object
     {
         if (!isset($this->services[$service])) {
             throw new InjectionException("Service {$service} is not defined and can't be accessed from a test");
@@ -179,8 +188,11 @@ class Metadata
     /**
      * Returns test params like: env, group, skip, incomplete, etc
      * Can return by annotation or return all if no key passed
+     *
+     * @param string|null $key
+     * @return mixed
      */
-    public function getParam(string $key = null): ?array
+    public function getParam(string $key = null)
     {
         if ($key) {
             if (isset($this->params[$key])) {

--- a/src/Codeception/Test/Metadata.php
+++ b/src/Codeception/Test/Metadata.php
@@ -12,6 +12,9 @@ use function array_unique;
 
 class Metadata
 {
+    /**
+     * @var string
+     */
     protected $name;
     /**
      * @var string

--- a/src/Codeception/Test/Test.php
+++ b/src/Codeception/Test/Test.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Codeception\Test;
 
 use Codeception\TestInterface;

--- a/src/Codeception/Test/Test.php
+++ b/src/Codeception/Test/Test.php
@@ -3,8 +3,16 @@ namespace Codeception\Test;
 
 use Codeception\TestInterface;
 use Codeception\Util\ReflectionHelper;
+use PHPUnit\Framework\AssertionFailedError;
+use PHPUnit\Framework\Exception;
+use PHPUnit\Framework\ExceptionWrapper;
+use PHPUnit\Framework\TestResult;
 use SebastianBergmann\Timer\Duration;
 use SebastianBergmann\Timer\Timer;
+use Throwable;
+use function array_reverse;
+use function class_exists;
+use function method_exists;
 
 /**
  * The most simple testcase (with only one test in it) which can be executed by PHPUnit/Codeception.
@@ -24,7 +32,13 @@ abstract class Test implements TestInterface, Interfaces\Descriptive
     use Feature\MetadataCollector;
     use Feature\IgnoreIfMetadataBlocked;
 
+    /**
+     * @var TestResult|null
+     */
     private $testResult;
+    /**
+     * @var bool
+     */
     private $ignored = false;
 
     /**
@@ -39,9 +53,21 @@ abstract class Test implements TestInterface, Interfaces\Descriptive
       'errorLogger'
     ];
 
+    /**
+     * @var string
+     */
     const STATUS_FAIL = 'fail';
+    /**
+     * @var string
+     */
     const STATUS_ERROR = 'error';
+    /**
+     * @var string
+     */
     const STATUS_OK = 'ok';
+    /**
+     * @var string
+     */
     const STATUS_PENDING = 'pending';
 
     /**
@@ -61,11 +87,8 @@ abstract class Test implements TestInterface, Interfaces\Descriptive
     /**
      * Runs a test and collects its result in a TestResult instance.
      * Executes before/after hooks coming from traits.
-     *
-     * @param  \PHPUnit\Framework\TestResult $result
-     * @return \PHPUnit\Framework\TestResult
      */
-    final public function run(\PHPUnit\Framework\TestResult $result = null): \PHPUnit\Framework\TestResult
+    final public function run(TestResult $result = null): TestResult
     {
         $this->testResult = $result;
 
@@ -97,23 +120,16 @@ abstract class Test implements TestInterface, Interfaces\Descriptive
             try {
                 $this->test();
                 $status = self::STATUS_OK;
-            } catch (\PHPUnit\Framework\AssertionFailedError $e) {
+            } catch (AssertionFailedError $assertionFailedError) {
                 $status = self::STATUS_FAIL;
-            } catch (\PHPUnit\Framework\Exception $e) {
+            } catch (Exception $exception) {
                 $status = self::STATUS_ERROR;
-            } catch (\Throwable $e) {
-                $e     = new \PHPUnit\Framework\ExceptionWrapper($e);
-                $status = self::STATUS_ERROR;
-            } catch (\Exception $e) {
-                $e     = new \PHPUnit\Framework\ExceptionWrapper($e);
+            } catch (Throwable $throwable) {
+                $throwable = new ExceptionWrapper($throwable);
                 $status = self::STATUS_ERROR;
             }
 
-            if (null !== $timer) {
-                $time = $timer->stop()->asSeconds();
-            } else {
-                $time = Timer::stop();
-            }
+            $time = null !== $timer ? $timer->stop()->asSeconds() : Timer::stop();
         }
 
         foreach (array_reverse($this->hooks) as $hook) {
@@ -126,26 +142,23 @@ abstract class Test implements TestInterface, Interfaces\Descriptive
         return $result;
     }
 
-    public function getTestResultObject()
+    public function getTestResultObject(): TestResult
     {
         return $this->testResult;
     }
 
     /**
      * This class represents exactly one test
-     * @return int
      */
-    public function count()
+    public function count(): int
     {
         return 1;
     }
 
     /**
      * Should a test be skipped (can be set from hooks)
-     *
-     * @param boolean $ignored
      */
-    protected function ignore($ignored)
+    protected function ignore(bool $ignored)
     {
         $this->ignored = $ignored;
     }

--- a/src/Codeception/Test/Test.php
+++ b/src/Codeception/Test/Test.php
@@ -10,11 +10,9 @@ use PHPUnit\Framework\AssertionFailedError;
 use PHPUnit\Framework\Exception;
 use PHPUnit\Framework\ExceptionWrapper;
 use PHPUnit\Framework\TestResult;
-use SebastianBergmann\Timer\Duration;
 use SebastianBergmann\Timer\Timer;
 use Throwable;
 use function array_reverse;
-use function class_exists;
 use function method_exists;
 
 /**
@@ -98,10 +96,7 @@ abstract class Test implements TestInterface, Interfaces\Descriptive
         $status = self::STATUS_PENDING;
         $time = 0;
         $e = null;
-        $timer = null;
-        if (class_exists(Duration::class)) {
-            $timer = new Timer();
-        }
+        $timer = new Timer();
 
         $result->startTest($this);
 
@@ -114,11 +109,7 @@ abstract class Test implements TestInterface, Interfaces\Descriptive
         $failedToStart = ReflectionHelper::readPrivateProperty($result, 'lastTestFailed');
 
         if (!$this->ignored && !$failedToStart) {
-            if (null !== $timer) {
-                $timer->start();
-            } else {
-                Timer::start();
-            }
+            $timer->start();
 
             try {
                 $this->test();
@@ -132,7 +123,7 @@ abstract class Test implements TestInterface, Interfaces\Descriptive
                 $status = self::STATUS_ERROR;
             }
 
-            $time = null !== $timer ? $timer->stop()->asSeconds() : Timer::stop();
+            $time = $timer->stop()->asSeconds();
         }
 
         foreach (array_reverse($this->hooks) as $hook) {
@@ -161,7 +152,7 @@ abstract class Test implements TestInterface, Interfaces\Descriptive
     /**
      * Should a test be skipped (can be set from hooks)
      */
-    protected function ignore(bool $ignored)
+    protected function ignore(bool $ignored): void
     {
         $this->ignored = $ignored;
     }

--- a/src/Codeception/Test/Unit.php
+++ b/src/Codeception/Test/Unit.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Codeception\Test;
 
 use Codeception\Configuration;
@@ -94,7 +97,7 @@ class Unit extends TestCase implements
     /**
      * Returns current values
      */
-    public function getCurrent($current): ?array
+    public function getCurrent(?string $current): ?array
     {
         return $this->getMetadata()->getCurrent($current);
     }

--- a/src/Codeception/Test/Unit.php
+++ b/src/Codeception/Test/Unit.php
@@ -85,7 +85,7 @@ class Unit extends TestCase implements
     {
     }
 
-    public function getModule($module): Module
+    public function getModule(string $module): Module
     {
         $modules = $this->getMetadata()->getCurrent('modules');
         if (!isset($modules[$module])) {
@@ -96,8 +96,11 @@ class Unit extends TestCase implements
 
     /**
      * Returns current values
+     *
+     * @param string|null $current
+     * @return mixed
      */
-    public function getCurrent(?string $current): ?array
+    public function getCurrent(?string $current)
     {
         return $this->getMetadata()->getCurrent($current);
     }

--- a/src/Codeception/Test/Unit.php
+++ b/src/Codeception/Test/Unit.php
@@ -4,26 +4,32 @@ namespace Codeception\Test;
 use Codeception\Configuration;
 use Codeception\Exception\ModuleException;
 use Codeception\Lib\Di;
-use Codeception\Lib\Notification;
+use Codeception\Module;
+use Codeception\PHPUnit\TestCase;
 use Codeception\Scenario;
+use Codeception\Test\Feature\Stub;
 use Codeception\TestInterface;
+use function get_class;
+use function lcfirst;
+use function method_exists;
+use function strpos;
 
 /**
  * Represents tests from PHPUnit compatible format.
  */
-class Unit extends \Codeception\PHPUnit\TestCase implements
+class Unit extends TestCase implements
     Interfaces\Reported,
     Interfaces\Dependent,
     TestInterface
 {
-    use \Codeception\Test\Feature\Stub;
+    use Stub;
 
     /**
      * @var Metadata
      */
     private $metadata;
 
-    public function getMetadata()
+    public function getMetadata(): Metadata
     {
         if (!$this->metadata) {
             $this->metadata = new Metadata();
@@ -43,7 +49,7 @@ class Unit extends \Codeception\PHPUnit\TestCase implements
             return;
         }
 
-        /** @var $di Di  **/
+        /** @var Di $di **/
         $di = $this->getMetadata()->getService('di');
         $di->set(new Scenario($this));
 
@@ -76,12 +82,7 @@ class Unit extends \Codeception\PHPUnit\TestCase implements
     {
     }
 
-    /**
-     * @param $module
-     * @return \Codeception\Module
-     * @throws ModuleException
-     */
-    public function getModule($module)
+    public function getModule($module): Module
     {
         $modules = $this->getMetadata()->getCurrent('modules');
         if (!isset($modules[$module])) {
@@ -93,15 +94,12 @@ class Unit extends \Codeception\PHPUnit\TestCase implements
     /**
      * Returns current values
      */
-    public function getCurrent($current)
+    public function getCurrent($current): ?array
     {
         return $this->getMetadata()->getCurrent($current);
     }
 
-    /**
-     * @return array
-     */
-    public function getReportFields()
+    public function getReportFields(): array
     {
         return [
             'name'    => $this->getName(),
@@ -110,12 +108,12 @@ class Unit extends \Codeception\PHPUnit\TestCase implements
         ];
     }
 
-    public function fetchDependencies()
+    public function fetchDependencies(): array
     {
         $names = [];
         foreach ($this->getMetadata()->getDependencies() as $required) {
-            if ((strpos($required, ':') === false) and method_exists($this, $required)) {
-                $required = get_class($this) . ":$required";
+            if (strpos($required, ':') === false && method_exists($this, $required)) {
+                $required = get_class($this) . ":{$required}";
             }
             $names[] = $required;
         }
@@ -124,9 +122,8 @@ class Unit extends \Codeception\PHPUnit\TestCase implements
 
     /**
      * Reset PHPUnit's dependencies
-     * @return bool
      */
-    public function handleDependencies()
+    public function handleDependencies(): bool
     {
         $dependencies = $this->fetchDependencies();
         if (empty($dependencies)) {

--- a/src/Codeception/Util/Annotation.php
+++ b/src/Codeception/Util/Annotation.php
@@ -136,6 +136,9 @@ class Annotation
         return [];
     }
 
+    /**
+     * @return string|false
+     */
     public function raw()
     {
         return $this->currentReflectedItem->getDocComment();


### PR DESCRIPTION
- [x] Use strict types in `src/Codeception/Test`.
- [x] Add type hints to Test.
- [x] Add 'use function' statements for performance reasons.
- [x] Fix naming in `src/Codeception/Test`.