### PR TITLE
Update code standards in Extensions

### DIFF
--- a/ext/DotReporter.php
+++ b/ext/DotReporter.php
@@ -43,14 +43,24 @@ class DotReporter extends Extension
      * @var Console
      */
     protected $standardReporter;
-
+    /**
+     * @var array
+     */
     protected $errors = [];
+    /**
+     * @var array
+     */
     protected $failures = [];
-
+    /**
+     * @var int
+     */
     protected $width = 10;
+    /**
+     * @var int
+     */
     protected $currentPos = 0;
 
-    public function _initialize()
+    public function _initialize(): void
     {
         $this->options['silent'] = false; // turn on printing for this extension
         $this->_reconfigure(['settings' => ['silent' => true]]); // turn off printing for everything else
@@ -58,7 +68,11 @@ class DotReporter extends Extension
         $this->width = $this->standardReporter->detectWidth();
     }
 
-    // we are listening for events
+    /**
+     * We are listening for events
+     *
+     * @var array<string, string>
+     */
     public static $events = [
         Events::SUITE_BEFORE => 'beforeSuite',
         Events::TEST_SUCCESS => 'success',
@@ -68,42 +82,42 @@ class DotReporter extends Extension
         Events::TEST_FAIL_PRINT => 'printFailed'
     ];
 
-    public function beforeSuite()
+    public function beforeSuite(): void
     {
-        $this->writeln("");
+        $this->writeln('');
     }
 
-    public function success()
+    public function success(): void
     {
         $this->printChar('.');
     }
 
-    public function fail(FailEvent $e)
+    public function fail(): void
     {
-        $this->printChar("<error>F</error>");
+        $this->printChar('<error>F</error>');
     }
 
-    public function error(FailEvent $e)
+    public function error(): void
     {
         $this->printChar('<error>E</error>');
     }
 
-    public function skipped()
+    public function skipped(): void
     {
         $this->printChar('S');
     }
-    
-    protected function printChar($char)
+
+    protected function printChar($char): void
     {
         if ($this->currentPos >= $this->width) {
             $this->writeln('');
             $this->currentPos = 0;
         }
         $this->write($char);
-        $this->currentPos++;
+        ++$this->currentPos;
     }
 
-    public function printFailed(FailEvent $event)
+    public function printFailed(FailEvent $event): void
     {
         $this->standardReporter->printFail($event);
     }

--- a/ext/DotReporter.php
+++ b/ext/DotReporter.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Codeception\Extension;
 
 use Codeception\Event\FailEvent;
@@ -92,12 +95,12 @@ class DotReporter extends Extension
         $this->printChar('.');
     }
 
-    public function fail(): void
+    public function fail(FailEvent $event): void
     {
         $this->printChar('<error>F</error>');
     }
 
-    public function error(): void
+    public function error(FailEvent $event): void
     {
         $this->printChar('<error>E</error>');
     }

--- a/ext/DotReporter.php
+++ b/ext/DotReporter.php
@@ -110,7 +110,7 @@ class DotReporter extends Extension
         $this->printChar('S');
     }
 
