### PR TITLE
Don't suppress failed assertions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -55,6 +55,9 @@ jobs:
       - name: Composer install
         run: composer install --no-interaction --no-progress --optimize-autoloader --ansi
 
+      - name: Test that failing test really fails
+        run: if php codecept run -c tests/data/claypit/ scenario FailedCept -vvv; then echo "Test hasn't failed"; false; fi;
+
       - name: Run tests without code coverage on PHP 7.3, 7.4
         if: matrix.php == '7.3' || matrix.php == '7.4'
         run: |

--- a/src/Codeception/GroupObject.php
+++ b/src/Codeception/GroupObject.php
@@ -15,7 +15,7 @@ abstract class GroupObject extends Extension
     {
     }
 
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents(): array
     {
         $inheritedEvents = parent::getSubscribedEvents();
         $events = [];

--- a/src/Codeception/Test/Cept.php
+++ b/src/Codeception/Test/Cept.php
@@ -42,6 +42,7 @@ class Cept extends Test implements Interfaces\Plain, Interfaces\ScenarioDriven, 
 
     public function test(): void
     {
+        $scenario = $this->getScenario();
         $testFile = $this->getMetadata()->getFilename();
         try {
             require $testFile;

--- a/src/Codeception/Test/Gherkin.php
+++ b/src/Codeception/Test/Gherkin.php
@@ -92,7 +92,7 @@ class Gherkin extends Test implements ScenarioDriven, Reported
     public function test(): void
     {
         $this->makeContexts();
-        $description = explode("\n", $this->featureNode->getDescription());
+        $description = explode("\n", (string)$this->featureNode->getDescription());
         foreach ($description as $line) {
             $this->getScenario()->runStep(new Comment($line));
         }

--- a/src/Codeception/Test/Test.php
+++ b/src/Codeception/Test/Test.php
@@ -114,12 +114,12 @@ abstract class Test implements TestInterface, Interfaces\Descriptive
             try {
                 $this->test();
                 $status = self::STATUS_OK;
-            } catch (AssertionFailedError $assertionFailedError) {
+            } catch (AssertionFailedError $e) {
                 $status = self::STATUS_FAIL;
-            } catch (Exception $exception) {
+            } catch (Exception $e) {
                 $status = self::STATUS_ERROR;
-            } catch (Throwable $throwable) {
-                $throwable = new ExceptionWrapper($throwable);
+            } catch (Throwable $e) {
+                $e = new ExceptionWrapper($e);
                 $status = self::STATUS_ERROR;
             }
 

--- a/tests/data/claypit/tests/_data/VerbosityLevelOutput.php
+++ b/tests/data/claypit/tests/_data/VerbosityLevelOutput.php
@@ -13,7 +13,7 @@ class VerbosityLevelOutput extends Extension
 
     public function printResult(PrintResultEvent $e)
     {
-        $this->writeln(var_export($this->options, false));
+        $this->writeln(var_export($this->options, true));
         $this->writeln("Modules used: " . implode(', ', $this->getCurrentModuleNames()));
 
         if ($this->options['verbosity'] <= OutputInterface::VERBOSITY_NORMAL) {


### PR DESCRIPTION
This issue was introduced by renaming some variables, $e is passed to hooks below.

It is impossible to test for this issue, because Codeception is self-testing and the test can't fail if all assertions are passing.
We could implement more robust test suite by moving some cli test to separate suite which is directly executed by PHPUnit, but it requires a lot of effort.