### PR TITLE
Update code standards to some src/PHPUnit classes

### DIFF
--- a/src/PHPUnit/ConsolePrinter.php
+++ b/src/PHPUnit/ConsolePrinter.php
@@ -1,5 +1,8 @@
 <?php
+
 namespace Codeception\PHPUnit;
+
+use PHPUnit\Framework\TestResult;
 
 /**
  * Printer implementing this interface prints output to console, thus should be marked as printer and not just a logger
@@ -9,7 +12,7 @@ namespace Codeception\PHPUnit;
  */
 interface ConsolePrinter
 {
-    public function write(string $buffer);
+    public function printResult(TestResult $result): void;
 
-    public function printResult(\PHPUnit\Framework\TestResult $result);
+    public function write(string $buffer): void;
 }

--- a/src/PHPUnit/Constraint/Crawler.php
+++ b/src/PHPUnit/Constraint/Crawler.php
@@ -6,6 +6,7 @@ namespace Codeception\PHPUnit\Constraint;
 
 use Codeception\Exception\ElementNotFound;
 use Codeception\Lib\Console\Message;
+use DOMElement;
 use Facebook\WebDriver\WebDriverBy;
 use PHPUnit\Framework\ExpectationFailedException;
 use SebastianBergmann\Comparator\ComparisonFailure;
@@ -14,9 +15,12 @@ use function strpos;
 
 class Crawler extends Page
 {
-    protected function matches($nodes) : bool
+    /**
+     * @param SymfonyDomCrawler $nodes
+     * @return bool
+     */
+    protected function matches($nodes): bool
     {
-        /** @var SymfonyDomCrawler $nodes **/
         if (!$nodes->count()) {
             return false;
         }
@@ -33,13 +37,12 @@ class Crawler extends Page
     }
 
     /**
-     * @param mixed $nodes
-     * @param string|array|WebDriverBy $selector
+     * @param SymfonyDomCrawler $nodes
+     * @param string $selector
      * @param ComparisonFailure|null $comparisonFailure
      */
-    protected function fail($nodes, $selector, ComparisonFailure $comparisonFailure = null):void
+    protected function fail($nodes, $selector, ComparisonFailure $comparisonFailure = null): void
     {
-        /** @var SymfonyDomCrawler $nodes **/
         if (!$nodes->count()) {
             throw new ElementNotFound($selector, 'Element located either by name, CSS or XPath');
         }
@@ -62,7 +65,11 @@ class Crawler extends Page
         );
     }
 