-    protected function printChar($char): void
+    protected function printChar(string $char): void
     {
         if ($this->currentPos >= $this->width) {
             $this->writeln('');

--- a/ext/Logger.php
+++ b/ext/Logger.php
@@ -60,6 +60,9 @@ class Logger extends Extension
         Events::TEST_SKIPPED    => 'testSkipped',
     ];
 
+    /**
+     * @var RotatingFileHandler
+     */
     protected $logHandler;
 
     /**
@@ -67,6 +70,9 @@ class Logger extends Extension
      */
     protected static $logger;
 
+    /**
+     * @var string
+     */
     protected $path;
 
     /**

--- a/ext/Logger.php
+++ b/ext/Logger.php
@@ -12,6 +12,10 @@ use Codeception\Extension;
 use Codeception\Test\Descriptor;
 use Monolog\Formatter\LineFormatter;
 use Monolog\Handler\RotatingFileHandler;
+use function class_exists;
+use function function_exists;
+use function str_replace;
+use function ucfirst;
 
 /**
  * Log suites/tests/steps using Monolog library.
@@ -38,6 +42,9 @@ use Monolog\Handler\RotatingFileHandler;
  */
 class Logger extends Extension
 {
+    /**
+     * @var array<string, string>
+     */
     public static $events = [
         Events::SUITE_BEFORE    => 'beforeSuite',
         Events::TEST_BEFORE     => 'beforeTest',
@@ -59,12 +66,15 @@ class Logger extends Extension
 
     protected $path;
 
+    /**
+     * @var array<string, int>
+     */
     protected $config = ['max_files' => 3];
 
-    public function _initialize()
+    public function _initialize(): void
     {
         if (!class_exists('\Monolog\Logger')) {
-            throw new ConfigurationException("Logger extension requires Monolog library to be installed");
+            throw new ConfigurationException('Logger extension requires Monolog library to be installed');
         }
         $this->path = $this->getLogDir();
 
@@ -80,67 +90,67 @@ class Logger extends Extension
         self::$logger->pushHandler($logHandler);
     }
 
-    public static function getLogger()
+    public static function getLogger(): \Monolog\Logger
     {
         return self::$logger;
     }
 
-    public function beforeSuite(SuiteEvent $e)
+    public function beforeSuite(SuiteEvent $event): void
     {
-        $suiteLogFile = str_replace('\\', '_', $e->getSuite()->getName()) . '.log';
+        $suiteLogFile = str_replace('\\', '_', $event->getSuite()->getName()) . '.log';
         $this->logHandler = new RotatingFileHandler($this->path . $suiteLogFile, $this->config['max_files']);
     }
 
-    public function beforeTest(TestEvent $e)
+    public function beforeTest(TestEvent $event): void
     {
-        self::$logger = new \Monolog\Logger(Descriptor::getTestFullName($e->getTest()));
+        self::$logger = new \Monolog\Logger(Descriptor::getTestFullName($event->getTest()));
         self::$logger->pushHandler($this->logHandler);
         self::$logger->info('------------------------------------');
-        self::$logger->info("STARTED: " . ucfirst(Descriptor::getTestAsString($e->getTest())));
+        self::$logger->info('STARTED: ' . ucfirst(Descriptor::getTestAsString($event->getTest())));
     }
 
-    public function afterTest(TestEvent $e)
+    public function afterTest(TestEvent $event): void
     {
     }
 
-    public function endTest(TestEvent $e)
+    public function endTest(TestEvent $event): void
     {
-        self::$logger->info("PASSED");
+        self::$logger->info('PASSED');
     }
 
-    public function testFail(FailEvent $e)
+    public function testFail(FailEvent $event): void
     {
-        self::$logger->alert($e->getFail()->getMessage());
-        self::$logger->info("# FAILED #");
+        self::$logger->alert($event->getFail()->getMessage());
+        self::$logger->info('# FAILED #');
     }
 
-    public function testError(FailEvent $e)
+    public function testError(FailEvent $event): void
     {
-        self::$logger->alert($e->getFail()->getMessage());
-        self::$logger->info("# ERROR #");
+        self::$logger->alert($event->getFail()->getMessage());
+        self::$logger->info('# ERROR #');
     }
 
-    public function testSkipped(FailEvent $e)
+    public function testSkipped(FailEvent $event): void
     {
-        self::$logger->info("# Skipped #");
+        self::$logger->info('# Skipped #');
     }
 
-    public function testIncomplete(FailEvent $e)
+    public function testIncomplete(FailEvent $event): void
     {
-        self::$logger->info("# Incomplete #");
+        self::$logger->info('# Incomplete #');
     }
 
-    public function beforeStep(StepEvent $e)
+    public function beforeStep(StepEvent $event): void
     {
-        self::$logger->info((string) $e->getStep());
+        self::$logger->info((string) $event->getStep());
     }
 }
 
 if (!function_exists('codecept_log')) {
-    function codecept_log()
+    function codecept_log(): \Monolog\Logger
     {
         return Logger::getLogger();
     }
 } else {
-    throw new ExtensionException('Codeception\Extension\Logger', "function 'codecept_log' already defined");
+    throw new ExtensionException(Logger::class, "function 'codecept_log' already defined");
 }

--- a/ext/Logger.php
+++ b/ext/Logger.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Codeception\Extension;
 
 use Codeception\Event\FailEvent;

--- a/ext/Recorder.php
+++ b/ext/Recorder.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Codeception\Extension;
 
 use Codeception\Event\StepEvent;
@@ -364,7 +366,7 @@ EOF;
         }
         $links = '';
 
-        if (count($this->slides) > 0) {
+        if (!empty($this->slides)) {
             foreach ($this->recordedTests as $suiteName => $suite) {
                 $links .= "<ul><li><b>{$suiteName}</b></li><ul>";
                 foreach ($suite as $fileName => $tests) {

--- a/ext/Recorder.php
+++ b/ext/Recorder.php
@@ -638,10 +638,7 @@ EOF;
         return basename($event->getTest()->getMetadata()->getFilename()) . '_' . preg_replace('/[^A-Za-z0-9\-\_]/', '_', $event->getTest()->getMetadata()->getName());
     }
 
-    /**
-     * @param string $message
-     */
-    protected function writeln($message): void
+    protected function writeln(string $message): void
     {
         parent::writeln(
             $this->ansi

--- a/ext/RunBefore.php
+++ b/ext/RunBefore.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Codeception\Extension;
 
 use Codeception\Events;

--- a/ext/RunBefore.php
+++ b/ext/RunBefore.php
@@ -6,6 +6,11 @@ use Codeception\Events;
 use Codeception\Exception\ExtensionException;
 use Codeception\Extension;
 use Symfony\Component\Process\Process;
+use function array_shift;
+use function class_exists;
+use function count;
+use function is_array;
+use function sleep;
 
 /**
  * Extension for execution of some processes before running tests.
@@ -35,8 +40,14 @@ use Symfony\Component\Process\Process;
  */
 class RunBefore extends Extension
 {
+    /**
+     * @var array
+     */
     protected $config = [];
 
+    /**
+     * @var array<string, string>
+     */
     protected static $events = [
         Events::SUITE_BEFORE => 'runBefore'
     ];
@@ -44,20 +55,20 @@ class RunBefore extends Extension
     /** @var array[] */
     private $processes = [];
 
-    public function _initialize()
+    public function _initialize(): void
     {
-        if (!class_exists('Symfony\Component\Process\Process')) {
+        if (!class_exists(Process::class)) {
             throw new ExtensionException($this, 'symfony/process package is required');
         }
     }
 
-    public function runBefore()
+    public function runBefore(): void
     {
         $this->runProcesses();
         $this->processMonitoring();
     }
 
-    private function runProcesses()
+    private function runProcesses(): void
     {
         foreach ($this->config as $item) {
             if (is_array($item)) {
@@ -73,20 +84,11 @@ class RunBefore extends Extension
         }
     }
 
-    /**
-     * @param string $command
-     * @return Process
-     */
-    private function runProcess($command)
+    private function runProcess(string $command): Process
     {
         $this->output->debug('[RunBefore] Starting ' . $command);
 
-        if (method_exists(Process::class, 'fromShellCommandline')) {
-            //Symfony 4.2+
-            $process = Process::fromShellCommandline($command, $this->getRootDir());
-        } else {
-            $process = new Process($command, $this->getRootDir());
-        }
+        $process = Process::fromShellCommandline($command, $this->getRootDir());
         $process->start();
 
         return $process;
@@ -95,7 +97,7 @@ class RunBefore extends Extension
     /**
      * @param string[] $followingCommands
      */
-    private function addProcessToMonitoring(Process $process, array $followingCommands)
+    private function addProcessToMonitoring(Process $process, array $followingCommands): void
     {
         $this->processes[] = [
             'instance' => $process,
@@ -103,15 +105,12 @@ class RunBefore extends Extension
         ];
     }
 
-    /**
-     * @param int $index
-     */
-    private function removeProcessFromMonitoring($index)
+    private function removeProcessFromMonitoring(int $index): void
     {
         unset($this->processes[$index]);
     }
 
-    private function processMonitoring()
+    private function processMonitoring(): void
     {
         while (count($this->processes) !== 0) {
             $this->checkProcesses();
@@ -119,7 +118,7 @@ class RunBefore extends Extension
         }
     }
 
-    private function checkProcesses()
+    private function checkProcesses(): void
     {
         foreach ($this->processes as $index => $process) {
             if (!$this->isRunning($process['instance'])) {
@@ -133,19 +132,16 @@ class RunBefore extends Extension
     /**
      * @param string[] $followingCommands
      */
-    private function runFollowingCommand(array $followingCommands)
+    private function runFollowingCommand(array $followingCommands): void
     {
-        if (count($followingCommands) > 0) {
+        if ($followingCommands !== []) {
             $process = $this->runProcess(array_shift($followingCommands));
             $this->addProcessToMonitoring($process, $followingCommands);
         }
     }
 
-    private function isRunning(Process $process)
+    private function isRunning(Process $process): bool
     {
-        if ($process->isRunning()) {
-            return true;
-        }
-        return false;
+        return $process->isRunning();
     }
 }

--- a/ext/RunFailed.php
+++ b/ext/RunFailed.php
@@ -5,6 +5,15 @@ use Codeception\Event\PrintResultEvent;
 use Codeception\Events;
 use Codeception\Extension;
 use Codeception\Test\Descriptor;
+use function array_key_exists;
+use function file_put_contents;
+use function implode;
+use function is_file;
+use function realpath;
+use function str_replace;
+use function strlen;
+use function substr;
+use function unlink;
 
 /**
  * Saves failed tests into tests/_output/failed in order to rerun failed tests.
@@ -32,6 +41,9 @@ use Codeception\Test\Descriptor;
  */
 class RunFailed extends Extension
 {
+    /**
+     * @var array<string, string>
+     */
     public static $events = [
         Events::RESULT_PRINT_AFTER => 'saveFailed'
     ];
@@ -39,7 +51,7 @@ class RunFailed extends Extension
     /** @var string filename/groupname for failed tests */
     protected $group = 'failed';
 
-    public function _initialize()
+    public function _initialize(): void
     {
         if (array_key_exists('fail-group', $this->config) && $this->config['fail-group']) {
             $this->group = $this->config['fail-group'];
@@ -48,10 +60,10 @@ class RunFailed extends Extension
         $this->_reconfigure(['groups' => [$this->group => $logPath . $this->group]]);
     }
 
-    public function saveFailed(PrintResultEvent $e)
+    public function saveFailed(PrintResultEvent $event): void
     {
         $file = $this->getLogDir() . $this->group;
-        $result = $e->getResult();
+        $result = $event->getResult();
         if ($result->wasSuccessful()) {
             if (is_file($file)) {
                 unlink($file);
@@ -69,10 +81,10 @@ class RunFailed extends Extension
         file_put_contents($file, implode("\n", $output));
     }
 
-    protected function localizePath($path)
+    protected function localizePath(string $path): string
     {
         $root = realpath($this->getRootDir()) . DIRECTORY_SEPARATOR;
-        if (substr($path, 0, strlen($root)) == $root) {
+        if (substr($path, 0, strlen($root)) === $root) {
             return substr($path, strlen($root));
         }
         return $path;

--- a/ext/RunFailed.php
+++ b/ext/RunFailed.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Codeception\Extension;
 
 use Codeception\Event\PrintResultEvent;

--- a/ext/RunProcess.php
+++ b/ext/RunProcess.php
@@ -6,6 +6,10 @@ use Codeception\Events;
 use Codeception\Exception\ExtensionException;
 use Codeception\Extension;
 use Symfony\Component\Process\Process;
+use function array_reverse;
+use function class_exists;
+use function is_int;
+use function sleep;
 
 /**
  * Extension to start and stop processes per suite.
@@ -51,23 +55,32 @@ use Symfony\Component\Process\Process;
  */
 class RunProcess extends Extension
 {
+    /**
+     * @var array<string, int>
+     */
     protected $config = ['sleep' => 0];
 
+    /**
+     * @var array<string, string>
+     */
     protected static $events = [
         Events::SUITE_BEFORE => 'runProcess',
         Events::SUITE_AFTER => 'stopProcess'
     ];
 
+    /**
+     * @var Process[]
+     */
     private $processes = [];
 
-    public function _initialize()
+    public function _initialize(): void
     {
-        if (!class_exists('Symfony\Component\Process\Process')) {
+        if (!class_exists(Process::class)) {
             throw new ExtensionException($this, 'symfony/process package is required');
         }
     }
 
-    public function runProcess()
+    public function runProcess(): void
     {
         $this->processes = [];
         foreach ($this->config as $key => $command) {
@@ -77,12 +90,7 @@ class RunProcess extends Extension
             if (!is_int($key)) {
                 continue; // configuration options
             }
-            if (method_exists(Process::class, 'fromShellCommandline')) {
-                //Symfony 4.2+
-                $process = Process::fromShellCommandline($command, $this->getRootDir(), null, null, null);
-            } else {
-                $process = new Process($command, $this->getRootDir(), null, null, null);
-            }
+            $process = Process::fromShellCommandline($command, $this->getRootDir(), null, null, null);
             $process->start();
             $this->processes[] = $process;
             $this->output->debug('[RunProcess] Starting '.$command);
@@ -95,7 +103,7 @@ class RunProcess extends Extension
         $this->stopProcess();
     }
 
-    public function stopProcess()
+    public function stopProcess(): void
     {
         foreach (array_reverse($this->processes) as $process) {
             /** @var $process Process  **/

--- a/ext/RunProcess.php
+++ b/ext/RunProcess.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Codeception\Extension;
 
 use Codeception\Events;

--- a/ext/SimpleReporter.php
+++ b/ext/SimpleReporter.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Codeception\Extension;
 
 use Codeception\Event\TestEvent;

--- a/ext/SimpleReporter.php
+++ b/ext/SimpleReporter.php
@@ -12,13 +12,17 @@ use Codeception\Test\Descriptor;
  */
 class SimpleReporter extends Extension
 {
-    public function _initialize()
+    public function _initialize(): void
     {
         $this->options['silent'] = false; // turn on printing for this extension
         $this->_reconfigure(['settings' => ['silent' => true]]); // turn off printing for everything else
     }
 
-    // we are listening for events
+    /**
+     * We are listening for events
+     *
+     * @var array<string, string>
+     */
     public static $events = [
         Events::SUITE_BEFORE => 'beforeSuite',
         Events::TEST_END     => 'after',
@@ -27,35 +31,35 @@ class SimpleReporter extends Extension
         Events::TEST_ERROR   => 'error',
     ];
 
-    public function beforeSuite()
+    public function beforeSuite(): void
     {
-        $this->writeln("");
+        $this->writeln('');
     }
 
-    public function success()
+    public function success(): void
     {
         $this->write('[+] ');
     }
 
-    public function fail()
+    public function fail(): void
     {
         $this->write('[-] ');
     }
 
-    public function error()
+    public function error(): void
     {
         $this->write('[E] ');
     }
 
     // we are printing test status and time taken
-    public function after(TestEvent $e)
+    public function after(TestEvent $event): void
     {
-        $seconds_input = $e->getTime();
-        // stack overflow: http://stackoverflow.com/questions/16825240/how-to-convert-microtime-to-hhmmssuu
-        $seconds = (int)($milliseconds = (int)($seconds_input * 1000)) / 1000;
+        $secondsInput = $event->getTime();
+        // See https://stackoverflow.com/q/16825240
+        $seconds = ($milliseconds = (int)($secondsInput * 1000)) / 1000;
         $time = ($seconds % 60) . (($milliseconds === 0) ? '' : '.' . $milliseconds);
 
-        $this->write(Descriptor::getTestSignature($e->getTest()));
+        $this->write(Descriptor::getTestSignature($event->getTest()));
         $this->writeln(' (' . $time . 's)');
     }
 }

--- a/src/Codeception/Extension.php
+++ b/src/Codeception/Extension.php
@@ -82,7 +82,7 @@ abstract class Extension implements EventSubscriberInterface
         }
     }
 
-    protected function writeln($message)
+    protected function writeln(string $message): void
     {
         if (!$this->options['silent']) {
             $this->output->writeln($message);

--- a/src/Codeception/Extension.php
+++ b/src/Codeception/Extension.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Codeception;
 
 use Codeception\Configuration as Config;
@@ -6,6 +9,9 @@ use Codeception\Event\SuiteEvent;
 use Codeception\Exception\ModuleRequireException;
 use Codeception\Lib\Console\Output;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use function array_keys;
+use function array_merge;
+use function is_array;
 
 /**
  * A base class for all Codeception Extensions and GroupObjects
@@ -18,13 +24,28 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
  */
 abstract class Extension implements EventSubscriberInterface
 {
+    /**
+     * @var array
+     */
     protected $config = [];
+    /**
+     * @var array
+     */
     protected $options;
+    /**
+     * @var Output
+     */
     protected $output;
+    /**
+     * @var array
+     */
     protected $globalConfig;
+    /**
+     * @var array
+     */
     private $modules = [];
 
-    public function __construct($config, $options)
+    public function __construct(array $config, array $options)
     {
         $this->config = array_merge($this->config, $config);
         $this->options = $options;
@@ -32,8 +53,7 @@ abstract class Extension implements EventSubscriberInterface
         $this->_initialize();
     }
 
-
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents(): array
     {
         if (!isset(static::$events)) {
             return [Events::SUITE_INIT => 'receiveModuleContainer'];
@@ -49,33 +69,32 @@ abstract class Extension implements EventSubscriberInterface
         return static::$events;
     }
 
-    public function receiveModuleContainer(SuiteEvent $e)
+    public function receiveModuleContainer(SuiteEvent $event): void
     {
-        $this->modules = $e->getSuite()->getModules();
+        $this->modules = $event->getSuite()->getModules();
     }
 
     /**
      * Pass config variables that should be injected into global config.
-     *
-     * @param array $config
      */
-    public function _reconfigure($config = [])
+    public function _reconfigure(array $config = []): void
     {
-        if (is_array($config)) {
-            Config::append($config);
-        }
+        Configuration::append($config);
     }
 
     /**
      * You can do all preparations here. No need to override constructor.
      * Also you can skip calling `_reconfigure` if you don't need to.
      */
-    public function _initialize()
+    public function _initialize(): void
     {
         $this->_reconfigure(); // hook for BC only.
     }
 
-    protected function write($message)
+    /**
+     * @param string|iterable $message
+     */
+    protected function write($message): void
     {
         if (!$this->options['silent']) {
             $this->output->write($message);
@@ -89,45 +108,48 @@ abstract class Extension implements EventSubscriberInterface
         }
     }
 
-    public function hasModule($name)
+    public function hasModule(string $name): bool
     {
         return isset($this->modules[$name]);
     }
 
-    public function getCurrentModuleNames()
+    /**
+     * @return string[]
+     */
+    public function getCurrentModuleNames(): array
     {
         return array_keys($this->modules);
     }
 
-    public function getModule($name)
+    public function getModule(string $name): Module
     {
         if (!$this->hasModule($name)) {
-            throw new ModuleRequireException($name, "module is not enabled");
+            throw new ModuleRequireException($name, 'module is not enabled');
         }
         return $this->modules[$name];
     }
 
-    public function getTestsDir()
+    public function getTestsDir(): string
     {
         return Config::testsDir();
     }
 
-    public function getLogDir()
+    public function getLogDir(): string
     {
         return Config::outputDir();
     }
 
-    public function getDataDir()
+    public function getDataDir(): string
     {
         return Config::dataDir();
     }
 
-    public function getRootDir()
+    public function getRootDir(): string
     {
         return Config::projectDir();
     }
 
-    public function getGlobalConfig()
+    public function getGlobalConfig(): array
     {
         return Config::config();
     }


### PR DESCRIPTION
- Use strict types in `src/ext`.
- Add some type hints to Extensions.
- Add 'use function' statements for performance reasons.