### PR TITLE
4.1 Use correct name of DataProviderTestSuite in conditions

### DIFF
--- a/src/Codeception/Command/DryRun.php
+++ b/src/Codeception/Command/DryRun.php
@@ -85,7 +85,7 @@ class DryRun extends Command
         $this->dispatch($dispatcher, Events::SUITE_INIT, new SuiteEvent($suiteManager->getSuite(), null, $settings));
         $this->dispatch($dispatcher, Events::SUITE_BEFORE, new SuiteEvent($suiteManager->getSuite(), null, $settings));
         foreach ($tests as $test) {
-            if ($test instanceof \PHPUnit\Framework\TestSuite\DataProvider) {
+            if ($test instanceof \PHPUnit\Framework\DataProviderTestSuite) {
                 foreach ($test as $t) {
                     if ($t instanceof Test) {
                         $this->dryRunTest($output, $dispatcher, $t);

--- a/src/Codeception/Lib/GroupManager.php
+++ b/src/Codeception/Lib/GroupManager.php
@@ -149,7 +149,7 @@ class GroupManager
         if ($test instanceof \PHPUnit\Framework\TestCase) {
             $groups = array_merge($groups, \PHPUnit\Util\Test::getGroups(get_class($test), $test->getName(false)));
         }
-        if ($test instanceof \PHPUnit\Framework\TestSuite\DataProvider) {
+        if ($test instanceof \PHPUnit\Framework\DataProviderTestSuite) {
             $firstTest = $test->testAt(0);
             if ($firstTest != false && $firstTest instanceof TestInterface) {
                 $groups = array_merge($groups, $firstTest->getMetadata()->getGroups());
@@ -169,7 +169,7 @@ class GroupManager
                     && mb_strtolower($filename . ':' . $test->getMetadata()->getFeature()) === mb_strtolower($testPattern)) {
                     $groups[] = $group;
                 }
-                if ($test instanceof \PHPUnit\Framework\TestSuite\DataProvider) {
+                if ($test instanceof \PHPUnit\Framework\DataProviderTestSuite) {
                     $firstTest = $test->testAt(0);
                     if ($firstTest != false && $firstTest instanceof TestInterface) {
                         if (strpos($filename . ':' . $firstTest->getName(false), $testPattern) === 0) {

--- a/src/Codeception/Subscriber/BeforeAfterTest.php
+++ b/src/Codeception/Subscriber/BeforeAfterTest.php
@@ -22,7 +22,7 @@ class BeforeAfterTest implements EventSubscriberInterface
     {
         foreach ($e->getSuite()->tests() as $test) {
             /** @var $test \PHPUnit\Framework\Test  * */
-            if ($test instanceof \PHPUnit\Framework\TestSuite\DataProvider) {
+            if ($test instanceof \PHPUnit\Framework\DataProviderTestSuite) {
                 $potentialTestClass = strstr($test->getName(), '::', true);
                 $this->hooks[$potentialTestClass] = \PHPUnit\Util\Test::getHookMethods($potentialTestClass);
             }


### PR DESCRIPTION
I accidently discovered that Codeception was using name of non-existant class in conditions.

PHPUnit_Framework_TestSuite_DataProvider class was renamed to PHPUnit\Framework\DataProviderTestSuite in PHPUnit 6.0.0, but Codeception code was updated to use PHPUnit\Framework\TestSuite\DataProvider in conditions.

2 things are obvious:
1. We have no tests covering these cases.
2. It hasn't caused any issues that are worth reporting.

Wouldn't it be better to delete the code in these blocks? It was dead for 5 years.

