### PR TITLE
Action file generator improvements

### DIFF
--- a/tests/cli/BuildCest.php
+++ b/tests/cli/BuildCest.php
@@ -76,8 +76,8 @@ class BuildCest
     
     public function noReturnForVoidType(CliGuy $I, Scenario $scenario)
     {
-        if (PHP_MAJOR_VERSION < 7) {
-            $scenario->skip('Does not work in PHP < 7');
+        if (PHP_VERSION_ID < 70100) {
+            $scenario->skip('Does not work in PHP < 7.1');
         }
 
         $I->wantToTest('no return keyword generated for void typehint');


### PR DESCRIPTION
* Don't crash on union type in PHP 8
* Generate return union types
* Generate parameter typehints
* Fix tests, because they were running assertions agaist source file instead of generated file

Closes #6122 