### PR TITLE
Fix the loading of project configuration before cleanup

### DIFF
--- a/src/Codeception/Command/Clean.php
+++ b/src/Codeception/Command/Clean.php
@@ -32,11 +32,12 @@ class Clean extends Command
 
     private function cleanProjectsRecursively(OutputInterface $output, $projectDir)
     {
+        $config = Configuration::config($projectDir);
+        
         $logDir = Configuration::logDir();
         $output->writeln("<info>Cleaning up output " . $logDir . "...</info>");
         FileSystem::doEmptyDir($logDir);
 
-        $config = Configuration::config($projectDir);
         $subProjects = $config['include'];
         foreach ($subProjects as $subProject) {
             $subProjectDir = $projectDir . $subProject;

--- a/tests/cli/IncludedCest.php
+++ b/tests/cli/IncludedCest.php
@@ -173,12 +173,14 @@ class IncludedCest
       */
     public function cleanIncluded(\CliGuy $I)
     {
-         $I->executeCommand('clean');
-         $I->seeInShellOutput('included/_log');
-         $I->seeInShellOutput('included/jazz/tests/_log');
-         $I->seeInShellOutput('included/jazz/pianist/tests/_log');
-         $I->seeInShellOutput('included/shire/tests/_log');
-         $I->seeInShellOutput('Done');
+        $ds = DIRECTORY_SEPARATOR;
+
+        $I->executeCommand('clean');
+        $I->seeInShellOutput("included{$ds}_log");
+        $I->seeInShellOutput("included{$ds}jazz{$ds}tests/_log");
+        $I->seeInShellOutput("included{$ds}jazz{$ds}pianist{$ds}tests/_log");
+        $I->seeInShellOutput("included{$ds}shire{$ds}tests/_log");
+        $I->seeInShellOutput('Done');
     }
 
 }

--- a/tests/cli/IncludedCest.php
+++ b/tests/cli/IncludedCest.php
@@ -166,4 +166,19 @@ class IncludedCest
         $I->seeInShellOutput('Jazz\\Pianist\\TestGuy');
         $I->seeInShellOutput('Shire\\TestGuy');
     }
+
+	/**
+      * @before moveToIncluded
+      * @param CliGuy $I
+      */
+    public function cleanIncluded(\CliGuy $I)
+    {
+         $I->executeCommand('clean');
+         $I->seeInShellOutput('included/_log');
+         $I->seeInShellOutput('included/jazz/tests/_log');
+         $I->seeInShellOutput('included/jazz/pianist/tests/_log');
+         $I->seeInShellOutput('included/shire/tests/_log');
+         $I->seeInShellOutput('Done');
+    }
+
 }


### PR DESCRIPTION
I came across an issue with the clean command when [multiple applications](https://codeception.com/docs/08-Customization#one-runner-for-multiple-applications) are set up using the `include` property in the global `codeception.yml`.

**Content of `codeception.yml`** 
```yml
include:
  - applications/*/
  - plugins/*/
```

**Before the changes:**
```bash
# php vendor/bin/codecept clean
Cleaning up output /var/www/html/tests/_output/...
Cleaning up output /var/www/html/tests/_output/...
Cleaning up output /var/www/html/plugins/someRandomPlugin/tests/_output/...
```

**After the changes:**
```bash
# php vendor/bin/codecept clean
Cleaning up output /var/www/html/tests/_output/...
Cleaning up output /var/www/html/applications/someRandomApplication/tests/_output/...
Cleaning up output /var/www/html/plugins/someRandomPlugin/tests/_output/...
```

Let me know if that is ok
