### PR TITLE
Update code standards to Lib and Templates

### DIFF
--- a/src/Codeception/Actor.php
+++ b/src/Codeception/Actor.php
@@ -20,10 +20,7 @@ abstract class Actor
         $this->scenario = $scenario;
     }
 
-    /**
-     * @return \Codeception\Scenario
-     */
-    protected function getScenario()
+    protected function getScenario(): Scenario
     {
         return $this->scenario;
     }

--- a/src/Codeception/Lib/Actor/Shared/Comment.php
+++ b/src/Codeception/Lib/Actor/Shared/Comment.php
@@ -29,7 +29,7 @@ trait Comment
     {
         $role = trim($role);
 
-        if (stripos('aeiou', (string) $role[0]) !== false) {
+        if (stripos('aeiou', $role[0]) !== false) {
             return $this->comment('As an ' . $role);
         }
 

--- a/src/Codeception/Lib/Actor/Shared/Comment.php
+++ b/src/Codeception/Lib/Actor/Shared/Comment.php
@@ -1,45 +1,47 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Codeception\Lib\Actor\Shared;
+
+use Codeception\Scenario;
 
 trait Comment
 {
-    /**
-     * @return \Codeception\Scenario
-     */
-    abstract protected function getScenario();
+    abstract protected function getScenario(): Scenario;
 
-    public function expectTo($prediction)
+    public function expectTo(string $prediction)
     {
         return $this->comment('I expect to ' . $prediction);
     }
 
-    public function expect($prediction)
+    public function expect(string $prediction)
     {
         return $this->comment('I expect ' . $prediction);
     }
 
-    public function amGoingTo($argumentation)
+    public function amGoingTo(string $argumentation)
     {
         return $this->comment('I am going to ' . $argumentation);
     }
 
-    public function am($role)
+    public function am(string $role)
     {
         $role = trim($role);
 
-        if (stripos('aeiou', $role[0]) !== false) {
+        if (stripos('aeiou', (string) $role[0]) !== false) {
             return $this->comment('As an ' . $role);
         }
 
         return $this->comment('As a ' . $role);
     }
 
-    public function lookForwardTo($achieveValue)
+    public function lookForwardTo(string $achieveValue)
     {
         return $this->comment('So that I ' . $achieveValue);
     }
 
-    public function comment($description)
+    public function comment(string $description)
     {
         $this->getScenario()->comment($description);
         return $this;

--- a/src/Codeception/Lib/Actor/Shared/Friend.php
+++ b/src/Codeception/Lib/Actor/Shared/Friend.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Codeception\Lib\Actor\Shared;
 
 use Codeception\Lib\Friend as LibFriend;
@@ -6,19 +9,14 @@ use Codeception\Scenario;
 
 trait Friend
 {
+    /**
+     * @var array
+     */
     protected $friends = [];
 
-    /**
-     * @return Scenario
-     */
-    abstract protected function getScenario();
+    abstract protected function getScenario(): Scenario;
 
-    /**
-     * @param $name
-     * @param $actorClass
-     * @return \Codeception\Lib\Friend
-     */
-    public function haveFriend($name, $actorClass = null)
+    public function haveFriend(string $name, string $actorClass = null): LibFriend
     {
         if (!isset($this->friends[$name])) {
             $actor = $actorClass === null ? $this : new $actorClass($this->getScenario());

--- a/src/Codeception/Lib/Actor/Shared/Pause.php
+++ b/src/Codeception/Lib/Actor/Shared/Pause.php
@@ -1,19 +1,24 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Codeception\Lib\Actor\Shared;
 
 use Codeception\Lib\Console\ReplHistory;
+use Codeception\Util\Debug;
+use Exception;
 use Symfony\Component\Console\Output\ConsoleOutput;
 
 trait Pause
 {
-    public function pause()
+    public function pause(): void
     {
-        if (!\Codeception\Util\Debug::isEnabled()) {
+        if (!Debug::isEnabled()) {
             return;
         }
 
         if (!class_exists('Hoa\Console\Readline\Readline')) {
-            throw new \Exception('Hoa Console is not installed. Please add `hoa/console` to composer.json');
+            throw new Exception('Hoa Console is not installed. Please add `hoa/console` to composer.json');
         }
 
         $autoStash = false;

--- a/src/Codeception/Lib/Actor/Shared/Retry.php
+++ b/src/Codeception/Lib/Actor/Shared/Retry.php
@@ -1,10 +1,18 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Codeception\Lib\Actor\Shared;
 
 trait Retry
 {
+    /**
+     * @var int
+     */
     protected $retryNum = 1;
+    /**
+     * @var int
+     */
     protected $retryInterval = 100;
 
     /**
@@ -12,11 +20,8 @@ trait Retry
      * Interval will be doubled on each unsuccessful execution.
      *
      * Use with \$I->retryXXX() methods;
-     *
-     * @param $num
-     * @param int $interval
      */
-    public function retry($num, $interval = 200)
+    public function retry(int $num, int $interval = 200): void
     {
         $this->retryNum = $num;
         $this->retryInterval = $interval;

--- a/src/Codeception/Lib/Connector/Shared/PhpSuperGlobalsConverter.php
+++ b/src/Codeception/Lib/Connector/Shared/PhpSuperGlobalsConverter.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Codeception\Lib\Connector\Shared;
 
 /**
@@ -14,12 +17,8 @@ trait PhpSuperGlobalsConverter
     /**
      * Rearrange files array to be compatible with PHP $_FILES superglobal structure
      * @see https://bugs.php.net/bug.php?id=25589
-     *
-     * @param array $requestFiles
-     *
-     * @return array
      */
-    protected function remapFiles(array $requestFiles)
+    protected function remapFiles(array $requestFiles): array
     {
         $files = $this->rearrangeFiles($requestFiles);
 
@@ -30,17 +29,13 @@ trait PhpSuperGlobalsConverter
      * Escape high-level variable name with dots, underscores and other "special" chars
      * to be compatible with PHP "bug"
      * @see https://bugs.php.net/bug.php?id=40000
-     *
-     * @param array $parameters
-     *
-     * @return array
      */
-    protected function remapRequestParameters(array $parameters)
+    protected function remapRequestParameters(array $parameters): array
     {
         return $this->replaceSpaces($parameters);
     }
 
-    private function rearrangeFiles($requestFiles)
+    private function rearrangeFiles(array $requestFiles): array
     {
         $files = [];
         foreach ($requestFiles as $name => $info) {
@@ -104,10 +99,9 @@ trait PhpSuperGlobalsConverter
      * @see https://bugs.php.net/bug.php?id=40000
      *
      * @param array $parameters Array of request parameters to be converted
-     *
      * @return array
      */
-    private function replaceSpaces($parameters)
+    private function replaceSpaces(array $parameters): array
     {
         $qs = http_build_query($parameters, '', '&');
         parse_str($qs, $output);

--- a/src/Codeception/Lib/Console/Colorizer.php
+++ b/src/Codeception/Lib/Console/Colorizer.php
@@ -1,15 +1,14 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Codeception\Lib\Console;
 
 use Symfony\Component\Console\Formatter\OutputFormatter;
 
 class Colorizer
 {
-    /**
-     * @param string $string
-     * @return string
-     */
-    public function colorize($string = '')
+    public function colorize(string $string = ''): string
     {
         $fp = fopen('php://memory', 'r+');
         fwrite($fp, $string);

--- a/src/Codeception/Lib/Console/DiffFactory.php
+++ b/src/Codeception/Lib/Console/DiffFactory.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Codeception\Lib\Console;
 
 use SebastianBergmann\Comparator\ComparisonFailure;
@@ -9,26 +12,17 @@ use SebastianBergmann\Diff\Differ;
  **/
 class DiffFactory
 {
-    /**
-     * @param ComparisonFailure $failure
-     * @return string|null
-     */
-    public function createDiff(ComparisonFailure $failure)
+    public function createDiff(ComparisonFailure $failure): ?string
     {
         $diff = $this->getDiff($failure->getExpectedAsString(), $failure->getActualAsString());
-        if (!$diff) {
+        if ($diff === '') {
             return null;
         }
 
         return $diff;
     }
 
-    /**
-     * @param string $expected
-     * @param string $actual
-     * @return string
-     */
-    private function getDiff($expected = '', $actual = '')
+    private function getDiff(string $expected = '', string $actual = ''): string
     {
         if (!$actual && !$expected) {
             return '';

--- a/src/Codeception/Lib/Console/DiffFactory.php
+++ b/src/Codeception/Lib/Console/DiffFactory.php
@@ -7,19 +7,11 @@ namespace Codeception\Lib\Console;
 use SebastianBergmann\Comparator\ComparisonFailure;
 use SebastianBergmann\Diff\Differ;
 
-/**
- * DiffFactory
- **/
 class DiffFactory
 {
-    public function createDiff(ComparisonFailure $failure): ?string
+    public function createDiff(ComparisonFailure $failure): string
     {
-        $diff = $this->getDiff($failure->getExpectedAsString(), $failure->getActualAsString());
-        if ($diff === '') {
-            return null;
-        }
-
-        return $diff;
+        return $this->getDiff($failure->getExpectedAsString(), $failure->getActualAsString());
     }
 
     private function getDiff(string $expected = '', string $actual = ''): string

--- a/src/Codeception/Lib/Console/Message.php
+++ b/src/Codeception/Lib/Console/Message.php
@@ -124,9 +124,9 @@ class Message
         return mb_strwidth($includeTags ? $this->message : strip_tags($this->message), 'utf-8');
     }
 
-    public static function ucfirst(?string $text): string
+    public static function ucfirst(string $text): string
     {
-        return mb_strtoupper(mb_substr((string)$text, 0, 1, 'utf-8'), 'utf-8') . mb_substr((string)$text, 1, null, 'utf-8');
+        return mb_strtoupper(mb_substr($text, 0, 1, 'utf-8'), 'utf-8') . mb_substr($text, 1, null, 'utf-8');
     }
 
     public function __toString(): string

--- a/src/Codeception/Lib/Console/Message.php
+++ b/src/Codeception/Lib/Console/Message.php
@@ -1,49 +1,58 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Codeception\Lib\Console;
 
 use Symfony\Component\Console\Output\OutputInterface;
 
 class Message
 {
+    /**
+     * @var Output|null
+     */
     protected $output;
+    /**
+     * @var string
+     */
     protected $message;
 
-    public function __construct($message, Output $output = null)
+    public function __construct(string $message, Output $output = null)
     {
         $this->message = $message;
         $this->output = $output;
     }
 
-    public function with($param)
+    public function with($param): self
     {
         $args = array_merge([$this->message], func_get_args());
-        $this->message = call_user_func_array('sprintf', $args);
+        $this->message = sprintf(...$args);
         return $this;
     }
 
-    public function style($name)
+    public function style(string $name): self
     {
         $this->message = sprintf('<%s>%s</%s>', $name, $this->message, $name);
         return $this;
     }
 
-    public function width($length, $char = ' ')
+    public function width(int $length, string $char = ' '): self
     {
-        $message_length = $this->getLength();
+        $messageLength = $this->getLength();
 
-        if ($message_length < $length) {
-            $this->message .= str_repeat($char, $length - $message_length);
+        if ($messageLength < $length) {
+            $this->message .= str_repeat($char, $length - $messageLength);
         }
         return $this;
     }
 
-    public function cut($length)
+    public function cut(int $length): self
     {
         $this->message = mb_substr($this->message, 0, $length, 'utf-8');
         return $this;
     }
 
-    public function write($verbose = OutputInterface::VERBOSITY_NORMAL)
+    public function write(int $verbose = OutputInterface::VERBOSITY_NORMAL): void
     {
         if ($verbose > $this->output->getVerbosity()) {
             return;
@@ -51,7 +60,7 @@ class Message
         $this->output->write($this->message);
     }
 
-    public function writeln($verbose = OutputInterface::VERBOSITY_NORMAL)
+    public function writeln(int $verbose = OutputInterface::VERBOSITY_NORMAL): void
     {
         if ($verbose > $this->output->getVerbosity()) {
             return;
@@ -59,7 +68,11 @@ class Message
         $this->output->writeln($this->message);
     }
 
-    public function prepend($string)
+    /**
+     * @param Message|string $string
+     * @return Message
+     */
+    public function prepend($string): self
     {
         if ($string instanceof Message) {
             $string = $string->getMessage();
@@ -68,7 +81,11 @@ class Message
         return $this;
     }
 
-    public function append($string)
+    /**
+     * @param Message|string $string
+     * @return Message
+     */
+    public function append($string): self
     {
         if ($string instanceof Message) {
             $string = $string->getMessage();
@@ -78,44 +95,41 @@ class Message
         return $this;
     }
 
-    public function apply($func)
+    public function apply(callable $func): self
     {
         $this->message = call_user_func($func, $this->message);
         return $this;
     }
 
-    public function center($char)
+    public function center(string $char): self
     {
         $this->message = $char . $this->message . $char;
         return $this;
     }
 
-    /**
-     * @return mixed
-     */
-    public function getMessage()
+    public function getMessage(): string
     {
         return $this->message;
     }
 
-    public function block($style)
+    public function block(string $style): self
     {
         $this->message = $this->output->formatHelper->formatBlock($this->message, $style, true);
 
         return $this;
     }
 
-    public function getLength($includeTags = false)
+    public function getLength(bool $includeTags = false): int
     {
         return mb_strwidth($includeTags ? $this->message : strip_tags($this->message), 'utf-8');
     }
 
-    public static function ucfirst($text)
+    public static function ucfirst(?string $text): string
     {
-        return mb_strtoupper(mb_substr($text, 0, 1, 'utf-8'), 'utf-8') . mb_substr($text, 1, null, 'utf-8');
+        return mb_strtoupper(mb_substr((string)$text, 0, 1, 'utf-8'), 'utf-8') . mb_substr((string)$text, 1, null, 'utf-8');
     }
 
-    public function __toString()
+    public function __toString(): string
     {
         return $this->message;
     }

--- a/src/Codeception/Lib/Console/MessageFactory.php
+++ b/src/Codeception/Lib/Console/MessageFactory.php
@@ -37,7 +37,7 @@ class MessageFactory
     public function prepareComparisonFailureMessage(ComparisonFailure $failure): string
     {
         $diff = $this->diffFactory->createDiff($failure);
-        if (!$diff) {
+        if ($diff !== '') {
             return '';
         }
         $diff = $this->colorizer->colorize($diff);

--- a/src/Codeception/Lib/Console/MessageFactory.php
+++ b/src/Codeception/Lib/Console/MessageFactory.php
@@ -1,11 +1,11 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Codeception\Lib\Console;
 
 use SebastianBergmann\Comparator\ComparisonFailure;
 
-/**
- * MessageFactory
- **/
 class MessageFactory
 {
     /**
@@ -22,10 +22,6 @@ class MessageFactory
      */
     protected $colorizer;
 
-    /**
-     * MessageFactory constructor.
-     * @param Output $output
-     */
     public function __construct(Output $output)
     {
         $this->output = $output;
@@ -33,20 +29,12 @@ class MessageFactory
         $this->colorizer = new Colorizer();
     }
 
-    /**
-     * @param string $text
-     * @return Message
-     */
-    public function message($text = '')
+    public function message(string $text = ''): Message
     {
         return new Message($text, $this->output);
     }
 
-    /**
-     * @param ComparisonFailure $failure
-     * @return string
-     */
-    public function prepareComparisonFailureMessage(ComparisonFailure $failure)
+    public function prepareComparisonFailureMessage(ComparisonFailure $failure): string
     {
         $diff = $this->diffFactory->createDiff($failure);
         if (!$diff) {
@@ -54,6 +42,6 @@ class MessageFactory
         }
         $diff = $this->colorizer->colorize($diff);
 
-        return "\n<comment>- Expected</comment> | <info>+ Actual</info>\n$diff";
+        return "\n<comment>- Expected</comment> | <info>+ Actual</info>\n{$diff}";
     }
 }

--- a/src/Codeception/Lib/Console/ReplHistory.php
+++ b/src/Codeception/Lib/Console/ReplHistory.php
@@ -1,11 +1,16 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Codeception\Lib\Console;
 
 class ReplHistory
 {
     protected $outputFile;
 
+    /**
+     * @var array
+     */
     protected $stashedCommands = [];
 
     /**
@@ -22,10 +27,7 @@ class ReplHistory
         }
     }
 
-    /**
-     * @return ReplHistory
-     */
-    public static function getInstance()
+    public static function getInstance(): ReplHistory
     {
         if (static::$instance == null) {
             static::$instance = new static();
@@ -34,22 +36,22 @@ class ReplHistory
         return static::$instance;
     }
 
-    public function add($command)
+    public function add($command): void
     {
         $this->stashedCommands[] = $command;
     }
 
-    public function getAll()
+    public function getAll(): array
     {
         return $this->stashedCommands;
     }
 
-    public function clear()
+    public function clear(): void
     {
         $this->stashedCommands = [];
     }
 
-    public function save()
+    public function save(): void
     {
         if (empty($this->stashedCommands)) {
             return;

--- a/src/Codeception/Lib/Di.php
+++ b/src/Codeception/Lib/Di.php
@@ -1,13 +1,27 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Codeception\Lib;
 
 use Codeception\Exception\InjectionException;
 use Codeception\Util\ReflectionHelper;
+use Exception;
+use ReflectionClass;
+use ReflectionException;
+use ReflectionMethod;
+use ReflectionObject;
 
 class Di
 {
+    /**
+     * @var string
+     */
     const DEFAULT_INJECT_METHOD_NAME = '_inject';
 
+    /**
+     * @var object[]
+     */
     protected $container = [];
 
     /**
@@ -15,35 +29,39 @@ class Di
      */
     protected $fallback;
 
-    public function __construct($fallback = null)
+    public function __construct(Di $fallback = null)
     {
         $this->fallback = $fallback;
     }
 
-    public function get($className)
+    /**
+     * @param string $className
+     * @return object|bool|null
+     */
+    public function get(string $className)
     {
         // normalize namespace
         $className = ltrim($className, '\\');
         return isset($this->container[$className]) ? $this->container[$className] : null;
     }
 
-    public function set($class)
+    public function set(object $class): void
     {
         $this->container[get_class($class)] = $class;
     }
 
     /**
      * @param string $className
-     * @param array $constructorArgs
+     * @param array|null $constructorArgs
      * @param string $injectMethodName Method which will be invoked after object creation;
      *                                 Resolved dependencies will be passed to it as arguments
-     * @throws InjectionException
+     * @throws InjectionException|ReflectionException
      * @return null|object
      */
     public function instantiate(
-        $className,
-        $constructorArgs = null,
-        $injectMethodName = self::DEFAULT_INJECT_METHOD_NAME
+        string $className,
+        array $constructorArgs = null,
+        string $injectMethodName = self::DEFAULT_INJECT_METHOD_NAME
     ) {
         // normalize namespace
         $className = ltrim($className, '\\');
@@ -58,15 +76,13 @@ class Di
         }
 
         // get class from parent container
-        if ($this->fallback) {
-            if ($class = $this->fallback->get($className)) {
-                return $class;
-            }
+        if ($this->fallback && ($class = $this->fallback->get($className))) {
+            return $class;
         }
 
         $this->container[$className] = false; // flag that object is being instantiated
 
-        $reflectedClass = new \ReflectionClass($className);
+        $reflectedClass = new ReflectionClass($className);
         if (!$reflectedClass->isInstantiable()) {
             return null;
         }
@@ -79,13 +95,13 @@ class Di
                 if (!$constructorArgs) {
                     $constructorArgs = $this->prepareArgs($reflectedConstructor);
                 }
-            } catch (\Exception $e) {
-                throw new InjectionException("Failed to create instance of '$className'. " . $e->getMessage());
+            } catch (Exception $e) {
+                throw new InjectionException("Failed to create instance of '{$className}'. " . $e->getMessage());
             }
             $object = $reflectedClass->newInstanceArgs($constructorArgs);
         }
 
-        if ($injectMethodName) {
+        if ($injectMethodName !== '') {
             $this->injectDependencies($object, $injectMethodName);
         }
 
@@ -96,25 +112,27 @@ class Di
     /**
      * @param $object
      * @param string $injectMethodName Method which will be invoked with resolved dependencies as its arguments
-     * @throws InjectionException
+     * @param array $defaults
+     * @throws InjectionException|ReflectionException
      */
-    public function injectDependencies($object, $injectMethodName = self::DEFAULT_INJECT_METHOD_NAME, $defaults = [])
+    public function injectDependencies($object, string $injectMethodName = self::DEFAULT_INJECT_METHOD_NAME, array $defaults = []): void
     {
         if (!is_object($object)) {
             return;
         }
 
-        $reflectedObject = new \ReflectionObject($object);
-        if (!$reflectedObject->hasMethod($injectMethodName)) {
+        $reflectedObject = new ReflectionObject($object);
+        $reflectionObjectHasMethod = $reflectedObject->hasMethod($injectMethodName);
+        if (!$reflectionObjectHasMethod) {
             return;
         }
 
         $reflectedMethod = $reflectedObject->getMethod($injectMethodName);
         try {
             $args = $this->prepareArgs($reflectedMethod, $defaults);
-        } catch (\Exception $e) {
+        } catch (Exception $e) {
             $msg = $e->getMessage();
-            if ($e->getPrevious()) { // injection failed because PHP code is invalid. See #3869
+            if ($e->getPrevious() !== null) { // injection failed because PHP code is invalid. See #3869
                 $msg .= '; '. $e->getPrevious();
             }
             throw new InjectionException(
@@ -128,13 +146,7 @@ class Di
         $reflectedMethod->invokeArgs($object, $args);
     }
 
-    /**
-     * @param \ReflectionMethod $method
-     * @param $defaults
-     * @throws InjectionException
-     * @return array
-     */
-    protected function prepareArgs(\ReflectionMethod $method, $defaults = [])
+    protected function prepareArgs(ReflectionMethod $method, array $defaults = []): array
     {
         $args = [];
         $parameters = $method->getParameters();
@@ -143,7 +155,7 @@ class Di
             if (is_null($dependency)) {
                 if (!$parameter->isOptional()) {
                     if (!isset($defaults[$k])) {
-                        throw new InjectionException("Parameter '$parameter->name' must have default value.");
+                        throw new InjectionException("Parameter '{$parameter->name}' must have default value.");
                     }
                     $args[] = $defaults[$k];
                     continue;
@@ -152,7 +164,7 @@ class Di
             } else {
                 $arg = $this->instantiate($dependency);
                 if (is_null($arg)) {
-                    throw new InjectionException("Failed to resolve dependency '$dependency'.");
+                    throw new InjectionException("Failed to resolve dependency '{$dependency}'.");
                 }
                 $args[] = $arg;
             }

--- a/src/Codeception/Lib/Friend.php
+++ b/src/Codeception/Lib/Friend.php
@@ -1,23 +1,39 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Codeception\Lib;
 
 use Codeception\Actor;
 use Codeception\Exception\TestRuntimeException;
+use Codeception\Lib\Interfaces\MultiSession;
 
 class Friend
 {
+    /**
+     * @var string
+     */
     protected $name;
+    /**
+     * @var Actor
+     */
     protected $actor;
+    /**
+     * @var array
+     */
     protected $data = [];
+    /**
+     * @var array|null
+     */
     protected $multiSessionModules = [];
 
-    public function __construct($name, Actor $actor, $modules = [])
+    public function __construct(string $name, Actor $actor, array $modules = [])
     {
         $this->name = $name;
         $this->actor = $actor;
 
         $this->multiSessionModules = array_filter($modules, function ($m) {
-            return $m instanceof Interfaces\MultiSession;
+            return $m instanceof MultiSession;
         });
 
         if (empty($this->multiSessionModules)) {
@@ -52,22 +68,22 @@ class Friend
         return $ret;
     }
 
-    public function isGoingTo($argumentation)
+    public function isGoingTo(string $argumentation): void
     {
         $this->actor->amGoingTo($argumentation);
     }
 
-    public function expects($prediction)
+    public function expects(string $prediction): void
     {
         $this->actor->expect($prediction);
     }
 
-    public function expectsTo($prediction)
+    public function expectsTo(string $prediction): void
     {
         $this->actor->expectTo($prediction);
     }
 
-    public function leave()
+    public function leave(): void
     {
         foreach ($this->multiSessionModules as $module) {
             if (isset($this->data[$module->_getName()])) {

--- a/src/Codeception/Lib/Generator/Actions.php
+++ b/src/Codeception/Lib/Generator/Actions.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Codeception\Lib\Generator;
 
 use Codeception\Codecept;
@@ -7,10 +10,26 @@ use Codeception\Lib\Di;
 use Codeception\Lib\ModuleContainer;
 use Codeception\Util\ReflectionHelper;
 use Codeception\Util\Template;
+use Exception;
+use ReflectionClass;
+use ReflectionException;
+use ReflectionMethod;
 
 class Actions
 {
+    /**
+     * @var Di
+     */
+    public $di;
 
+    /**
+     * @var ModuleContainer
+     */
+    public $moduleContainer;
+
+    /**
+     * @var string
+     */
     protected $template = <<<EOF
 <?php  //[STAMP] {{hash}}
 namespace {{namespace}}_generated;
@@ -31,6 +50,9 @@ trait {{name}}Actions
 
 EOF;
 
+    /**
+     * @var string
+     */
     protected $methodTemplate = <<<EOF
 
     /**
@@ -44,10 +66,29 @@ EOF;
     }
 EOF;
 
+    /**
+     * @var string
+     */
     protected $name;
+
+    /**
+     * @var array
+     */
     protected $settings;
+
+    /**
+     * @var array
+     */
     protected $modules = [];
+
+    /**
+     * @var array
+     */
     protected $actions;
+
+    /**
+     * @var int
+     */
     protected $numMethods = 0;
 
     /**
@@ -55,7 +96,7 @@ EOF;
      */
     protected $generatedSteps = [];
 
-    public function __construct($settings)
+    public function __construct(array $settings)
     {
         $this->name = $settings['actor'];
         $this->settings = $settings;
@@ -72,7 +113,7 @@ EOF;
     }
 
 
-    public function produce()
+    public function produce(): string
     {
         $namespace = rtrim($this->settings['namespace'], '\\');
 
@@ -82,22 +123,22 @@ EOF;
             if (in_array($action, $methods)) {
                 continue;
             }
-            $class = new \ReflectionClass($this->modules[$moduleName]);
+            $class = new ReflectionClass($this->modules[$moduleName]);
             $method = $class->getMethod($action);
             $code[] = $this->addMethod($method);
             $methods[] = $action;
-            $this->numMethods++;
+            ++$this->numMethods;
         }
 
         return (new Template($this->template))
-            ->place('namespace', $namespace ? $namespace . '\\' : '')
+            ->place('namespace', $namespace !== '' ? $namespace . '\\' : '')
             ->place('hash', self::genHash($this->modules, $this->settings))
             ->place('name', $this->name)
             ->place('methods', implode("\n\n ", $code))
             ->produce();
     }
 
-    protected function addMethod(\ReflectionMethod $refMethod)
+    protected function addMethod(ReflectionMethod $refMethod): string
     {
         $class = $refMethod->getDeclaringClass();
         $params = $this->getParamsString($refMethod);
@@ -105,9 +146,9 @@ EOF;
 
         $body = '';
         $doc = $this->addDoc($class, $refMethod);
-        $doc = str_replace('/**', '', $doc);
+        $doc = str_replace('/**', '', (string)$doc);
         $doc = trim(str_replace('*/', '', $doc));
-        if (!$doc) {
+        if ($doc === '') {
             $doc = "*";
         }
         $returnType = $this->createReturnTypeHint($refMethod);
@@ -136,7 +177,7 @@ EOF;
         // add auto generated steps
         foreach (array_unique($this->generatedSteps) as $generator) {
             if (!is_callable([$generator, 'getTemplate'])) {
-                throw new \Exception("Wrong configuration for generated steps. $generator doesn't implement \Codeception\Step\GeneratedStep interface");
+                throw new Exception("Wrong configuration for generated steps. {$generator} doesn't implement \Codeception\Step\GeneratedStep interface");
             }
             $template = call_user_func([$generator, 'getTemplate'], clone $methodTemplate);
             if ($template) {
@@ -147,11 +188,7 @@ EOF;
         return $body;
     }
 
-    /**
-     * @param \ReflectionMethod $refMethod
-     * @return array
-     */
-    protected function getParamsString(\ReflectionMethod $refMethod)
+    protected function getParamsString(ReflectionMethod $refMethod): string
     {
         $params = [];
         foreach ($refMethod->getParameters() as $param) {
@@ -165,18 +202,19 @@ EOF;
     }
 
     /**
-     * @param \ReflectionClass $class
-     * @param \ReflectionMethod $refMethod
-     * @return string
+     * @param ReflectionClass $class
+     * @param ReflectionMethod $refMethod
+     * @return string|false
+     * @throws ReflectionException
      */
-    protected function addDoc(\ReflectionClass $class, \ReflectionMethod $refMethod)
+    protected function addDoc(ReflectionClass $class, ReflectionMethod $refMethod)
     {
         $doc = $refMethod->getDocComment();
 
         if (!$doc) {
             $interfaces = $class->getInterfaces();
             foreach ($interfaces as $interface) {
-                $i = new \ReflectionClass($interface->name);
+                $i = new ReflectionClass($interface->name);
                 if ($i->hasMethod($refMethod->name)) {
                     $doc = $i->getMethod($refMethod->name)->getDocComment();
                     break;
@@ -184,18 +222,17 @@ EOF;
             }
         }
 
-        if (!$doc and $class->getParentClass()) {
-            $parent = new \ReflectionClass($class->getParentClass()->name);
+        if (!$doc && $class->getParentClass()) {
+            $parent = new ReflectionClass($class->getParentClass()->name);
             if ($parent->hasMethod($refMethod->name)) {
-                $doc = $parent->getMethod($refMethod->name)->getDocComment();
-                return $doc;
+                return $parent->getMethod($refMethod->name)->getDocComment();
             }
             return $doc;
         }
         return $doc;
     }
 
-    public static function genHash($modules, $settings)
+    public static function genHash(array $modules, array $settings): string
     {
         $actions = [];
         foreach ($modules as $moduleName => $module) {
@@ -205,12 +242,12 @@ EOF;
         return md5(Codecept::VERSION . serialize($actions) . serialize($settings['modules']) . implode(',', (array) $settings['step_decorators']));
     }
 
-    public function getNumMethods()
+    public function getNumMethods(): int
     {
         return $this->numMethods;
     }
 
-    private function createReturnTypeHint(\ReflectionMethod $refMethod)
+    private function createReturnTypeHint(ReflectionMethod $refMethod): string
     {
         $returnType = $refMethod->getReturnType();
 

--- a/src/Codeception/Lib/Generator/Actor.php
+++ b/src/Codeception/Lib/Generator/Actor.php
@@ -71,7 +71,7 @@ EOF;
      */
     protected $actions;
 
-    public function __construct($settings)
+    public function __construct(array $settings)
     {
         $this->settings = $settings;
         $this->di = new Di();

--- a/src/Codeception/Lib/Generator/Actor.php
+++ b/src/Codeception/Lib/Generator/Actor.php
@@ -56,11 +56,16 @@ EOF;
      */
     protected $inheritedMethodTemplate = ' * @method {{return}} {{method}}({{params}})';
 
+    /**
+     * @var array
+     */
     protected $settings;
+
     /**
      * @var array
      */
     protected $modules;
+
     /**
      * @var array
      */

--- a/src/Codeception/Lib/Generator/Actor.php
+++ b/src/Codeception/Lib/Generator/Actor.php
@@ -1,16 +1,37 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Codeception\Lib\Generator;
 
 use Codeception\Configuration;
 use Codeception\Lib\Di;
+use Codeception\Lib\Friend;
 use Codeception\Lib\ModuleContainer;
 use Codeception\Util\ReflectionHelper;
 use Codeception\Util\Template;
+use ReflectionClass;
+use ReflectionMethod;
 
 class Actor
 {
+    /**
+     * @var Di
+     */
+    public $di;
+
+    /**
+     * @var ModuleContainer
+     */
+    public $moduleContainer;
+
+    /**
+     * @var string
+     */
     protected $template = <<<EOF
 <?php
+
+declare(strict_types=1);
 {{hasNamespace}}
 
 /**
@@ -30,10 +51,19 @@ class {{actor}} extends \Codeception\Actor
 
 EOF;
 
+    /**
+     * @var string
+     */
     protected $inheritedMethodTemplate = ' * @method {{return}} {{method}}({{params}})';
 
     protected $settings;
+    /**
+     * @var array
+     */
     protected $modules;
+    /**
+     * @var array
+     */
     protected $actions;
 
     public function __construct($settings)
@@ -51,7 +81,7 @@ EOF;
         $this->actions = $this->moduleContainer->getActions();
     }
 
-    public function produce()
+    public function produce(): string
     {
         $namespace = rtrim($this->settings['namespace'], '\\');
 
@@ -60,18 +90,18 @@ EOF;
         }
 
         return (new Template($this->template))
-            ->place('hasNamespace', $namespace ? "namespace $namespace;" : '')
+            ->place('hasNamespace', $namespace ? "namespace {$namespace};" : '')
             ->place('actor', $this->settings['actor'])
             ->place('inheritedMethods', $this->prependAbstractActorDocBlocks())
             ->produce();
     }
 
-    protected function prependAbstractActorDocBlocks()
+    protected function prependAbstractActorDocBlocks(): string
     {
         $inherited = [];
 
-        $class = new \ReflectionClass('\Codeception\\Actor');
-        $methods = $class->getMethods(\ReflectionMethod::IS_PUBLIC);
+        $class = new ReflectionClass(\Codeception\Actor::class);
+        $methods = $class->getMethods(ReflectionMethod::IS_PUBLIC);
 
         foreach ($methods as $method) {
             if ($method->name == '__call') {
@@ -82,7 +112,7 @@ EOF;
             } // skipping magic
             $returnType = 'void';
             if ($method->name == 'haveFriend') {
-                $returnType = '\Codeception\Lib\Friend';
+                $returnType = Friend::class;
             }
             $params = $this->getParamsString($method);
             $inherited[] = (new Template($this->inheritedMethodTemplate))
@@ -95,11 +125,7 @@ EOF;
         return implode("\n", $inherited);
     }
 
-    /**
-     * @param \ReflectionMethod $refMethod
-     * @return array
-     */
-    protected function getParamsString(\ReflectionMethod $refMethod)
+    protected function getParamsString(ReflectionMethod $refMethod): string
     {
         $params = [];
         foreach ($refMethod->getParameters() as $param) {
@@ -117,7 +143,10 @@ EOF;
         return $this->settings['actor'];
     }
 
-    public function getModules()
+    /**
+     * @return string[]
+     */
+    public function getModules(): array
     {
         return array_keys($this->modules);
     }

--- a/src/Codeception/Lib/Generator/Cept.php
+++ b/src/Codeception/Lib/Generator/Cept.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Codeception\Lib\Generator;
 
 use Codeception\Exception\ConfigurationException;
@@ -6,7 +9,9 @@ use Codeception\Util\Template;
 
 class Cept
 {
-
+    /**
+     * @var string
+     */
     protected $template = <<<EOF
 <?php {{use}}
 \$I = new {{actor}}(\$scenario);
@@ -14,14 +19,17 @@ class Cept
 
 EOF;
 
+    /**
+     * @var array
+     */
     protected $settings;
 
-    public function __construct($settings)
+    public function __construct(array $settings)
     {
         $this->settings = $settings;
     }
 
-    public function produce()
+    public function produce(): string
     {
         $actor = $this->settings['actor'];
         if (!$actor) {

--- a/src/Codeception/Lib/Generator/Cest.php
+++ b/src/Codeception/Lib/Generator/Cest.php
@@ -1,15 +1,22 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Codeception\Lib\Generator;
 
 use Codeception\Exception\ConfigurationException;
+use Codeception\Lib\Generator\Shared\Classname;
 use Codeception\Util\Shared\Namespaces;
 use Codeception\Util\Template;
 
 class Cest
 {
-    use Shared\Classname;
+    use Classname;
     use Namespaces;
 
+    /**
+     * @var string
+     */
     protected $template = <<<EOF
 <?php {{namespace}}
 
@@ -27,16 +34,23 @@ class {{name}}Cest
 
 EOF;
 
+    /**
+     * @var array
+     */
     protected $settings;
+
+    /**
+     * @var string
+     */
     protected $name;
 
-    public function __construct($className, $settings)
+    public function __construct(string $className, array $settings)
     {
         $this->name = $this->removeSuffix($className, 'Cest');
         $this->settings = $settings;
     }
 
-    public function produce()
+    public function produce(): string
     {
         $actor = $this->settings['actor'];
         if (!$actor) {
@@ -51,7 +65,7 @@ EOF;
 
         $ns = $this->getNamespaceHeader($namespace.'\\'.$this->name);
 
-        if ($namespace) {
+        if ($namespace !== '') {
             $ns .= "use ".$this->settings['namespace'].'\\'.$actor.";";
         }
 

--- a/src/Codeception/Lib/Generator/Feature.php
+++ b/src/Codeception/Lib/Generator/Feature.php
@@ -1,10 +1,16 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Codeception\Lib\Generator;
 
 use Codeception\Util\Template;
 
 class Feature
 {
+    /**
+     * @var string
+     */
     protected $template = <<<EOF
 Feature: {{name}}
   In order to ...
@@ -15,14 +21,17 @@ Feature: {{name}}
 
 EOF;
 
+    /**
+     * @var string
+     */
     protected $name;
 
-    public function __construct($name)
+    public function __construct(string $name)
     {
         $this->name = $name;
     }
 
-    public function produce()
+    public function produce(): string
     {
         return (new Template($this->template))
             ->place('name', $this->name)

--- a/src/Codeception/Lib/Generator/GherkinSnippets.php
+++ b/src/Codeception/Lib/Generator/GherkinSnippets.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Codeception\Lib\Generator;
 
 use Behat\Gherkin\Node\StepNode;
@@ -8,6 +11,9 @@ use Symfony\Component\Finder\Finder;
 
 class GherkinSnippets
 {
+    /**
+     * @var string
+     */
     protected $template = <<<EOF
     /**
      * @{{type}} {{text}}
@@ -19,11 +25,20 @@ class GherkinSnippets
 
 EOF;
 
+    /**
+     * @var string[]
+     */
     protected $snippets = [];
+    /**
+     * @var string[]
+     */
     protected $processed = [];
+    /**
+     * @var string[]
+     */
     protected $features = [];
 
-    public function __construct($settings, $test = null)
+    public function __construct(array $settings, $test = null)
     {
         $loader = new Gherkin($settings);
         $pattern = $loader->getPattern();
@@ -53,7 +68,6 @@ EOF;
             $allSteps = array_merge($allSteps, $stepGroup);
         }
         foreach ($loader->getTests() as $test) {
-            /** @var $test \Codeception\Test\Gherkin  **/
             $steps = $test->getScenarioNode()->getSteps();
             if ($test->getFeatureNode()->hasBackground()) {
                 $steps = array_merge($steps, $test->getFeatureNode()->getBackground()->getSteps());
@@ -82,7 +96,7 @@ EOF;
         }
     }
 
-    public function addSnippet(StepNode $step)
+    public function addSnippet(StepNode $step): void
     {
         $args = [];
         $pattern = $step->getText();
@@ -90,24 +104,24 @@ EOF;
         // match numbers (not in quotes)
         if (preg_match_all('~([\d\.])(?=([^"]*"[^"]*")*[^"]*$)~', $pattern, $matches)) {
             foreach ($matches[1] as $num => $param) {
-                $num++;
+                ++$num;
                 $args[] = '$num' . $num;
-                $pattern = str_replace($param, ":num$num", $pattern);
+                $pattern = str_replace($param, ":num{$num}", $pattern);
             }
         }
 
         // match quoted string
         if (preg_match_all('~"(.*?)"~', $pattern, $matches)) {
             foreach ($matches[1] as $num => $param) {
-                $num++;
+                ++$num;
                 $args[] = '$arg' . $num;
-                $pattern = str_replace('"'.$param.'"', ":arg$num", $pattern);
+                $pattern = str_replace('"'.$param.'"', ":arg{$num}", $pattern);
             }
         }
         // Has multiline argument at the end of step?
         if (self::stepHasPyStringArgument($step)) {
             $num = count($args) + 1;
-            $pattern .= " :arg$num";
+            $pattern .= " :arg{$num}";
             $args[] = '$arg' . $num;
         }
         if (in_array($pattern, $this->processed)) {
@@ -129,17 +143,23 @@ EOF;
         $this->processed[] = $pattern;
     }
 
-    public function getSnippets()
+    /**
+     * @return string[]
+     */
+    public function getSnippets(): array
     {
         return $this->snippets;
     }
 
-    public function getFeatures()
+    /**
+     * @return string[]
+     */
+    public function getFeatures(): array
     {
         return $this->features;
     }
 
-    public static function stepHasPyStringArgument(StepNode $step)
+    public static function stepHasPyStringArgument(StepNode $step): bool
     {
         if ($step->hasArguments()) {
             $stepArgs = $step->getArguments();

--- a/src/Codeception/Lib/Generator/Group.php
+++ b/src/Codeception/Lib/Generator/Group.php
@@ -1,16 +1,26 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Codeception\Lib\Generator;
 
+use Codeception\Lib\Generator\Shared\Classname;
 use Codeception\Util\Shared\Namespaces;
 use Codeception\Util\Template;
 
 class Group
 {
     use Namespaces;
-    use Shared\Classname;
+    use Classname;
 
+    /**
+     * @var string
+     */
     protected $template = <<<EOF
 <?php
+
+declare(strict_types=1);
+
 namespace {{namespace}};
 
 use \Codeception\Event\TestEvent;
@@ -39,20 +49,30 @@ class {{class}} extends \Codeception\Platform\Group
 
 EOF;
 
+    /**
+     * @var string
+     */
     protected $name;
+
+    /**
+     * @var string
+     */
     protected $namespace;
+
+    /**
+     * @var array
+     */
     protected $settings;
 
-    public function __construct($settings, $name)
+    public function __construct(array $settings, string $name)
     {
         $this->settings = $settings;
         $this->name = $name;
         $this->namespace = $this->getNamespaceString($this->settings['namespace'] . '\\Group\\' . $name);
     }
 
-    public function produce()
+    public function produce(): string
     {
-        $ns = $this->getNamespaceString($this->settings['namespace'] . '\\' . $this->name);
         return (new Template($this->template))
             ->place('class', ucfirst($this->name))
             ->place('name', $this->name)

--- a/src/Codeception/Lib/Generator/Helper.php
+++ b/src/Codeception/Lib/Generator/Helper.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Codeception\Lib\Generator;
 
 use Codeception\Util\Shared\Namespaces;
@@ -8,8 +11,13 @@ class Helper
 {
     use Namespaces;
 
+    /**
+     * @var string
+     */
     protected $template = <<<EOF
 <?php
+
+declare(strict_types=1);
 {{namespace}}
 // here you can define custom actions
 // all public methods declared in helper class will be available in \$I
@@ -21,16 +29,23 @@ class {{name}} extends \\Codeception\\Module
 
 EOF;
 
+    /**
+     * @var string
+     */
     protected $namespace;
+
+    /**
+     * @var string
+     */
     protected $name;
 
-    public function __construct($name, $namespace = '')
+    public function __construct(string $name, string $namespace = '')
     {
         $this->namespace = $namespace;
         $this->name = $name;
     }
 
-    public function produce()
+    public function produce(): string
     {
         return (new Template($this->template))
             ->place('namespace', $this->getNamespaceHeader($this->namespace . '\\Helper\\' . $this->name))
@@ -38,7 +53,7 @@ EOF;
             ->produce();
     }
 
-    public function getHelperName()
+    public function getHelperName(): string
     {
         return rtrim('\\' . $this->namespace, '\\') . '\\Helper\\' . $this->name;
     }

--- a/src/Codeception/Lib/Generator/PageObject.php
+++ b/src/Codeception/Lib/Generator/PageObject.php
@@ -1,16 +1,26 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Codeception\Lib\Generator;
 
+use Codeception\Lib\Generator\Shared\Classname;
 use Codeception\Util\Shared\Namespaces;
 use Codeception\Util\Template;
 
 class PageObject
 {
     use Namespaces;
-    use Shared\Classname;
+    use Classname;
 
+    /**
+     * @var string
+     */
     protected $template = <<<EOF
 <?php
+
+declare(strict_types=1);
+
 namespace {{namespace}};
 
 class {{class}}
@@ -39,6 +49,9 @@ class {{class}}
 
 EOF;
 
+    /**
+     * @var string
+     */
     protected $actionsTemplate = <<<EOF
     /**
      * @var \\{{actorClass}};
@@ -52,19 +65,34 @@ EOF;
 
 EOF;
 
+    /**
+     * @var string
+     */
     protected $actions = '';
+
+    /**
+     * @var array
+     */
     protected $settings;
+
+    /**
+     * @var string
+     */
     protected $name;
+
+    /**
+     * @var string
+     */
     protected $namespace;
 
-    public function __construct($settings, $name)
+    public function __construct(array $settings, string $name)
     {
         $this->settings = $settings;
         $this->name = $this->getShortClassName($name);
         $this->namespace = $this->getNamespaceString($this->settings['namespace'] . '\\Page\\' . $name);
     }
 
-    public function produce()
+    public function produce(): string
     {
         return (new Template($this->template))
             ->place('namespace', $this->namespace)
@@ -73,7 +101,7 @@ EOF;
             ->produce();
     }
 
-    protected function produceActions()
+    protected function produceActions(): string
     {
         if (!isset($this->settings['actor'])) {
             return ''; // global pageobject

--- a/src/Codeception/Lib/Generator/Shared/Classname.php
+++ b/src/Codeception/Lib/Generator/Shared/Classname.php
@@ -1,11 +1,14 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Codeception\Lib\Generator\Shared;
 
 trait Classname
 {
-    protected function removeSuffix($classname, $suffix)
+    protected function removeSuffix(string $classname, string $suffix)
     {
         $classname = preg_replace('~\.php$~', '', $classname);
-        return preg_replace("~$suffix$~", '', $classname);
+        return preg_replace("~{$suffix}$~", '', $classname);
     }
 }

--- a/src/Codeception/Lib/Generator/Snapshot.php
+++ b/src/Codeception/Lib/Generator/Snapshot.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Codeception\Lib\Generator;
 
 use Codeception\Util\Shared\Namespaces;
@@ -8,8 +11,14 @@ class Snapshot
 {
     use Namespaces;
 
+    /**
+     * @var string
+     */
     protected $template = <<<EOF
 <?php
+
+declare(strict_types=1);
+
 namespace {{namespace}};
 
 class {{name}} extends \\Codeception\\Snapshot
@@ -24,6 +33,9 @@ class {{name}} extends \\Codeception\\Snapshot
 }
 EOF;
 
+    /**
+     * @var string
+     */
     protected $actionsTemplate = <<<EOF
     /**
      * @var \\{{actorClass}};
@@ -36,18 +48,29 @@ EOF;
     }
 EOF;
 
+    /**
+     * @var string
+     */
     protected $namespace;
+
+    /**
+     * @var string
+     */
     protected $name;
+
+    /**
+     * @var array
+     */
     protected $settings;
 
-    public function __construct($settings, $name)
+    public function __construct(array $settings, string $name)
     {
         $this->settings = $settings;
         $this->name = $this->getShortClassName($name);
         $this->namespace = $this->getNamespaceString($this->settings['namespace'] . '\\Snapshot\\' . $name);
     }
 
-    public function produce()
+    public function produce(): string
     {
         return (new Template($this->template))
             ->place('namespace', $this->namespace)
@@ -56,7 +79,7 @@ EOF;
             ->produce();
     }
 
-    protected function produceActions()
+    protected function produceActions(): string
     {
         if (!isset($this->settings['actor'])) {
             return ''; // no actor in suite

--- a/src/Codeception/Lib/Generator/StepObject.php
+++ b/src/Codeception/Lib/Generator/StepObject.php
@@ -1,17 +1,27 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Codeception\Lib\Generator;
 
 use Codeception\Exception\ConfigurationException;
+use Codeception\Lib\Generator\Shared\Classname;
 use Codeception\Util\Shared\Namespaces;
 use Codeception\Util\Template;
 
 class StepObject
 {
     use Namespaces;
-    use Shared\Classname;
+    use Classname;
 
+    /**
+     * @var string
+     */
     protected $template = <<<EOF
 <?php
+
+declare(strict_types=1);
+
 namespace {{namespace}};
 
 class {{name}} extends {{actorClass}}
@@ -20,6 +30,9 @@ class {{name}} extends {{actorClass}}
 }
 EOF;
 
+    /**
+     * @var string
+     */
     protected $actionTemplate = <<<EOF
 
     public function {{action}}()
@@ -29,18 +42,34 @@ EOF;
 
 EOF;
 
+    /**
+     * @var array
+     */
     protected $settings;
+
+    /**
+     * @var string
+     */
     protected $name;
+
+    /**
+     * @var string
+     */
     protected $actions = '';
 
-    public function __construct($settings, $name)
+    /**
+     * @var string
+     */
+    public $namespace;
+
+    public function __construct(array $settings, string $name)
     {
         $this->settings = $settings;
         $this->name = $this->getShortClassName($name);
         $this->namespace = $this->getNamespaceString($this->settings['namespace'] . '\\Step\\' . $name);
     }
 
-    public function produce()
+    public function produce(): string
     {
         $actor = $this->settings['actor'];
         if (!$actor) {
@@ -59,7 +88,7 @@ EOF;
             ->produce();
     }
 
-    public function createAction($action)
+    public function createAction($action): void
     {
         $this->actions .= (new Template($this->actionTemplate))
             ->place('action', $action)

--- a/src/Codeception/Lib/Generator/Test.php
+++ b/src/Codeception/Lib/Generator/Test.php
@@ -1,15 +1,22 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Codeception\Lib\Generator;
 
 use Codeception\Configuration;
+use Codeception\Lib\Generator\Shared\Classname;
 use Codeception\Util\Shared\Namespaces;
 use Codeception\Util\Template;
 
 class Test
 {
     use Namespaces;
-    use Shared\Classname;
+    use Classname;
 
+    /**
+     * @var string
+     */
     protected $template = <<<EOF
 <?php {{namespace}}
 class {{name}}Test extends \Codeception\Test\Unit
@@ -31,6 +38,9 @@ class {{name}}Test extends \Codeception\Test\Unit
 }
 EOF;
 
+    /**
+     * @var string
+     */
     protected $testerTemplate = <<<EOF
     /**
      * @var \{{actorClass}}
@@ -39,17 +49,23 @@ EOF;
     
 EOF;
 
-
+    /**
+     * @var array
+     */
     protected $settings;
+
+    /**
+     * @var string
+     */
     protected $name;
 
-    public function __construct($settings, $name)
+    public function __construct(array $settings, string $name)
     {
         $this->settings = $settings;
         $this->name = $this->removeSuffix($name, 'Test');
     }
 
-    public function produce()
+    public function produce(): string
     {
         $actor = $this->settings['actor'];
         if ($this->settings['namespace']) {

--- a/src/Codeception/Lib/GroupManager.php
+++ b/src/Codeception/Lib/GroupManager.php
@@ -172,10 +172,12 @@ class GroupManager
                     $groups[] = $group;
                 }
                 if ($test instanceof \PHPUnit\Framework\TestSuite\DataProvider) {
-                    $firstTest = $test->testAt(0);
-                    $firstTestName = $firstTest->getName(false);
-                    if ($firstTest != false && $firstTest instanceof TestInterface && strpos($filename . ':' . $firstTestName, (string) $testPattern) === 0) {
-                        $groups[] = $group;
+                    if ($firstTest = $test->testAt(0)) {
+                        $firstTestName = $firstTest->getName(false);
+                        $startsWithPattern = strpos($filename . ':' . $firstTestName, (string) $testPattern) === 0;
+                        if ($firstTest instanceof TestInterface & $startsWithPattern) {
+                            $groups[] = $group;
+                        }
                     }
                 }
             }

--- a/src/Codeception/Lib/GroupManager.php
+++ b/src/Codeception/Lib/GroupManager.php
@@ -1,12 +1,17 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Codeception\Lib;
 
 use Codeception\Configuration;
 use Codeception\Exception\ConfigurationException;
-use Codeception\Test\Interfaces\Reported;
 use Codeception\Test\Descriptor;
-use Codeception\TestInterface;
 use Codeception\Test\Gherkin;
+use Codeception\Test\Interfaces\Reported;
+use Codeception\TestInterface;
+use PHPUnit\Framework\Test;
+use PHPUnit\Framework\TestCase;
 use Symfony\Component\Finder\Finder;
 use Symfony\Component\Finder\SplFileInfo;
 
@@ -15,7 +20,14 @@ use Symfony\Component\Finder\SplFileInfo;
  */
 class GroupManager
 {
+    /**
+     * @var string[]
+     */
     protected $configuredGroups;
+
+    /**
+     * @var mixed[][]
+     */
     protected $testsInGroups = [];
 
     public function __construct(array $groups)
@@ -36,7 +48,7 @@ class GroupManager
      * ]
      * ```
      */
-    protected function loadGroupsByPattern()
+    protected function loadGroupsByPattern(): void
     {
         foreach ($this->configuredGroups as $group => $pattern) {
             if (strpos($group, '*') === false) {
@@ -45,19 +57,19 @@ class GroupManager
             $files = Finder::create()->files()
                 ->name(basename($pattern))
                 ->sortByName()
-                ->in(Configuration::projectDir().dirname($pattern));
+                ->in(Configuration::projectDir() . dirname($pattern));
 
             $i = 1;
             foreach ($files as $file) {
                 /** @var SplFileInfo $file * */
-                $this->configuredGroups[str_replace('*', $i, $group)] = dirname($pattern).DIRECTORY_SEPARATOR.$file->getRelativePathname();
-                $i++;
+                $this->configuredGroups[str_replace('*', (string)$i, $group)] = dirname($pattern) . DIRECTORY_SEPARATOR . $file->getRelativePathname();
+                ++$i;
             }
             unset($this->configuredGroups[$group]);
         }
     }
 
-    protected function loadConfiguredGroupSettings()
+    protected function loadConfiguredGroupSettings(): void
     {
         foreach ($this->configuredGroups as $group => $tests) {
             $this->testsInGroups[$group] = [];
@@ -86,13 +98,7 @@ class GroupManager
         }
     }
 
-    /**
-     * @param string $file
-     * @param string $group
-     * @return false|string
-     * @throws ConfigurationException
-     */
-    private function normalizeFilePath($file, $group)
+    private function normalizeFilePath(string $file, string $group): string
     {
         $pathParts = explode(':', $file);
         if (codecept_is_path_absolute($file)) {
@@ -100,7 +106,7 @@ class GroupManager
                 //take segment before first :
                 $this->checkIfFileExists($pathParts[0], $group);
                 return sprintf('%s:%s', realpath($pathParts[0]), $pathParts[1]);
-            } else if (count($pathParts) > 2) {
+            } elseif (count($pathParts) > 2) {
                 //on Windows take segment before second :
                 $fullPath = $pathParts[0] . ':' . $pathParts[1];
                 $this->checkIfFileExists($fullPath, $group);
@@ -120,19 +126,14 @@ class GroupManager
         return sprintf('%s:%s', realpath($dirtyPath), $pathParts[1]);
     }
 
-    /**
-     * @param string $path
-     * @param string $group
-     * @throws ConfigurationException
-     */
-    private function checkIfFileExists($path, $group)
+    private function checkIfFileExists(string $path, string $group): void
     {
         if (!file_exists($path)) {
-            throw new ConfigurationException('GroupManager: File or directory ' . $path . ' set in ' . $group. ' group does not exist');
+            throw new ConfigurationException('GroupManager: File or directory ' . $path . ' set in ' . $group . ' group does not exist');
         }
     }
 
-    public function groupsForTest(\PHPUnit\Framework\Test $test)
+    public function groupsForTest(Test $test): array
     {
         $groups = [];
         $filename = Descriptor::getTestFileName($test);
@@ -146,7 +147,7 @@ class GroupManager
             }
             $filename = str_replace(['\\\\', '//', '/./'], ['\\', '/', '/'], $info['file']);
         }
-        if ($test instanceof \PHPUnit\Framework\TestCase) {
+        if ($test instanceof TestCase) {
             $groups = array_merge($groups, \PHPUnit\Util\Test::getGroups(get_class($test), $test->getName(false)));
         }
         if ($test instanceof \PHPUnit\Framework\TestSuite\DataProvider) {
@@ -162,7 +163,8 @@ class GroupManager
                 if ($filename == $testPattern) {
                     $groups[] = $group;
                 }
-                if (strpos($filename . ':' . $test->getName(false), $testPattern) === 0) {
+                $testName = $test->getName(false);
+                if (strpos($filename . ':' . $testName, (string) $testPattern) === 0) {
                     $groups[] = $group;
                 }
                 if ($test instanceof Gherkin
@@ -171,10 +173,9 @@ class GroupManager
                 }
                 if ($test instanceof \PHPUnit\Framework\TestSuite\DataProvider) {
                     $firstTest = $test->testAt(0);
-                    if ($firstTest != false && $firstTest instanceof TestInterface) {
-                        if (strpos($filename . ':' . $firstTest->getName(false), $testPattern) === 0) {
-                            $groups[] = $group;
-                        }
+                    $firstTestName = $firstTest->getName(false);
+                    if ($firstTest != false && $firstTest instanceof TestInterface && strpos($filename . ':' . $firstTestName, (string) $testPattern) === 0) {
+                        $groups[] = $group;
                     }
                 }
             }

--- a/src/Codeception/Lib/Interfaces/API.php
+++ b/src/Codeception/Lib/Interfaces/API.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Codeception\Lib\Interfaces;
 
 /**

--- a/src/Codeception/Lib/Interfaces/ActiveRecord.php
+++ b/src/Codeception/Lib/Interfaces/ActiveRecord.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Codeception\Lib\Interfaces;
 
 interface ActiveRecord extends ORM

--- a/src/Codeception/Lib/Interfaces/ConflictsWithModule.php
+++ b/src/Codeception/Lib/Interfaces/ConflictsWithModule.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Codeception\Lib\Interfaces;
 
 interface ConflictsWithModule

--- a/src/Codeception/Lib/Interfaces/DataMapper.php
+++ b/src/Codeception/Lib/Interfaces/DataMapper.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Codeception\Lib\Interfaces;
 
 interface DataMapper extends ORM, DoctrineProvider

--- a/src/Codeception/Lib/Interfaces/DependsOnModule.php
+++ b/src/Codeception/Lib/Interfaces/DependsOnModule.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Codeception\Lib\Interfaces;
 
 interface DependsOnModule

--- a/src/Codeception/Lib/Interfaces/DoctrineProvider.php
+++ b/src/Codeception/Lib/Interfaces/DoctrineProvider.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Codeception\Lib\Interfaces;
 
 interface DoctrineProvider

--- a/src/Codeception/Lib/Interfaces/ElementLocator.php
+++ b/src/Codeception/Lib/Interfaces/ElementLocator.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Codeception\Lib\Interfaces;
 
 interface ElementLocator

--- a/src/Codeception/Lib/Interfaces/MultiSession.php
+++ b/src/Codeception/Lib/Interfaces/MultiSession.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Codeception\Lib\Interfaces;
 
 interface MultiSession

--- a/src/Codeception/Lib/Interfaces/ORM.php
+++ b/src/Codeception/Lib/Interfaces/ORM.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Codeception\Lib\Interfaces;
 
 interface ORM

--- a/src/Codeception/Lib/Interfaces/PageSourceSaver.php
+++ b/src/Codeception/Lib/Interfaces/PageSourceSaver.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Codeception\Lib\Interfaces;
 
 interface PageSourceSaver

--- a/src/Codeception/Lib/Interfaces/PartedModule.php
+++ b/src/Codeception/Lib/Interfaces/PartedModule.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Codeception\Lib\Interfaces;
 
 /**

--- a/src/Codeception/Lib/Interfaces/Remote.php
+++ b/src/Codeception/Lib/Interfaces/Remote.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Codeception\Lib\Interfaces;
 
 interface Remote

--- a/src/Codeception/Lib/Interfaces/RequiresPackage.php
+++ b/src/Codeception/Lib/Interfaces/RequiresPackage.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Codeception\Lib\Interfaces;
 
 interface RequiresPackage

--- a/src/Codeception/Lib/Interfaces/Web.php
+++ b/src/Codeception/Lib/Interfaces/Web.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Codeception\Lib\Interfaces;
 
 interface Web
@@ -81,7 +82,7 @@ interface Web
      * @param array|string $selector optional
      */
     public function dontSee($text, $selector = null);
-    
+
     /**
      * Checks that the current page contains the given string in its
      * raw source code.
@@ -306,7 +307,6 @@ interface Web
      * $I->click('Logout', '#nav');
      * // using strict locator
      * $I->click(['link' => 'Login']);
-     * ?>
      * ```
      *
      * @param $link
@@ -322,7 +322,6 @@ interface Web
      * <?php
      * $I->seeLink('Logout'); // matches <a href="#">Logout</a>
      * $I->seeLink('Logout','/logout'); // matches <a href="/logout">Logout</a>
-     * ?>
      * ```
      *
      * @param string $text
@@ -338,7 +337,6 @@ interface Web
      * <?php
      * $I->dontSeeLink('Logout'); // I suppose user is not logged in
      * $I->dontSeeLink('Checkout now', '/store/cart.php');
-     * ?>
      * ```
      *
      * @param string $text
@@ -355,7 +353,6 @@ interface Web
      * $I->seeInCurrentUrl('home');
      * // to match: /users/1
      * $I->seeInCurrentUrl('/users/');
-     * ?>
      * ```
      *
      * @param string $uri
@@ -370,7 +367,6 @@ interface Web
      * <?php
      * // to match root url
      * $I->seeCurrentUrlEquals('/');
-     * ?>
      * ```
      *
      * @param string $uri
@@ -384,7 +380,6 @@ interface Web
      * <?php
      * // to match root url
      * $I->seeCurrentUrlMatches('~^/users/(\d+)~');
-     * ?>
      * ```
      *
      * @param string $uri
@@ -397,7 +392,6 @@ interface Web
      * ``` php
      * <?php
      * $I->dontSeeInCurrentUrl('/users/');
-     * ?>
      * ```
      *
      * @param string $uri
@@ -412,7 +406,6 @@ interface Web
      * <?php
      * // current url is not root
      * $I->dontSeeCurrentUrlEquals('/');
-     * ?>
      * ```
      *
      * @param string $uri
@@ -426,7 +419,6 @@ interface Web
      * <?php
      * // to match root url
      * $I->dontSeeCurrentUrlMatches('~^/users/(\d+)~');
-     * ?>
      * ```
      *
      * @param string $uri
@@ -441,7 +433,6 @@ interface Web
      * <?php
      * $user_id = $I->grabFromCurrentUrl('~^/user/(\d+)/~');
      * $uri = $I->grabFromCurrentUrl();
-     * ?>
      * ```
      *
      * @param string $uri optional
@@ -458,7 +449,6 @@ interface Web
      * $I->seeCheckboxIsChecked('#agree'); // I suppose user agreed to terms
      * $I->seeCheckboxIsChecked('#signup_form input[type=checkbox]'); // I suppose user agreed to terms, If there is only one checkbox in form.
      * $I->seeCheckboxIsChecked('//form/input[@type=checkbox and @name=agree]');
-     * ?>
      * ```
      *
      * @param $checkbox
@@ -472,7 +462,6 @@ interface Web
      * <?php
      * $I->dontSeeCheckboxIsChecked('#agree'); // I suppose user didn't agree to terms
      * $I->seeCheckboxIsChecked('#signup_form input[type=checkbox]'); // I suppose user didn't check the first checkbox in form.
-     * ?>
      * ```
      *
      * @param $checkbox
@@ -491,7 +480,6 @@ interface Web
      * $I->seeInField('#searchform input','Search');
      * $I->seeInField('//form/*[@name=search]','Search');
      * $I->seeInField(['name' => 'search'], 'Search');
-     * ?>
      * ```
      *
      * @param $field
@@ -511,7 +499,6 @@ interface Web
      * $I->dontSeeInField('#searchform input','Search');
      * $I->dontSeeInField('//form/*[@name=search]','Search');
      * $I->dontSeeInField(['name' => 'search'], 'Search');
-     * ?>
      * ```
      *
      * @param $field
@@ -529,7 +516,6 @@ interface Web
      *      'input1' => 'value',
      *      'input2' => 'other value',
      * ]);
-     * ?>
      * ```
      *
      * For multi-select elements, or to check values of multiple elements with the same name, an
@@ -547,7 +533,6 @@ interface Web
      *          'another checked value',
      *      ],
      * ]);
-     * ?>
      * ```
      *
      * Additionally, checkbox values can be checked with a boolean.
@@ -558,7 +543,6 @@ interface Web
      *      'checkbox1' => true,        // passes if checked
      *      'checkbox2' => false,       // passes if unchecked
      * ]);
-     * ?>
      * ```
      *
      * Pair this with submitForm for quick testing magic.
@@ -574,7 +558,6 @@ interface Web
      * $I->submitForm('//form[@id=my-form]', $form, 'submitButton');
      * // $I->amOnPage('/path/to/form-page') may be needed
      * $I->seeInFormFields('//form[@id=my-form]', $form);
-     * ?>
      * ```
      *
      * @param $formSelector
@@ -592,7 +575,6 @@ interface Web
      *      'input1' => 'non-existent value',
      *      'input2' => 'other non-existent value',
      * ]);
-     * ?>
      * ```
      *
      * To check that an element hasn't been assigned any one of many values, an array can be passed
@@ -606,7 +588,6 @@ interface Web
      *          'And this value shouldn\'t be set',
      *      ],
      * ]);
-     * ?>
      * ```
      *
      * Additionally, checkbox values can be checked with a boolean.
@@ -617,7 +598,6 @@ interface Web
      *      'checkbox1' => true,        // fails if checked
      *      'checkbox2' => false,       // fails if unchecked
      * ]);
-     * ?>
      * ```
      *
      * @param $formSelector
@@ -633,7 +613,6 @@ interface Web
      * $I->selectOption('form select[name=account]', 'Premium');
      * $I->selectOption('form input[name=payment]', 'Monthly');
      * $I->selectOption('//form/select[@name=account]', 'Monthly');
-     * ?>
      * ```
      *
      * Provide an array for the second argument to select multiple options:
@@ -641,7 +620,6 @@ interface Web
      * ``` php
      * <?php
      * $I->selectOption('Which OS do you use?', array('Windows','Linux'));
-     * ?>
      * ```
      *
      * Or provide an associative array for the second argument to specifically define which selection method should be used:
@@ -650,7 +628,6 @@ interface Web
      * <?php
      * $I->selectOption('Which OS do you use?', array('text' => 'Windows')); // Only search by text 'Windows'
      * $I->selectOption('Which OS do you use?', array('value' => 'windows')); // Only search by value 'windows'
-     * ?>
      * ```
      *
      * @param $select
@@ -664,7 +641,6 @@ interface Web
      * ``` php
      * <?php
      * $I->checkOption('#agree');
-     * ?>
      * ```
      *
      * @param $option
@@ -677,7 +653,6 @@ interface Web
      * ``` php
      * <?php
      * $I->uncheckOption('#notify');
-     * ?>
      * ```
      *
      * @param $option
@@ -691,14 +666,13 @@ interface Web
      * <?php
      * $I->fillField("//input[@type='text']", "Hello World!");
      * $I->fillField(['name' => 'email'], 'jon@mail.com');
-     * ?>
      * ```
      *
      * @param $field
      * @param $value
      */
     public function fillField($field, $value);
-    
+
     /**
      * Attaches a file relative to the Codeception `_data` directory to the given file upload field.
      *
@@ -706,7 +680,6 @@ interface Web
      * <?php
      * // file is stored in 'tests/_data/prices.xls'
      * $I->attachFile('input[@type="file"]', 'prices.xls');
-     * ?>
      * ```
      *
      * @param $field
@@ -724,7 +697,6 @@ interface Web
      * $heading = $I->grabTextFrom('h1');
      * $heading = $I->grabTextFrom('descendant-or-self::h1');
      * $value = $I->grabTextFrom('~<input value=(.*?)]~sgi'); // match with a regex
-     * ?>
      * ```
      *
      * @param $cssOrXPathOrRegex
@@ -743,7 +715,6 @@ interface Web
      * $name = $I->grabValueFrom('input[name=username]');
      * $name = $I->grabValueFrom('descendant-or-self::form/descendant::input[@name = 'username']');
      * $name = $I->grabValueFrom(['name' => 'username']);
-     * ?>
      * ```
      *
      * @param $field
@@ -760,7 +731,6 @@ interface Web
      * ``` php
      * <?php
      * $I->grabAttributeFrom('#tooltip', 'title');
-     * ?>
      * ```
      *
      *
@@ -770,7 +740,7 @@ interface Web
      * @return mixed
      */
     public function grabAttributeFrom($cssOrXpath, $attribute);
-    
+
     /**
      * Grabs either the text content, or attribute values, of nodes
      * matched by $cssOrXpath and returns them as an array.
@@ -788,7 +758,6 @@ interface Web
      *
      * // would return ['#first', '#second', '#third']
      * $aLinks = $I->grabMultiple('a', 'href');
-     * ?>
      * ```
      *
      * @param $cssOrXpath
@@ -810,7 +779,6 @@ interface Web
      *
      * // strict locator in first arg, attributes in second
      * $I->seeElement(['css' => 'form input'], ['name' => 'login']);
-     * ?>
      * ```
      *
      * @param $selector
@@ -829,7 +797,6 @@ interface Web
      * $I->dontSeeElement('//form/input[1]');
      * $I->dontSeeElement('input', ['name' => 'login']);
      * $I->dontSeeElement('input', ['value' => '123456']);
-     * ?>
      * ```
      *
      * @param $selector
@@ -844,7 +811,6 @@ interface Web
      * <?php
      * $I->seeNumberOfElements('tr', 10);
      * $I->seeNumberOfElements('tr', [0,10]); // between 0 and 10 elements
-     * ?>
      * ```
      * @param $selector
      * @param mixed $expected int or int[]
@@ -857,7 +823,6 @@ interface Web
      * ``` php
      * <?php
      * $I->seeOptionIsSelected('#form input[name=payment]', 'Visa');
-     * ?>
      * ```
      *
      * @param $selector
@@ -873,7 +838,6 @@ interface Web
      * ``` php
      * <?php
      * $I->dontSeeOptionIsSelected('#form input[name=payment]', 'Visa');
-     * ?>
      * ```
      *
      * @param $selector
@@ -889,7 +853,6 @@ interface Web
      * ``` php
      * <?php
      * $I->seeInTitle('Blog - Post #1');
-     * ?>
      * ```
      *
      * @param $title
@@ -914,7 +877,6 @@ interface Web
      * ``` php
      * <?php
      * $I->seeCookie('PHPSESSID');
-     * ?>
      * ```
      *
      * @param $cookie
@@ -941,7 +903,6 @@ interface Web
      * ``` php
      * <?php
      * $I->setCookie('PHPSESSID', 'el4ukv0kqbvoirg7nkp4dncpk3');
-     * ?>
      * ```
      *
      * @param $name

--- a/src/Codeception/Lib/ModuleContainer.php
+++ b/src/Codeception/Lib/ModuleContainer.php
@@ -1,15 +1,23 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Codeception\Lib;
 
 use Codeception\Configuration;
 use Codeception\Exception\ConfigurationException;
+use Codeception\Exception\InjectionException;
 use Codeception\Exception\ModuleConflictException;
 use Codeception\Exception\ModuleException;
 use Codeception\Exception\ModuleRequireException;
 use Codeception\Lib\Interfaces\ConflictsWithModule;
 use Codeception\Lib\Interfaces\DependsOnModule;
 use Codeception\Lib\Interfaces\PartedModule;
+use Codeception\Module;
 use Codeception\Util\Annotation;
+use ReflectionClass;
+use ReflectionException;
+use ReflectionMethod;
 
 /**
  * Class ModuleContainer
@@ -27,6 +35,9 @@ class ModuleContainer
      */
     const MAXIMUM_LEVENSHTEIN_DISTANCE = 5;
 
+    /**
+     * @var array<string, string>
+     */
     public static $packages = [
         'AMQP' => 'codeception/module-amqp',
         'Apc' => 'codeception/module-apc',
@@ -58,7 +69,7 @@ class ModuleContainer
     /**
      * @var array
      */
-    private $config;
+    private $config = [];
 
     /**
      * @var Di
@@ -80,16 +91,12 @@ class ModuleContainer
      */
     private $actions = [];
 
-    /**
-     * Constructor.
-     *
-     * @param Di $di
-     * @param array $config
-     */
-    public function __construct(Di $di, $config)
+
+    public function __construct(Di $di, array $config)
     {
         $this->di = $di;
         $this->di->set($this);
+
         $this->config = $config;
     }
 
@@ -98,13 +105,14 @@ class ModuleContainer
      *
      * @param string $moduleName
      * @param bool $active
-     * @return \Codeception\Module
-     * @throws \Codeception\Exception\ConfigurationException
-     * @throws \Codeception\Exception\ModuleException
-     * @throws \Codeception\Exception\ModuleRequireException
-     * @throws \Codeception\Exception\InjectionException
+     * @return object|null
+     * @throws ConfigurationException
+     * @throws InjectionException
+     * @throws ModuleException
+     * @throws ModuleRequireException
+     * @throws ReflectionException
      */
-    public function create($moduleName, $active = true)
+    public function create(string $moduleName, bool $active = true): ?object
     {
         $this->active[$moduleName] = $active;
 
@@ -112,9 +120,9 @@ class ModuleContainer
         if (!class_exists($moduleClass)) {
             if (isset(self::$packages[$moduleName])) {
                 $package = self::$packages[$moduleName];
-                throw new ConfigurationException("Module $moduleName is not installed.\nUse Composer to install corresponding package:\n\ncomposer require $package --dev");
+                throw new ConfigurationException("Module {$moduleName} is not installed.\nUse Composer to install corresponding package:\n\ncomposer require {$package} --dev");
             }
-            throw new ConfigurationException("Module $moduleName could not be found and loaded");
+            throw new ConfigurationException("Module {$moduleName} could not be found and loaded");
         }
 
         $config = $this->getModuleConfig($moduleName);
@@ -125,8 +133,9 @@ class ModuleContainer
             // Explicitly setting $config to null skips this validation.
             $config = null;
         }
+        $this->modules[$moduleName] = $this->di->instantiate($moduleClass, [$this, $config], (string)false);
 
-        $this->modules[$moduleName] = $module = $this->di->instantiate($moduleClass, [$this, $config], false);
+        $module = $this->modules[$moduleName];
 
         if ($this->moduleHasDependencies($module)) {
             $this->injectModuleDependencies($moduleName, $module);
@@ -137,18 +146,15 @@ class ModuleContainer
 
         foreach ($actions as $action) {
             $this->actions[$action] = $moduleName;
-        };
+        }
 
         return $module;
     }
 
     /**
      * Does a module have dependencies?
-     *
-     * @param \Codeception\Module $module
-     * @return bool
      */
-    private function moduleHasDependencies($module)
+    private function moduleHasDependencies(Module $module): bool
     {
         if (!$module instanceof DependsOnModule) {
             return false;
@@ -160,16 +166,14 @@ class ModuleContainer
     /**
      * Get the actions of a module.
      *
-     * @param \Codeception\Module $module
-     * @param array $config
-     * @return array
+     * @return string[]
      */
-    private function getActionsForModule($module, $config)
+    private function getActionsForModule(Module $module, array $config): array
     {
-        $reflectionClass = new \ReflectionClass($module);
+        $reflectionClass = new ReflectionClass($module);
 
         // Only public methods can be actions
-        $methods = $reflectionClass->getMethods(\ReflectionMethod::IS_PUBLIC);
+        $methods = $reflectionClass->getMethods(ReflectionMethod::IS_PUBLIC);
 
         // Should this module be loaded partially?
         $configuredParts = null;
@@ -189,13 +193,8 @@ class ModuleContainer
 
     /**
      * Should a method be included as an action?
-     *
-     * @param \Codeception\Module $module
-     * @param \ReflectionMethod $method
-     * @param array|null $configuredParts
-     * @return bool
      */
-    private function includeMethodAsAction($module, $method, $configuredParts = null)
+    private function includeMethodAsAction(Module $module, ReflectionMethod $method, ?array $configuredParts = null): bool
     {
         // Filter out excluded actions
         if ($module::$excludeActions && in_array($method->name, $module::$excludeActions)) {
@@ -235,22 +234,16 @@ class ModuleContainer
 
     /**
      * Is the module a helper?
-     *
-     * @param string $moduleName
-     * @return bool
      */
-    private function isHelper($moduleName)
+    private function isHelper(string $moduleName): bool
     {
         return strpos($moduleName, '\\') !== false;
     }
 
     /**
      * Get the fully qualified class name for a module.
-     *
-     * @param string $moduleName
-     * @return string
      */
-    private function getModuleClass($moduleName)
+    private function getModuleClass(string $moduleName): string
     {
         if ($this->isHelper($moduleName)) {
             return $moduleName;
@@ -261,11 +254,8 @@ class ModuleContainer
 
     /**
      * Is a module instantiated in this ModuleContainer?
-     *
-     * @param string $moduleName
-     * @return bool
      */
-    public function hasModule($moduleName)
+    public function hasModule(string $moduleName): bool
     {
         return isset($this->modules[$moduleName]);
     }
@@ -273,11 +263,9 @@ class ModuleContainer
     /**
      * Get a module from this ModuleContainer.
      *
-     * @param string $moduleName
-     * @return \Codeception\Module
-     * @throws \Codeception\Exception\ModuleException
+     * @throws ModuleException
      */
-    public function getModule($moduleName)
+    public function getModule(string $moduleName): Module
     {
         if (!$this->hasModule($moduleName)) {
             $this->throwMissingModuleExceptionWithSuggestion(__CLASS__, $moduleName);
@@ -286,17 +274,17 @@ class ModuleContainer
         return $this->modules[$moduleName];
     }
 
-    public function throwMissingModuleExceptionWithSuggestion($className, $moduleName)
+    public function throwMissingModuleExceptionWithSuggestion(string $className, string $moduleName): void
     {
         $suggestedModuleNameInfo = $this->getModuleSuggestion($moduleName);
-        throw new ModuleException($className, "Module $moduleName couldn't be connected" . $suggestedModuleNameInfo);
+        throw new ModuleException($className, "Module {$moduleName} couldn't be connected" . $suggestedModuleNameInfo);
     }
 
-    protected function getModuleSuggestion($missingModuleName)
+    protected function getModuleSuggestion($missingModuleName): string
     {
         $shortestLevenshteinDistance = null;
         $suggestedModuleName = null;
-        foreach ($this->modules as $moduleName => $module) {
+        foreach (array_keys($this->modules) as $moduleName) {
             $levenshteinDistance = levenshtein($missingModuleName, $moduleName);
             if ($shortestLevenshteinDistance === null || $levenshteinDistance <= $shortestLevenshteinDistance) {
                 $shortestLevenshteinDistance = $levenshteinDistance;
@@ -305,7 +293,7 @@ class ModuleContainer
         }
 
         if ($suggestedModuleName !== null && $shortestLevenshteinDistance <= self::MAXIMUM_LEVENSHTEIN_DISTANCE) {
-            return " (did you mean '$suggestedModuleName'?)";
+            return " (did you mean '{$suggestedModuleName}'?)";
         }
 
         return '';
@@ -314,10 +302,9 @@ class ModuleContainer
     /**
      * Get the module for an action.
      *
-     * @param string $action
-     * @return \Codeception\Module|null This method returns null if there is no module for $action
+     * @return Module|null
      */
-    public function moduleForAction($action)
+    public function moduleForAction(string $action)
     {
         if (!isset($this->actions[$action])) {
             return null;
@@ -331,7 +318,7 @@ class ModuleContainer
      *
      * @return array An array with actions as keys and module names as values.
      */
-    public function getActions()
+    public function getActions(): array
     {
         return $this->actions;
     }
@@ -341,18 +328,15 @@ class ModuleContainer
      *
      * @return array An array with module names as keys and modules as values.
      */
-    public function all()
+    public function all(): array
     {
         return $this->modules;
     }
 
     /**
      * Mock a module in this ModuleContainer.
-     *
-     * @param string $moduleName
-     * @param object $mock
      */
-    public function mock($moduleName, $mock)
+    public function mock(string $moduleName, object $mock): void
     {
         $this->modules[$moduleName] = $mock;
     }
@@ -360,12 +344,10 @@ class ModuleContainer
     /**
      * Inject the dependencies of a module.
      *
-     * @param string $moduleName
-     * @param \Codeception\Lib\Interfaces\DependsOnModule $module
-     * @throws \Codeception\Exception\ModuleException
-     * @throws \Codeception\Exception\ModuleRequireException
+     * @throws ModuleException
+     * @throws ModuleRequireException
      */
-    private function injectModuleDependencies($moduleName, DependsOnModule $module)
+    private function injectModuleDependencies(string $moduleName, DependsOnModule $module): void
     {
         $this->checkForMissingDependencies($moduleName, $module);
 
@@ -383,12 +365,9 @@ class ModuleContainer
     /**
      * Check for missing dependencies.
      *
-     * @param string $moduleName
-     * @param \Codeception\Lib\Interfaces\DependsOnModule $module
-     * @throws \Codeception\Exception\ModuleException
-     * @throws \Codeception\Exception\ModuleRequireException
+     * @throws ModuleException|ModuleRequireException
      */
-    private function checkForMissingDependencies($moduleName, DependsOnModule $module)
+    private function checkForMissingDependencies(string $moduleName, DependsOnModule $module): void
     {
         $dependencies = $this->getModuleDependencies($module);
         $configuredDependenciesCount = count($this->getConfiguredDependencies($moduleName));
@@ -409,11 +388,9 @@ class ModuleContainer
     /**
      * Get the dependencies of a module.
      *
-     * @param \Codeception\Lib\Interfaces\DependsOnModule $module
-     * @return array
-     * @throws \Codeception\Exception\ModuleException
+     * @throws ModuleException
      */
-    private function getModuleDependencies(DependsOnModule $module)
+    private function getModuleDependencies(DependsOnModule $module): array
     {
         $depends = $module->_depends();
 
@@ -431,11 +408,8 @@ class ModuleContainer
 
     /**
      * Get the configured dependencies for a module.
-     *
-     * @param string $moduleName
-     * @return array
      */
-    private function getConfiguredDependencies($moduleName)
+    private function getConfiguredDependencies(string $moduleName): array
     {
         $config = $this->getModuleConfig($moduleName);
 
@@ -448,12 +422,8 @@ class ModuleContainer
 
     /**
      * Get the error message for a module dependency that is missing.
-     *
-     * @param \Codeception\Module $module
-     * @param string $missingDependency
-     * @return string
      */
-    private function getErrorMessageForDependency($module, $missingDependency)
+    private function getErrorMessageForDependency(Module $module, string $missingDependency): string
     {
         $depends = $module->_depends();
 
@@ -470,11 +440,8 @@ class ModuleContainer
      * This method checks both locations for configuration. If there is configuration at both locations
      * this method merges them, where the configuration at modules.enabled.$moduleName takes precedence
      * over modules.config.$moduleName if the same parameters are configured at both locations.
-     *
-     * @param string $moduleName
-     * @return array
      */
-    private function getModuleConfig($moduleName)
+    private function getModuleConfig(string $moduleName): array
     {
         $config = isset($this->config['modules']['config'][$moduleName])
             ? $this->config['modules']['config'][$moduleName]
@@ -505,9 +472,9 @@ class ModuleContainer
     /**
      * Check if there are conflicting modules in this ModuleContainer.
      *
-     * @throws \Codeception\Exception\ModuleConflictException
+     * @throws ModuleConflictException
      */
-    public function validateConflicts()
+    public function validateConflicts(): void
     {
         $canConflict = [];
         foreach ($this->modules as $moduleName => $module) {
@@ -528,11 +495,9 @@ class ModuleContainer
     /**
      * Check if the modules passed as arguments to this method conflict with each other.
      *
-     * @param \Codeception\Module $module
-     * @param \Codeception\Module $otherModule
-     * @throws \Codeception\Exception\ModuleConflictException
+     * @throws ModuleConflictException
      */
-    private function validateConflict($module, $otherModule)
+    private function validateConflict(Module $module, Module $otherModule): void
     {
         if ($module === $otherModule || !$module instanceof ConflictsWithModule) {
             return;
@@ -548,10 +513,9 @@ class ModuleContainer
      * Normalize the return value of ConflictsWithModule::_conflicts() to a class name.
      * This is necessary because it can return a module name instead of the name of a class or interface.
      *
-     * @param string $conflicts
-     * @return string
+     * @return class-string|Module|string
      */
-    private function normalizeConflictSpecification($conflicts)
+    private function normalizeConflictSpecification(string $conflicts)
     {
         if (interface_exists($conflicts) || class_exists($conflicts)) {
             return $conflicts;

--- a/src/Codeception/Lib/ModuleContainer.php
+++ b/src/Codeception/Lib/ModuleContainer.php
@@ -280,7 +280,7 @@ class ModuleContainer
         throw new ModuleException($className, "Module {$moduleName} couldn't be connected" . $suggestedModuleNameInfo);
     }
 
-    protected function getModuleSuggestion($missingModuleName): string
+    protected function getModuleSuggestion(string $missingModuleName): string
     {
         $shortestLevenshteinDistance = null;
         $suggestedModuleName = null;

--- a/src/Codeception/Lib/Notification.php
+++ b/src/Codeception/Lib/Notification.php
@@ -1,29 +1,35 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Codeception\Lib;
 
 class Notification
 {
+    /**
+     * @var string[]
+     */
     protected static $messages = [];
 
-    public static function warning($message, $location)
+    public static function warning(string $message, string $location): void
     {
         self::$messages[] = 'WARNING: ' . self::formatMessage($message, $location);
     }
 
-    public static function deprecate($message, $location = '')
+    public static function deprecate(string $message, string $location = ''): void
     {
         self::$messages[] = 'DEPRECATION: ' . self::formatMessage($message, $location);
     }
 
-    private static function formatMessage($message, $location = '')
+    private static function formatMessage(string $message, string $location = ''): string
     {
         if ($location) {
-            return "<bold>$message</bold> <info>$location</info>";
+            return "<bold>{$message}</bold> <info>{$location}</info>";
         }
         return $message;
     }
 
-    public static function all()
+    public static function all(): array
     {
         $messages = self::$messages;
         self::$messages = [];

--- a/src/Codeception/Lib/Parser.php
+++ b/src/Codeception/Lib/Parser.php
@@ -95,7 +95,7 @@ class Parser
         }
     }
 
-    protected function addStep(string $matches): void
+    protected function addStep(array $matches): void
     {
         list($m, $action, $params) = $matches;
         if (in_array($action, ['wantTo', 'wantToTest'])) {

--- a/src/Codeception/Lib/Parser.php
+++ b/src/Codeception/Lib/Parser.php
@@ -22,6 +22,9 @@ class Parser
      * @var Metadata
      */
     protected $metadata;
+    /**
+     * @var string
+     */
     protected $code;
 
     public function __construct(Scenario $scenario, Metadata $metadata)
@@ -30,13 +33,13 @@ class Parser
         $this->metadata = $metadata;
     }
 
-    public function prepareToRun($code): void
+    public function prepareToRun(string $code): void
     {
         $this->parseFeature($code);
         $this->parseScenarioOptions($code);
     }
 
-    public function parseFeature($code): void
+    public function parseFeature(string $code): void
     {
         $matches = [];
         $code = $this->stripComments($code);
@@ -52,12 +55,12 @@ class Parser
         }
     }
 
-    public function parseScenarioOptions($code): void
+    public function parseScenarioOptions(string $code): void
     {
         $this->metadata->setParamsFromAnnotations($this->matchComments($code));
     }
 
-    public function parseSteps($code): void
+    public function parseSteps(string $code): void
     {
         // parse per line
         $friends = [];
@@ -92,7 +95,7 @@ class Parser
         }
     }
 
-    protected function addStep($matches): void
+    protected function addStep(string $matches): void
     {
         list($m, $action, $params) = $matches;
         if (in_array($action, ['wantTo', 'wantToTest'])) {
@@ -101,12 +104,12 @@ class Parser
         $this->scenario->addStep(new Action($action, explode(',', $params)));
     }
 
-    protected function addCommentStep($comment): void
+    protected function addCommentStep(string $comment): void
     {
         $this->scenario->addStep(new Comment($comment, []));
     }
 
-    public static function load($file): void
+    public static function load(string $file): void
     {
         try {
             self::includeFile($file);
@@ -120,7 +123,7 @@ class Parser
     /**
      * @return string[]
      */
-    public static function getClassesFromFile($file): array
+    public static function getClassesFromFile(string $file): array
     {
         $sourceCode = file_get_contents($file);
         $classes = [];
@@ -165,23 +168,19 @@ class Parser
     /*
      * Include in different scope to prevent included file from affecting $file variable
      */
-    private static function includeFile($file): void
+    private static function includeFile(string $file): void
     {
         include_once $file;
     }
 
-    /**
-     * @param $code
-     * @return mixed
-     */
-    protected function stripComments($code)
+    protected function stripComments(string $code): string
     {
         $code = preg_replace('~\/\/.*?$~m', '', $code); // remove inline comments
         $code = preg_replace('~\/*\*.*?\*\/~ms', '', $code);
         return $code; // remove block comment
     }
 
-    protected function matchComments($code): string
+    protected function matchComments(string $code): string
     {
         $matches = [];
         $comments = '';

--- a/src/Codeception/Lib/Parser.php
+++ b/src/Codeception/Lib/Parser.php
@@ -1,11 +1,16 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Codeception\Lib;
 
-use Codeception\Configuration;
 use Codeception\Exception\TestParseException;
 use Codeception\Scenario;
-use Codeception\Step;
+use Codeception\Step\Action;
+use Codeception\Step\Comment;
 use Codeception\Test\Metadata;
+use Exception;
+use ParseError;
 
 class Parser
 {
@@ -25,13 +30,13 @@ class Parser
         $this->metadata = $metadata;
     }
 
-    public function prepareToRun($code)
+    public function prepareToRun($code): void
     {
         $this->parseFeature($code);
         $this->parseScenarioOptions($code);
     }
 
-    public function parseFeature($code)
+    public function parseFeature($code): void
     {
         $matches = [];
         $code = $this->stripComments($code);
@@ -47,12 +52,12 @@ class Parser
         }
     }
 
-    public function parseScenarioOptions($code)
+    public function parseScenarioOptions($code): void
     {
         $this->metadata->setParamsFromAnnotations($this->matchComments($code));
     }
 
-    public function parseSteps($code)
+    public function parseSteps($code): void
     {
         // parse per line
         $friends = [];
@@ -70,7 +75,7 @@ class Parser
                     continue;
                 }
                 $isFriend = true;
-                $this->addCommentStep("\n----- $friend does -----");
+                $this->addCommentStep("\n----- {$friend} does -----");
                 continue;
             }
 
@@ -87,32 +92,35 @@ class Parser
         }
     }
 
-    protected function addStep($matches)
+    protected function addStep($matches): void
     {
         list($m, $action, $params) = $matches;
         if (in_array($action, ['wantTo', 'wantToTest'])) {
             return;
         }
-        $this->scenario->addStep(new Step\Action($action, explode(',', $params)));
+        $this->scenario->addStep(new Action($action, explode(',', $params)));
     }
 
-    protected function addCommentStep($comment)
+    protected function addCommentStep($comment): void
     {
-        $this->scenario->addStep(new \Codeception\Step\Comment($comment, []));
+        $this->scenario->addStep(new Comment($comment, []));
     }
 
-    public static function load($file)
+    public static function load($file): void
     {
         try {
             self::includeFile($file);
-        } catch (\ParseError $e) {
-            throw new TestParseException($file, $e->getMessage(), $e->getLine());
-        } catch (\Exception $e) {
+        } catch (ParseError $e) {
+            throw new TestParseException($file, $e->getMessage(), (string)$e->getLine());
+        } catch (Exception $e) {
             // file is valid otherwise
         }
     }
 
-    public static function getClassesFromFile($file)
+    /**
+     * @return string[]
+     */
+    public static function getClassesFromFile($file): array
     {
         $sourceCode = file_get_contents($file);
         $classes = [];
@@ -120,10 +128,10 @@ class Parser
         $tokenCount = count($tokens);
         $namespace = '';
 
-        for ($i = 0; $i < $tokenCount; $i++) {
+        for ($i = 0; $i < $tokenCount; ++$i) {
             if ($tokens[$i][0] === T_NAMESPACE) {
                 $namespace = '';
-                for ($j = $i + 1; $j < $tokenCount; $j++) {
+                for ($j = $i + 1; $j < $tokenCount; ++$j) {
                     if ($tokens[$j] === '{' || $tokens[$j] === ';') {
                         break;
                     }
@@ -141,7 +149,7 @@ class Parser
                 if ($tokens[$i - 2][0] === T_NEW) {
                     continue;
                 }
-                if ($tokens[$i - 1][0] === T_WHITESPACE and $tokens[$i - 2][0] === T_DOUBLE_COLON) {
+                if ($tokens[$i - 1][0] === T_WHITESPACE && $tokens[$i - 2][0] === T_DOUBLE_COLON) {
                     continue;
                 }
                 if ($tokens[$i - 1][0] === T_DOUBLE_COLON) {
@@ -157,7 +165,7 @@ class Parser
     /*
      * Include in different scope to prevent included file from affecting $file variable
      */
-    private static function includeFile($file)
+    private static function includeFile($file): void
     {
         include_once $file;
     }
@@ -173,7 +181,7 @@ class Parser
         return $code; // remove block comment
     }
 
-    protected function matchComments($code)
+    protected function matchComments($code): string
     {
         $matches = [];
         $comments = '';

--- a/src/Codeception/Scenario.php
+++ b/src/Codeception/Scenario.php
@@ -40,12 +40,12 @@ class Scenario
         $this->test = $test;
     }
 
-    public function setFeature($feature)
+    public function setFeature(string $feature): void
     {
         $this->metadata->setFeature($feature);
     }
 
-    public function getFeature()
+    public function getFeature(): string
     {
         return $this->metadata->getFeature();
     }

--- a/src/Codeception/Template/Acceptance.php
+++ b/src/Codeception/Template/Acceptance.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Codeception\Template;
 
 use Codeception\InitTemplate;
@@ -8,6 +10,9 @@ use Symfony\Component\Yaml\Yaml;
 
 class Acceptance extends InitTemplate
 {
+    /**
+     * @var string
+     */
     protected $configTemplate = <<<EOF
 # suite config
 suites:
@@ -48,6 +53,9 @@ settings:
     lint: true
 EOF;
 
+    /**
+     * @var string
+     */
     protected $firstTest = <<<EOF
 <?php
 class LoginCest 
@@ -68,7 +76,6 @@ class LoginCest
     }       
 }
 EOF;
-
 
     public function setup()
     {
@@ -94,7 +101,7 @@ EOF;
         $this->createDirectoryFor($supportDir . DIRECTORY_SEPARATOR . '_generated');
         $this->gitIgnore($outputDir);
         $this->gitIgnore($supportDir . DIRECTORY_SEPARATOR . '_generated');
-        $this->sayInfo("Created test directories inside at $dir");
+        $this->sayInfo("Created test directories inside at {$dir}");
 
         if (!class_exists('\\Codeception\\Module\\WebDriver')) {
             // composer version
@@ -107,9 +114,9 @@ EOF;
             ->place('baseDir', $dir)
             ->produce();
 
-        if ($this->namespace) {
+        if ($this->namespace !== '') {
             $namespace = rtrim($this->namespace, '\\');
-            $configFile = "namespace: $namespace\n" . $configFile;
+            $configFile = "namespace: {$namespace}\n" . $configFile;
         }
 
         $this->createFile('codeception.yml', $configFile);
@@ -126,7 +133,7 @@ EOF;
         $this->say();
         $this->say("<bold>Next steps:</bold>");
         $this->say('1. Launch Selenium Server and webserver');
-        $this->say("2. Edit <bold>$dir/LoginCest.php</bold> to test login of your application");
+        $this->say("2. Edit <bold>{$dir}/LoginCest.php</bold> to test login of your application");
         $this->say("3. Run tests using: <comment>codecept run</comment>");
         $this->say();
         $this->say("HINT: Add '\\Codeception\\Step\\Retry' trait to AcceptanceTester class to enable auto-retries");

--- a/src/Codeception/Template/Api.php
+++ b/src/Codeception/Template/Api.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Codeception\Template;
 
 use Codeception\InitTemplate;
@@ -8,6 +10,9 @@ use Symfony\Component\Yaml\Yaml;
 
 class Api extends InitTemplate
 {
+    /**
+     * @var string
+     */
     protected $configTemplate = <<<EOF
 # suite config
 suites:
@@ -31,6 +36,9 @@ settings:
     lint: true
 EOF;
 
+    /**
+     * @var string
+     */
     protected $firstTest = <<<EOF
 <?php
 class ApiCest 
@@ -55,7 +63,7 @@ EOF;
 
         $url = $this->ask("Start url for tests", "http://localhost/api");
 
-        if (!class_exists('\\Codeception\\Module\\REST') || !class_exists('\\Codeception\\Module\\PhpBrowser')) {
+        if (!class_exists('\\Codeception\\Module\\REST') || !class_exists(\Codeception\Module\PhpBrowser::class)) {
             $this->addModulesToComposer(['REST', 'PhpBrowser']);
         }
 
@@ -65,16 +73,16 @@ EOF;
         $this->createDirectoryFor($supportDir . DIRECTORY_SEPARATOR . '_generated');
         $this->gitIgnore($outputDir);
         $this->gitIgnore($supportDir . DIRECTORY_SEPARATOR . '_generated');
-        $this->sayInfo("Created test directories inside at $dir");
+        $this->sayInfo("Created test directories inside at {$dir}");
 
         $configFile = (new Template($this->configTemplate))
             ->place('url', $url)
             ->place('baseDir', $dir)
             ->produce();
 
-        if ($this->namespace) {
+        if ($this->namespace !== '') {
             $namespace = rtrim($this->namespace, '\\');
-            $configFile = "namespace: $namespace\n" . $configFile;
+            $configFile = "namespace: {$namespace}\n" . $configFile;
         }
 
         $this->createFile('codeception.yml', $configFile);
@@ -92,7 +100,7 @@ EOF;
 
         $this->say();
         $this->say("<bold>Next steps:</bold>");
-        $this->say("1. Edit <bold>$dir/ApiCest.php</bold> to write first API tests");
+        $this->say("1. Edit <bold>{$dir}/ApiCest.php</bold> to write first API tests");
         $this->say("2. Run tests using: <comment>codecept run</comment>");
         $this->say();
         $this->say("<bold>Happy testing!</bold>");

--- a/src/Codeception/Template/Bootstrap.php
+++ b/src/Codeception/Template/Bootstrap.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Codeception\Template;
 
 use Codeception\InitTemplate;
@@ -7,10 +9,21 @@ use Symfony\Component\Yaml\Yaml;
 
 class Bootstrap extends InitTemplate
 {
-    // defaults
+    /**
+     * @var string
+     */
     protected $supportDir = 'tests/_support';
+    /**
+     * @var string
+     */
     protected $outputDir = 'tests/_output';
+    /**
+     * @var string
+     */
     protected $dataDir = 'tests/_data';
+    /**
+     * @var string
+     */
     protected $envsDir = 'tests/_envs';
 
     public function setup()
@@ -39,7 +52,7 @@ class Bootstrap extends InitTemplate
             return;
         }
 
-        if (!class_exists('\\Codeception\\Module\\Asserts') || !class_exists('\\Codeception\\Module\\PhpBrowser')) {
+        if (!class_exists(\Codeception\Module\Asserts::class) || !class_exists(\Codeception\Module\PhpBrowser::class)) {
             $this->addModulesToComposer(['PhpBrowser', 'Asserts']);
         }
 
@@ -60,7 +73,7 @@ class Bootstrap extends InitTemplate
         $this->say("5. Run tests using: <comment>codecept run</comment>");
     }
 
-    protected function createDirs()
+    protected function createDirs(): void
     {
          $this->createDirectoryFor('tests');
          $this->createEmptyDirectory($this->outputDir);
@@ -71,7 +84,7 @@ class Bootstrap extends InitTemplate
          $this->gitIgnore('tests/_support/_generated');
     }
 
-    protected function createFunctionalSuite($actor = 'Functional')
+    protected function createFunctionalSuite($actor = 'Functional'): void
     {
         $suiteConfig = <<<EOF
 # Codeception Test Suite Configuration
@@ -93,7 +106,7 @@ EOF;
         $this->say("tests/functional.suite.yml written <- functional tests suite configuration");
     }
 
-    protected function createAcceptanceSuite($actor = 'Acceptance')
+    protected function createAcceptanceSuite($actor = 'Acceptance'): void
     {
         $suiteConfig = <<<EOF
 # Codeception Test Suite Configuration
@@ -115,7 +128,7 @@ EOF;
         $this->say("tests/acceptance.suite.yml written <- acceptance tests suite configuration");
     }
 
-    protected function createUnitSuite($actor = 'Unit')
+    protected function createUnitSuite($actor = 'Unit'): void
     {
         $suiteConfig = <<<EOF
 # Codeception Test Suite Configuration
@@ -134,7 +147,7 @@ EOF;
         $this->say("tests/unit.suite.yml written       <- unit tests suite configuration");
     }
 
-    public function createGlobalConfig()
+    public function createGlobalConfig(): void
     {
         $basicConfig = [
             'paths'    => [
@@ -146,24 +159,23 @@ EOF;
             ],
             'actor_suffix' => 'Tester',
             'extensions' => [
-                'enabled' => ['Codeception\Extension\RunFailed']
+                'enabled' => [\Codeception\Extension\RunFailed::class]
             ]
         ];
 
         $str = Yaml::dump($basicConfig, 4);
-        if ($this->namespace) {
+        if ($this->namespace !== '') {
             $namespace = rtrim($this->namespace, '\\');
-            $str = "namespace: $namespace\n" . $str;
+            $str = "namespace: {$namespace}\n" . $str;
         }
         $this->createFile('codeception.yml', $str);
     }
 
-
-    protected function createSuite($suite, $actor, $config)
+    protected function createSuite($suite, $actor, $config): void
     {
-        $this->createDirectoryFor("tests/$suite", "$suite.suite.yml");
+        $this->createDirectoryFor("tests/{$suite}", "{$suite}.suite.yml");
         $this->createHelper($actor, $this->supportDir);
         $this->createActor($actor . $this->actorSuffix, $this->supportDir, Yaml::parse($config));
-        $this->createFile('tests' . DIRECTORY_SEPARATOR . "$suite.suite.yml", $config);
+        $this->createFile('tests' . DIRECTORY_SEPARATOR . "{$suite}.suite.yml", $config);
     }
 }

--- a/src/Codeception/Template/Bootstrap.php
+++ b/src/Codeception/Template/Bootstrap.php
@@ -84,7 +84,7 @@ class Bootstrap extends InitTemplate
          $this->gitIgnore('tests/_support/_generated');
     }
 
-    protected function createFunctionalSuite($actor = 'Functional'): void
+    protected function createFunctionalSuite(string $actor = 'Functional'): void
     {
         $suiteConfig = <<<EOF
 # Codeception Test Suite Configuration
@@ -106,7 +106,7 @@ EOF;
         $this->say("tests/functional.suite.yml written <- functional tests suite configuration");
     }
 
-    protected function createAcceptanceSuite($actor = 'Acceptance'): void
+    protected function createAcceptanceSuite(string $actor = 'Acceptance'): void
     {
         $suiteConfig = <<<EOF
 # Codeception Test Suite Configuration
@@ -128,7 +128,7 @@ EOF;
         $this->say("tests/acceptance.suite.yml written <- acceptance tests suite configuration");
     }
 
-    protected function createUnitSuite($actor = 'Unit'): void
+    protected function createUnitSuite(string $actor = 'Unit'): void
     {
         $suiteConfig = <<<EOF
 # Codeception Test Suite Configuration
@@ -171,7 +171,7 @@ EOF;
         $this->createFile('codeception.yml', $str);
     }
 
-    protected function createSuite($suite, $actor, $config): void
+    protected function createSuite(string $suite, string $actor, string $config): void
     {
         $this->createDirectoryFor("tests/{$suite}", "{$suite}.suite.yml");
         $this->createHelper($actor, $this->supportDir);

--- a/src/Codeception/Template/Unit.php
+++ b/src/Codeception/Template/Unit.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Codeception\Template;
 
 use Codeception\InitTemplate;
@@ -8,6 +10,9 @@ use Symfony\Component\Yaml\Yaml;
 
 class Unit extends InitTemplate
 {
+    /**
+     * @var string
+     */
     protected $configTemplate = <<<EOF
 suites:
     unit:
@@ -24,6 +29,9 @@ paths:
      
 EOF;
 
+    /**
+     * @var string
+     */
     protected $testerAndModules = <<<EOF
         actor: UnitTester
         modules:
@@ -40,7 +48,7 @@ EOF;
         $this->say();
         $dir = $this->ask("Where tests will be stored?", 'tests');
 
-        if (!$this->namespace) {
+        if ($this->namespace === '') {
             $this->namespace = $this->ask("Enter a default namespace for tests (or skip this step)");
         }
 
@@ -57,14 +65,14 @@ EOF;
             ->place('tester', $haveTester ? $this->testerAndModules : '')
             ->produce();
 
-        if ($this->namespace) {
+        if ($this->namespace !== '') {
             $namespace = rtrim($this->namespace, '\\');
-            $configFile = "namespace: $namespace\n" . $configFile;
+            $configFile = "namespace: {$namespace}\n" . $configFile;
         }
 
         $this->createFile('codeception.yml', $configFile);
 
-        if (!class_exists('\\Codeception\\Module\\Asserts')) {
+        if (!class_exists(\Codeception\Module\Asserts::class)) {
             $this->addModulesToComposer(['Asserts']);
         }
 
@@ -74,7 +82,7 @@ EOF;
         }
 
         $this->gitIgnore($outputDir);
-        $this->sayInfo("Created test directory inside at $dir");
+        $this->sayInfo("Created test directory inside at {$dir}");
 
         $this->say();
         $this->saySuccess("INSTALLATION COMPLETE");

--- a/src/Codeception/Template/Upgrade4.php
+++ b/src/Codeception/Template/Upgrade4.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Codeception\Template;
 
 use Codeception\Configuration;
@@ -6,7 +9,13 @@ use Codeception\InitTemplate;
 
 class Upgrade4 extends InitTemplate
 {
-    const SURVEY_LINK = 'http://bit.ly/codecept-survey';
+    /**
+     * @var string
+     */
+    const SURVEY_LINK = 'https://bit.ly/codecept-survey';
+    /**
+     * @var string
+     */
     const DONATE_LINK = 'https://opencollective.com/codeception';
 
     public function setup()
@@ -58,11 +67,11 @@ class Upgrade4 extends InitTemplate
         $this->say('');
         $this->say('<bold>' . self::DONATE_LINK . '</bold>');
         $this->say('');
-        $this->say('It\'s ok to pay for reliable software.');
+        $this->say("It's ok to pay for reliable software.");
         $this->say('Talk to your manager & support further development of Codeception!');
     }
 
-    private function isInstalled()
+    private function isInstalled(): bool
     {
         try {
             $this->checkInstalled();

--- a/src/Codeception/Test/Feature/ScenarioLoader.php
+++ b/src/Codeception/Test/Feature/ScenarioLoader.php
@@ -27,7 +27,7 @@ trait ScenarioLoader
         return $this->scenario;
     }
 
-    public function getFeature(): ?string
+    public function getFeature(): string
     {
         return $this->getScenario()->getFeature();
     }

--- a/src/Codeception/Test/Gherkin.php
+++ b/src/Codeception/Test/Gherkin.php
@@ -60,7 +60,7 @@ class Gherkin extends Test implements ScenarioDriven, Reported
         $this->setMetadata(new Metadata());
         $this->scenario = new Scenario($this);
         $this->getMetadata()->setName($scenarioNode->getTitle());
-        $this->getMetadata()->setFeature($featureNode->getTitle());
+        $this->getMetadata()->setFeature((string) $featureNode->getTitle());
         $this->getMetadata()->setFilename($featureNode->getFile());
     }
 
@@ -216,7 +216,7 @@ class Gherkin extends Test implements ScenarioDriven, Reported
         return $this->getFeature() . ': ' . $this->getScenarioTitle();
     }
 
-    public function getFeature(): ?string
+    public function getFeature(): string
     {
         return $this->getMetadata()->getFeature();
     }

--- a/src/Codeception/Test/Metadata.php
+++ b/src/Codeception/Test/Metadata.php
@@ -21,9 +21,9 @@ class Metadata
      */
     protected $filename;
     /**
-     * @var string|null
+     * @var string
      */
-    protected $feature;
+    protected $feature = '';
     protected $index;
 
     /**
@@ -152,12 +152,12 @@ class Metadata
         return $this->getSkip() !== null || $this->getIncomplete() !== null;
     }
 
-    public function getFeature(): ?string
+    public function getFeature(): string
     {
         return $this->feature;
     }
 
-    public function setFeature(?string $feature): void
+    public function setFeature(string $feature): void
     {
         $this->feature = $feature;
     }

--- a/tests/unit/Codeception/Lib/Console/DiffFactoryTest.php
+++ b/tests/unit/Codeception/Lib/Console/DiffFactoryTest.php
@@ -27,7 +27,7 @@ class DiffFactoryTest extends \Codeception\Test\Unit
         $failure = $this->createFailure();
         $message = $this->diffFactory->createDiff($failure);
 
-        $this->assertEquals($expectedDiff, (string) $message, 'The diff should be generated.');
+        $this->assertEquals($expectedDiff, $message, 'The diff should be generated.');
     }
 
     protected function createFailure(): \SebastianBergmann\Comparator\ComparisonFailure

--- a/tests/unit/Codeception/Lib/ParserTest.php
+++ b/tests/unit/Codeception/Lib/ParserTest.php
@@ -83,11 +83,11 @@ EOF;
     {
         $code = "<?php\n //\\\$I->wantTo('run this test'); ";
         $this->parser->parseFeature($code);
-        $this->assertNull($this->scenario->getFeature());
+        $this->assertEmpty($this->scenario->getFeature());
 
         $code = "<?php\n /*\n \\\$I->wantTo('run this test'); \n */";
         $this->parser->parseFeature($code);
-        $this->assertNull($this->scenario->getFeature());
+        $this->assertEmpty($this->scenario->getFeature());
     }
 
     public function testScenarioSkipOptionsHandled()


### PR DESCRIPTION
- [x] Use strict types in `src/Codeception/Lib` and `src/Codeception/Template`.
- [x] Add type hints to Libs and Templates.
- [x] Remove unnecessary qualifiers in `src/Codeception/Lib` and `src/Codeception/Template`.
- [x] Longer aliases for ambiguous class names.
- [x] Fix naming in `src/Codeception/Lib` and `src/Codeception/Template`.