### PR TITLE
AssertSame instead of AssertEquals

### DIFF
--- a/src/Codeception/Snapshot.php
+++ b/src/Codeception/Snapshot.php
@@ -38,7 +38,7 @@ abstract class Snapshot
      */
     protected function assertData($data)
     {
-        $this->assertEquals($this->dataSet, $data, 'Snapshot doesn\'t match real data');
+        $this->assertSame($this->dataSet, $data, 'Snapshot doesn\'t match real data');
     }
 
     /**

--- a/src/PHPUnit/Constraint/JsonContains.php
+++ b/src/PHPUnit/Constraint/JsonContains.php
@@ -46,7 +46,7 @@ class JsonContains extends Constraint
         $comparator = new ArrayComparator();
         $comparator->setFactory(new Factory);
         try {
-            $comparator->assertEquals($this->expected, $jsonResponseArray->toArray());
+            $comparator->assertSame($this->expected, $jsonResponseArray->toArray());
         } catch (ComparisonFailure $failure) {
             throw new ExpectationFailedException(
                 "Response JSON does not contain the provided JSON\n",

--- a/tests/README.md
+++ b/tests/README.md
@@ -90,7 +90,7 @@ function testPasswordField()
        'password' => '123456'
     ));
     $form = data::get('form');
-    $this->assertEquals('123456', $form['password']);
+    $this->assertSame('123456', $form['password']);
 }
 ?>
 ```

--- a/tests/cli/BuildCest.php
+++ b/tests/cli/BuildCest.php
@@ -29,7 +29,7 @@ class BuildCest
         $I->seeInThisFile('use _generated\CliGuyActions');
         $I->seeFileFound('CliGuyActions.php', 'tests/support/_generated');
         $I->seeInThisFile('seeFileFound(');
-        $I->seeInThisFile('public function assertEquals($expected, $actual, $message = "") {');
+        $I->seeInThisFile('public function assertSame($expected, $actual, $message = "") {');
     }
 
     public function usesTypehintsWherePossible(CliGuy $I, Scenario $scenario)

--- a/tests/cli/RunCest.php
+++ b/tests/cli/RunCest.php
@@ -622,7 +622,7 @@ EOF
         $newOutput = $I->grabFromOutput('/---\n((.|\n)*?)---/m');
         $newOutput = preg_replace('~\(\d\.\d+s\)~m', '', $newOutput);
 
-        $I->assertNotEquals($output, $newOutput, 'order of tests is the same');
+        $I->assertNotSame($output, $newOutput, 'order of tests is the same');
         }
 
     public function runCustomBootstrap(\CliGuy $I)

--- a/tests/cli/RunCest.php
+++ b/tests/cli/RunCest.php
@@ -616,7 +616,7 @@ EOF
         $newOutput = $I->grabFromOutput('/---\n((.|\n)*?)---/m');
         $newOutput = preg_replace('~\(\d\.\d+s\)~m', '', $newOutput);
 
-        $I->assertEquals($output, $newOutput, 'order of tests is the same');
+        $I->assertSame($output, $newOutput, 'order of tests is the same');
 
         $I->executeCommand('run unit -o "settings: shuffle: true"', false);
         $newOutput = $I->grabFromOutput('/---\n((.|\n)*?)---/m');

--- a/tests/data/claypit/tests/math/MathCest.php
+++ b/tests/data/claypit/tests/math/MathCest.php
@@ -16,20 +16,20 @@ class MathCest
 
     public function testAddition(MathTester $I)
     {
-        $I->assertEquals(3, $this->calc->add(1, 2));
-        $I->assertEquals(0, $this->calc->add(10, -10));
+        $I->assertSame(3, $this->calc->add(1, 2));
+        $I->assertSame(0, $this->calc->add(10, -10));
     }
 
     public function testSubtraction(MathTester $I)
     {
-        $I->assertEquals(1, $this->calc->subtract(3, 2));
-        $I->assertEquals(0, $this->calc->subtract(5, 5));
+        $I->assertSame(1, $this->calc->subtract(3, 2));
+        $I->assertSame(0, $this->calc->subtract(5, 5));
     }
 
     public function testSquare(MathTester $I)
     {
-        $I->assertEquals(3, $this->calc->squareOfCircle(1));
-        $I->assertEquals(12, $this->calc->squareOfCircle(2));
+        $I->assertSame(3, $this->calc->squareOfCircle(1));
+        $I->assertSame(12, $this->calc->squareOfCircle(2));
     }
 
     public function testTrigonometry(MathTester $I, \Page\Math\Trigonometry $t)

--- a/tests/data/claypit/tests/math/MathTest.php
+++ b/tests/data/claypit/tests/math/MathTest.php
@@ -21,8 +21,8 @@ class MathTest extends \Codeception\Test\Unit
 
     public function testAll()
     {
-        $this->assertEquals(3, $this->calc->add(1, 2));
-        $this->assertEquals(1, $this->calc->subtract(3, 2));
-        $this->assertEquals(75, $this->calc->squareOfCircle(5));
+        $this->assertSame(3, $this->calc->add(1, 2));
+        $this->assertSame(1, $this->calc->subtract(3, 2));
+        $this->assertSame(75, $this->calc->squareOfCircle(5));
     }
 }

--- a/tests/data/claypit/tests/unit/DependsTest.php
+++ b/tests/data/claypit/tests/unit/DependsTest.php
@@ -8,7 +8,7 @@ class DependsTest extends \Codeception\Test\Unit {
     public function testTwo($res)
     {
         $this->assertTrue(true);
-        $this->assertEquals(1, $res);
+        $this->assertSame(1, $res);
     }
     
     /**

--- a/tests/data/php55Test
+++ b/tests/data/php55Test
@@ -3,7 +3,7 @@
 class php55Test extends \PHPUnit\Framework\TestCase
 {
     public function testOfTest() {
-        $this->assertEquals('PHPUnit_Framework_TestCase', PHPUnit_Framework_TestCase::class);
+        $this->assertSame('PHPUnit_Framework_TestCase', PHPUnit_Framework_TestCase::class);
     }
 
     function justTest() {}

--- a/tests/data/presets/tests/unit/PresetTest.php
+++ b/tests/data/presets/tests/unit/PresetTest.php
@@ -5,7 +5,7 @@ class PresetTest extends \Codeception\Test\Unit
     public function testSomeFeature()
     {
         $this->assertSame(true, true);
-        $this->assertNotEquals(true, false);
+        $this->assertNotSame(true, false);
     }
 
 }

--- a/tests/data/presets/tests/unit/PresetTest.php
+++ b/tests/data/presets/tests/unit/PresetTest.php
@@ -4,7 +4,7 @@ class PresetTest extends \Codeception\Test\Unit
 {
     public function testSomeFeature()
     {
-        $this->assertEquals(true, true);
+        $this->assertSame(true, true);
         $this->assertNotEquals(true, false);
     }
 

--- a/tests/data/snapshots/tests/SnapshotDisplayDiffCest.php
+++ b/tests/data/snapshots/tests/SnapshotDisplayDiffCest.php
@@ -22,8 +22,8 @@ class SnapshotDisplayDiffCest
             $snapshot->assert();
             $I->fail('Snapshot assert must throw an exception.');
         } catch (\PHPUnit\Framework\ExpectationFailedException $t) {
-            $I->assertEquals($expected, $t->getComparisonFailure()->getExpected());
-            $I->assertEquals($actual, $t->getComparisonFailure()->getActual());
+            $I->assertSame($expected, $t->getComparisonFailure()->getExpected());
+            $I->assertSame($actual, $t->getComparisonFailure()->getActual());
         } catch (Throwable $t) {
             $I->fail('Snapshot assert must throw "\PHPUnit\Framework\ExpectationFailedException"');
         }

--- a/tests/data/snapshots/tests/SnapshotNonJsonDataCest.php
+++ b/tests/data/snapshots/tests/SnapshotNonJsonDataCest.php
@@ -31,7 +31,7 @@ class SnapshotNonJsonDataCest
         $snapshot->shouldRefreshSnapshot(true);
         $snapshot->assert();
 
-        $I->assertEquals(
+        $I->assertSame(
             file_get_contents(codecept_data_dir($snapshot->sourceFile)),
             file_get_contents(codecept_data_dir('Snapshot.NotAJsonSnapshot.xml')),
             'Snapshot stored data must be identical to source.'

--- a/tests/unit/C3Test.php
+++ b/tests/unit/C3Test.php
@@ -56,7 +56,7 @@ class C3Test extends \Codeception\PHPUnit\TestCase
         $cc_file = $this->c3_dir . 'dummy.txt';
         file_put_contents($cc_file, 'nothing');
         include $this->c3;
-        $this->assertEquals('clear', $route);
+        $this->assertSame('clear', $route);
         $this->assertFileNotExists($cc_file);
     }
 
@@ -64,7 +64,7 @@ class C3Test extends \Codeception\PHPUnit\TestCase
     {
         $_SERVER['REQUEST_URI'] = '/c3/report/html';
         include $this->c3;
-        $this->assertEquals('html', $route);
+        $this->assertSame('html', $route);
         $this->assertFileExists($this->c3_dir . 'codecoverage.tar');
     }
 
@@ -72,7 +72,7 @@ class C3Test extends \Codeception\PHPUnit\TestCase
     {
         $_SERVER['REQUEST_URI'] = '/c3/report/clover';
         include $this->c3;
-        $this->assertEquals('clover', $route);
+        $this->assertSame('clover', $route);
         $this->assertFileExists($this->c3_dir . 'codecoverage.clover.xml');
     }
 
@@ -80,7 +80,7 @@ class C3Test extends \Codeception\PHPUnit\TestCase
     {
         $_SERVER['REQUEST_URI'] = '/c3/report/serialized';
         include $this->c3;
-        $this->assertEquals('serialized', $route);
+        $this->assertSame('serialized', $route);
         $this->assertInstanceOf('PHP_CodeCoverage', $codeCoverage);
     }
 }

--- a/tests/unit/Codeception/Command/BaseCommandRunner.php
+++ b/tests/unit/Codeception/Command/BaseCommandRunner.php
@@ -110,6 +110,6 @@ class BaseCommandRunner extends \Codeception\PHPUnit\TestCase
         exec('php -l ' . $tempFile, $output, $code);
         unlink($tempFile);
 
-        $this->assertEquals(0, $code, $php);
+        $this->assertSame(0, $code, $php);
     }
 }

--- a/tests/unit/Codeception/Command/GenerateCeptTest.php
+++ b/tests/unit/Codeception/Command/GenerateCeptTest.php
@@ -19,7 +19,7 @@ class GenerateCeptTest extends BaseCommandRunner
     public function testGenerateBasic()
     {
         $this->execute(['suite' => 'shire', 'test' => 'HomeCanInclude12Dwarfs']);
-        $this->assertEquals($this->filename, 'tests/shire/HomeCanInclude12DwarfsCept.php');
+        $this->assertSame($this->filename, 'tests/shire/HomeCanInclude12DwarfsCept.php');
         $this->assertStringContainsString('$I = new HobbitGuy($scenario);', $this->content);
         $this->assertStringContainsString('Test was created in tests/shire/HomeCanInclude12DwarfsCept.php', $this->output);
         $this->assertIsValidPhp($this->content);
@@ -28,7 +28,7 @@ class GenerateCeptTest extends BaseCommandRunner
     public function testGenerateWithSuffix()
     {
         $this->execute(['suite' => 'shire', 'test' => 'HomeCanInclude12DwarfsCept']);
-        $this->assertEquals($this->filename, 'tests/shire/HomeCanInclude12DwarfsCept.php');
+        $this->assertSame($this->filename, 'tests/shire/HomeCanInclude12DwarfsCept.php');
         $this->assertIsValidPhp($this->content);
     }
 
@@ -38,7 +38,7 @@ class GenerateCeptTest extends BaseCommandRunner
     public function testGenerateWithFullName()
     {
         $this->execute(['suite' => 'shire', 'test' => 'HomeCanInclude12DwarfsCept.php']);
-        $this->assertEquals($this->filename, 'tests/shire/HomeCanInclude12DwarfsCept.php');
+        $this->assertSame($this->filename, 'tests/shire/HomeCanInclude12DwarfsCept.php');
         $this->assertIsValidPhp($this->content);
     }
 
@@ -49,7 +49,7 @@ class GenerateCeptTest extends BaseCommandRunner
     {
         $this->config['namespace'] = 'MiddleEarth';
         $this->execute(['suite' => 'shire', 'test' => 'HomeCanInclude12Dwarfs']);
-        $this->assertEquals($this->filename, 'tests/shire/HomeCanInclude12DwarfsCept.php');
+        $this->assertSame($this->filename, 'tests/shire/HomeCanInclude12DwarfsCept.php');
         $this->assertStringContainsString('use MiddleEarth\HobbitGuy;', $this->content);
         $this->assertStringContainsString('$I = new HobbitGuy($scenario);', $this->content);
         $this->assertIsValidPhp($this->content);

--- a/tests/unit/Codeception/Command/GenerateCestTest.php
+++ b/tests/unit/Codeception/Command/GenerateCestTest.php
@@ -21,7 +21,7 @@ class GenerateCestTest extends BaseCommandRunner
     public function testBasic()
     {
         $this->execute(['suite' => 'shire', 'class' => 'HallUnderTheHill']);
-        $this->assertEquals('tests/shire/HallUnderTheHillCest.php', $this->filename);
+        $this->assertSame('tests/shire/HallUnderTheHillCest.php', $this->filename);
 
         $this->assertStringContainsString('class HallUnderTheHillCest', $this->content);
         $this->assertStringContainsString('public function _before(HobbitGuy $I)', $this->content);
@@ -47,7 +47,7 @@ class GenerateCestTest extends BaseCommandRunner
     public function testGenerateWithFullName()
     {
         $this->execute(['suite' => 'shire', 'class' => 'HomeCanInclude12DwarfsCest.php']);
-        $this->assertEquals('tests/shire/HomeCanInclude12DwarfsCest.php', $this->filename);
+        $this->assertSame('tests/shire/HomeCanInclude12DwarfsCest.php', $this->filename);
     }
 
     /**
@@ -56,7 +56,7 @@ class GenerateCestTest extends BaseCommandRunner
     public function testGenerateWithSuffix()
     {
         $this->execute(['suite' => 'shire', 'class' => 'HomeCanInclude12DwarfsCest']);
-        $this->assertEquals($this->filename, 'tests/shire/HomeCanInclude12DwarfsCest.php');
+        $this->assertSame($this->filename, 'tests/shire/HomeCanInclude12DwarfsCest.php');
         $this->assertIsValidPhp($this->content);
     }
 
@@ -64,7 +64,7 @@ class GenerateCestTest extends BaseCommandRunner
     {
         $this->config['namespace'] = 'MiddleEarth';
         $this->execute(['suite' => 'shire', 'class' => 'HallUnderTheHillCest']);
-        $this->assertEquals($this->filename, 'tests/shire/HallUnderTheHillCest.php');
+        $this->assertSame($this->filename, 'tests/shire/HallUnderTheHillCest.php');
         $this->assertStringContainsString('namespace MiddleEarth;', $this->content);
         $this->assertStringContainsString('use MiddleEarth\\HobbitGuy;', $this->content);
         $this->assertStringContainsString('public function tryToTest(HobbitGuy $I)', $this->content);
@@ -74,7 +74,7 @@ class GenerateCestTest extends BaseCommandRunner
     public function testCreateWithNamespace()
     {
         $this->execute(['suite' => 'shire', 'class' => 'MiddleEarth\HallUnderTheHillCest']);
-        $this->assertEquals('tests/shire/MiddleEarth/HallUnderTheHillCest.php', $this->filename);
+        $this->assertSame('tests/shire/MiddleEarth/HallUnderTheHillCest.php', $this->filename);
         $this->assertStringContainsString('namespace MiddleEarth;', $this->content);
         $this->assertStringContainsString('class HallUnderTheHillCest', $this->content);
         $this->assertStringContainsString('Test was created in tests/shire/MiddleEarth/HallUnderTheHillCest.php', $this->output);
@@ -86,7 +86,7 @@ class GenerateCestTest extends BaseCommandRunner
         $this->config['namespace'] = 'MiddleEarth';
         $this->config['actor'] = 'HobbitGuy';
         $this->execute(['suite' => 'shire', 'class' => 'HallUnderTheHillCest']);
-        $this->assertEquals($this->filename, 'tests/shire/HallUnderTheHillCest.php');
+        $this->assertSame($this->filename, 'tests/shire/HallUnderTheHillCest.php');
         $this->assertStringContainsString('namespace MiddleEarth\\Bosses;', $this->content);
         $this->assertStringContainsString('use MiddleEarth\\HobbitGuy', $this->content);
         $this->assertStringContainsString('public function tryToTest(HobbitGuy $I)', $this->content);

--- a/tests/unit/Codeception/Command/GenerateEnvironmentTest.php
+++ b/tests/unit/Codeception/Command/GenerateEnvironmentTest.php
@@ -20,7 +20,7 @@ class GenerateEnvironmentTest extends BaseCommandRunner
     {
         $this->execute(['env' => 'firefox']);
         $this->assertStringContainsString('firefox config was created in tests/_envs/firefox.yml', $this->output);
-        $this->assertEquals('tests/_envs/firefox.yml', $this->filename);
+        $this->assertSame('tests/_envs/firefox.yml', $this->filename);
     }
 
     public function testFailed()

--- a/tests/unit/Codeception/Command/GenerateGroupTest.php
+++ b/tests/unit/Codeception/Command/GenerateGroupTest.php
@@ -27,7 +27,7 @@ class GenerateGroupTest extends BaseCommandRunner
         $this->execute(['group' => 'Core']);
 
         $generated = $this->log[0];
-        $this->assertEquals(\Codeception\Configuration::supportDir().'Group/Core.php', $generated['filename']);
+        $this->assertSame(\Codeception\Configuration::supportDir().'Group/Core.php', $generated['filename']);
         $this->assertStringContainsString('namespace Group;', $generated['content']);
         $this->assertStringContainsString('class Core', $generated['content']);
         $this->assertStringContainsString('public function _before', $generated['content']);
@@ -42,7 +42,7 @@ class GenerateGroupTest extends BaseCommandRunner
         $this->execute(['group' => 'Core']);
 
         $generated = $this->log[0];
-        $this->assertEquals(\Codeception\Configuration::supportDir().'Group/Core.php', $generated['filename']);
+        $this->assertSame(\Codeception\Configuration::supportDir().'Group/Core.php', $generated['filename']);
         $this->assertStringContainsString('namespace Shire\Group;', $generated['content']);
         $this->assertIsValidPhp($generated['content']);
     }

--- a/tests/unit/Codeception/Command/GeneratePageObjectTest.php
+++ b/tests/unit/Codeception/Command/GeneratePageObjectTest.php
@@ -21,7 +21,7 @@ class GeneratePageObjectTest extends BaseCommandRunner
     {
         unset($this->config['actor']);
         $this->execute(['suite' => 'Login'], false);
-        $this->assertEquals(\Codeception\Configuration::supportDir().'Page/Login.php', $this->filename);
+        $this->assertSame(\Codeception\Configuration::supportDir().'Page/Login.php', $this->filename);
         $this->assertStringContainsString('class Login', $this->content);
         $this->assertStringContainsString('public static', $this->content);
         $this->assertStringNotContainsString('public function __construct', $this->content);
@@ -33,7 +33,7 @@ class GeneratePageObjectTest extends BaseCommandRunner
         unset($this->config['actor']);
         $this->config['namespace'] = 'MiddleEarth';
         $this->execute(['suite' => 'Login'], false);
-        $this->assertEquals(\Codeception\Configuration::supportDir().'Page/Login.php', $this->filename);
+        $this->assertSame(\Codeception\Configuration::supportDir().'Page/Login.php', $this->filename);
         $this->assertStringContainsString('namespace MiddleEarth\Page;', $this->content);
         $this->assertStringContainsString('class Login', $this->content);
         $this->assertStringContainsString('public static', $this->content);
@@ -43,7 +43,7 @@ class GeneratePageObjectTest extends BaseCommandRunner
     public function testCreateForSuite()
     {
         $this->execute(['suite' => 'shire', 'page' => 'Login']);
-        $this->assertEquals(\Codeception\Configuration::supportDir().'Page/Shire/Login.php', $this->filename);
+        $this->assertSame(\Codeception\Configuration::supportDir().'Page/Shire/Login.php', $this->filename);
         $this->assertStringContainsString('namespace Page\Shire;', $this->content);
         $this->assertStringContainsString('class Login', $this->content);
         $this->assertStringContainsString('protected $hobbitGuy;', $this->content);
@@ -55,7 +55,7 @@ class GeneratePageObjectTest extends BaseCommandRunner
     {
         $this->config['namespace'] = 'MiddleEarth';
         $this->execute(['suite' => 'shire', 'page' => 'Login']);
-        $this->assertEquals(\Codeception\Configuration::supportDir().'Page/Shire/Login.php', $this->filename);
+        $this->assertSame(\Codeception\Configuration::supportDir().'Page/Shire/Login.php', $this->filename);
         $this->assertStringContainsString('namespace MiddleEarth\Page\Shire;', $this->content);
         $this->assertStringContainsString('class Login', $this->content);
         $this->assertStringContainsString('protected $hobbitGuy;', $this->content);
@@ -66,7 +66,7 @@ class GeneratePageObjectTest extends BaseCommandRunner
     public function testCreateInSubpath()
     {
         $this->execute(['suite' => 'User/View']);
-        $this->assertEquals(\Codeception\Configuration::supportDir().'Page/User/View.php', $this->filename);
+        $this->assertSame(\Codeception\Configuration::supportDir().'Page/User/View.php', $this->filename);
         $this->assertIsValidPhp($this->content);
     }
 }

--- a/tests/unit/Codeception/Command/GenerateScenarioTest.php
+++ b/tests/unit/Codeception/Command/GenerateScenarioTest.php
@@ -84,7 +84,7 @@ class GenerateScenarioTest extends BaseCommandRunner
         $this->config['class_name'] = 'SkipGuy';
 
         $this->execute(['suite' => 'skipped', '--single-file' => true]);
-        $this->assertEquals(codecept_root_dir().'tests/data/scenarios/skipped.txt', $this->filename);
+        $this->assertSame(codecept_root_dir().'tests/data/scenarios/skipped.txt', $this->filename);
         $this->assertStringContainsString('I WANT TO SKIP IT', $this->content);
         $this->assertStringContainsString('I WANT TO MAKE IT INCOMPLETE', $this->content);
         $this->assertStringContainsString('* Skip_Me rendered', $this->output);
@@ -97,7 +97,7 @@ class GenerateScenarioTest extends BaseCommandRunner
         $this->config['class_name'] = 'SkipGuy';
 
         $this->execute(['suite' => 'skipped', '--single-file' => true, '--format' => 'html']);
-        $this->assertEquals(codecept_root_dir().'tests/data/scenarios/skipped.html', $this->filename);
+        $this->assertSame(codecept_root_dir().'tests/data/scenarios/skipped.html', $this->filename);
         $this->assertStringContainsString('<h3>I WANT TO MAKE IT INCOMPLETE</h3>', $this->content);
         $this->assertStringContainsString('<h3>I WANT TO SKIP IT</h3>', $this->content);
         $this->assertStringContainsString('<body><h3>', $this->content);
@@ -109,7 +109,7 @@ class GenerateScenarioTest extends BaseCommandRunner
     public function testDifferentPath()
     {
         $this->execute(['suite' => 'dummy', '--single-file' => true, '--path' => 'docs']);
-        $this->assertEquals('docs/dummy.txt', $this->filename);
+        $this->assertSame('docs/dummy.txt', $this->filename);
         $this->assertStringContainsString('I WANT TO CHECK CONFIG EXISTS', $this->content);
         $this->assertStringContainsString('* File_Exists rendered', $this->output);
     }

--- a/tests/unit/Codeception/Command/GenerateStepObjectTest.php
+++ b/tests/unit/Codeception/Command/GenerateStepObjectTest.php
@@ -25,7 +25,7 @@ class GenerateStepObjectTest extends BaseCommandRunner
         $this->execute(['suite' => 'shire', 'step' => 'Login', '--silent' => true]);
 
         $generated = $this->log[0];
-        $this->assertEquals(\Codeception\Configuration::supportDir().'Step/Shire/Login.php', $generated['filename']);
+        $this->assertSame(\Codeception\Configuration::supportDir().'Step/Shire/Login.php', $generated['filename']);
         $this->assertStringContainsString('class Login extends \HobbitGuy', $generated['content']);
         $this->assertStringContainsString('namespace Step\\Shire;', $generated['content']);
         $this->assertIsValidPhp($generated['content']);
@@ -38,7 +38,7 @@ class GenerateStepObjectTest extends BaseCommandRunner
         $this->config['namespace'] = 'MiddleEarth';
         $this->execute(['suite' => 'shire', 'step' => 'Login', '--silent' => true]);
         $generated = $this->log[0];
-        $this->assertEquals(\Codeception\Configuration::supportDir().'Step/Shire/Login.php', $generated['filename']);
+        $this->assertSame(\Codeception\Configuration::supportDir().'Step/Shire/Login.php', $generated['filename']);
         $this->assertStringContainsString('namespace MiddleEarth\Step\Shire;', $generated['content']);
         $this->assertStringContainsString('class Login extends \MiddleEarth\HobbitGuy', $generated['content']);
         $this->assertIsValidPhp($generated['content']);
@@ -50,7 +50,7 @@ class GenerateStepObjectTest extends BaseCommandRunner
     {
         $this->execute(['suite' => 'shire', 'step' => 'User/Login', '--silent' => true]);
         $generated = $this->log[0];
-        $this->assertEquals(
+        $this->assertSame(
             \Codeception\Configuration::supportDir().'Step/Shire/User/Login.php',
             $generated['filename']
         );

--- a/tests/unit/Codeception/Command/GenerateSuiteTest.php
+++ b/tests/unit/Codeception/Command/GenerateSuiteTest.php
@@ -26,19 +26,19 @@ class GenerateSuiteTest extends BaseCommandRunner
 
         $configFile = $this->log[1];
 
-        $this->assertEquals(\Codeception\Configuration::projectDir().'tests/shire.suite.yml', $configFile['filename']);
+        $this->assertSame(\Codeception\Configuration::projectDir().'tests/shire.suite.yml', $configFile['filename']);
         $conf = \Symfony\Component\Yaml\Yaml::parse($configFile['content']);
-        $this->assertEquals('Hobbit', $conf['actor']);
+        $this->assertSame('Hobbit', $conf['actor']);
         $this->assertContains('\Helper\Shire', $conf['modules']['enabled']);
         $this->assertStringContainsString('Suite shire generated', $this->output);
 
         $actor = $this->log[2];
-        $this->assertEquals(\Codeception\Configuration::supportDir().'Hobbit.php', $actor['filename']);
+        $this->assertSame(\Codeception\Configuration::supportDir().'Hobbit.php', $actor['filename']);
         $this->assertStringContainsString('class Hobbit extends \Codeception\Actor', $actor['content']);
 
 
         $helper = $this->log[0];
-        $this->assertEquals(\Codeception\Configuration::supportDir().'Helper/Shire.php', $helper['filename']);
+        $this->assertSame(\Codeception\Configuration::supportDir().'Helper/Shire.php', $helper['filename']);
         $this->assertStringContainsString('namespace Helper;', $helper['content']);
         $this->assertStringContainsString('class Shire extends \Codeception\Module', $helper['content']);
     }
@@ -49,11 +49,11 @@ class GenerateSuiteTest extends BaseCommandRunner
 
         $configFile = $this->log[1];
         $conf = \Symfony\Component\Yaml\Yaml::parse($configFile['content']);
-        $this->assertEquals('HobbitTester', $conf['actor']);
+        $this->assertSame('HobbitTester', $conf['actor']);
         $this->assertContains('\Helper\Shire', $conf['modules']['enabled']);
 
         $helper = $this->log[0];
-        $this->assertEquals(\Codeception\Configuration::supportDir().'Helper/Shire.php', $helper['filename']);
+        $this->assertSame(\Codeception\Configuration::supportDir().'Helper/Shire.php', $helper['filename']);
         $this->assertStringContainsString('class Shire extends \Codeception\Module', $helper['content']);
     }
 }

--- a/tests/unit/Codeception/Command/GenerateTestTest.php
+++ b/tests/unit/Codeception/Command/GenerateTestTest.php
@@ -19,7 +19,7 @@ class GenerateTestTest extends BaseCommandRunner
     public function testBasic()
     {
         $this->execute(['suite' => 'shire', 'class' => 'HallUnderTheHill']);
-        $this->assertEquals('tests/shire/HallUnderTheHillTest.php', $this->filename);
+        $this->assertSame('tests/shire/HallUnderTheHillTest.php', $this->filename);
         $this->assertStringContainsString('class HallUnderTheHillTest extends \Codeception\Test\Unit', $this->content);
         $this->assertStringContainsString('Test was created in tests/shire/HallUnderTheHillTest.php', $this->output);
         $this->assertStringContainsString('protected function _before()', $this->content);
@@ -29,14 +29,14 @@ class GenerateTestTest extends BaseCommandRunner
     public function testCreateWithSuffix()
     {
         $this->execute(['suite' => 'shire', 'class' => 'HallUnderTheHillTest']);
-        $this->assertEquals('tests/shire/HallUnderTheHillTest.php', $this->filename);
+        $this->assertSame('tests/shire/HallUnderTheHillTest.php', $this->filename);
         $this->assertStringContainsString('Test was created in tests/shire/HallUnderTheHillTest.php', $this->output);
     }
 
     public function testCreateWithNamespace()
     {
         $this->execute(['suite' => 'shire', 'class' => 'MiddleEarth\HallUnderTheHillTest']);
-        $this->assertEquals('tests/shire/MiddleEarth/HallUnderTheHillTest.php', $this->filename);
+        $this->assertSame('tests/shire/MiddleEarth/HallUnderTheHillTest.php', $this->filename);
         $this->assertStringContainsString('namespace MiddleEarth;', $this->content);
         $this->assertStringContainsString('class HallUnderTheHillTest extends \Codeception\Test\Unit', $this->content);
         $this->assertStringContainsString('Test was created in tests/shire/MiddleEarth/HallUnderTheHillTest.php', $this->output);
@@ -45,7 +45,7 @@ class GenerateTestTest extends BaseCommandRunner
     public function testCreateWithExtension()
     {
         $this->execute(['suite' => 'shire', 'class' => 'HallUnderTheHillTest.php']);
-        $this->assertEquals('tests/shire/HallUnderTheHillTest.php', $this->filename);
+        $this->assertSame('tests/shire/HallUnderTheHillTest.php', $this->filename);
         $this->assertStringContainsString('class HallUnderTheHillTest extends \Codeception\Test\Unit', $this->content);
         $this->assertStringContainsString('protected $tester;', $this->content);
         $this->assertStringContainsString('@var \HobbitGuy', $this->content);

--- a/tests/unit/Codeception/Command/MyCustomCommandTest.php
+++ b/tests/unit/Codeception/Command/MyCustomCommandTest.php
@@ -20,6 +20,6 @@ class MyCustomCommandTest extends \Codeception\PHPUnit\TestCase
     public function testHasCommandName()
     {
         $commandName = MyCustomCommand::getCommandName();
-        $this->assertEquals('myProject:myCommand', $commandName);
+        $this->assertSame('myProject:myCommand', $commandName);
     }
 }

--- a/tests/unit/Codeception/ConfigurationTest.php
+++ b/tests/unit/Codeception/ConfigurationTest.php
@@ -37,10 +37,10 @@ class ConfigurationTest extends \Codeception\PHPUnit\TestCase
     public function testFunctionForStrippingClassNames()
     {
         $matches = [];
-        $this->assertEquals(1, preg_match('~\\\\?(\\w*?Helper)$~', '\\Codeception\\Module\\UserHelper', $matches));
-        $this->assertEquals('UserHelper', $matches[1]);
-        $this->assertEquals(1, preg_match('~\\\\?(\\w*?Helper)$~', 'UserHelper', $matches));
-        $this->assertEquals('UserHelper', $matches[1]);
+        $this->assertSame(1, preg_match('~\\\\?(\\w*?Helper)$~', '\\Codeception\\Module\\UserHelper', $matches));
+        $this->assertSame('UserHelper', $matches[1]);
+        $this->assertSame(1, preg_match('~\\\\?(\\w*?Helper)$~', 'UserHelper', $matches));
+        $this->assertSame('UserHelper', $matches[1]);
     }
 
     /**

--- a/tests/unit/Codeception/Exception/ModuleConfigTest.php
+++ b/tests/unit/Codeception/Exception/ModuleConfigTest.php
@@ -8,7 +8,7 @@ class ModuleConfigTest extends \PHPUnit\Framework\TestCase
     public function testCanBeCreatedForModuleName()
     {
         $exception = new \Codeception\Exception\ModuleConfigException('Codeception\Module\WebDriver', "Hello world");
-        $this->assertEquals("WebDriver module is not configured!\n \nHello world", $exception->getMessage());
+        $this->assertSame("WebDriver module is not configured!\n \nHello world", $exception->getMessage());
     }
 
     public function testCanBeCreatedForModuleObject()
@@ -17,6 +17,6 @@ class ModuleConfigTest extends \PHPUnit\Framework\TestCase
             new \Codeception\Module\CodeHelper(make_container()),
             "Hello world"
         );
-        $this->assertEquals("CodeHelper module is not configured!\n \nHello world", $exception->getMessage());
+        $this->assertSame("CodeHelper module is not configured!\n \nHello world", $exception->getMessage());
     }
 }

--- a/tests/unit/Codeception/Lib/Console/ColorizerTest.php
+++ b/tests/unit/Codeception/Lib/Console/ColorizerTest.php
@@ -46,6 +46,6 @@ COLORED;
         $actual = $this->colorizer->colorize($toColorizeInput);
 
 
-        $this->assertEquals($expectedColorized, $actual, 'it should add the format tags');
+        $this->assertSame($expectedColorized, $actual, 'it should add the format tags');
     }
 }

--- a/tests/unit/Codeception/Lib/Console/DiffFactoryTest.php
+++ b/tests/unit/Codeception/Lib/Console/DiffFactoryTest.php
@@ -27,7 +27,7 @@ class DiffFactoryTest extends \Codeception\Test\Unit
         $failure = $this->createFailure();
         $message = $this->diffFactory->createDiff($failure);
 
-        $this->assertEquals($expectedDiff, (string) $message, 'The diff should be generated.');
+        $this->assertSame($expectedDiff, (string) $message, 'The diff should be generated.');
     }
 
     protected function createFailure(): \SebastianBergmann\Comparator\ComparisonFailure

--- a/tests/unit/Codeception/Lib/Console/MessageTest.php
+++ b/tests/unit/Codeception/Lib/Console/MessageTest.php
@@ -11,10 +11,10 @@ class MessageTest extends \Codeception\Test\Unit
     public function testCut()
     {
         $message = new Message('very long text');
-        $this->assertEquals('very long ', $message->cut(10)->getMessage());
+        $this->assertSame('very long ', $message->cut(10)->getMessage());
 
         $message = new Message('очень длинный текст');
-        $this->assertEquals('очень длин', $message->cut(10)->getMessage());
+        $this->assertSame('очень длин', $message->cut(10)->getMessage());
     }
     
     //test message cutting
@@ -28,9 +28,9 @@ class MessageTest extends \Codeception\Test\Unit
     public function testWidth()
     {
         $message = new Message('message example');
-        $this->assertEquals('message example               ', $message->width(30)->getMessage());
+        $this->assertSame('message example               ', $message->width(30)->getMessage());
 
         $message = new Message('пример текста');
-        $this->assertEquals('пример текста                 ', $message->width(30)->getMessage());
+        $this->assertSame('пример текста                 ', $message->width(30)->getMessage());
     }
 }

--- a/tests/unit/Codeception/Lib/Console/ReplHistoryTest.php
+++ b/tests/unit/Codeception/Lib/Console/ReplHistoryTest.php
@@ -32,8 +32,8 @@ class ReplHistoryTest extends Unit
 
         $commands = $this->replHistory->getAll();
         $this->assertCount(2, $commands);
-        $this->assertEquals('$I->click(".something")', $commands[0]);
-        $this->assertEquals('$I->anotherCommand()', $commands[1]);
+        $this->assertSame('$I->click(".something")', $commands[0]);
+        $this->assertSame('$I->anotherCommand()', $commands[1]);
     }
 
     public function testClear()

--- a/tests/unit/Codeception/Lib/ModuleContainerTest.php
+++ b/tests/unit/Codeception/Lib/ModuleContainerTest.php
@@ -59,7 +59,7 @@ class ModuleContainerTest extends Unit
         $this->moduleContainer->create('EmulateModuleHelper');
         $actions = $this->moduleContainer->getActions();
         $this->assertArrayHasKey('seeEquals', $actions);
-        $this->assertEquals('EmulateModuleHelper', $actions['seeEquals']);
+        $this->assertSame('EmulateModuleHelper', $actions['seeEquals']);
     }
 
     /**
@@ -142,8 +142,8 @@ class ModuleContainerTest extends Unit
         $this->moduleContainer = new ModuleContainer(Stub::make('Codeception\Lib\Di'), $config);
         $module = $this->moduleContainer->create('Codeception\Lib\StubModule');
 
-        $this->assertEquals('firstValue', $module->_getFirstField());
-        $this->assertEquals('secondValue', $module->_getSecondField());
+        $this->assertSame('firstValue', $module->_getFirstField());
+        $this->assertSame('secondValue', $module->_getSecondField());
     }
 
     /**
@@ -164,11 +164,11 @@ class ModuleContainerTest extends Unit
         $this->moduleContainer = new ModuleContainer(Stub::make('Codeception\Lib\Di'), $config);
         $module = $this->moduleContainer->create('Codeception\Lib\StubModule');
         $module->_reconfigure(['firstField' => '1st', 'secondField' => '2nd']);
-        $this->assertEquals('1st', $module->_getFirstField());
-        $this->assertEquals('2nd', $module->_getSecondField());
+        $this->assertSame('1st', $module->_getFirstField());
+        $this->assertSame('2nd', $module->_getSecondField());
         $module->_resetConfig();
-        $this->assertEquals('firstValue', $module->_getFirstField());
-        $this->assertEquals('secondValue', $module->_getSecondField());
+        $this->assertSame('firstValue', $module->_getFirstField());
+        $this->assertSame('secondValue', $module->_getSecondField());
     }
 
     public function testConflictsByModuleName()
@@ -355,8 +355,8 @@ class ModuleContainerTest extends Unit
         $this->moduleContainer = new ModuleContainer(Stub::make('Codeception\Lib\Di'), $config);
         $module = $this->moduleContainer->create('Codeception\Lib\StubModule');
 
-        $this->assertEquals('firstValue', $module->_getFirstField());
-        $this->assertEquals('secondValue', $module->_getSecondField());
+        $this->assertSame('firstValue', $module->_getFirstField());
+        $this->assertSame('secondValue', $module->_getSecondField());
     }
 
     public function testShortConfigDependencies()

--- a/tests/unit/Codeception/Lib/ParserTest.php
+++ b/tests/unit/Codeception/Lib/ParserTest.php
@@ -38,18 +38,18 @@ class ParserTest extends \Codeception\Test\Unit
     {
         $code = "<?php\n \\\$I->wantTo('run this test'); ";
         $this->parser->parseFeature($code);
-        $this->assertEquals('run this test', $this->scenario->getFeature());
+        $this->assertSame('run this test', $this->scenario->getFeature());
 
         $code = "<?php\n \\\$I->wantToTest('this run'); ";
         $this->parser->parseFeature($code);
-        $this->assertEquals('test this run', $this->scenario->getFeature());
+        $this->assertSame('test this run', $this->scenario->getFeature());
     }
 
     public function testParsingWithWhitespace()
     {
         $code = "<?php\n \\\$I->wantTo( 'run this test' ); ";
         $this->parser->parseFeature($code);
-        $this->assertEquals('run this test', $this->scenario->getFeature());
+        $this->assertSame('run this test', $this->scenario->getFeature());
     }
 
     public function testScenarioOptions()
@@ -127,19 +127,19 @@ EOF;
     public function testParseFile()
     {
         $classes = Parser::getClassesFromFile(codecept_data_dir('SimpleTest.php'));
-        $this->assertEquals(['SampleTest'], $classes);
+        $this->assertSame(['SampleTest'], $classes);
     }
 
     public function testParseFileWithClass()
     {
         $classes = Parser::getClassesFromFile(codecept_data_dir('php55Test'));
-        $this->assertEquals(['php55Test'], $classes);
+        $this->assertSame(['php55Test'], $classes);
     }
 
     public function testParseFileWithAnonymousClass()
     {
         $classes = Parser::getClassesFromFile(codecept_data_dir('php70Test'));
-        $this->assertEquals(['php70Test'], $classes);
+        $this->assertSame(['php70Test'], $classes);
     }
     
     /*
@@ -148,7 +148,7 @@ EOF;
     public function testParseFileWhichUnsetsFileVariable()
     {
         $classes = Parser::getClassesFromFile(codecept_data_dir('unsetFile.php'));
-        $this->assertEquals([], $classes);
+        $this->assertSame([], $classes);
     }
 
     /**

--- a/tests/unit/Codeception/Step/ConditionalAssertionTest.php
+++ b/tests/unit/Codeception/Step/ConditionalAssertionTest.php
@@ -9,6 +9,6 @@ class ConditionalAssertionTest extends \PHPUnit\Framework\TestCase
     public function testCantSeeToString()
     {
         $assertion = new ConditionalAssertion('dontSee', ['text']);
-        $this->assertEquals('cant see "text"', $assertion->toString(200));
+        $this->assertSame('cant see "text"', $assertion->toString(200));
     }
 }

--- a/tests/unit/Codeception/Step/ExecutorTest.php
+++ b/tests/unit/Codeception/Step/ExecutorTest.php
@@ -18,7 +18,7 @@ class ExecutorTest extends \PHPUnit\Framework\TestCase
         });
         $actual = $executor->run();
 
-        $this->assertEquals($expected, $actual);
+        $this->assertSame($expected, $actual);
     }
 
     /**

--- a/tests/unit/Codeception/StepTest.php
+++ b/tests/unit/Codeception/StepTest.php
@@ -22,28 +22,28 @@ class StepTest extends \PHPUnit\Framework\TestCase
         //facebook/php-webdriver is no longer a dependency of core so this behaviour can't be tested anymore
         //$by = WebDriverBy::cssSelector('.something');
         //$step = $this->getStep([null, [$by]]);
-        //$this->assertEquals('"' . Locator::humanReadableString($by) . '"', $step->getArgumentsAsString());
+        //$this->assertSame('"' . Locator::humanReadableString($by) . '"', $step->getArgumentsAsString());
 
         $step = $this->getStep([null, [['just', 'array']]]);
-        $this->assertEquals('["just","array"]', $step->getArgumentsAsString());
+        $this->assertSame('["just","array"]', $step->getArgumentsAsString());
 
         $step = $this->getStep([null, [function () {
         }]]);
-        $this->assertEquals('"Closure"', $step->getArgumentsAsString());
+        $this->assertSame('"Closure"', $step->getArgumentsAsString());
 
         $step = $this->getStep([null, [[$this, 'testGetArguments']]]);
-        $this->assertEquals('["StepTest","testGetArguments"]', $step->getArgumentsAsString());
+        $this->assertSame('["StepTest","testGetArguments"]', $step->getArgumentsAsString());
 
         $step = $this->getStep([null, [[\PDO::class, 'getAvailableDrivers']]]);
-        $this->assertEquals('["PDO","getAvailableDrivers"]', $step->getArgumentsAsString());
+        $this->assertSame('["PDO","getAvailableDrivers"]', $step->getArgumentsAsString());
 
         $step = $this->getStep([null, [[Stub::make($this, []), 'testGetArguments']]]);
-        $this->assertEquals('["StepTest","testGetArguments"]', $step->getArgumentsAsString());
+        $this->assertSame('["StepTest","testGetArguments"]', $step->getArgumentsAsString());
 
         $mock = $this->createMock(get_class($this));
         $step = $this->getStep([null, [[$mock, 'testGetArguments']]]);
         $className = get_class($mock);
-        $this->assertEquals('["' . $className . '","testGetArguments"]', $step->getArgumentsAsString());
+        $this->assertSame('["' . $className . '","testGetArguments"]', $step->getArgumentsAsString());
     }
 
     public function testGetHtml()
@@ -67,60 +67,60 @@ class StepTest extends \PHPUnit\Framework\TestCase
 
         $step = $this->getStep(['have in database', [str_repeat('a', 100), str_repeat('b', 100)]]);
         $output = $step->toString(50);
-        $this->assertEquals(50, strlen($output), 'Incorrect length of output: ' . $output);
-        $this->assertEquals('have in database "aaaaaaaaaaa...","bbbbbbbbbbb..."', $output);
+        $this->assertSame(50, strlen($output), 'Incorrect length of output: ' . $output);
+        $this->assertSame('have in database "aaaaaaaaaaa...","bbbbbbbbbbb..."', $output);
 
         $step = $this->getStep(['have in database', [1, str_repeat('b', 100)]]);
         $output = $step->toString(50);
-        $this->assertEquals('have in database 1,"bbbbbbbbbbbbbbbbbbbbbbbbbb..."', $output);
+        $this->assertSame('have in database 1,"bbbbbbbbbbbbbbbbbbbbbbbbbb..."', $output);
 
         $step = $this->getStep(['have in database', [str_repeat('b', 100), 1]]);
         $output = $step->toString(50);
-        $this->assertEquals('have in database "bbbbbbbbbbbbbbbbbbbbbbbbbb...",1', $output);
+        $this->assertSame('have in database "bbbbbbbbbbbbbbbbbbbbbbbbbb...",1', $output);
     }
 
     public function testArrayAsArgument()
     {
         $step = $this->getStep(['see array', [[1,2,3], 'two']]);
         $output = $step->toString(200);
-        $this->assertEquals('see array [1,2,3],"two"', $output);
+        $this->assertSame('see array [1,2,3],"two"', $output);
     }
 
     public function testSingleQuotedStringAsArgument()
     {
         $step = $this->getStep(['see array', [[1,2,3], "'two'"]]);
         $output = $step->toString(200);
-        $this->assertEquals('see array [1,2,3],"\'two\'"', $output);
+        $this->assertSame('see array [1,2,3],"\'two\'"', $output);
     }
 
     public function testSeeUppercaseText()
     {
         $step = $this->getStep(['see', ['UPPER CASE']]);
         $output = $step->toString(200);
-        $this->assertEquals('see "UPPER CASE"', $output);
+        $this->assertSame('see "UPPER CASE"', $output);
     }
 
     public function testMultiByteTextLengthIsMeasuredCorrectly()
     {
         $step = $this->getStep(['see', ['ŽŽŽŽŽŽŽŽŽŽ', 'AAAAAAAAAAA']]);
         $output = $step->toString(30);
-        $this->assertEquals('see "ŽŽŽŽŽŽŽŽŽŽ","AAAAAAAAAAA"', $output);
+        $this->assertSame('see "ŽŽŽŽŽŽŽŽŽŽ","AAAAAAAAAAA"', $output);
     }
 
     public function testAmOnUrl()
     {
         $step = $this->getStep(['amOnUrl', ['http://www.example.org/test']]);
         $output = $step->toString(200);
-        $this->assertEquals('am on url "http://www.example.org/test"', $output);
+        $this->assertSame('am on url "http://www.example.org/test"', $output);
     }
 
     public function testNoArgs()
     {
         $step = $this->getStep(['acceptPopup', []]);
         $output = $step->toString(200);
-        $this->assertEquals('accept popup ', $output);
+        $this->assertSame('accept popup ', $output);
         $output = $step->toString(-5);
-        $this->assertEquals('accept popup ', $output);
+        $this->assertSame('accept popup ', $output);
 
     }
 
@@ -128,7 +128,7 @@ class StepTest extends \PHPUnit\Framework\TestCase
     {
         $step = $this->getStep(['see', ["aaaa\nbbbb\nc"]]);
         $output = $step->toString(200);
-        $this->assertEquals('see "aaaa\nbbbb\nc"', $output);
+        $this->assertSame('see "aaaa\nbbbb\nc"', $output);
     }
 
     public function testFormattedOutput()
@@ -138,6 +138,6 @@ class StepTest extends \PHPUnit\Framework\TestCase
 
         $step = $this->getStep(['argument', [$argument]]);
         $output = $step->toString(200);
-        $this->assertEquals('argument "some formatted output"', $output);
+        $this->assertSame('argument "some formatted output"', $output);
     }
 }

--- a/tests/unit/Codeception/Subscriber/ErrorHandlerTest.php
+++ b/tests/unit/Codeception/Subscriber/ErrorHandlerTest.php
@@ -38,7 +38,7 @@ class ErrorHandlerTest extends \Codeception\PHPUnit\TestCase
         Notification::all(); //clear the messages
         $errorHandler->errorHandler(E_USER_DEPRECATED, 'deprecated message', __FILE__, (string)__LINE__, []);
 
-        $this->assertEquals([], Notification::all(), 'Deprecation message was added to notifications');
+        $this->assertSame([], Notification::all(), 'Deprecation message was added to notifications');
     }
 
     public function testShowsLocationOfWarning()

--- a/tests/unit/Codeception/Subscriber/ModuleTest.php
+++ b/tests/unit/Codeception/Subscriber/ModuleTest.php
@@ -47,9 +47,9 @@ class ModuleTest extends Unit
         $subject = new Module();
         $subject->beforeSuite($suiteEvent);
 
-        $this->assertEquals(0, $module1->getCallOrder());
-        $this->assertEquals(0, $module2->getCallOrder());
-        $this->assertEquals(0, $module3->getCallOrder());
+        $this->assertSame(0, $module1->getCallOrder());
+        $this->assertSame(0, $module2->getCallOrder());
+        $this->assertSame(0, $module3->getCallOrder());
     }
 
     public function testBeforeSuite()
@@ -81,9 +81,9 @@ class ModuleTest extends Unit
         $subject = new Module();
         $subject->beforeSuite($suiteEvent);
 
-        $this->assertEquals(1, $module1->getCallOrder());
-        $this->assertEquals(2, $module2->getCallOrder());
-        $this->assertEquals(3, $module3->getCallOrder());
+        $this->assertSame(1, $module1->getCallOrder());
+        $this->assertSame(2, $module2->getCallOrder());
+        $this->assertSame(3, $module3->getCallOrder());
     }
 
     public function testAfterSuite()
@@ -104,9 +104,9 @@ class ModuleTest extends Unit
         );
         $subject->afterSuite();
 
-        $this->assertEquals(3, $module1->getCallOrder());
-        $this->assertEquals(2, $module2->getCallOrder());
-        $this->assertEquals(1, $module3->getCallOrder());
+        $this->assertSame(3, $module1->getCallOrder());
+        $this->assertSame(2, $module2->getCallOrder());
+        $this->assertSame(1, $module3->getCallOrder());
     }
 
     public function testBeforeDoesNothingWhenEventTestHasIncorrectType()
@@ -132,9 +132,9 @@ class ModuleTest extends Unit
         );
         $subject->before($testEvent);
 
-        $this->assertEquals(0, $module1->getCallOrder());
-        $this->assertEquals(0, $module2->getCallOrder());
-        $this->assertEquals(0, $module3->getCallOrder());
+        $this->assertSame(0, $module1->getCallOrder());
+        $this->assertSame(0, $module2->getCallOrder());
+        $this->assertSame(0, $module3->getCallOrder());
     }
 
     public function testBefore()
@@ -160,9 +160,9 @@ class ModuleTest extends Unit
         );
         $subject->before($testEvent);
 
-        $this->assertEquals(1, $module1->getCallOrder());
-        $this->assertEquals(2, $module2->getCallOrder());
-        $this->assertEquals(3, $module3->getCallOrder());
+        $this->assertSame(1, $module1->getCallOrder());
+        $this->assertSame(2, $module2->getCallOrder());
+        $this->assertSame(3, $module3->getCallOrder());
     }
 
     public function testAfterDoesNothingWhenEventTestHasIncorrectType()
@@ -188,9 +188,9 @@ class ModuleTest extends Unit
         );
         $subject->after($testEvent);
 
-        $this->assertEquals(0, $module1->getCallOrder());
-        $this->assertEquals(0, $module2->getCallOrder());
-        $this->assertEquals(0, $module3->getCallOrder());
+        $this->assertSame(0, $module1->getCallOrder());
+        $this->assertSame(0, $module2->getCallOrder());
+        $this->assertSame(0, $module3->getCallOrder());
     }
 
     public function testAfter()
@@ -216,9 +216,9 @@ class ModuleTest extends Unit
         );
         $subject->after($testEvent);
 
-        $this->assertEquals(3, $module1->getCallOrder());
-        $this->assertEquals(2, $module2->getCallOrder());
-        $this->assertEquals(1, $module3->getCallOrder());
+        $this->assertSame(3, $module1->getCallOrder());
+        $this->assertSame(2, $module2->getCallOrder());
+        $this->assertSame(1, $module3->getCallOrder());
     }
 
     public function testFailedDoesNothingWhenEventTestHasIncorrectType()
@@ -245,9 +245,9 @@ class ModuleTest extends Unit
         );
         $subject->failed($failed);
 
-        $this->assertEquals(0, $module1->getCallOrder());
-        $this->assertEquals(0, $module2->getCallOrder());
-        $this->assertEquals(0, $module3->getCallOrder());
+        $this->assertSame(0, $module1->getCallOrder());
+        $this->assertSame(0, $module2->getCallOrder());
+        $this->assertSame(0, $module3->getCallOrder());
     }
 
     public function testFailed()
@@ -274,9 +274,9 @@ class ModuleTest extends Unit
         );
         $subject->failed($failed);
 
-        $this->assertEquals(3, $module1->getCallOrder());
-        $this->assertEquals(2, $module2->getCallOrder());
-        $this->assertEquals(1, $module3->getCallOrder());
+        $this->assertSame(3, $module1->getCallOrder());
+        $this->assertSame(2, $module2->getCallOrder());
+        $this->assertSame(1, $module3->getCallOrder());
     }
 
     public function testBeforeStep()
@@ -303,9 +303,9 @@ class ModuleTest extends Unit
         );
         $subject->beforeStep($stepEvent);
 
-        $this->assertEquals(1, $module1->getCallOrder());
-        $this->assertEquals(2, $module2->getCallOrder());
-        $this->assertEquals(3, $module3->getCallOrder());
+        $this->assertSame(1, $module1->getCallOrder());
+        $this->assertSame(2, $module2->getCallOrder());
+        $this->assertSame(3, $module3->getCallOrder());
     }
 
     public function testAfterStep()
@@ -332,9 +332,9 @@ class ModuleTest extends Unit
         );
         $subject->afterStep($stepEvent);
 
-        $this->assertEquals(3, $module1->getCallOrder());
-        $this->assertEquals(2, $module2->getCallOrder());
-        $this->assertEquals(1, $module3->getCallOrder());
+        $this->assertSame(3, $module1->getCallOrder());
+        $this->assertSame(2, $module2->getCallOrder());
+        $this->assertSame(1, $module3->getCallOrder());
     }
 }
 

--- a/tests/unit/Codeception/SuiteManagerTest.php
+++ b/tests/unit/Codeception/SuiteManagerTest.php
@@ -56,7 +56,7 @@ class SuiteManagerTest extends \Codeception\PHPUnit\TestCase
             new \PHPUnit\Framework\TestResult,
             ['colors' => false, 'steps' => true, 'debug' => false, 'report_useless_tests' => false, 'disallow_test_output' => false]
         );
-        $this->assertEquals($events, ['suite.before', 'suite.after']);
+        $this->assertSame($events, ['suite.before', 'suite.after']);
     }
 
     /**
@@ -67,11 +67,11 @@ class SuiteManagerTest extends \Codeception\PHPUnit\TestCase
         $file = \Codeception\Configuration::dataDir().'SimpleCest.php';
 
         $this->suiteman->loadTests($file);
-        $this->assertEquals(2, $this->suiteman->getSuite()->count());
+        $this->assertSame(2, $this->suiteman->getSuite()->count());
 
         $file = \Codeception\Configuration::dataDir().'SimpleWithNoClassCest.php';
         $this->suiteman->loadTests($file);
-        $this->assertEquals(3, $this->suiteman->getSuite()->count());
+        $this->assertSame(3, $this->suiteman->getSuite()->count());
     }
 
     /**
@@ -85,20 +85,20 @@ class SuiteManagerTest extends \Codeception\PHPUnit\TestCase
     {
         $file = \Codeception\Configuration::dataDir().'SimpleNamespacedTest.php';
         $this->suiteman->loadTests($file);
-        $this->assertEquals(3, $this->suiteman->getSuite()->count());
+        $this->assertSame(3, $this->suiteman->getSuite()->count());
         $newSuiteMan = new \Codeception\SuiteManager(
             $this->dispatcher,
             'suite',
             \Codeception\Configuration::$defaultSuiteSettings
         );
         $newSuiteMan->loadTests($file);
-        $this->assertEquals(3, $newSuiteMan->getSuite()->count());
+        $this->assertSame(3, $newSuiteMan->getSuite()->count());
     }
 
     public function testDependencyResolution()
     {
         $this->suiteman->loadTests(codecept_data_dir().'SimpleWithDependencyInjectionCest.php');
-        $this->assertEquals(3, $this->suiteman->getSuite()->count());
+        $this->assertSame(3, $this->suiteman->getSuite()->count());
     }
 
     public function testGroupEventsAreFired()

--- a/tests/unit/Codeception/Test/CeptTest.php
+++ b/tests/unit/Codeception/Test/CeptTest.php
@@ -14,15 +14,15 @@ class CeptTest extends \Codeception\Test\Unit
 
         $path = 'tests' . DIRECTORY_SEPARATOR . 'cli' . DIRECTORY_SEPARATOR;
 
-        $this->assertEquals(
+        $this->assertSame(
             $path . 'AutoRebuildCept.php',
             \Codeception\Test\Descriptor::getTestFileName($cept)
         );
-        $this->assertEquals(
+        $this->assertSame(
             $path . 'AutoRebuildCept.php',
             \Codeception\Test\Descriptor::getTestFullName($cept)
         );
-        $this->assertEquals(
+        $this->assertSame(
             'AutoRebuildCept',
             \Codeception\Test\Descriptor::getTestSignature($cept)
         );

--- a/tests/unit/Codeception/Test/CestTest.php
+++ b/tests/unit/Codeception/Test/CestTest.php
@@ -18,17 +18,17 @@ class CestTest extends \Codeception\Test\Unit
 
         $path = 'tests' . DIRECTORY_SEPARATOR . 'cli' . DIRECTORY_SEPARATOR;
 
-        $this->assertEquals(
+        $this->assertSame(
             $path . 'BootstrapCest.php',
             \Codeception\Test\Descriptor::getTestFileName($cest)
         );
 
-        $this->assertEquals(
+        $this->assertSame(
             $path . 'BootstrapCest.php:user',
             \Codeception\Test\Descriptor::getTestFullName($cest)
         );
 
-        $this->assertEquals(
+        $this->assertSame(
             'stdClass:user',
             \Codeception\Test\Descriptor::getTestSignature($cest)
         );

--- a/tests/unit/Codeception/Test/GherkinTest.php
+++ b/tests/unit/Codeception/Test/GherkinTest.php
@@ -48,7 +48,7 @@ class GherkinTest extends \Codeception\Test\Unit
         $this->assertCount(1, $tests);
         $test = $tests[0];
         $this->assertInstanceOf('\Codeception\Test\Gherkin', $test);
-        $this->assertEquals('Refund item', $test->getFeature());
+        $this->assertSame('Refund item', $test->getFeature());
     }
 
     public function testGherkinScenario()
@@ -58,7 +58,7 @@ class GherkinTest extends \Codeception\Test\Unit
         $this->assertCount(1, $tests);
         $test = $tests[0];
         $this->assertInstanceOf('\Codeception\Test\Gherkin', $test);
-        $this->assertEquals('Jeff returns a faulty microwave', $test->getScenarioTitle());
+        $this->assertSame('Jeff returns a faulty microwave', $test->getScenarioTitle());
     }
 
     /**
@@ -70,7 +70,7 @@ class GherkinTest extends \Codeception\Test\Unit
         $test = $this->loader->getTests()[0];
         $test->getMetadata()->setServices($this->getServices());
         $test->test();
-        $this->assertEquals('abc', self::$calls);
+        $this->assertSame('abc', self::$calls);
     }
 
     public function testBadRegex()
@@ -110,7 +110,7 @@ class GherkinTest extends \Codeception\Test\Unit
         $test = $this->loader->getTests()[0];
         $test->getMetadata()->setServices($this->getServices());
         $test->test();
-        $this->assertEquals('aXc', self::$calls);
+        $this->assertSame('aXc', self::$calls);
     }
 
     public function testRoles()
@@ -131,7 +131,7 @@ class GherkinTest extends \Codeception\Test\Unit
         $test = $this->loader->getTests()[0];
         $test->getMetadata()->setServices($this->getServices());
         $test->test();
-        $this->assertEquals('aXc', self::$calls);
+        $this->assertSame('aXc', self::$calls);
     }
 
 

--- a/tests/unit/Codeception/Test/UnitTest.php
+++ b/tests/unit/Codeception/Test/UnitTest.php
@@ -7,10 +7,10 @@ class TestTest extends \Codeception\Test\Unit
     public function testReportedInterface()
     {
         $this->assertInstanceOf(\Codeception\Test\Interfaces\Reported::class, $this);
-        $this->assertEquals([
-            'file' => __FILE__,
+        $this->assertSame([
             'name' => 'testReportedInterface',
-            'class' => 'TestTest'
+            'class' => 'TestTest',
+            'file' => __FILE__
         ], $this->getReportFields());
     }
 }

--- a/tests/unit/Codeception/TestLoaderTest.php
+++ b/tests/unit/Codeception/TestLoaderTest.php
@@ -102,7 +102,7 @@ class TestLoaderTest extends \Codeception\PHPUnit\TestCase
         /** @var \PHPUnit\Framework\DataProviderTestSuite $firstTest */
         $firstTest = $tests[0];
 
