### PR TITLE
Clean: Do not delete .gitkeep files

### DIFF
--- a/src/Codeception/Util/FileSystem.php
+++ b/src/Codeception/Util/FileSystem.php
@@ -20,7 +20,7 @@ class FileSystem
 
         foreach ($iterator as $path) {
             $basename = basename((string)$path);
-            if ($basename === '.' || $basename === '..' || $basename === '.gitignore') {
+            if ($basename === '.' || $basename === '..' || $basename === '.gitignore' || $basename === '.gitkeep') {
                 continue;
             }
 

--- a/tests/cli/CleanCest.php
+++ b/tests/cli/CleanCest.php
@@ -1,0 +1,21 @@
+<?php
+
+class CleanCest
+{
+    public function cleanDoesNotDeleteGitKeepFiles(\CliGuy $I)
+    {
+        $ds = DIRECTORY_SEPARATOR;
+
+        $I->amInPath('tests/data/included');
+        $I->executeCommand('clean');
+        $I->seeInShellOutput("included{$ds}_log");
+        $I->seeInShellOutput("included{$ds}jazz{$ds}tests/_log");
+        $I->seeInShellOutput("included{$ds}jazz{$ds}pianist{$ds}tests/_log");
+        $I->seeInShellOutput("included{$ds}shire{$ds}tests/_log");
+        $I->seeInShellOutput('Done');
+        $I->seeFileFound("_log/.gitkeep");
+        $I->seeFileFound("jazz{$ds}tests/_log/.gitkeep");
+        $I->seeFileFound("jazz{$ds}pianist{$ds}tests/_log/.gitkeep");
+        $I->seeFileFound("shire{$ds}tests/_log/.gitkeep");
+    }
+}

--- a/tests/cli/IncludedCest.php
+++ b/tests/cli/IncludedCest.php
@@ -6,7 +6,6 @@ class IncludedCest
     {
         $logDir = codecept_root_dir('tests/data/included/_log');
         \Codeception\Util\FileSystem::doEmptyDir($logDir);
-        file_put_contents($logDir . '/.gitkeep', '');
     }
 
     /**


### PR DESCRIPTION
Because they are often used in _output directories.

Relates to #6117