-    protected function failureDescription($other) : string
+    /**
+     * @param DOMElement[] $other
+     * @return string
+     */
+    protected function failureDescription($other): string
     {
         $description = '';
         foreach ($other as $o) {
@@ -71,11 +78,11 @@ class Crawler extends Page
         return $description;
     }
 
-    protected function nodesList(SymfonyDomCrawler $domCrawler, $contains = null): string
+    protected function nodesList(SymfonyDomCrawler $domCrawler, string $contains = null): string
     {
         $output = '';
         foreach ($domCrawler as $node) {
-            if ($contains && strpos($node->nodeValue, (string) $contains) === false) {
+            if ($contains && strpos($node->nodeValue, $contains) === false) {
                 continue;
             }
             $output .= "\n+ " . $node->C14N();

--- a/src/PHPUnit/Constraint/CrawlerNot.php
+++ b/src/PHPUnit/Constraint/CrawlerNot.php
@@ -11,13 +11,17 @@ use Symfony\Component\DomCrawler\Crawler as SymfonyCrawler;
 
 class CrawlerNot extends Crawler
 {
+    /**
+     * @param SymfonyCrawler $nodes
+     * @return bool
+     */
     protected function matches($nodes): bool
     {
         return !parent::matches($nodes);
     }
 
     /**
-     * @param mixed $nodes
+     * @param SymfonyCrawler $nodes
      * @param string|array|WebDriverBy $selector
      * @param ComparisonFailure|null $comparisonFailure
      */
@@ -29,7 +33,6 @@ class CrawlerNot extends Crawler
                 $comparisonFailure
             );
         }
-        /** @var SymfonyCrawler $nodes **/
 
         $output = "There was '{$selector}' element";
         $output .= $this->uriMessage('on page');

--- a/src/PHPUnit/Constraint/CrawlerNot.php
+++ b/src/PHPUnit/Constraint/CrawlerNot.php
@@ -1,37 +1,48 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Codeception\PHPUnit\Constraint;
 
+use Facebook\WebDriver\WebDriverBy;
+use PHPUnit\Framework\ExpectationFailedException;
 use SebastianBergmann\Comparator\ComparisonFailure;
+use Symfony\Component\DomCrawler\Crawler as SymfonyCrawler;
 
 class CrawlerNot extends Crawler
 {
-    protected function matches($nodes) : bool
+    protected function matches($nodes): bool
     {
         return !parent::matches($nodes);
     }
 
-    protected function fail($nodes, $selector, ComparisonFailure $comparisonFailure = null) : void
+    /**
+     * @param mixed $nodes
+     * @param string|array|WebDriverBy $selector
+     * @param ComparisonFailure|null $comparisonFailure
+     */
+    protected function fail($nodes, $selector, ComparisonFailure $comparisonFailure = null): void
     {
         if (!$this->string) {
-            throw new \PHPUnit\Framework\ExpectationFailedException(
-                "Element '$selector' was found",
+            throw new ExpectationFailedException(
+                "Element '{$selector}' was found",
                 $comparisonFailure
             );
         }
-        /** @var $nodes DomCrawler  * */
+        /** @var SymfonyCrawler $nodes **/
 
-        $output = "There was '$selector' element";
+        $output = "There was '{$selector}' element";
         $output .= $this->uriMessage('on page');
         $output .= $this->nodesList($nodes, $this->string);
         $output .= "\ncontaining '{$this->string}'";
 
-        throw new \PHPUnit\Framework\ExpectationFailedException(
+        throw new ExpectationFailedException(
             $output,
             $comparisonFailure
         );
     }
 
-    public function toString() : string
+    public function toString(): string
     {
         if ($this->string) {
             return 'that contains text "' . $this->string . '"';

--- a/src/PHPUnit/Constraint/JsonContains.php
+++ b/src/PHPUnit/Constraint/JsonContains.php
@@ -1,16 +1,22 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Codeception\PHPUnit\Constraint;
 
-use SebastianBergmann\Comparator\ComparisonFailure;
-use SebastianBergmann\Comparator\ArrayComparator;
-use SebastianBergmann\Comparator\Factory;
 use Codeception\Util\JsonArray;
+use PHPUnit\Framework\AssertionFailedError;
+use PHPUnit\Framework\Constraint\Constraint;
+use PHPUnit\Framework\ExpectationFailedException;
+use SebastianBergmann\Comparator\ArrayComparator;
+use SebastianBergmann\Comparator\ComparisonFailure;
+use SebastianBergmann\Comparator\Factory;
+use function is_array;
 
-class JsonContains extends \PHPUnit\Framework\Constraint\Constraint
+class JsonContains extends Constraint
 {
     /**
-     * @var
+     * @var array
      */
     protected $expected;
 
@@ -24,17 +30,16 @@ class JsonContains extends \PHPUnit\Framework\Constraint\Constraint
      * constraint is met, false otherwise.
      *
      * @param mixed $other Value or object to evaluate.
-     *
-     * @return bool
      */
-    protected function matches($other) : bool
+    protected function matches($other): bool
     {
         $jsonResponseArray = new JsonArray($other);
         if (!is_array($jsonResponseArray->toArray())) {
-            throw new \PHPUnit\Framework\AssertionFailedError('JSON response is not an array: ' . $other);
+            throw new AssertionFailedError('JSON response is not an array: ' . $other);
         }
+        $jsonArrayContainsArray = $jsonResponseArray->containsArray($this->expected);
 
-        if ($jsonResponseArray->containsArray($this->expected)) {
+        if ($jsonArrayContainsArray) {
             return true;
         }
 
@@ -43,7 +48,7 @@ class JsonContains extends \PHPUnit\Framework\Constraint\Constraint
         try {
             $comparator->assertEquals($this->expected, $jsonResponseArray->toArray());
         } catch (ComparisonFailure $failure) {
-            throw new \PHPUnit\Framework\ExpectationFailedException(
+            throw new ExpectationFailedException(
                 "Response JSON does not contain the provided JSON\n",
                 $failure
             );
@@ -54,16 +59,14 @@ class JsonContains extends \PHPUnit\Framework\Constraint\Constraint
 
     /**
      * Returns a string representation of the constraint.
-     *
-     * @return string
      */
-    public function toString() : string
+    public function toString(): string
     {
         //unused
         return '';
     }
 
-    protected function failureDescription($other) : string
+    protected function failureDescription($other): string
     {
         //unused
         return '';

--- a/src/PHPUnit/Constraint/JsonType.php
+++ b/src/PHPUnit/Constraint/JsonType.php
@@ -1,16 +1,27 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Codeception\PHPUnit\Constraint;
 
-use Codeception\Util\JsonType as JsonTypeUtil;
 use Codeception\Util\JsonArray;
+use Codeception\Util\JsonType as JsonTypeUtil;
+use PHPUnit\Framework\Constraint\Constraint;
+use PHPUnit\Framework\ExpectationFailedException;
+use function json_encode;
 
-class JsonType extends \PHPUnit\Framework\Constraint\Constraint
+class JsonType extends Constraint
 {
+    /**
+     * @var array
+     */
     protected $jsonType;
+    /**
+     * @var bool
+     */
     private $match;
 
-    public function __construct(array $jsonType, $match = true)
+    public function __construct(array $jsonType, bool $match = true)
     {
         $this->jsonType = $jsonType;
         $this->match = $match;
@@ -21,10 +32,8 @@ class JsonType extends \PHPUnit\Framework\Constraint\Constraint
      * constraint is met, false otherwise.
      *
      * @param mixed $jsonArray Value or object to evaluate.
-     *
-     * @return bool
      */
-    protected function matches($jsonArray) : bool
+    protected function matches($jsonArray): bool
     {
         if ($jsonArray instanceof JsonArray) {
             $jsonArray = $jsonArray->toArray();
@@ -34,28 +43,25 @@ class JsonType extends \PHPUnit\Framework\Constraint\Constraint
 
         if ($this->match) {
             if ($matched !== true) {
-                throw new \PHPUnit\Framework\ExpectationFailedException($matched);
+                throw new ExpectationFailedException($matched);
             }
-        } else {
-            if ($matched === true) {
-                throw new \PHPUnit\Framework\ExpectationFailedException('Unexpectedly response matched: ' . json_encode($jsonArray));
-            }
+        } elseif ($matched === true) {
+            $jsonArray = json_encode($jsonArray, JSON_THROW_ON_ERROR);
+            throw new ExpectationFailedException('Unexpectedly response matched: ' . $jsonArray);
         }
         return true;
     }
 
     /**
      * Returns a string representation of the constraint.
-     *
-     * @return string
      */
-    public function toString() : string
+    public function toString(): string
     {
         //unused
         return '';
     }
 
-    protected function failureDescription($other) : string
+    protected function failureDescription($other): string
     {
         //unused
         return '';

--- a/src/PHPUnit/Constraint/Page.php
+++ b/src/PHPUnit/Constraint/Page.php
@@ -1,16 +1,34 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Codeception\PHPUnit\Constraint;
 
 use Codeception\Lib\Console\Message;
+use PHPUnit\Framework\Constraint\Constraint;
+use function codecept_output_dir;
+use function mb_stripos;
+use function mb_strlen;
+use function mb_substr;
+use function preg_replace;
+use function sprintf;
+use function strtr;
+use function trim;
 
-class Page extends \PHPUnit\Framework\Constraint\Constraint
+class Page extends Constraint
 {
+    /**
+     * @var string
+     */
     protected $uri;
+    /**
+     * @var string
+     */
     protected $string;
 
-    public function __construct($string, $uri = '')
+    public function __construct(string $string, string $uri = '')
     {
-        $this->string = $this->normalizeText((string)$string);
+        $this->string = $this->normalizeText($string);
         $this->uri = $uri;
     }
 
@@ -22,17 +40,13 @@ class Page extends \PHPUnit\Framework\Constraint\Constraint
      *
      * @return bool
      */
-    protected function matches($other) : bool
+    protected function matches($other): bool
     {
         $other = $this->normalizeText($other);
-        return mb_stripos($other, $this->string, null, 'UTF-8') !== false;
+        return mb_stripos($other, $this->string, 0, 'UTF-8') !== false;
     }
 
-    /**
-     * @param $text
-     * @return string
-     */
-    private function normalizeText($text)
+    private function normalizeText(string $text): string
     {
         $text = strtr($text, "\r\n", "  ");
         return trim(preg_replace('/\\s{2,}/', ' ', $text));
@@ -40,10 +54,8 @@ class Page extends \PHPUnit\Framework\Constraint\Constraint
 
     /**
      * Returns a string representation of the constraint.
-     *
-     * @return string
      */
-    public function toString() : string
+    public function toString(): string
     {
         return sprintf(
             'contains "%s"',
@@ -66,13 +78,13 @@ class Page extends \PHPUnit\Framework\Constraint\Constraint
         return $message->getMessage() . $this->toString();
     }
 
-    protected function uriMessage($onPage = "")
+    protected function uriMessage(string $onPage = ''): Message
     {
         if (!$this->uri) {
             return new Message('');
         }
         $message = new Message($this->uri);
-        $message->prepend(" $onPage ");
+        $message->prepend(" {$onPage} ");
         return $message;
     }
 }

--- a/src/PHPUnit/Constraint/Page.php
+++ b/src/PHPUnit/Constraint/Page.php
@@ -36,8 +36,7 @@ class Page extends Constraint
      * Evaluates the constraint for parameter $other. Returns true if the
      * constraint is met, false otherwise.
      *
-     * @param mixed $other Value or object to evaluate.
-     *
+     * @param string $other Value or object to evaluate.
      * @return bool
      */
     protected function matches($other): bool
@@ -63,7 +62,11 @@ class Page extends Constraint
         );
     }
 
-    protected function failureDescription($pageContent) : string
+    /**
+     * @param string $pageContent
+     * @return string
+     */
+    protected function failureDescription($pageContent): string
     {
         $message = $this->uriMessage('on page');
         $message->append("\n--> ");

--- a/src/PHPUnit/Constraint/WebDriver.php
+++ b/src/PHPUnit/Constraint/WebDriver.php
@@ -8,6 +8,7 @@ use Codeception\Exception\ElementNotFound;
 use Codeception\Lib\Console\Message;
 use Codeception\Util\Locator;
 use Facebook\WebDriver\WebDriverBy;
+use Facebook\WebDriver\WebDriverElement;
 use PHPUnit\Framework\ExpectationFailedException;
 use SebastianBergmann\Comparator\ComparisonFailure;
 use function count;
@@ -16,6 +17,10 @@ use function strpos;
 
 class WebDriver extends Page
 {
+    /**
+     * @param WebDriverElement[] $nodes
+     * @return bool
+     */
     protected function matches($nodes): bool
     {
         if (count($nodes) === 0) {
@@ -26,7 +31,6 @@ class WebDriver extends Page
         }
 
         foreach ($nodes as $node) {
-            /** @var \WebDriverElement $node **/
             if (!$node->isDisplayed()) {
                 continue;
             }
@@ -38,7 +42,7 @@ class WebDriver extends Page
     }
 
     /**
-     * @param mixed $nodes
+     * @param WebDriverElement[] $nodes
      * @param string|array|WebDriverBy $selector
      * @param ComparisonFailure|null $comparisonFailure
      */
@@ -66,6 +70,10 @@ class WebDriver extends Page
         );
     }
 
+    /**
+     * @param WebDriverElement[] $nodes
+     * @return string
+     */
     protected function failureDescription($nodes): string
     {
         $desc = '';
@@ -75,14 +83,18 @@ class WebDriver extends Page
         return $desc;
     }
 
-    protected function nodesList($nodes, $contains = null): string
+    /**
+     * @param WebDriverElement[] $nodes
+     * @param string|null $contains
+     * @return string
+     */
+    protected function nodesList(array $nodes, string $contains = null): string
     {
         $output = "";
         foreach ($nodes as $node) {
-            if ($contains && strpos($node->getText(), (string) $contains) === false) {
+            if ($contains && strpos($node->getText(), $contains) === false) {
                 continue;
             }
-            /** @var \WebDriverElement $node **/
             $message = new Message("\n+ <%s> %s");
             $output .= $message->with($node->getTagName(), $node->getText());
         }

--- a/src/PHPUnit/Constraint/WebDriver.php
+++ b/src/PHPUnit/Constraint/WebDriver.php
@@ -1,17 +1,24 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Codeception\PHPUnit\Constraint;
 
 use Codeception\Exception\ElementNotFound;
 use Codeception\Lib\Console\Message;
 use Codeception\Util\Locator;
+use Facebook\WebDriver\WebDriverBy;
+use PHPUnit\Framework\ExpectationFailedException;
 use SebastianBergmann\Comparator\ComparisonFailure;
+use function count;
+use function htmlspecialchars_decode;
+use function strpos;
 
 class WebDriver extends Page
 {
-
-    protected function matches($nodes) : bool
+    protected function matches($nodes): bool
     {
-        if (!count($nodes)) {
+        if (count($nodes) === 0) {
             return false;
         }
         if ($this->string === '') {
@@ -19,7 +26,7 @@ class WebDriver extends Page
         }
 
         foreach ($nodes as $node) {
-            /** @var $node \WebDriverElement  * */
+            /** @var \WebDriverElement $node **/
             if (!$node->isDisplayed()) {
                 continue;
             }
@@ -30,9 +37,14 @@ class WebDriver extends Page
         return false;
     }
 
-    protected function fail($nodes, $selector, ComparisonFailure $comparisonFailure = null) : void
+    /**
+     * @param mixed $nodes
+     * @param string|array|WebDriverBy $selector
+     * @param ComparisonFailure|null $comparisonFailure
+     */
+    protected function fail($nodes, $selector, ComparisonFailure $comparisonFailure = null): void
     {
-        if (!count($nodes)) {
+        if (count($nodes) === 0) {
             throw new ElementNotFound($selector, 'Element located either by name, CSS or XPath');
         }
 
@@ -48,13 +60,13 @@ class WebDriver extends Page
         }
         $output .= "\ncontains text '" . $this->string . "'";
 
-        throw new \PHPUnit\Framework\ExpectationFailedException(
+        throw new ExpectationFailedException(
             $output,
             $comparisonFailure
         );
     }
 
-    protected function failureDescription($nodes) : string
+    protected function failureDescription($nodes): string
     {
         $desc = '';
         foreach ($nodes as $node) {
@@ -63,14 +75,14 @@ class WebDriver extends Page
         return $desc;
     }
 
-    protected function nodesList($nodes, $contains = null)
+    protected function nodesList($nodes, $contains = null): string
     {
         $output = "";
         foreach ($nodes as $node) {
-            if ($contains && strpos($node->getText(), $contains) === false) {
+            if ($contains && strpos($node->getText(), (string) $contains) === false) {
                 continue;
             }
-            /** @var $node \WebDriverElement  * */
+            /** @var \WebDriverElement $node **/
             $message = new Message("\n+ <%s> %s");
             $output .= $message->with($node->getTagName(), $node->getText());
         }

--- a/src/PHPUnit/Constraint/WebDriverNot.php
+++ b/src/PHPUnit/Constraint/WebDriverNot.php
@@ -6,6 +6,7 @@ namespace Codeception\PHPUnit\Constraint;
 
 use Codeception\Util\Locator;
 use Facebook\WebDriver\WebDriverBy;
+use Facebook\WebDriver\WebDriverElement;
 use PHPUnit\Framework\ExpectationFailedException;
 use SebastianBergmann\Comparator\ComparisonFailure;
 use function is_string;
@@ -19,7 +20,7 @@ class WebDriverNot extends WebDriver
     }
 
     /**
-     * @param mixed $nodes
+     * @param WebDriverElement[] $nodes
      * @param string|array|WebDriverBy $selector
      * @param ComparisonFailure|null $comparisonFailure
      */

--- a/src/PHPUnit/Constraint/WebDriverNot.php
+++ b/src/PHPUnit/Constraint/WebDriverNot.php
@@ -1,40 +1,52 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Codeception\PHPUnit\Constraint;
 
-use SebastianBergmann\Comparator\ComparisonFailure;
 use Codeception\Util\Locator;
+use Facebook\WebDriver\WebDriverBy;
+use PHPUnit\Framework\ExpectationFailedException;
+use SebastianBergmann\Comparator\ComparisonFailure;
+use function is_string;
+use function strpos;
 
 class WebDriverNot extends WebDriver
 {
-    protected function matches($nodes) : bool
+    protected function matches($nodes): bool
     {
         return !parent::matches($nodes);
     }
 
-    protected function fail($nodes, $selector, ComparisonFailure $comparisonFailure = null) : void
+    /**
+     * @param mixed $nodes
+     * @param string|array|WebDriverBy $selector
+     * @param ComparisonFailure|null $comparisonFailure
+     */
+    protected function fail($nodes, $selector, ComparisonFailure $comparisonFailure = null): void
     {
         if (!is_string($selector) || strpos($selector, "'") === false) {
             $selector = Locator::humanReadableString($selector);
         }
         if (!$this->string) {
-            throw new \PHPUnit\Framework\ExpectationFailedException(
-                "Element $selector was found",
+            throw new ExpectationFailedException(
+                "Element {$selector} was found",
                 $comparisonFailure
             );
         }
 
-        $output = "There was $selector element";
+        $output = "There was {$selector} element";
         $output .= $this->uriMessage("on page");
         $output .= $this->nodesList($nodes, $this->string);
         $output .= "\ncontaining '{$this->string}'";
 
-        throw new \PHPUnit\Framework\ExpectationFailedException(
+        throw new ExpectationFailedException(
             $output,
             $comparisonFailure
         );
     }
 
-    public function toString() : string
+    public function toString(): string
     {
         if ($this->string) {
             return 'that contains text "' . $this->string . '"';

--- a/src/PHPUnit/FilterTest.php
+++ b/src/PHPUnit/FilterTest.php
@@ -1,8 +1,16 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Codeception\PHPUnit;
 
 use Codeception\PHPUnit\NonFinal\NameFilterIterator;
 use Codeception\Test\Descriptor;
+use PHPUnit\Framework\TestSuite;
+use PHPUnit\Framework\WarningTestCase;
+use function end;
+use function is_null;
+use function preg_match;
 
 /**
  * Extended Filter Test from PHPUnit to use Codeception's Descriptor to locate tests.
@@ -12,11 +20,11 @@ use Codeception\Test\Descriptor;
  */
 class FilterTest extends NameFilterIterator
 {
-    public function accept():bool
+    public function accept(): bool
     {
         $test = $this->getInnerIterator()->current();
 
-        if ($test instanceof \PHPUnit\Framework\TestSuite) {
+        if ($test instanceof TestSuite) {
             return true;
         }
 
@@ -29,17 +37,17 @@ class FilterTest extends NameFilterIterator
 
         $accepted = preg_match($this->filter, $name, $matches);
 
-        // This fix the issue when an invalid dataprovider method generate a warning
-        // See issue https://github.com/Codeception/Codeception/issues/4888
-        if($test instanceof \PHPUnit\Framework\WarningTestCase) {
+        // This fix the issue when an invalid DataProvider method generate a warning
+        // See https://github.com/Codeception/Codeception/issues/4888
+        if ($test instanceof WarningTestCase) {
             $message = $test->getMessage();
             $accepted = preg_match($this->filter, $message, $matches);
         }
 
-        if ($accepted && isset($this->filterMax)) {
+        if ($accepted && $this->filterMax !== null) {
             $set = end($matches);
             $accepted = $set >= $this->filterMin && $set <= $this->filterMax;
         }
-        return $accepted;
+        return (bool) $accepted;
     }
 }

--- a/src/PHPUnit/Util/Log/JSON.php
+++ b/src/PHPUnit/Util/Log/JSON.php
@@ -193,11 +193,11 @@ class JSON extends Printer implements TestListener
         }
     }
 
-    protected function writeCase(string $status, float $time, array $trace = [], string $message = '', ?TestCase $test = null): void
+    protected function writeCase(string $status, float $time, array $trace = [], string $message = '', ?PHPUnitTest $test = null): void
     {
         $output = '';
-        // take care of TestSuite producing error (e.g. by running into exception) as TestSuite doesn't have hasOutput
-        if ($test !== null && method_exists($test, 'hasOutput') && $test->hasOutput()) {
+        // take care of TestSuite producing error (e.g. by running into exception)
+        if ($test instanceof TestCase && $test->hasOutput()) {
             $output = $test->getActualOutput();
         }
         $this->addLogEvent(

--- a/src/PHPUnit/Util/Log/JSON.php
+++ b/src/PHPUnit/Util/Log/JSON.php
@@ -45,10 +45,6 @@ class JSON extends Printer implements TestListener
 
     /**
      * An error occurred.
-     *
-     * @param TestCase|PHPUnitTest $test
-     * @param Throwable $t
-     * @param float $time
      */
     public function addError(PHPUnitTest $test, Throwable $t, float $time): void
     {
@@ -65,10 +61,6 @@ class JSON extends Printer implements TestListener
 
     /**
      * A warning occurred.
-     *
-     * @param TestCase|PHPUnitTest $test
-     * @param Warning $e
-     * @param float $time
      */
     public function addWarning(PHPUnitTest $test, Warning $e, float $time): void
     {
@@ -85,10 +77,6 @@ class JSON extends Printer implements TestListener
 
     /**
      * A failure occurred.
-     *
-     * @param TestCase|PHPUnitTest $test
-     * @param AssertionFailedError $e
-     * @param float $time
      */
     public function addFailure(PHPUnitTest $test, AssertionFailedError $e, float $time): void
     {
@@ -105,10 +93,6 @@ class JSON extends Printer implements TestListener
 
     /**
      * Incomplete test.
-     *
-     * @param TestCase|PHPUnitTest $test
-     * @param AssertionFailedError|Throwable $t
-     * @param float $time
      */
     public function addIncompleteTest(PHPUnitTest $test, Throwable $t, float $time): void
     {
@@ -125,10 +109,6 @@ class JSON extends Printer implements TestListener
 
     /**
      * Risky test.
-     *
-     * @param TestCase|PHPUnitTest $test
-     * @param Throwable $t
-     * @param float $time
      */
     public function addRiskyTest(PHPUnitTest $test, Throwable $t, float $time): void
     {
@@ -145,10 +125,6 @@ class JSON extends Printer implements TestListener
 
     /**
      * Skipped test.
-     *
-     * @param TestCase|PHPUnitTest $test
-     * @param Throwable $t
-     * @param float $time
      */
     public function addSkippedTest(PHPUnitTest $test, Throwable $t, float $time): void
     {
@@ -165,8 +141,6 @@ class JSON extends Printer implements TestListener
 
     /**
      * A testsuite started.
-     *
-     * @param TestSuite $suite
      */
     public function startTestSuite(TestSuite $suite): void
     {
@@ -184,8 +158,6 @@ class JSON extends Printer implements TestListener
 
     /**
      * A testsuite ended.
-     *
-     * @param TestSuite $suite
      */
     public function endTestSuite(TestSuite $suite): void
     {
@@ -196,8 +168,6 @@ class JSON extends Printer implements TestListener
 
     /**
      * A test started.
-     *
-     * @param PHPUnitTest $test
      */
     public function startTest(PHPUnitTest $test): void
     {
@@ -215,9 +185,6 @@ class JSON extends Printer implements TestListener
 
     /**
      * A test ended.
-     *
-     * @param PHPUnitTest|TestCase $test
-     * @param float $time
      */
     public function endTest(PHPUnitTest $test, float $time): void
     {

--- a/src/PHPUnit/Util/Log/JSON.php
+++ b/src/PHPUnit/Util/Log/JSON.php
@@ -1,27 +1,43 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Codeception\PHPUnit\Util\Log;
+
+use PHPUnit\Framework\AssertionFailedError;
+use PHPUnit\Framework\Test as PHPUnitTest;
+use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\TestFailure;
+use PHPUnit\Framework\TestListener;
+use PHPUnit\Framework\TestSuite;
+use PHPUnit\Framework\Warning;
+use PHPUnit\Util\Filter;
+use PHPUnit\Util\Printer;
+use Throwable;
+use function array_walk_recursive;
+use function count;
+use function is_string;
+use function json_encode;
+use function mb_convert_encoding;
+use function method_exists;
 
 /**
  * A TestListener that generates JSON messages.
  */
-class JSON extends \PHPUnit\Util\Printer implements \PHPUnit\Framework\TestListener
+class JSON extends Printer implements TestListener
 {
     /**
      * @var string
      */
     protected $currentTestSuiteName = '';
-
     /**
      * @var string
      */
     protected $currentTestName = '';
-
     /**
      * @var bool
      */
     protected $currentTestPass = true;
-
     /**
      * @var array
      */
@@ -30,17 +46,17 @@ class JSON extends \PHPUnit\Util\Printer implements \PHPUnit\Framework\TestListe
     /**
      * An error occurred.
      *
-     * @param \PHPUnit\Framework\Test $test
-     * @param \Throwable $e
+     * @param TestCase|PHPUnitTest $test
+     * @param Throwable $t
      * @param float $time
      */
-    public function addError(\PHPUnit\Framework\Test $test, \Throwable $e, float $time): void
+    public function addError(PHPUnitTest $test, Throwable $t, float $time): void
     {
         $this->writeCase(
             'error',
             $time,
-            \PHPUnit\Util\Filter::getFilteredStacktrace($e, false),
-            \PHPUnit\Framework\TestFailure::exceptionToString($e),
+            Filter::getFilteredStacktrace($t, false),
+            TestFailure::exceptionToString($t),
             $test
         );
 
@@ -50,17 +66,17 @@ class JSON extends \PHPUnit\Util\Printer implements \PHPUnit\Framework\TestListe
     /**
      * A warning occurred.
      *
-     * @param \PHPUnit\Framework\Test $test
-     * @param \PHPUnit\Framework\Warning $e
+     * @param TestCase|PHPUnitTest $test
+     * @param Warning $e
      * @param float $time
      */
-    public function addWarning(\PHPUnit\Framework\Test $test, \PHPUnit\Framework\Warning $e, float $time): void
+    public function addWarning(PHPUnitTest $test, Warning $e, float $time): void
     {
         $this->writeCase(
             'warning',
             $time,
-            \PHPUnit\Util\Filter::getFilteredStacktrace($e, false),
-            \PHPUnit\Framework\TestFailure::exceptionToString($e),
+            Filter::getFilteredStacktrace($e, false),
+            TestFailure::exceptionToString($e),
             $test
         );
 
@@ -70,21 +86,17 @@ class JSON extends \PHPUnit\Util\Printer implements \PHPUnit\Framework\TestListe
     /**
      * A failure occurred.
      *
-     * @param \PHPUnit\Framework\Test $test
-     * @param \PHPUnit\Framework\AssertionFailedError $e
+     * @param TestCase|PHPUnitTest $test
+     * @param AssertionFailedError $e
      * @param float $time
      */
-    public function addFailure(
-        \PHPUnit\Framework\Test $test,
-        \PHPUnit\Framework\AssertionFailedError $e,
-        float $time
-    ): void
+    public function addFailure(PHPUnitTest $test, AssertionFailedError $e, float $time): void
     {
         $this->writeCase(
             'fail',
             $time,
-            \PHPUnit\Util\Filter::getFilteredStacktrace($e, false),
-            \PHPUnit\Framework\TestFailure::exceptionToString($e),
+            Filter::getFilteredStacktrace($e, false),
+            TestFailure::exceptionToString($e),
             $test
         );
 
@@ -94,17 +106,17 @@ class JSON extends \PHPUnit\Util\Printer implements \PHPUnit\Framework\TestListe
     /**
      * Incomplete test.
      *
-     * @param \PHPUnit\Framework\Test $test
-     * @param Throwable $e
+     * @param TestCase|PHPUnitTest $test
+     * @param AssertionFailedError|Throwable $t
      * @param float $time
      */
-    public function addIncompleteTest(\PHPUnit\Framework\Test $test, \Throwable $e, float $time): void
+    public function addIncompleteTest(PHPUnitTest $test, Throwable $t, float $time): void
     {
         $this->writeCase(
             'error',
             $time,
-            \PHPUnit\Util\Filter::getFilteredStacktrace($e, false),
-            'Incomplete Test: ' . $e->getMessage(),
+            Filter::getFilteredStacktrace($t, false),
+            'Incomplete Test: ' . $t->getMessage(),
             $test
         );
 
@@ -114,17 +126,17 @@ class JSON extends \PHPUnit\Util\Printer implements \PHPUnit\Framework\TestListe
     /**
      * Risky test.
      *
-     * @param \PHPUnit\Framework\Test $test
-     * @param Throwable $e
+     * @param TestCase|PHPUnitTest $test
+     * @param Throwable $t
      * @param float $time
      */
-    public function addRiskyTest(\PHPUnit\Framework\Test $test, \Throwable $e, float $time): void
+    public function addRiskyTest(PHPUnitTest $test, Throwable $t, float $time): void
     {
         $this->writeCase(
             'error',
             $time,
-            \PHPUnit\Util\Filter::getFilteredStacktrace($e, false),
-            'Risky Test: ' . $e->getMessage(),
+            Filter::getFilteredStacktrace($t, false),
+            'Risky Test: ' . $t->getMessage(),
             $test
         );
 
@@ -134,17 +146,17 @@ class JSON extends \PHPUnit\Util\Printer implements \PHPUnit\Framework\TestListe
     /**
      * Skipped test.
      *
-     * @param \PHPUnit\Framework\Test $test
-     * @param Throwable $e
+     * @param TestCase|PHPUnitTest $test
+     * @param Throwable $t
      * @param float $time
      */
-    public function addSkippedTest(\PHPUnit\Framework\Test $test, \Throwable $e, float $time): void
+    public function addSkippedTest(PHPUnitTest $test, Throwable $t, float $time): void
     {
         $this->writeCase(
             'error',
             $time,
-            \PHPUnit\Util\Filter::getFilteredStacktrace($e, false),
-            'Skipped Test: ' . $e->getMessage(),
+            Filter::getFilteredStacktrace($t, false),
+            'Skipped Test: ' . $t->getMessage(),
             $test
         );
 
@@ -154,9 +166,9 @@ class JSON extends \PHPUnit\Util\Printer implements \PHPUnit\Framework\TestListe
     /**
      * A testsuite started.
      *
-     * @param \PHPUnit\Framework\TestSuite $suite
+     * @param TestSuite $suite
      */
-    public function startTestSuite(\PHPUnit\Framework\TestSuite $suite): void
+    public function startTestSuite(TestSuite $suite): void
     {
         $this->currentTestSuiteName = $suite->getName();
         $this->currentTestName      = '';
@@ -173,22 +185,21 @@ class JSON extends \PHPUnit\Util\Printer implements \PHPUnit\Framework\TestListe
     /**
      * A testsuite ended.
      *
-     * @param \PHPUnit\Framework\TestSuite $suite
+     * @param TestSuite $suite
      */
-    public function endTestSuite(\PHPUnit\Framework\TestSuite $suite): void
+    public function endTestSuite(TestSuite $suite): void
     {
         $this->currentTestSuiteName = '';
         $this->currentTestName      = '';
-
         $this->writeArray($this->logEvents);
     }
 
     /**
      * A test started.
      *
-     * @param \PHPUnit\Framework\Test $test
+     * @param PHPUnitTest $test
      */
-    public function startTest(\PHPUnit\Framework\Test $test): void
+    public function startTest(PHPUnitTest $test): void
     {
         $this->currentTestName = \PHPUnit\Util\Test::describe($test);
         $this->currentTestPass = true;
@@ -205,24 +216,17 @@ class JSON extends \PHPUnit\Util\Printer implements \PHPUnit\Framework\TestListe
     /**
      * A test ended.
      *
-     * @param \PHPUnit\Framework\Test $test
+     * @param PHPUnitTest|TestCase $test
      * @param float $time
      */
-    public function endTest(\PHPUnit\Framework\Test $test, float $time): void
+    public function endTest(PHPUnitTest $test, float $time): void
     {
         if ($this->currentTestPass) {
             $this->writeCase('pass', $time, [], '', $test);
         }
     }
 
-    /**
-     * @param string $status
-     * @param float $time
-     * @param array $trace
-     * @param string $message
-     * @param \PHPUnit\Framework\TestCase|null $test
-     */
-    protected function writeCase($status, float $time, array $trace = [], $message = '', $test = null): void
+    protected function writeCase(string $status, float $time, array $trace = [], string $message = '', ?TestCase $test = null): void
     {
         $output = '';
         // take care of TestSuite producing error (e.g. by running into exception) as TestSuite doesn't have hasOutput
@@ -243,20 +247,14 @@ class JSON extends \PHPUnit\Util\Printer implements \PHPUnit\Framework\TestListe
         );
     }
 
-    /**
-     * @param array $event_data
-     */
-    protected function addLogEvent($event_data = []): void
+    protected function addLogEvent(array $eventData = []): void
     {
-        if (count($event_data)) {
-            array_push($this->logEvents, $event_data);
+        if (count($eventData) > 0) {
+            $this->logEvents[] = $eventData;
         }
     }
 
-    /**
-     * @param array $buffer
-     */
-    public function writeArray($buffer)
+    public function writeArray(array $buffer): void
     {
         array_walk_recursive(
             $buffer, function (&$input) {
@@ -269,7 +267,7 @@ class JSON extends \PHPUnit\Util\Printer implements \PHPUnit\Framework\TestListe
         $this->write(json_encode($buffer, JSON_PRETTY_PRINT));
     }
 
-    private function convertToUtf8($string)
+    private function convertToUtf8(string $string): string
     {
         return mb_convert_encoding($string, 'UTF-8');
     }


### PR DESCRIPTION
- Use strict types in `src/PHPUnit/ConsolePrinter`, `src/PHPUnit/Constraint`, `src/PHPUnit/FilterTest`, `src/PHPUnit/Util/Log`.
- Add some type hints to `src/PHPUnit`.
- Add 'use function' statements for performance reasons.