-        $this->assertEquals(5, $firstTest->count());
+        $this->assertSame(5, $firstTest->count());
     }
 
     public function testDataProviderReturningGenerator()
@@ -112,6 +112,6 @@ class TestLoaderTest extends \Codeception\PHPUnit\TestCase
         /** @var \PHPUnit\Framework\DataProviderTestSuite $firstTest */
         $firstTest = $tests[0];
 
-        $this->assertEquals(5, $firstTest->count());
+        $this->assertSame(5, $firstTest->count());
     }
 }

--- a/tests/unit/Codeception/Util/AnnotationTest.php
+++ b/tests/unit/Codeception/Util/AnnotationTest.php
@@ -16,8 +16,8 @@ class AnnotationTest extends \PHPUnit\Framework\TestCase
 
     public function testClassAnnotation()
     {
-        $this->assertEquals('davert', Annotation::forClass(__CLASS__)->fetch('author'));
-        $this->assertEquals('codeception', Annotation::forClass(__CLASS__)->fetch('tag'));
+        $this->assertSame('davert', Annotation::forClass(__CLASS__)->fetch('author'));
+        $this->assertSame('codeception', Annotation::forClass(__CLASS__)->fetch('tag'));
     }
 
     /**
@@ -27,19 +27,19 @@ class AnnotationTest extends \PHPUnit\Framework\TestCase
      */
     public function testMethodAnnotation()
     {
-        $this->assertEquals('null', Annotation::forClass(__CLASS__)
+        $this->assertSame('null', Annotation::forClass(__CLASS__)
                 ->method('testMethodAnnotation')
                 ->fetch('return'));
     }
 
     public function testMultipleClassAnnotations()
     {
-        $this->assertEquals(['codeception', 'tdd'], Annotation::forClass(__CLASS__)->fetchAll('tag'));
+        $this->assertSame(['codeception', 'tdd'], Annotation::forClass(__CLASS__)->fetchAll('tag'));
     }
 
     public function testMultipleMethodAnnotations()
     {
-        $this->assertEquals(
+        $this->assertSame(
             ['$var1', '$var2'],
             Annotation::forClass(__CLASS__)->method('testMethodAnnotation')->fetchAll('param')
         );
@@ -53,8 +53,8 @@ class AnnotationTest extends \PHPUnit\Framework\TestCase
 @param key2
 EOF;
 
-        $this->assertEquals(['davert'], Annotation::fetchAnnotationsFromDocblock('user', $docblock));
-        $this->assertEquals(['key1', 'key2'], Annotation::fetchAnnotationsFromDocblock('param', $docblock));
+        $this->assertSame(['davert'], Annotation::fetchAnnotationsFromDocblock('user', $docblock));
+        $this->assertSame(['key1', 'key2'], Annotation::fetchAnnotationsFromDocblock('param', $docblock));
     }
 
 
@@ -68,7 +68,7 @@ EOF;
 
         $all = Annotation::fetchAllAnnotationsFromDocblock($docblock);
         codecept_debug($all);
-        $this->assertEquals([
+        $this->assertSame([
             'user' => ['davert'],
             'param' => ['key1', 'key2']
         ], Annotation::fetchAllAnnotationsFromDocblock($docblock));
@@ -78,19 +78,19 @@ EOF;
     public function testValueToSupportJson()
     {
         $values = Annotation::arrayValue('{ "code": "200", "user": "davert", "email": "davert@gmail.com" }');
-        $this->assertEquals(['code' => '200', 'user' => 'davert', 'email' => 'davert@gmail.com'], $values);
+        $this->assertSame(['code' => '200', 'user' => 'davert', 'email' => 'davert@gmail.com'], $values);
     }
 
     public function testValueToSupportAnnotationStyle()
     {
         $values = Annotation::arrayValue('( code="200", user="davert", email = "davert@gmail.com")');
-        $this->assertEquals(['code' => '200', 'user' => 'davert', 'email' => 'davert@gmail.com'], $values);
+        $this->assertSame(['code' => '200', 'user' => 'davert', 'email' => 'davert@gmail.com'], $values);
     }
 
     /** @value foobar */
     public function testSingleLineAnnotation()
     {
-        $this->assertEquals('foobar', Annotation::forClass(__CLASS__)
+        $this->assertSame('foobar', Annotation::forClass(__CLASS__)
                 ->method('testSingleLineAnnotation')
                 ->fetch('value'));
     }

--- a/tests/unit/Codeception/Util/LocatorTest.php
+++ b/tests/unit/Codeception/Util/LocatorTest.php
@@ -11,10 +11,10 @@ class LocatorTest extends \PHPUnit\Framework\TestCase
     public function testCombine()
     {
         $result = Locator::combine('//button[@value="Click Me"]', '//a[.="Click Me"]');
-        $this->assertEquals('//button[@value="Click Me"] | //a[.="Click Me"]', $result);
+        $this->assertSame('//button[@value="Click Me"] | //a[.="Click Me"]', $result);
 
         $result = Locator::combine('button[value="Click Me"]', '//a[.="Click Me"]');
-        $this->assertEquals('descendant-or-self::button[@value = \'Click Me\'] | //a[.="Click Me"]', $result);
+        $this->assertSame('descendant-or-self::button[@value = \'Click Me\'] | //a[.="Click Me"]', $result);
 
         $xml = new SimpleXMLElement("<root><button value='Click Me' /></root>");
         $this->assertNotEmpty($xml->xpath($result));
@@ -71,15 +71,15 @@ class LocatorTest extends \PHPUnit\Framework\TestCase
 
     public function testContains()
     {
-        $this->assertEquals(
+        $this->assertSame(
             "descendant-or-self::label[contains(., 'enter a name')]",
             Locator::contains('label', 'enter a name')
         );
-        $this->assertEquals(
+        $this->assertSame(
             "descendant-or-self::label[@id = 'user'][contains(., 'enter a name')]",
             Locator::contains('label#user', 'enter a name')
         );
-        $this->assertEquals(
+        $this->assertSame(
             '//label[@for="name"][contains(., \'enter a name\')]',
             Locator::contains('//label[@for="name"]', 'enter a name')
         );
@@ -87,10 +87,10 @@ class LocatorTest extends \PHPUnit\Framework\TestCase
 
     public function testHumanReadableString()
     {
-        $this->assertEquals("'string selector'", Locator::humanReadableString("string selector"));
-        $this->assertEquals("css '.something'", Locator::humanReadableString(['css' => '.something']));
+        $this->assertSame("'string selector'", Locator::humanReadableString("string selector"));
+        $this->assertSame("css '.something'", Locator::humanReadableString(['css' => '.something']));
         //WebDriver is no longer a dependency of core, so this can't be testedI
-        //$this->assertEquals("css selector '.something'", Locator::humanReadableString(WebDriverBy::cssSelector('.something')) );
+        //$this->assertSame("css selector '.something'", Locator::humanReadableString(WebDriverBy::cssSelector('.something')) );
 
         try {
             Locator::humanReadableString(null);
@@ -101,10 +101,10 @@ class LocatorTest extends \PHPUnit\Framework\TestCase
 
     public function testLocatingElementPosition()
     {
-        $this->assertEquals('(descendant-or-self::p)[position()=1]', Locator::firstElement('p'));
-        $this->assertEquals('(descendant-or-self::p)[position()=last()]', Locator::lastElement('p'));
-        $this->assertEquals('(descendant-or-self::p)[position()=1]', Locator::elementAt('p', 1));
-        $this->assertEquals('(descendant-or-self::p)[position()=last()-0]', Locator::elementAt('p', -1));
-        $this->assertEquals('(descendant-or-self::p)[position()=last()-1]', Locator::elementAt('p', -2));
+        $this->assertSame('(descendant-or-self::p)[position()=1]', Locator::firstElement('p'));
+        $this->assertSame('(descendant-or-self::p)[position()=last()]', Locator::lastElement('p'));
+        $this->assertSame('(descendant-or-self::p)[position()=1]', Locator::elementAt('p', 1));
+        $this->assertSame('(descendant-or-self::p)[position()=last()-0]', Locator::elementAt('p', -1));
+        $this->assertSame('(descendant-or-self::p)[position()=last()-1]', Locator::elementAt('p', -2));
     }
 }

--- a/tests/unit/Codeception/Util/PathResolverTest.php
+++ b/tests/unit/Codeception/Util/PathResolverTest.php
@@ -13,7 +13,7 @@ class PathResolverTest extends \Codeception\Test\Unit
     public function testGetRelativeDir(string $path, string $projDir, string $dirSep, string $expectedOutput)
     {
         $relativeDir = PathResolver::getRelativeDir($path, $projDir, $dirSep);
-        $this->assertEquals($expectedOutput, $relativeDir);
+        $this->assertSame($expectedOutput, $relativeDir);
     }
 
     /**

--- a/tests/unit/Codeception/Util/ReflectionHelperTest.php
+++ b/tests/unit/Codeception/Util/ReflectionHelperTest.php
@@ -18,19 +18,19 @@ class ReflectionHelperTest extends \Codeception\PHPUnit\TestCase
         $object = new ReflectionTestClass();
         $object->setValue($expected);
 
-        $this->assertEquals(
+        $this->assertSame(
             $expected,
             ReflectionHelper::readPrivateProperty($object, 'value', ReflectionTestClass::class)
         );
 
-        $this->assertEquals(
+        $this->assertSame(
             $expected,
             ReflectionHelper::readPrivateProperty($object, 'value', null)
         );
 
         $this->expectException(ReflectionException::class);
 
-        $this->assertEquals(
+        $this->assertSame(
             $expected,
             ReflectionHelper::readPrivateProperty($object, 'value', '')
         );
@@ -43,19 +43,19 @@ class ReflectionHelperTest extends \Codeception\PHPUnit\TestCase
         $object = new ReflectionTestClass();
         $object->setValue($expected);
 
-        $this->assertEquals(
+        $this->assertSame(
             $expected,
             ReflectionHelper::invokePrivateMethod($object, 'getSecret', ['cat'], ReflectionTestClass::class)
         );
 
-        $this->assertEquals(
+        $this->assertSame(
             $expected,
             ReflectionHelper::invokePrivateMethod($object, 'getSecret', ['cat'], null)
         );
 
         $this->expectException(ReflectionException::class);
 
-        $this->assertEquals(
+        $this->assertSame(
             $expected,
             ReflectionHelper::invokePrivateMethod($object, 'getSecret', ['cat'], '')
         );
@@ -63,12 +63,12 @@ class ReflectionHelperTest extends \Codeception\PHPUnit\TestCase
 
     public function testGetClassShortName()
     {
-        $this->assertEquals(
+        $this->assertSame(
             'ReflectionTestClass',
             ReflectionHelper::getClassShortName(new ReflectionTestClass())
         );
 
-        $this->assertEquals(
+        $this->assertSame(
             'ReflectionHelper',
             ReflectionHelper::getClassShortName(new ReflectionHelper())
         );
@@ -79,22 +79,22 @@ class ReflectionHelperTest extends \Codeception\PHPUnit\TestCase
         $object = new ReflectionTestClass();
         $object->setValue('elephant');
 
-        $this->assertEquals(
+        $this->assertSame(
             \Codeception\Util\Debug::class,
             ReflectionHelper::getClassFromParameter(new ReflectionParameter([$object, 'setDebug'], 0))
         );
 
-        $this->assertEquals(
+        $this->assertSame(
             null,
             ReflectionHelper::getClassFromParameter(new ReflectionParameter([$object, 'setDebug'], 1))
         );
 
-        $this->assertEquals(
+        $this->assertSame(
             null,
             ReflectionHelper::getClassFromParameter(new ReflectionParameter([$object, 'setDebug'], 'flavor'))
         );
 
-        $this->assertEquals(
+        $this->assertSame(
             null,
             ReflectionHelper::getClassFromParameter(new ReflectionParameter([$object, 'setInt'], 'i'))
         );
@@ -105,37 +105,37 @@ class ReflectionHelperTest extends \Codeception\PHPUnit\TestCase
         $object = new ReflectionTestClass();
         $object->setValue('elephant');
 
-        $this->assertEquals(
+        $this->assertSame(
             'null',
             ReflectionHelper::getDefaultValue(new ReflectionParameter([$object, 'setDebug'], 0))
         );
 
-        $this->assertEquals(
+        $this->assertSame(
             '\Codeception\Util\ReflectionTestClass::FOO',
             ReflectionHelper::getDefaultValue(new ReflectionParameter([$object, 'setDebug'], 1))
         );
 
-        $this->assertEquals(
+        $this->assertSame(
             '\Codeception\Util\ReflectionTestClass::FOO',
             ReflectionHelper::getDefaultValue(new ReflectionParameter([$object, 'setDebug'], 'flavor'))
         );
 
-        $this->assertEquals(
+        $this->assertSame(
             '\Codeception\Codecept::VERSION',
             ReflectionHelper::getDefaultValue(new ReflectionParameter([$object, 'setFlavorImportedDefault'], 'flavor'))
         );
 
-        $this->assertEquals(
+        $this->assertSame(
             "''",
             ReflectionHelper::getDefaultValue(new ReflectionParameter([$object, 'setValue'], 0))
         );
 
-        $this->assertEquals(
+        $this->assertSame(
             '0',
             ReflectionHelper::getDefaultValue(new ReflectionParameter([$object, 'setInt'], 0))
         );
 
-        $this->assertEquals(
+        $this->assertSame(
             'null',
             ReflectionHelper::getDefaultValue(new ReflectionParameter([$object, 'setMixed'], 0))
         );
@@ -143,27 +143,27 @@ class ReflectionHelperTest extends \Codeception\PHPUnit\TestCase
 
     public function testPhpEncodeValue()
     {
-        $this->assertEquals(
+        $this->assertSame(
             '0',
             ReflectionHelper::phpEncodeValue(0)
         );
 
-        $this->assertEquals(
+        $this->assertSame(
             '1',
             ReflectionHelper::phpEncodeValue(1)
         );
 
-        $this->assertEquals(
+        $this->assertSame(
             '"\\u00fcber"',
             ReflectionHelper::phpEncodeValue('über')
         );
 
-        $this->assertEquals(
+        $this->assertSame(
             '["foo" => "bar"]',
             ReflectionHelper::phpEncodeValue(['foo' => 'bar'])
         );
 
-        $this->assertEquals(
+        $this->assertSame(
             '["foo" => "bar", "baz" => ["cat", "dog"]]',
             ReflectionHelper::phpEncodeValue(['foo' => 'bar', 'baz' => ['cat', 'dog']])
         );
@@ -171,12 +171,12 @@ class ReflectionHelperTest extends \Codeception\PHPUnit\TestCase
 
     public function testPhpEncodeArray()
     {
-        $this->assertEquals(
+        $this->assertSame(
             '["foo" => "bar"]',
             ReflectionHelper::phpEncodeArray(['foo' => 'bar'])
         );
 
-        $this->assertEquals(
+        $this->assertSame(
             '["foo" => "bar", "baz" => ["cat", "dog"]]',
             ReflectionHelper::phpEncodeArray(['foo' => 'bar', 'baz' => ['cat', 'dog']])
         );

--- a/tests/unit/Codeception/Util/StubTest.php
+++ b/tests/unit/Codeception/Util/StubTest.php
@@ -44,20 +44,20 @@ class StubTest extends \Codeception\PHPUnit\TestCase
     public function testMakeEmptyExcept()
     {
         $dummy = Stub::makeEmptyExcept('DummyClass', 'helloWorld');
-        $this->assertEquals($this->dummy->helloWorld(), $dummy->helloWorld());
+        $this->assertSame($this->dummy->helloWorld(), $dummy->helloWorld());
         $this->assertNull($dummy->goodByeWorld());
     }
 
     public function testMakeEmptyExceptPropertyReplaced()
     {
         $dummy = Stub::makeEmptyExcept('DummyClass', 'getCheckMe', ['checkMe' => 'checked!']);
-        $this->assertEquals('checked!', $dummy->getCheckMe());
+        $this->assertSame('checked!', $dummy->getCheckMe());
     }
 
     public function testMakeEmptyExceptMagicalPropertyReplaced()
     {
         $dummy = Stub::makeEmptyExcept('DummyClass', 'getCheckMeToo', ['checkMeToo' => 'checked!']);
-        $this->assertEquals('checked!', $dummy->getCheckMeToo());
+        $this->assertSame('checked!', $dummy->getCheckMeToo());
     }
 
     public function testFactory()
@@ -72,8 +72,8 @@ class StubTest extends \Codeception\PHPUnit\TestCase
         $dummy = Stub::make('DummyClass', ['goodByeWorld' => function () {
             return 'hello world';
         }]);
-        $this->assertEquals($this->dummy->helloWorld(), $dummy->helloWorld());
-        $this->assertEquals("hello world", $dummy->goodByeWorld());
+        $this->assertSame($this->dummy->helloWorld(), $dummy->helloWorld());
+        $this->assertSame("hello world", $dummy->goodByeWorld());
     }
 
     public function testMakeMethodReplaced()
@@ -87,7 +87,7 @@ class StubTest extends \Codeception\PHPUnit\TestCase
     public function testMakeWithMagicalPropertiesReplaced()
     {
         $dummy = Stub::make('DummyClass', ['checkMeToo' => 'checked!']);
-        $this->assertEquals('checked!', $dummy->checkMeToo);
+        $this->assertSame('checked!', $dummy->checkMeToo);
     }
 
     public function testMakeMethodSimplyReplaced()
@@ -99,15 +99,15 @@ class StubTest extends \Codeception\PHPUnit\TestCase
     public function testCopy()
     {
         $dummy = Stub::copy($this->dummy, ['checkMe' => 'checked!']);
-        $this->assertEquals('checked!', $dummy->getCheckMe());
+        $this->assertSame('checked!', $dummy->getCheckMe());
         $dummy = Stub::copy($this->dummy, ['checkMeToo' => 'checked!']);
-        $this->assertEquals('checked!', $dummy->getCheckMeToo());
+        $this->assertSame('checked!', $dummy->getCheckMeToo());
     }
 
     public function testConstruct()
     {
         $dummy = Stub::construct('DummyClass', ['checkMe' => 'checked!']);
-        $this->assertEquals('constructed: checked!', $dummy->getCheckMe());
+        $this->assertSame('constructed: checked!', $dummy->getCheckMe());
 
         $dummy = Stub::construct(
             'DummyClass',
@@ -116,8 +116,8 @@ class StubTest extends \Codeception\PHPUnit\TestCase
                 return false;
             }]
         );
-        $this->assertEquals('constructed: checked!', $dummy->getCheckMe());
-        $this->assertEquals(false, $dummy->targetMethod());
+        $this->assertSame('constructed: checked!', $dummy->getCheckMe());
+        $this->assertSame(false, $dummy->targetMethod());
     }
 
     public function testConstructMethodReplaced()
@@ -148,16 +148,16 @@ class StubTest extends \Codeception\PHPUnit\TestCase
     {
         $dummy = Stub::constructEmptyExcept('DummyClass', 'getCheckMe', ['checkMe' => 'checked!']);
         $this->assertNull($dummy->targetMethod());
-        $this->assertEquals('constructed: checked!', $dummy->getCheckMe());
+        $this->assertSame('constructed: checked!', $dummy->getCheckMe());
     }
 
     public function testUpdate()
     {
         $dummy = Stub::construct('DummyClass');
         Stub::update($dummy, ['checkMe' => 'done']);
-        $this->assertEquals('done', $dummy->getCheckMe());
+        $this->assertSame('done', $dummy->getCheckMe());
         Stub::update($dummy, ['checkMeToo' => 'done']);
-        $this->assertEquals('done', $dummy->getCheckMeToo());
+        $this->assertSame('done', $dummy->getCheckMeToo());
     }
 
     public function testStubsFromObject()
@@ -210,7 +210,7 @@ class StubTest extends \Codeception\PHPUnit\TestCase
     {
         $this->assertTrue(method_exists($dummy, 'helloWorld'));
         $this->assertNotEquals($this->dummy->helloWorld(), $dummy->helloWorld());
-        $this->assertEquals($dummy->helloWorld(), 'good bye world');
+        $this->assertSame($dummy->helloWorld(), 'good bye world');
     }
 
     public static function matcherAndFailMessageProvider(): array
@@ -379,7 +379,7 @@ class StubTest extends \Codeception\PHPUnit\TestCase
         for ($i = 0; $i < $count; $i++) {
             $actual = call_user_func($callable);
             if ($expected) {
-                $this->assertEquals($expected, $actual);
+                $this->assertSame($expected, $actual);
             }
         }
     }
@@ -388,10 +388,10 @@ class StubTest extends \Codeception\PHPUnit\TestCase
     {
         $dummy = Stub::make('DummyClass', ['helloWorld' => Stub::consecutive('david', 'emma', 'sam', 'amy')]);
 
-        $this->assertEquals('david', $dummy->helloWorld());
-        $this->assertEquals('emma', $dummy->helloWorld());
-        $this->assertEquals('sam', $dummy->helloWorld());
-        $this->assertEquals('amy', $dummy->helloWorld());
+        $this->assertSame('david', $dummy->helloWorld());
+        $this->assertSame('emma', $dummy->helloWorld());
+        $this->assertSame('sam', $dummy->helloWorld());
+        $this->assertSame('amy', $dummy->helloWorld());
 
         // Expected null value when no more values
         $this->assertNull($dummy->helloWorld());
@@ -410,15 +410,15 @@ class StubTest extends \Codeception\PHPUnit\TestCase
                  }
             ]
         );
-        $this->assertEquals('gamma', $tester->getName());
-        $this->assertEquals('randomstuff', $tester->getRandomName());
-        $this->assertEquals('ticky2', $tester->getT());
+        $this->assertSame('gamma', $tester->getName());
+        $this->assertSame('randomstuff', $tester->getRandomName());
+        $this->assertSame('ticky2', $tester->getT());
     }
 
     public function testStubMakeEmptyInterface()
     {
         $stub = Stub::makeEmpty('\Countable', ['count' => 5]);
-        $this->assertEquals(5, $stub->count());
+        $this->assertSame(5, $stub->count());
     }
 }
 

--- a/tests/unit/Codeception/Util/StubTest.php
+++ b/tests/unit/Codeception/Util/StubTest.php
@@ -209,7 +209,7 @@ class StubTest extends \Codeception\PHPUnit\TestCase
     protected function assertMethodReplaced($dummy)
     {
         $this->assertTrue(method_exists($dummy, 'helloWorld'));
-        $this->assertNotEquals($this->dummy->helloWorld(), $dummy->helloWorld());
+        $this->assertNotSame($this->dummy->helloWorld(), $dummy->helloWorld());
         $this->assertSame($dummy->helloWorld(), 'good bye world');
     }
 

--- a/tests/unit/Codeception/Util/TemplateTest.php
+++ b/tests/unit/Codeception/Util/TemplateTest.php
@@ -10,26 +10,26 @@ class TemplateTest extends \PHPUnit\Framework\TestCase
     {
         $template = new Template("hello, {{name}}");
         $template->place('name', 'davert');
-        $this->assertEquals('hello, davert', $template->produce());
+        $this->assertSame('hello, davert', $template->produce());
     }
 
     public function testTemplateCanHaveOtherPlaceholder()
     {
         $template = new Template("hello, %name%", '%', '%');
         $template->place('name', 'davert');
-        $this->assertEquals('hello, davert', $template->produce());
+        $this->assertSame('hello, davert', $template->produce());
     }
 
     public function testTemplateSupportsDotNotationForArrays()
     {
         $template = new Template("hello, {{user.data.name}}");
         $template->place('user', ['data' => ['name' => 'davert']]);
-        $this->assertEquals('hello, davert', $template->produce());
+        $this->assertSame('hello, davert', $template->produce());
     }
 
     public function testShouldSkipUnmatchedPlaceholder()
     {
         $template = new Template("hello, {{name}}");
-        $this->assertEquals('hello, {{name}}', $template->produce());
+        $this->assertSame('hello, {{name}}', $template->produce());
     }
 }

--- a/tests/unit/Codeception/Util/UriTest.php
+++ b/tests/unit/Codeception/Util/UriTest.php
@@ -9,19 +9,19 @@ class UriTest extends \Codeception\Test\Unit
     // tests
     public function testUrlMerge()
     {
-        $this->assertEquals(
+        $this->assertSame(
             'http://codeception.com/quickstart',
             Uri::mergeUrls('http://codeception.com/hello', '/quickstart'),
             'merge paths'
         );
 
-        $this->assertEquals(
+        $this->assertSame(
             'http://codeception.com/hello/davert',
             Uri::mergeUrls('http://codeception.com/hello/world', 'davert'),
             'merge relative urls'
         );
 
-        $this->assertEquals(
+        $this->assertSame(
             'https://github.com/codeception/codeception',
             Uri::mergeUrls('http://codeception.com/hello/world', 'https://github.com/codeception/codeception'),
             'merge absolute urls'
@@ -33,12 +33,12 @@ class UriTest extends \Codeception\Test\Unit
      */
     public function testMergingScheme()
     {
-        $this->assertEquals(
+        $this->assertSame(
             'https://google.com/account/',
             Uri::mergeUrls('http://google.com/', 'https://google.com/account/')
         );
-        $this->assertEquals('https://facebook.com/', Uri::mergeUrls('https://google.com/test/', '//facebook.com/'));
-        $this->assertEquals(
+        $this->assertSame('https://facebook.com/', Uri::mergeUrls('https://google.com/test/', '//facebook.com/'));
+        $this->assertSame(
             'https://facebook.com/#anchor2',
             Uri::mergeUrls('https://google.com/?param=1#anchor', '//facebook.com/#anchor2')
         );
@@ -49,10 +49,10 @@ class UriTest extends \Codeception\Test\Unit
      */
     public function testMergingPath()
     {
-        $this->assertEquals('/form/?param=1#anchor', Uri::mergeUrls('/form/?param=1', '#anchor'));
-        $this->assertEquals('/form/?param=1#anchor2', Uri::mergeUrls('/form/?param=1#anchor1', '#anchor2'));
-        $this->assertEquals('/form/?param=2', Uri::mergeUrls('/form/?param=1#anchor', '?param=2'));
-        $this->assertEquals('/page/', Uri::mergeUrls('/form/?param=1#anchor', '/page/'));
+        $this->assertSame('/form/?param=1#anchor', Uri::mergeUrls('/form/?param=1', '#anchor'));
+        $this->assertSame('/form/?param=1#anchor2', Uri::mergeUrls('/form/?param=1#anchor1', '#anchor2'));
+        $this->assertSame('/form/?param=2', Uri::mergeUrls('/form/?param=1#anchor', '?param=2'));
+        $this->assertSame('/page/', Uri::mergeUrls('/form/?param=1#anchor', '/page/'));
     }   
 
     /**
@@ -60,7 +60,7 @@ class UriTest extends \Codeception\Test\Unit
      */
     public function testMergingNonParsingPath()
     {
-        $this->assertEquals('/3.0/en/index/page:5', Uri::mergeUrls('https://cakephp.org/', '/3.0/en/index/page:5'));
+        $this->assertSame('/3.0/en/index/page:5', Uri::mergeUrls('https://cakephp.org/', '/3.0/en/index/page:5'));
     }
 
     /**
@@ -68,12 +68,12 @@ class UriTest extends \Codeception\Test\Unit
      */
     public function testAppendAnchor()
     {
-        $this->assertEquals(
+        $this->assertSame(
             'http://codeception.com/quickstart#anchor',
             Uri::appendPath('http://codeception.com/quickstart', '#anchor')
         );
 
-        $this->assertEquals(
+        $this->assertSame(
             'http://codeception.com/quickstart#anchor',
             Uri::appendPath('http://codeception.com/quickstart#first', '#anchor')
         );
@@ -81,12 +81,12 @@ class UriTest extends \Codeception\Test\Unit
 
     public function testAppendPath()
     {
-        $this->assertEquals(
+        $this->assertSame(
             'http://codeception.com/quickstart/path',
             Uri::appendPath('http://codeception.com/quickstart', 'path')
         );
 
-        $this->assertEquals(
+        $this->assertSame(
             'http://codeception.com/quickstart/path',
             Uri::appendPath('http://codeception.com/quickstart', '/path')
         );
@@ -94,7 +94,7 @@ class UriTest extends \Codeception\Test\Unit
 
     public function testAppendEmptyPath()
     {
-        $this->assertEquals(
+        $this->assertSame(
             'http://codeception.com/quickstart',
             Uri::appendPath('http://codeception.com/quickstart', '')
         );
@@ -102,7 +102,7 @@ class UriTest extends \Codeception\Test\Unit
 
     public function testAppendPathRemovesQueryStringAndAnchor()
     {
-        $this->assertEquals(
+        $this->assertSame(
             'http://codeception.com/quickstart',
             Uri::appendPath('http://codeception.com/quickstart?a=b#c', '')
         );
@@ -110,14 +110,14 @@ class UriTest extends \Codeception\Test\Unit
 
     public function testMergeUrlsWhenBaseUriHasNoTrailingSlashAndUriPathHasNoLeadingSlash()
     {
-        $this->assertEquals(
+        $this->assertSame(
             'http://codeception.com/test',
             Uri::mergeUrls('http://codeception.com', 'test'));
     }
 
     public function testMergeUrlsWhenBaseUriEndsWithSlashButUriPathHasNoLeadingSlash()
     {
-        $this->assertEquals(
+        $this->assertSame(
             'http://codeception.com/test',
             Uri::mergeUrls('http://codeception.com/', 'test'));
     }


### PR DESCRIPTION
Now that much of the source code uses `strict types`, it makes sense to stop using the *weak* assertion `assertEquals` in favor of `assertSame`.