### PR TITLE
Standardize code style

### DIFF
--- a/src/Codeception/Application.php
+++ b/src/Codeception/Application.php
@@ -80,7 +80,6 @@ class Application extends BaseApplication
      * Validate and get the name of the command
      *
      * @param CustomCommandInterface|string $commandClass
-     * @return string
      * @throws ConfigurationException
      */
     protected function getCustomCommandName($commandClass): string
@@ -149,7 +148,7 @@ class Application extends BaseApplication
             $argv = $_SERVER['argv'];
 
             for ($i = 0; $i < count($argv); ++$i) {
-                if (preg_match('/^(?:-([^c-]*)?c|--config(?:=|$))(.*)$/', $argv[$i], $match)) {
+                if (preg_match('#^(?:-([^c-]*)?c|--config(?:=|$))(.*)$#', $argv[$i], $match)) {
                     if (!empty($match[2])) { //same index
                         $this->preloadConfiguration($match[2]);
                     } elseif (isset($argv[$i + 1])) { //next index

--- a/src/Codeception/Command/Bootstrap.php
+++ b/src/Codeception/Command/Bootstrap.php
@@ -38,7 +38,7 @@ class Bootstrap extends Command
                     'Namespace to add for actor classes and helpers'
                 ),
                 new InputOption('actor', 'a', InputOption::VALUE_OPTIONAL, 'Custom actor instead of Tester'),
-                new InputOption('empty', 'e', InputOption::VALUE_NONE, 'Don\'t create standard suites')
+                new InputOption('empty', 'e', InputOption::VALUE_NONE, "Don't create standard suites")
             ]
         );
     }

--- a/src/Codeception/Command/Build.php
+++ b/src/Codeception/Command/Build.php
@@ -109,7 +109,7 @@ class Build extends Command
         $this->buildSuiteActors();
 
         foreach ($config['include'] as $subConfig) {
-            $this->output->writeln("\n<comment>Included Configuration: $subConfig</comment>");
+            $this->output->writeln("\n<comment>Included Configuration: {$subConfig}</comment>");
             $this->buildActorsForConfig($dir . DIRECTORY_SEPARATOR . $subConfig);
         }
     }

--- a/src/Codeception/Command/Completion.php
+++ b/src/Codeception/Command/Completion.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Codeception\Command;
 
-if (!class_exists('Stecman\Component\Symfony\Console\BashCompletion\Completion')) {
+if (!class_exists(\Stecman\Component\Symfony\Console\BashCompletion\Completion::class)) {
     echo "Please install `stecman/symfony-console-completion\n` to enable auto completion";
     return;
 }

--- a/src/Codeception/Command/ConfigValidate.php
+++ b/src/Codeception/Command/ConfigValidate.php
@@ -13,7 +13,6 @@ use Symfony\Component\Console\Output\OutputInterface;
 use function codecept_data_dir;
 use function codecept_output_dir;
 use function codecept_root_dir;
-use function count;
 use function implode;
 use function preg_replace;
 use function print_r;
@@ -66,11 +65,11 @@ class ConfigValidate extends Command
         $this->addStyles($output);
 
         if ($suite = $input->getArgument('suite')) {
-            $output->write("Validating <bold>$suite</bold> config... ");
+            $output->write("Validating <bold>{$suite}</bold> config... ");
             $config = $this->getSuiteConfig($suite);
             $output->writeln("Ok");
             $output->writeln("------------------------------\n");
-            $output->writeln("<info>$suite Suite Config</info>:\n");
+            $output->writeln("<info>{$suite} Suite Config</info>:\n");
             $output->writeln($this->formatOutput($config));
 
             return 0;
@@ -79,7 +78,7 @@ class ConfigValidate extends Command
         $output->write("Validating global config... ");
         $config = $this->getGlobalConfig();
         $output->writeln($input->getOption('override'));
-        if (count($input->getOption('override'))) {
+        if (!empty($input->getOption('override'))) {
             $config = $this->overrideConfig($input->getOption('override'));
         }
         $suites = Configuration::suites();
@@ -98,7 +97,7 @@ class ConfigValidate extends Command
         $output->writeln("<info>Available suites</info>: " . implode(', ', $suites));
 
         foreach ($suites as $suite) {
-            $output->write("Validating suite <bold>$suite</bold>... ");
+            $output->write("Validating suite <bold>{$suite}</bold>... ");
             $this->getSuiteConfig($suite);
             $output->writeln('Ok');
         }
@@ -111,6 +110,6 @@ class ConfigValidate extends Command
     protected function formatOutput($config): ?string
     {
         $output = print_r($config, true);
-        return preg_replace('~\[(.*?)\] =>~', "<fg=yellow>$1</fg=yellow> =>", $output);
+        return preg_replace('#\[(.*?)\] =>#', "<fg=yellow>$1</fg=yellow> =>", $output);
     }
 }

--- a/src/Codeception/Command/Console.php
+++ b/src/Codeception/Command/Console.php
@@ -114,7 +114,7 @@ class Console extends Command
 
         $this->listenToSignals();
 
-        $output->writeln("<info>Interactive console started for suite $suiteName</info>");
+        $output->writeln("<info>Interactive console started for suite {$suiteName}</info>");
         $output->writeln("<info>Try Codeception commands without writing a test</info>");
 
         $suiteEvent = new SuiteEvent($this->suite, $this->codecept->getResult(), $settings);
@@ -130,6 +130,7 @@ class Console extends Command
 
         $eventDispatcher->dispatch(new TestEvent($this->test), Events::TEST_AFTER);
         $eventDispatcher->dispatch(new SuiteEvent($this->suite), Events::SUITE_AFTER);
+
         $output->writeln("<info>Bye-bye!</info>");
         return 0;
     }

--- a/src/Codeception/Command/DryRun.php
+++ b/src/Codeception/Command/DryRun.php
@@ -69,7 +69,7 @@ class DryRun extends Command
             isset($config['settings']['memory_limit']) ? $config['settings']['memory_limit'] : '1024M'
         );
         if (! Configuration::isEmpty() && ! $test && strpos($suite, (string) $config['paths']['tests']) === 0) {
-            list(, $suite, $test) = $this->matchTestFromFilename($suite, $config['paths']['tests']);
+            [, $suite, $test] = $this->matchTestFromFilename($suite, $config['paths']['tests']);
         }
         $settings = $this->getSuiteConfig($suite);
 
@@ -111,7 +111,7 @@ class DryRun extends Command
     protected function matchTestFromFilename($filename, $testsPath)
     {
         $filename = str_replace(['//', '\/', '\\'], '/', $filename);
-        $res = preg_match("~^$testsPath/(.*?)/(.*)$~", $filename, $matches);
+        $res = preg_match("~^{$testsPath}/(.*?)/(.*)$~", $filename, $matches);
         if (!$res) {
             throw new InvalidArgumentException("Test file can't be matched");
         }

--- a/src/Codeception/Command/GenerateCept.php
+++ b/src/Codeception/Command/GenerateCept.php
@@ -51,10 +51,10 @@ class GenerateCept extends Command
         $fullPath = rtrim($config['path'], DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR . $filename;
         $res = $this->createFile($fullPath, $cept->produce());
         if (!$res) {
-            $output->writeln("<error>Test $filename already exists</error>");
+            $output->writeln("<error>Test {$filename} already exists</error>");
             return 1;
         }
-        $output->writeln("<info>Test was created in $fullPath</info>");
+        $output->writeln("<info>Test was created in {$fullPath}</info>");
         return 0;
     }
 }

--- a/src/Codeception/Command/GenerateCest.php
+++ b/src/Codeception/Command/GenerateCest.php
@@ -51,17 +51,17 @@ class GenerateCest extends Command
         $filename = $path . $filename;
 
         if (file_exists($filename)) {
-            $output->writeln("<error>Test $filename already exists</error>");
+            $output->writeln("<error>Test {$filename} already exists</error>");
             return 1;
         }
         $cest = new CestGenerator($class, $config);
         $res = $this->createFile($filename, $cest->produce());
         if (!$res) {
-            $output->writeln("<error>Test $filename already exists</error>");
+            $output->writeln("<error>Test {$filename} already exists</error>");
             return 1;
         }
 
-        $output->writeln("<info>Test was created in $filename</info>");
+        $output->writeln("<info>Test was created in {$filename}</info>");
         return 0;
     }
 }

--- a/src/Codeception/Command/GenerateEnvironment.php
+++ b/src/Codeception/Command/GenerateEnvironment.php
@@ -47,16 +47,16 @@ class GenerateEnvironment extends Command
         }
         $relativePath = $config['paths']['envs'];
         $env = $input->getArgument('env');
-        $file = "$env.yml";
+        $file = "{$env}.yml";
 
         $path = $this->createDirectoryFor($relativePath, $file);
-        $saved = $this->createFile($path . $file, "# `$env` environment config goes here");
+        $saved = $this->createFile($path . $file, "# `{$env}` environment config goes here");
 
         if ($saved) {
-            $output->writeln("<info>$env config was created in $relativePath/$file</info>");
+            $output->writeln("<info>{$env} config was created in {$relativePath}/{$file}</info>");
             return 0;
         } else {
-            $output->writeln("<error>File $relativePath/$file already exists</error>");
+            $output->writeln("<error>File {$relativePath}/{$file} already exists</error>");
             return 1;
         }
     }

--- a/src/Codeception/Command/GenerateFeature.php
+++ b/src/Codeception/Command/GenerateFeature.php
@@ -50,16 +50,16 @@ class GenerateFeature extends Command
         $this->createDirectoryFor($config['path'], $filename);
 
         $feature = new Feature(basename($filename));
-        if (!preg_match('~\.feature$~', $filename)) {
+        if (!preg_match('#\.feature$#', $filename)) {
             $filename .= '.feature';
         }
         $fullPath = rtrim($config['path'], DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR . $filename;
         $res = $this->createFile($fullPath, $feature->produce());
         if (!$res) {
-            $output->writeln("<error>Feature $filename already exists</error>");
+            $output->writeln("<error>Feature {$filename} already exists</error>");
             return 1;
         }
-        $output->writeln("<info>Feature was created in $fullPath</info>");
+        $output->writeln("<info>Feature was created in {$fullPath}</info>");
         return 0;
     }
 }

--- a/src/Codeception/Command/GenerateGroup.php
+++ b/src/Codeception/Command/GenerateGroup.php
@@ -48,11 +48,11 @@ class GenerateGroup extends Command
         $res = $this->createFile($filename, $group->produce());
 
         if (!$res) {
-            $output->writeln("<error>Group $filename already exists</error>");
+            $output->writeln("<error>Group {$filename} already exists</error>");
             return 1;
         }
 
-        $output->writeln("<info>Group extension was created in $filename</info>");
+        $output->writeln("<info>Group extension was created in {$filename}</info>");
         $output->writeln(
             'To use this group extension, include it to "extensions" option of global Codeception config.'
         );

--- a/src/Codeception/Command/GenerateHelper.php
+++ b/src/Codeception/Command/GenerateHelper.php
@@ -46,10 +46,10 @@ class GenerateHelper extends Command
 
         $res = $this->createFile($filename, (new Helper($name, $config['namespace']))->produce());
         if ($res) {
-            $output->writeln("<info>Helper $filename created</info>");
+            $output->writeln("<info>Helper {$filename} created</info>");
             return 0;
         } else {
-            $output->writeln("<error>Error creating helper $filename</error>");
+            $output->writeln("<error>Error creating helper {$filename}</error>");
             return 1;
         }
     }

--- a/src/Codeception/Command/GeneratePageObject.php
+++ b/src/Codeception/Command/GeneratePageObject.php
@@ -67,10 +67,10 @@ class GeneratePageObject extends Command
         $res = $this->createFile($filename, $pageObject->produce());
 
         if (!$res) {
-            $output->writeln("<error>PageObject $filename already exists</error>");
+            $output->writeln("<error>PageObject {$filename} already exists</error>");
             return 1;
         }
-        $output->writeln("<info>PageObject was created in $filename</info>");
+        $output->writeln("<info>PageObject was created in {$filename}</info>");
         return 0;
     }
 }

--- a/src/Codeception/Command/GenerateScenarios.php
+++ b/src/Codeception/Command/GenerateScenarios.php
@@ -65,7 +65,7 @@ class GenerateScenarios extends Command
 
         if (!is_writable($path)) {
             throw new ConfigurationException(
-                "Path $path is not writable. Please, set valid permissions for folder to store scenarios."
+                "Path {$path} is not writable. Please, set valid permissions for folder to store scenarios."
             );
         }
 
@@ -98,11 +98,11 @@ class GenerateScenarios extends Command
 
             if ($input->getOption('single-file')) {
                 $scenarios .= $feature;
-                $output->writeln("* $name rendered");
+                $output->writeln("* {$name} rendered");
             } else {
                 $feature = $this->decorate($feature, $format);
                 $this->createFile($path . DIRECTORY_SEPARATOR . $name . $this->formatExtension($format), $feature, true);
-                $output->writeln("* $name generated");
+                $output->writeln("* {$name} generated");
             }
         }
 
@@ -118,7 +118,7 @@ class GenerateScenarios extends Command
             case 'text':
                 return $text;
             case 'html':
-                return "<html><body>$text</body></html>";
+                return "<html><body>{$text}</body></html>";
         }
     }
 
@@ -140,11 +140,10 @@ class GenerateScenarios extends Command
 
     private function underscore(string $name): string
     {
-        $name = preg_replace('/([A-Z]+)([A-Z][a-z])/', '\\1_\\2', $name);
-        $name = preg_replace('/([a-z\d])([A-Z])/', '\\1_\\2', $name);
+        $name = preg_replace('#([A-Z]+)([A-Z][a-z])#', '\\1_\\2', $name);
+        $name = preg_replace('#([a-z\d])([A-Z])#', '\\1_\\2', $name);
         $name = str_replace(['/', '\\'], ['.', '.'], $name);
-        $name = preg_replace('/_Cept$/', '', $name);
-        $name = preg_replace('/_Cest$/', '', $name);
-        return $name;
+        $name = preg_replace('#_Cept$#', '', $name);
+        return preg_replace('#_Cest$#', '', $name);
     }
 }

--- a/src/Codeception/Command/GenerateSnapshot.php
+++ b/src/Codeception/Command/GenerateSnapshot.php
@@ -68,10 +68,10 @@ class GenerateSnapshot extends Command
         $res = $this->createFile($filename, $snapshot->produce());
 
         if (!$res) {
-            $output->writeln("<error>Snapshot $filename already exists</error>");
+            $output->writeln("<error>Snapshot {$filename} already exists</error>");
             return 1;
         }
-        $output->writeln("<info>Snapshot was created in $filename</info>");
+        $output->writeln("<info>Snapshot was created in {$filename}</info>");
         return 0;
     }
 }

--- a/src/Codeception/Command/GenerateStepObject.php
+++ b/src/Codeception/Command/GenerateStepObject.php
@@ -71,10 +71,10 @@ class GenerateStepObject extends Command
         $res = $this->createFile($filename, $stepObject->produce());
 
         if (!$res) {
-            $output->writeln("<error>StepObject $filename already exists</error>");
+            $output->writeln("<error>StepObject {$filename} already exists</error>");
             return 1;
         }
-        $output->writeln("<info>StepObject was created in $filename</info>");
+        $output->writeln("<info>StepObject was created in {$filename}</info>");
         return 0;
     }
 }

--- a/src/Codeception/Command/GenerateSuite.php
+++ b/src/Codeception/Command/GenerateSuite.php
@@ -53,7 +53,7 @@ class GenerateSuite extends Command
         $actor = $input->getArgument('actor');
 
         if ($this->containsInvalidCharacters($suite)) {
-            $output->writeln("<error>Suite name '$suite' contains invalid characters. ([A-Za-z0-9_]).</error>");
+            $output->writeln("<error>Suite name '{$suite}' contains invalid characters. ([A-Za-z0-9_]).</error>");
             return 1;
         }
 
@@ -64,7 +64,7 @@ class GenerateSuite extends Command
 
         $dir = Configuration::testsDir();
         if (file_exists($dir . $suite . '.suite.yml')) {
-            throw new Exception("Suite configuration file '$suite.suite.yml' already exists.");
+            throw new Exception("Suite configuration file '{$suite}.suite.yml' already exists.");
         }
 
         $this->createDirectoryFor($dir . $suite);
@@ -82,8 +82,8 @@ class GenerateSuite extends Command
 
         $file = $this->createDirectoryFor(
             Configuration::supportDir() . "Helper",
-            "$helperName.php"
-        ) . "$helperName.php";
+            "{$helperName}.php"
+        ) . "{$helperName}.php";
 
         $helper = new HelperGenerator($helperName, $config['namespace']);
         // generate helper
@@ -92,7 +92,7 @@ class GenerateSuite extends Command
             $helper->produce()
         );
 
-        $output->writeln("Helper <info>" . $helper->getHelperName() . "</info> was created in $file");
+        $output->writeln("Helper <info>" . $helper->getHelperName() . "</info> was created in {$file}");
 
         $yamlSuiteConfigTemplate = <<<EOF
 actor: {{actor}}
@@ -122,16 +122,16 @@ EOF;
 
         $this->createFile($file, $content);
 
-        $output->writeln("Actor <info>" . $actor . "</info> was created in $file");
+        $output->writeln("Actor <info>" . $actor . "</info> was created in {$file}");
 
-        $output->writeln("Suite config <info>$suite.suite.yml</info> was created.");
+        $output->writeln("Suite config <info>{$suite}.suite.yml</info> was created.");
         $output->writeln(' ');
         $output->writeln("Next steps:");
-        $output->writeln("1. Edit <bold>$suite.suite.yml</bold> to enable modules for this suite");
+        $output->writeln("1. Edit <bold>{$suite}.suite.yml</bold> to enable modules for this suite");
         $output->writeln("2. Create first test with <bold>generate:cest testName</bold> ( or test|cept) command");
-        $output->writeln("3. Run tests of this suite with <bold>codecept run $suite</bold> command");
+        $output->writeln("3. Run tests of this suite with <bold>codecept run {$suite}</bold> command");
 
-        $output->writeln("<info>Suite $suite generated</info>");
+        $output->writeln("<info>Suite {$suite} generated</info>");
         return 0;
     }
 

--- a/src/Codeception/Command/GenerateTest.php
+++ b/src/Codeception/Command/GenerateTest.php
@@ -55,10 +55,10 @@ class GenerateTest extends Command
         $res = $this->createFile($filename, $test->produce());
 
         if (!$res) {
-            $output->writeln("<error>Test $filename already exists</error>");
+            $output->writeln("<error>Test {$filename} already exists</error>");
             return 1;
         }
-        $output->writeln("<info>Test was created in $filename</info>");
+        $output->writeln("<info>Test was created in {$filename}</info>");
         return 0;
     }
 }

--- a/src/Codeception/Command/GherkinSteps.php
+++ b/src/Codeception/Command/GherkinSteps.php
@@ -55,7 +55,7 @@ class GherkinSteps extends Command
         foreach ($steps as $name => $context) {
             $table = new Table($output);
             $table->setHeaders(['Step', 'Implementation']);
-            $output->writeln("Steps from <bold>$name</bold> context:");
+            $output->writeln("Steps from <bold>{$name}</bold> context:");
 
             foreach ($context as $step => $callable) {
                 if (count($callable) < 2) {

--- a/src/Codeception/Command/Init.php
+++ b/src/Codeception/Command/Init.php
@@ -43,13 +43,13 @@ class Init extends Command
             $className = 'Codeception\Template\\' . ucfirst($template);
 
             if (!class_exists($className)) {
-                throw new Exception("Template from a $className can't be loaded; Init can't be executed");
+                throw new Exception("Template from a {$className} can't be loaded; Init can't be executed");
             }
         }
 
         $initProcess = new $className($input, $output);
         if (!$initProcess instanceof InitTemplate) {
-            throw new Exception("$className is not a valid template");
+            throw new Exception("{$className} is not a valid template");
         }
         if ($path = $input->getOption('path')) {
             $initProcess->initDir($path);

--- a/src/Codeception/Command/Run.php
+++ b/src/Codeception/Command/Run.php
@@ -262,8 +262,6 @@ class Run extends Command
     /**
      * Executes Run
      *
-     * @param InputInterface $input
-     * @param OutputInterface $output
      * @return int|null|void
      * @throws ConfigurationException|ParseException
      */
@@ -282,7 +280,7 @@ class Run extends Command
         $config = $this->getGlobalConfig();
 
         // update config from options
-        if (count($this->options['override'])) {
+        if (!empty($this->options['override'])) {
             $config = $this->overrideConfig($this->options['override']);
         }
         if ($this->options['ext']) {
@@ -385,7 +383,7 @@ class Run extends Command
                         $testsPath = $include . DIRECTORY_SEPARATOR.  $config['paths']['tests'];
 
                         try {
-                            list(, $suite, $test) = $this->matchTestFromFilename($suite, $testsPath);
+                            [, $suite, $test] = $this->matchTestFromFilename($suite, $testsPath);
                             $isIncludeTest = true;
                         } catch (InvalidArgumentException $e) {
                             // Incorrect include match, continue trying to find one
@@ -394,7 +392,7 @@ class Run extends Command
                     } else {
                         $result = $this->matchSingleTest($suite, $config);
                         if ($result) {
-                            list(, $suite, $test) = $result;
+                            [, $suite, $test] = $result;
                         }
                     }
                 }
@@ -406,7 +404,7 @@ class Run extends Command
             } elseif (!empty($suite)) {
                 $result = $this->matchSingleTest($suite, $config);
                 if ($result) {
-                    list(, $suite, $test) = $result;
+                    [, $suite, $test] = $result;
                 }
             }
         }
@@ -458,7 +456,7 @@ class Run extends Command
     {
         // Workaround when codeception.yml is inside tests directory and tests path is set to "."
         // @see https://github.com/Codeception/Codeception/issues/4432
-        if (isset($config['paths']['tests']) && $config['paths']['tests'] === '.' && !preg_match('~^\.[/\\\]~', $suite)) {
+        if (isset($config['paths']['tests']) && $config['paths']['tests'] === '.' && !preg_match('#^\.[/\\\]#', $suite)) {
             $suite = './' . $suite;
         }
 
@@ -472,7 +470,7 @@ class Run extends Command
                 if ($suiteConfig['path'] === '.') {
                     $testsPath = $config['paths']['tests'];
                 }
-                if (preg_match("~^$testsPath/(.*?)$~", $suite, $matches)) {
+                if (preg_match("~^{$testsPath}/(.*?)$~", $suite, $matches)) {
                     $matches[2] = $matches[1];
                     $matches[1] = $s;
                     return $matches;
@@ -492,7 +490,7 @@ class Run extends Command
             if (strpos($realTestDir, $cwd) === 0) {
                 $file = $suite;
                 if (strpos($file, ':') !== false) {
-                    list($file) = explode(':', $suite, -1);
+                    [$file] = explode(':', $suite, -1);
                 }
                 $realPath = $cwd . DIRECTORY_SEPARATOR . $file;
                 if (file_exists($realPath) && strpos($realPath, $realTestDir) === 0) {
@@ -511,8 +509,6 @@ class Run extends Command
     /**
      * Runs included suites recursively
      *
-     * @param array $suites
-     * @param string $parentDir
      * @throws ConfigurationException
      */
     protected function runIncludedSuites(array $suites, string $parentDir): void
@@ -524,7 +520,7 @@ class Run extends Command
 
             $namespace = $this->currentNamespace();
             $this->output->writeln(
-                "\n<fg=white;bg=magenta>\n[$namespace]: tests from $currentDir\n</fg=white;bg=magenta>"
+                "\n<fg=white;bg=magenta>\n[{$namespace}]: tests from {$currentDir}\n</fg=white;bg=magenta>"
             );
 
             $this->executed += $this->runSuites($suites, $this->options['skip']);
@@ -570,13 +566,13 @@ class Run extends Command
         if (strpos($filename, ':') !== false) {
             if ((PHP_OS === 'Windows' || PHP_OS === 'WINNT') && $filename[1] === ':') {
                 // match C:\...
-                list($drive, $path, $filter) = explode(':', $filename, 3);
+                [$drive, $path, $filter] = explode(':', $filename, 3);
                 $filename = $drive . ':' . $path;
             } else {
-                list($filename, $filter) = explode(':', $filename, 2);
+                [$filename, $filter] = explode(':', $filename, 2);
             }
 
-            if ($filter) {
+            if ($filter !== '') {
                 $filter = ':' . $filter;
             }
         }
@@ -588,7 +584,7 @@ class Run extends Command
             //codecept run tests
             return ['', '', $filter];
         }
-        $res = preg_match("~^$testsPath/(.*?)(?>/(.*))?$~", $filename, $matches);
+        $res = preg_match("~^{$testsPath}/(.*?)(?>/(.*))?$~", $filename, $matches);
 
         if (!$res) {
             throw new InvalidArgumentException("Test file can't be matched");
@@ -596,7 +592,7 @@ class Run extends Command
         if (!isset($matches[2])) {
             $matches[2] = '';
         }
-        if ($filter) {
+        if ($filter !== '') {
             $matches[2] .= $filter;
         }
 
@@ -607,7 +603,7 @@ class Run extends Command
     {
         $testParts = explode(':', $path, 2);
         if (count($testParts) > 1) {
-            list($path, $filter) = $testParts;
+            [$path, $filter] = $testParts;
             // use carat to signify start of string like in normal regex
             // phpunit --filter matches against the fully qualified method name, so tests actually begin with :
             $caratPos = strpos($filter, '^');
@@ -621,7 +617,6 @@ class Run extends Command
     }
 
     /**
-     * @param InputInterface $input
      * @return string[]
      */
     protected function passedOptionKeys(InputInterface $input): array
@@ -630,7 +625,7 @@ class Run extends Command
         $request = (string)$input;
         $tokens = explode(' ', $request);
         foreach ($tokens as $token) {
-            $token = preg_replace('~=.*~', '', $token); // strip = from options
+            $token = preg_replace('#=.*#', '', $token); // strip = from options
 
             if (empty($token)) {
                 continue;
@@ -651,11 +646,9 @@ class Run extends Command
     }
 
     /**
-     * @param InputInterface $input
-     * @param array $options
      * @return array<string, bool>
      */
-    protected function booleanOptions(InputInterface $input, $options = []): array
+    protected function booleanOptions(InputInterface $input, array $options = []): array
     {
         $values = [];
         $request = (string)$input;
@@ -671,7 +664,6 @@ class Run extends Command
     }
 
     /**
-     * @param string $ext
      * @throws Exception
      */
     private function ensurePhpExtIsAvailable(string $ext): void

--- a/src/Codeception/Command/Shared/ConfigTrait.php
+++ b/src/Codeception/Command/Shared/ConfigTrait.php
@@ -52,7 +52,7 @@ trait ConfigTrait
             try {
                 $config = Yaml::parse($yaml);
             } catch (ParseException $e) {
-                throw new \Codeception\Exception\ParseException("Overridden config can't be parsed: \n$yaml\n" . $e->getParsedLine());
+                throw new \Codeception\Exception\ParseException("Overridden config can't be parsed: \n{$yaml}\n" . $e->getParsedLine());
             }
             $updatedConfig = array_merge_recursive($updatedConfig, $config);
         }
@@ -66,7 +66,7 @@ trait ConfigTrait
             if (!class_exists($name)) {
                 $className = 'Codeception\\Extension\\' . ucfirst($name);
                 if (!class_exists($className)) {
-                    throw new InvalidOptionException("Extension $name can't be loaded (tried by $name and $className)");
+                    throw new InvalidOptionException("Extension {$name} can't be loaded (tried by {$name} and {$className})");
                 }
                 $config['extensions']['enabled'][] = $className;
                 continue;

--- a/src/Codeception/Command/Shared/FileSystemTrait.php
+++ b/src/Codeception/Command/Shared/FileSystemTrait.php
@@ -51,8 +51,8 @@ trait FileSystemTrait
 
     protected function removeSuffix(string $classname, string $suffix): string
     {
-        $classname = preg_replace('~\.php$~', '', $classname);
-        return preg_replace("~$suffix$~", '', $classname);
+        $classname = preg_replace('#\.php$#', '', $classname);
+        return preg_replace("~{$suffix}$~", '', $classname);
     }
 
     protected function createFile(string $filename, string $contents, bool $force = false, int $flags = 0): bool

--- a/src/Codeception/Configuration.php
+++ b/src/Codeception/Configuration.php
@@ -286,7 +286,6 @@ class Configuration
 
     /**
      * @param string|false $bootstrap
-     * @param string $path
      * @throws ConfigurationException
      */
     public static function loadBootstrap($bootstrap, string $path): void
@@ -323,7 +322,7 @@ class Configuration
 
         /** @var SplFileInfo $suite */
         foreach ($suites as $suite) {
-            preg_match('~(.*?)(\.suite|\.suite\.dist)\.yml~', $suite->getFilename(), $matches);
+            preg_match('#(.*?)(\.suite|\.suite\.dist)\.yml#', $suite->getFilename(), $matches);
             self::$suites[$matches[1]] = $matches[1];
         }
     }
@@ -332,7 +331,6 @@ class Configuration
      * Returns suite configuration. Requires suite name and global config used (Configuration::config)
      *
      * @throws Exception
-     * @return array
      */
     public static function suiteSettings(string $suite, array $config): array
     {
@@ -430,7 +428,6 @@ class Configuration
      *
      * @param string $contents Yaml config file contents
      * @param string $filename which is supposed to be loaded
-     * @return array
      * @throws ConfigurationException
      */
     protected static function getConfFromContents(string $contents, string $filename = '(.yml)'): array
@@ -463,7 +460,6 @@ class Configuration
      *
      * @param string $filename filename
      * @param array|null $nonExistentValue value used if filename is not found
-     * @return array|null
      * @throws ConfigurationException
      */
     protected static function getConfFromFile(string $filename, ?array $nonExistentValue = []): ?array
@@ -487,7 +483,6 @@ class Configuration
      * Return list of enabled modules according suite config.
      *
      * @param array $settings suite settings
-     * @return array
      */
     public static function modules(array $settings): array
     {
@@ -709,9 +704,8 @@ class Configuration
         }
 
         $settings = self::mergeConfigs($settings, $suiteDistConf);
-        $settings = self::mergeConfigs($settings, $suiteConf);
 
-        return $settings;
+        return self::mergeConfigs($settings, $suiteConf);
     }
 
     /**
@@ -739,7 +733,7 @@ class Configuration
      */
     protected static function expandWildcardsFor(string $include): array
     {
-        if (1 !== preg_match('/[\?\.\*]/', $include)) {
+        if (1 !== preg_match('#[\?\.\*]#', $include)) {
             return [$include,];
         }
 

--- a/src/Codeception/Coverage/Filter.php
+++ b/src/Codeception/Coverage/Filter.php
@@ -54,8 +54,6 @@ class Filter
     }
 
     /**
-     * @param array $config
-     * @return Filter
      * @throws ConfigurationException
      */
     public function whiteList(array $config): self
@@ -124,8 +122,6 @@ class Filter
     }
 
     /**
-     * @param array $config
-     * @return Filter
      * @throws ModuleException
      */
     public function blackList(array $config): self
@@ -144,7 +140,7 @@ class Filter
         $parts = explode('/', $fileOrDir);
         $file = array_pop($parts);
         $finder->name($file);
-        if (count($parts) > 0) {
+        if ($parts !== []) {
             $lastPath = array_pop($parts);
             if ($lastPath === '*') {
                 $finder->in(Configuration::projectDir() . implode('/', $parts));

--- a/src/Codeception/Coverage/Subscriber/Local.php
+++ b/src/Codeception/Coverage/Subscriber/Local.php
@@ -30,7 +30,7 @@ class Local extends SuiteSubscriber
 
     protected function isEnabled(): bool
     {
-        return $this->module === null && $this->settings['enabled'];
+        return !$this->module instanceof Remote && $this->settings['enabled'];
     }
 
     public function beforeSuite(SuiteEvent $event): void

--- a/src/Codeception/Coverage/Subscriber/LocalServer.php
+++ b/src/Codeception/Coverage/Subscriber/LocalServer.php
@@ -215,7 +215,7 @@ class LocalServer extends SuiteSubscriber
         $okHeaders = array_filter(
             $http_response_header,
             function ($h) {
-                return preg_match('~^HTTP(.*?)\s200~', $h);
+                return preg_match('#^HTTP(.*?)\s200#', $h);
             }
         );
         if (empty($okHeaders)) {
@@ -234,7 +234,7 @@ class LocalServer extends SuiteSubscriber
             'CodeCoverage_Suite'  => $this->suiteName,
             'CodeCoverage_Config' => $this->settings['remote_config']
         ];
-        $value = json_encode($value);
+        $value = json_encode($value, JSON_THROW_ON_ERROR);
 
         if ($this->module instanceof WebDriverModule) {
             $this->module->amOnPage('/');
@@ -308,7 +308,7 @@ class LocalServer extends SuiteSubscriber
 
     protected function addC3AccessHeader(string $header, string $value): void
     {
-        $headerString = "$header: $value\r\n";
+        $headerString = "{$header}: {$value}\r\n";
         if (strpos($this->c3Access['http']['header'], $headerString) === false) {
             $this->c3Access['http']['header'] .= $headerString;
         }

--- a/src/Codeception/Coverage/Subscriber/Printer.php
+++ b/src/Codeception/Coverage/Subscriber/Printer.php
@@ -56,7 +56,7 @@ class Printer implements EventSubscriberInterface
     /**
      * @var array
      */
-    protected $options;
+    protected $options = [];
     /**
      * @var string
      */

--- a/src/Codeception/Coverage/SuiteSubscriber.php
+++ b/src/Codeception/Coverage/SuiteSubscriber.php
@@ -62,7 +62,7 @@ abstract class SuiteSubscriber implements EventSubscriberInterface
     /**
      * @var array
      */
-    protected $options;
+    protected $options = [];
     /**
      * @var array
      */
@@ -73,7 +73,6 @@ abstract class SuiteSubscriber implements EventSubscriberInterface
     /**
      * SuiteSubscriber constructor.
      *
-     * @param array $options
      * @throws ConfigurationException
      */
     public function __construct(array $options = [])
@@ -83,7 +82,6 @@ abstract class SuiteSubscriber implements EventSubscriberInterface
     }
 
     /**
-     * @param array $settings
      * @throws Exception
      */
     protected function applySettings(array $settings): void
@@ -119,10 +117,6 @@ abstract class SuiteSubscriber implements EventSubscriberInterface
         }
     }
 
-    /**
-     * @param array $modules
-     * @return RemoteInterface|null
-     */
     protected function getServerConnectionModule(array $modules): ?RemoteInterface
     {
         foreach ($modules as $module) {
@@ -134,7 +128,6 @@ abstract class SuiteSubscriber implements EventSubscriberInterface
     }
 
     /**
-     * @param TestResult $result
      * @throws ConfigurationException|ModuleException|Exception
      */
     public function applyFilter(TestResult $result): void

--- a/src/Codeception/Event/SuiteEvent.php
+++ b/src/Codeception/Event/SuiteEvent.php
@@ -22,7 +22,7 @@ class SuiteEvent extends Event
     protected $result;
 
     /**
-     * @var array
+     * @var array|null
      */
     protected $settings = [];
 

--- a/src/Codeception/Example.php
+++ b/src/Codeception/Example.php
@@ -43,7 +43,7 @@ class Example implements ArrayAccess, Countable, IteratorAggregate
     public function offsetGet($offset)
     {
         if (!$this->offsetExists($offset)) {
-            throw new AssertionFailedError(sprintf('Example %s doesn\'t exist', $offset));
+            throw new AssertionFailedError(sprintf("Example %s doesn't exist", $offset));
         };
         return $this->data[$offset];
     }
@@ -54,7 +54,6 @@ class Example implements ArrayAccess, Countable, IteratorAggregate
      * @link http://php.net/manual/en/arrayaccess.offsetset.php
      * @param mixed $offset <p>The offset to assign the value to.</p>
      * @param mixed $value <p>The value to set.</p>
-     * @return void
      */
     public function offsetSet($offset, $value): void
     {
@@ -66,7 +65,6 @@ class Example implements ArrayAccess, Countable, IteratorAggregate
      *
      * @link http://php.net/manual/en/arrayaccess.offsetunset.php
      * @param mixed $offset <p>The offset to unset.</p>
-     * @return void
      */
     public function offsetUnset($offset): void
     {

--- a/src/Codeception/Exception/ExtensionException.php
+++ b/src/Codeception/Exception/ExtensionException.php
@@ -14,7 +14,6 @@ class ExtensionException extends Exception
      * ExtensionException constructor.
      *
      * @param object|string $extension
-     * @param string $message
      * @param Exception|null $previous
      */
     public function __construct($extension, string $message, Exception $previous = null)

--- a/src/Codeception/Exception/ModuleConfigException.php
+++ b/src/Codeception/Exception/ModuleConfigException.php
@@ -16,7 +16,6 @@ class ModuleConfigException extends Exception
      * ModuleConfigException constructor.
      *
      * @param object|string $module
-     * @param string $message
      * @param Exception|null $previous
      */
     public function __construct($module, string $message, Exception $previous = null)

--- a/src/Codeception/Exception/ModuleConflictException.php
+++ b/src/Codeception/Exception/ModuleConflictException.php
@@ -17,7 +17,6 @@ class ModuleConflictException extends Exception
      *
      * @param object|string $module
      * @param object|string $conflicted
-     * @param string $additional
      */
     public function __construct($module, $conflicted, string $additional = '')
     {

--- a/src/Codeception/Exception/ModuleException.php
+++ b/src/Codeception/Exception/ModuleException.php
@@ -21,7 +21,6 @@ class ModuleException extends Exception
      * ModuleException constructor.
      *
      * @param object|string $module
-     * @param string $message
      */
     public function __construct($module, string $message)
     {
@@ -31,6 +30,6 @@ class ModuleException extends Exception
         $module = ltrim(str_replace('Codeception\Module\\', '', $module), '\\');
         $this->module = $module;
         parent::__construct($message);
-        $this->message = "$module: {$this->message}";
+        $this->message = "{$module}: {$this->message}";
     }
 }

--- a/src/Codeception/Exception/ModuleRequireException.php
+++ b/src/Codeception/Exception/ModuleRequireException.php
@@ -16,7 +16,6 @@ class ModuleRequireException extends Exception
      * ModuleRequireException constructor.
      *
      * @param object|string $module
-     * @param string $message
      */
     public function __construct($module, string $message)
     {

--- a/src/Codeception/InitTemplate.php
+++ b/src/Codeception/InitTemplate.php
@@ -111,7 +111,6 @@ abstract class InitTemplate
      * $this->ask('do you want to proceed (y/n)', true);
      * ```
      *
-     * @param string $question
      * @param array|bool|null $answer
      * @return mixed|string
      */
@@ -195,7 +194,7 @@ abstract class InitTemplate
             $gen->produce()
         );
         require_once $file;
-        $this->sayInfo("{$name} helper has been created in $dir");
+        $this->sayInfo("{$name} helper has been created in {$dir}");
     }
 
     /**

--- a/src/Codeception/Lib/Actor/Shared/Pause.php
+++ b/src/Codeception/Lib/Actor/Shared/Pause.php
@@ -117,7 +117,7 @@ trait Pause
                 return;
             }
             try {
-                $value = eval("return \$I->$command;");
+                $value = eval("return \$I->{$command};");
                 if ($value) {
                     $result = $value;
                     if (!is_object($result)) {

--- a/src/Codeception/Lib/Connector/Shared/PhpSuperGlobalsConverter.php
+++ b/src/Codeception/Lib/Connector/Shared/PhpSuperGlobalsConverter.php
@@ -99,7 +99,6 @@ trait PhpSuperGlobalsConverter
      * @see https://bugs.php.net/bug.php?id=40000
      *
      * @param array $parameters Array of request parameters to be converted
-     * @return array
      */
     private function replaceSpaces(array $parameters): array
     {

--- a/src/Codeception/Lib/Console/Colorizer.php
+++ b/src/Codeception/Lib/Console/Colorizer.php
@@ -21,10 +21,10 @@ class Colorizer
 
             switch ($char) {
                 case '+':
-                    $line = "<info>$line</info>";
+                    $line = "<info>{$line}</info>";
                     break;
                 case '-':
-                    $line = "<comment>$line</comment>";
+                    $line = "<comment>{$line}</comment>";
                     break;
             }
 

--- a/src/Codeception/Lib/Console/Message.php
+++ b/src/Codeception/Lib/Console/Message.php
@@ -70,7 +70,6 @@ class Message
 
     /**
      * @param Message|string $string
-     * @return Message
      */
     public function prepend($string): self
     {
@@ -83,7 +82,6 @@ class Message
 
     /**
      * @param Message|string $string
-     * @return Message
      */
     public function append($string): self
     {

--- a/src/Codeception/Lib/Di.php
+++ b/src/Codeception/Lib/Di.php
@@ -35,10 +35,9 @@ class Di
     }
 
     /**
-     * @param string $className
      * @return object|bool|null
      */
-    public function get(string $className)
+    public function get(string $className): ?object
     {
         // normalize namespace
         $className = ltrim($className, '\\');
@@ -51,9 +50,8 @@ class Di
     }
 
     /**
-     * @param string $className
      * @param array|null $constructorArgs
-     * @param string $injectMethodName Method which will be invoked after object creation;
+     * @param string $injectMethodName Method which will be invoked after object creation;
      *                                 Resolved dependencies will be passed to it as arguments
      * @throws InjectionException|ReflectionException
      * @return null|object
@@ -72,7 +70,7 @@ class Di
                 return $this->container[$className];
             }
 
-            throw new InjectionException("Failed to resolve cyclic dependencies for class '$className'");
+            throw new InjectionException("Failed to resolve cyclic dependencies for class '{$className}'");
         }
 
         // get class from parent container
@@ -112,7 +110,6 @@ class Di
     /**
      * @param $object
      * @param string $injectMethodName Method which will be invoked with resolved dependencies as its arguments
-     * @param array $defaults
      * @throws InjectionException|ReflectionException
      */
     public function injectDependencies($object, string $injectMethodName = self::DEFAULT_INJECT_METHOD_NAME, array $defaults = []): void
@@ -136,7 +133,7 @@ class Di
                 $msg .= '; '. $e->getPrevious();
             }
             throw new InjectionException(
-                "Failed to inject dependencies in instance of '{$reflectedObject->name}'. $msg"
+                "Failed to inject dependencies in instance of '{$reflectedObject->name}'. {$msg}"
             );
         }
 

--- a/src/Codeception/Lib/Generator/Actions.php
+++ b/src/Codeception/Lib/Generator/Actions.php
@@ -14,6 +14,7 @@ use Exception;
 use ReflectionClass;
 use ReflectionException;
 use ReflectionMethod;
+use ReflectionType;
 
 class Actions
 {
@@ -74,7 +75,7 @@ EOF;
     /**
      * @var array
      */
-    protected $settings;
+    protected $settings = [];
 
     /**
      * @var array
@@ -84,7 +85,7 @@ EOF;
     /**
      * @var array
      */
-    protected $actions;
+    protected $actions = [];
 
     /**
      * @var int
@@ -202,8 +203,6 @@ EOF;
     }
 
     /**
-     * @param ReflectionClass $class
-     * @param ReflectionMethod $refMethod
      * @return string|false
      * @throws ReflectionException
      */
@@ -251,7 +250,7 @@ EOF;
     {
         $returnType = $refMethod->getReturnType();
 
-        if ($returnType === null) {
+        if (!$returnType instanceof ReflectionType) {
             return '';
         }
 

--- a/src/Codeception/Lib/Generator/Actor.php
+++ b/src/Codeception/Lib/Generator/Actor.php
@@ -59,17 +59,17 @@ EOF;
     /**
      * @var array
      */
-    protected $settings;
+    protected $settings = [];
 
     /**
      * @var array
      */
-    protected $modules;
+    protected $modules = [];
 
     /**
      * @var array
      */
-    protected $actions;
+    protected $actions = [];
 
     public function __construct(array $settings)
     {
@@ -95,7 +95,7 @@ EOF;
         }
 
         return (new Template($this->template))
-            ->place('hasNamespace', $namespace ? "namespace {$namespace};" : '')
+            ->place('hasNamespace', $namespace !== '' ? "namespace {$namespace};" : '')
             ->place('actor', $this->settings['actor'])
             ->place('inheritedMethods', $this->prependAbstractActorDocBlocks())
             ->produce();

--- a/src/Codeception/Lib/Generator/Cept.php
+++ b/src/Codeception/Lib/Generator/Cept.php
@@ -22,7 +22,7 @@ EOF;
     /**
      * @var array
      */
-    protected $settings;
+    protected $settings = [];
 
     public function __construct(array $settings)
     {
@@ -38,7 +38,7 @@ EOF;
         $use = '';
         if (! empty($this->settings['namespace'])) {
             $namespace = rtrim($this->settings['namespace'], '\\');
-            $use = "use {$namespace}\\$actor;";
+            $use = "use {$namespace}\\{$actor};";
         }
 
         return (new Template($this->template))

--- a/src/Codeception/Lib/Generator/Cest.php
+++ b/src/Codeception/Lib/Generator/Cest.php
@@ -37,7 +37,7 @@ EOF;
     /**
      * @var array
      */
-    protected $settings;
+    protected $settings = [];
 
     /**
      * @var string

--- a/src/Codeception/Lib/Generator/GherkinSnippets.php
+++ b/src/Codeception/Lib/Generator/GherkinSnippets.php
@@ -102,7 +102,7 @@ EOF;
         $pattern = $step->getText();
 
         // match numbers (not in quotes)
-        if (preg_match_all('~([\d\.])(?=([^"]*"[^"]*")*[^"]*$)~', $pattern, $matches)) {
+        if (preg_match_all('#([\d\.])(?=([^"]*"[^"]*")*[^"]*$)#', $pattern, $matches)) {
             foreach ($matches[1] as $num => $param) {
                 ++$num;
                 $args[] = '$num' . $num;
@@ -111,7 +111,7 @@ EOF;
         }
 
         // match quoted string
-        if (preg_match_all('~"(.*?)"~', $pattern, $matches)) {
+        if (preg_match_all('#"(.*?)"#', $pattern, $matches)) {
             foreach ($matches[1] as $num => $param) {
                 ++$num;
                 $args[] = '$arg' . $num;
@@ -128,7 +128,7 @@ EOF;
             return;
         }
 
-        $methodName = preg_replace('~(\s+?|\'|\"|\W)~', '', ucwords(preg_replace('~"(.*?)"|\d+~', '', $step->getText())));
+        $methodName = preg_replace('#(\s+?|\'|\"|\W)#', '', ucwords(preg_replace('#"(.*?)"|\d+#', '', $step->getText())));
         if (empty($methodName)) {
             $methodName = 'step_' . substr(sha1($pattern), 0, 9);
         }

--- a/src/Codeception/Lib/Generator/Group.php
+++ b/src/Codeception/Lib/Generator/Group.php
@@ -62,7 +62,7 @@ EOF;
     /**
      * @var array
      */
-    protected $settings;
+    protected $settings = [];
 
     public function __construct(array $settings, string $name)
     {

--- a/src/Codeception/Lib/Generator/PageObject.php
+++ b/src/Codeception/Lib/Generator/PageObject.php
@@ -73,7 +73,7 @@ EOF;
     /**
      * @var array
      */
-    protected $settings;
+    protected $settings = [];
 
     /**
      * @var string

--- a/src/Codeception/Lib/Generator/Shared/Classname.php
+++ b/src/Codeception/Lib/Generator/Shared/Classname.php
@@ -8,7 +8,7 @@ trait Classname
 {
     protected function removeSuffix(string $classname, string $suffix)
     {
-        $classname = preg_replace('~\.php$~', '', $classname);
+        $classname = preg_replace('#\.php$#', '', $classname);
         return preg_replace("~{$suffix}$~", '', $classname);
     }
 }

--- a/src/Codeception/Lib/Generator/Snapshot.php
+++ b/src/Codeception/Lib/Generator/Snapshot.php
@@ -61,7 +61,7 @@ EOF;
     /**
      * @var array
      */
-    protected $settings;
+    protected $settings = [];
 
     public function __construct(array $settings, string $name)
     {

--- a/src/Codeception/Lib/Generator/StepObject.php
+++ b/src/Codeception/Lib/Generator/StepObject.php
@@ -45,7 +45,7 @@ EOF;
     /**
      * @var array
      */
-    protected $settings;
+    protected $settings = [];
 
     /**
      * @var string

--- a/src/Codeception/Lib/Generator/Test.php
+++ b/src/Codeception/Lib/Generator/Test.php
@@ -52,7 +52,7 @@ EOF;
     /**
      * @var array
      */
-    protected $settings;
+    protected $settings = [];
 
     /**
      * @var string

--- a/src/Codeception/Lib/GroupManager.php
+++ b/src/Codeception/Lib/GroupManager.php
@@ -23,7 +23,7 @@ class GroupManager
     /**
      * @var string[]
      */
-    protected $configuredGroups;
+    protected $configuredGroups = [];
 
     /**
      * @var mixed[][]

--- a/src/Codeception/Lib/ModuleContainer.php
+++ b/src/Codeception/Lib/ModuleContainer.php
@@ -103,9 +103,6 @@ class ModuleContainer
     /**
      * Create a module.
      *
-     * @param string $moduleName
-     * @param bool $active
-     * @return object|null
      * @throws ConfigurationException
      * @throws InjectionException
      * @throws ModuleException

--- a/src/Codeception/Lib/Notification.php
+++ b/src/Codeception/Lib/Notification.php
@@ -23,7 +23,7 @@ class Notification
 
     private static function formatMessage(string $message, string $location = ''): string
     {
-        if ($location) {
+        if ($location !== '') {
             return "<bold>{$message}</bold> <info>{$location}</info>";
         }
         return $message;

--- a/src/Codeception/Lib/ParamsLoader.php
+++ b/src/Codeception/Lib/ParamsLoader.php
@@ -39,23 +39,23 @@ class ParamsLoader
         }
 
         try {
-            if (preg_match('~\.ya?ml$~', $paramStorage)) {
+            if (preg_match('#\.ya?ml$#', $paramStorage)) {
                 return $this->loadYamlFile();
             }
 
-            if (preg_match('~\.ini$~', $paramStorage)) {
+            if (preg_match('#\.ini$#', $paramStorage)) {
                 return $this->loadIniFile();
             }
 
-            if (preg_match('~\.php$~', $paramStorage)) {
+            if (preg_match('#\.php$#', $paramStorage)) {
                 return $this->loadPhpFile();
             }
 
-            if (preg_match('~(\.env(\.|$))~', $paramStorage)) {
+            if (preg_match('#(\.env(\.|$))#', $paramStorage)) {
                 return $this->loadDotEnvFile();
             }
 
-            if (preg_match('~\.xml$~', $paramStorage)) {
+            if (preg_match('#\.xml$#', $paramStorage)) {
                 return $this->loadXmlFile();
             }
         } catch (\Exception $e) {

--- a/src/Codeception/Lib/Parser.php
+++ b/src/Codeception/Lib/Parser.php
@@ -43,12 +43,12 @@ class Parser
     {
         $matches = [];
         $code = $this->stripComments($code);
-        $res = preg_match("~\\\$I->wantTo\\(\s*?['\"](.*?)['\"]\s*?\\);~", $code, $matches);
+        $res = preg_match("#\\\$I->wantTo\\(\\s*?['\"](.*?)['\"]\\s*?\\);#", $code, $matches);
         if ($res) {
             $this->scenario->setFeature($matches[1]);
             return;
         }
-        $res = preg_match("~\\\$I->wantToTest\\(['\"](.*?)['\"]\\);~", $code, $matches);
+        $res = preg_match("#\\\$I->wantToTest\\(['\"](.*?)['\"]\\);#", $code, $matches);
         if ($res) {
             $this->scenario->setFeature("test " . $matches[1]);
             return;
@@ -68,11 +68,11 @@ class Parser
         $isFriend = false;
         foreach ($lines as $line) {
             // friends
-            if (preg_match("~\\\$I->haveFriend\((.*?)\);~", $line, $matches)) {
+            if (preg_match("#\\\$I->haveFriend\\((.*?)\\);#", $line, $matches)) {
                 $friends[] = trim($matches[1], '\'"');
             }
             // friend's section start
-            if (preg_match("~\\\$(.*?)->does\(~", $line, $matches)) {
+            if (preg_match("#\\\$(.*?)->does\\(#", $line, $matches)) {
                 $friend = $matches[1];
                 if (!in_array($friend, $friends)) {
                     continue;
@@ -83,7 +83,7 @@ class Parser
             }
 
             // actions
-            if (preg_match("~\\\$I->(.*)\((.*?)\);~", $line, $matches)) {
+            if (preg_match("#\\\$I->(.*)\\((.*?)\\);#", $line, $matches)) {
                 $this->addStep($matches);
             }
 
@@ -97,7 +97,7 @@ class Parser
 
     protected function addStep(array $matches): void
     {
-        list($m, $action, $params) = $matches;
+        [$m, $action, $params] = $matches;
         if (in_array($action, ['wantTo', 'wantToTest'])) {
             return;
         }
@@ -175,8 +175,8 @@ class Parser
 
     protected function stripComments(string $code): string
     {
-        $code = preg_replace('~\/\/.*?$~m', '', $code); // remove inline comments
-        $code = preg_replace('~\/*\*.*?\*\/~ms', '', $code);
+        $code = preg_replace('#\/\/.*?$#m', '', $code); // remove inline comments
+        $code = preg_replace('#\/*\*.*?\*\/#ms', '', $code);
         return $code; // remove block comment
     }
 
@@ -184,13 +184,13 @@ class Parser
     {
         $matches = [];
         $comments = '';
-        $hasLineComment = preg_match_all('~\/\/(.*?)$~m', $code, $matches);
+        $hasLineComment = preg_match_all('#\/\/(.*?)$#m', $code, $matches);
         if ($hasLineComment) {
             foreach ($matches[1] as $line) {
                 $comments .= $line."\n";
             }
         }
-        $hasBlockComment = preg_match('~\/*\*(.*?)\*\/~ms', $code, $matches);
+        $hasBlockComment = preg_match('#\/*\*(.*?)\*\/#ms', $code, $matches);
         if ($hasBlockComment) {
             $comments .= $matches[1]."\n";
         }

--- a/src/Codeception/Module.php
+++ b/src/Codeception/Module.php
@@ -104,7 +104,6 @@ abstract class Module
      * }
      * ```
      *
-     * @param array $config
      * @throws ModuleConfigException|ModuleException
      */
     public function _setConfig(array $config): void
@@ -128,7 +127,6 @@ abstract class Module
      * }
      * ```
      *
-     * @param array $config
      * @throws ModuleConfigException|ModuleException
      */
     public function _reconfigure(array $config): void
@@ -162,7 +160,7 @@ abstract class Module
     protected function validateConfig(): void
     {
         $fields = array_keys($this->config);
-        if (array_intersect($this->requiredFields, $fields) != $this->requiredFields) {
+        if (array_intersect($this->requiredFields, $fields) !== $this->requiredFields) {
             throw new ModuleConfigException(
                 get_class($this),
                 "\nOptions: " . implode(', ', $this->requiredFields) . " are required\n" .
@@ -258,11 +256,8 @@ abstract class Module
 
     /**
      * **HOOK** executed when test fails but before `_after`
-     *
-     * @param TestInterface $test
-     * @param Exception $fail
      */
-    public function _failed(TestInterface $test, $fail)
+    public function _failed(TestInterface $test, \Exception $fail)
     {
     }
 
@@ -279,7 +274,6 @@ abstract class Module
     /**
      * Print debug message with a title
      *
-     * @param string $title
      * @param mixed $message
      */
     protected function debugSection(string $title, $message): void
@@ -287,7 +281,7 @@ abstract class Module
         if (is_array($message) || is_object($message)) {
             $message = stripslashes(json_encode($message, JSON_THROW_ON_ERROR));
         }
-        $this->debug("[{$title}] $message");
+        $this->debug("[{$title}] {$message}");
     }
 
     /**

--- a/src/Codeception/Scenario.php
+++ b/src/Codeception/Scenario.php
@@ -68,7 +68,6 @@ class Scenario
     }
 
     /**
-     * @param Step $step
      * @return array|bool|null
      * @throws InjectionException
      */

--- a/src/Codeception/Snapshot.php
+++ b/src/Codeception/Snapshot.php
@@ -97,7 +97,7 @@ abstract class Snapshot
     protected function getFileName(): string
     {
         if (!$this->fileName) {
-            $this->fileName = preg_replace('/\W/', '.', get_class($this)) . '.' . $this->extension;
+            $this->fileName = preg_replace('#\W#', '.', get_class($this)) . '.' . $this->extension;
         }
         return codecept_data_dir() . $this->fileName;
     }

--- a/src/Codeception/Step.php
+++ b/src/Codeception/Step.php
@@ -15,8 +15,14 @@ use RuntimeException;
 
 abstract class Step
 {
+    /**
+     * @var int
+     */
     const DEFAULT_MAX_LENGTH = 200;
 
+    /**
+     * @var int
+     */
     const STACK_POSITION = 3;
 
     /**
@@ -27,7 +33,7 @@ abstract class Step
     /**
      * @var array
      */
-    protected $arguments;
+    protected $arguments = [];
 
     protected $debugOutput;
 
@@ -52,7 +58,7 @@ abstract class Step
     protected $prefix = 'I';
 
     /**
-     * @var MetaStep
+     * @var MetaStep|null
      */
     protected $metaStep = null;
 
@@ -102,7 +108,7 @@ abstract class Step
         return end($class);
     }
 
-    public function getAction(): ?string
+    public function getAction(): string
     {
         return $this->action;
     }
@@ -153,7 +159,7 @@ abstract class Step
             $lengthRemaining = $maxLength;
             $argumentsRemaining = $argumentCount;
             foreach ($arguments as $key => $argument) {
-                $argumentsRemaining--;
+                --$argumentsRemaining;
                 if (mb_strlen($argument, 'utf-8') > $allowedLength) {
                     $arguments[$key] = mb_substr($argument, 0, (int) $allowedLength - 4, 'utf-8') . '...' . mb_substr($argument, -1, 1, 'utf-8');
                     $lengthRemaining -= ($allowedLength + 1);
@@ -175,7 +181,6 @@ abstract class Step
 
     /**
      * @param mixed $argument
-     * @return string
      */
     protected function stringifyArgument($argument): string
     {
@@ -207,8 +212,8 @@ abstract class Step
     protected function getClassName(object $argument): string
     {
         if ($argument instanceof Closure) {
-            return 'Closure';
-        } elseif ($argument instanceof MockObject && isset($argument->__mocked)) {
+            return \Closure::class;
+        } elseif ($argument instanceof MockObject && (property_exists($argument, '__mocked') && $argument->__mocked !== null)) {
             return $this->formatClassName($argument->__mocked);
         }
 
@@ -224,9 +229,7 @@ abstract class Step
     {
         $result = "\${$this->prefix}->" . $this->getAction() . '(';
         $maxLength = $maxLength - mb_strlen($result, 'utf-8') - 1;
-
-        $result .= $this->getHumanizedArguments($maxLength) .')';
-        return $result;
+        return $result . ($this->getHumanizedArguments($maxLength) .')');
     }
 
     public function getMetaStep(): ?MetaStep
@@ -273,9 +276,9 @@ abstract class Step
 
     protected function humanize(string $text): string
     {
-        $text = preg_replace('/([A-Z]+)([A-Z][a-z])/', '\\1 \\2', $text);
-        $text = preg_replace('/([a-z\d])([A-Z])/', '\\1 \\2', $text);
-        $text = preg_replace('~\bdont\b~', 'don\'t', $text);
+        $text = preg_replace('#([A-Z]+)([A-Z][a-z])#', '\\1 \\2', $text);
+        $text = preg_replace('#([a-z\d])([A-Z])#', '\\1 \\2', $text);
+        $text = preg_replace('#\bdont\b#', "don't", $text);
         return mb_strtolower($text, 'UTF-8');
     }
 
@@ -286,7 +289,7 @@ abstract class Step
     public function run(ModuleContainer $container = null)
     {
         $this->executed = true;
-        if (!$container) {
+        if ($container === null) {
             return null;
         }
         $activeModule = $container->moduleForAction($this->action);
@@ -302,7 +305,7 @@ abstract class Step
                 throw $e;
             }
             $this->failed = true;
-            if ($this->getMetaStep()) {
+            if ($this->getMetaStep() !== null) {
                 $this->getMetaStep()->setFailed(true);
             }
             throw $e;
@@ -316,7 +319,7 @@ abstract class Step
      */
     protected function addMetaStep(array $step, array $stack): void
     {
-        if (($this->isTestFile($this->file)) || ($step['class'] == 'Codeception\Scenario')) {
+        if (($this->isTestFile($this->file)) || ($step['class'] == \Codeception\Scenario::class)) {
             return;
         }
 
@@ -325,8 +328,8 @@ abstract class Step
         // get into test file and retrieve its actual call
         while (isset($stack[$i])) {
             $step = $stack[$i];
-            $i--;
-            if (!isset($step['file']) or !isset($step['function']) or !isset($step['class'])) {
+            --$i;
+            if (!isset($step['file']) || !isset($step['function']) || !isset($step['class'])) {
                 continue;
             }
 
@@ -341,7 +344,7 @@ abstract class Step
             $this->metaStep->setTraceInfo($step['file'], $step['line']);
 
             // page objects or other classes should not be included with "I"
-            if (!in_array('Codeception\Actor', class_parents($step['class']))) {
+            if (!in_array(\Codeception\Actor::class, class_parents($step['class']))) {
                 if (isset($step['object'])) {
                     $this->metaStep->setPrefix(get_class($step['object']) . ':');
                     return;

--- a/src/Codeception/Step/ConditionalAssertion.php
+++ b/src/Codeception/Step/ConditionalAssertion.php
@@ -27,7 +27,7 @@ class ConditionalAssertion extends Assertion implements GeneratedStep
     public function getAction(): string
     {
         $action = 'can' . ucfirst($this->action);
-        return (string)preg_replace('/^canDont/', 'cant', $action);
+        return (string)preg_replace('#^canDont#', 'cant', $action);
     }
 
     public function getHumanizedAction(): string

--- a/src/Codeception/Step/Executor.php
+++ b/src/Codeception/Step/Executor.php
@@ -5,8 +5,8 @@ declare(strict_types=1);
 namespace Codeception\Step;
 
 use Closure;
-use Codeception\Step as CodeceptionStep;
 use Codeception\Lib\ModuleContainer;
+use Codeception\Step as CodeceptionStep;
 
 class Executor extends CodeceptionStep
 {

--- a/src/Codeception/Step/Incomplete.php
+++ b/src/Codeception/Step/Incomplete.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace Codeception\Step;
 
-use Codeception\Step as CodeceptionStep;
 use Codeception\Lib\ModuleContainer;
+use Codeception\Step as CodeceptionStep;
 use PHPUnit\Framework\IncompleteTestError;
 
 class Incomplete extends CodeceptionStep

--- a/src/Codeception/Step/Retry.php
+++ b/src/Codeception/Step/Retry.php
@@ -65,7 +65,7 @@ EOF;
                 if (!$this->isTry) {
                     throw $e;
                 }
-                codecept_debug("Retrying #{$retry} in ${interval}ms");
+                codecept_debug("Retrying #{$retry} in {$interval}ms");
                 usleep($interval * 1000);
                 $interval *= 2;
             }
@@ -84,7 +84,7 @@ EOF;
             return null; // dont retry waiters
         }
 
-        $doc = "* Executes $action and retries on failure.";
+        $doc = "* Executes {$action} and retries on failure.";
 
         return (new Template(self::$methodTemplate))
             ->place('method', $template->getVar('method'))

--- a/src/Codeception/Step/Skip.php
+++ b/src/Codeception/Step/Skip.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace Codeception\Step;
 
-use Codeception\Step as CodeceptionStep;
 use Codeception\Lib\ModuleContainer;
+use Codeception\Step as CodeceptionStep;
 use PHPUnit\Framework\SkippedTestError;
 
 class Skip extends CodeceptionStep

--- a/src/Codeception/Subscriber/AutoRebuild.php
+++ b/src/Codeception/Subscriber/AutoRebuild.php
@@ -53,7 +53,7 @@ class AutoRebuild implements EventSubscriberInterface
         $handle = @fopen($actorActionsFile, "r");
         if ($handle && is_writable($actorActionsFile)) {
             $line = @fgets($handle);
-            if (preg_match('~\[STAMP\] ([a-f0-9]*)~', $line, $matches)) {
+            if (preg_match('#\[STAMP\] ([a-f0-9]*)#', $line, $matches)) {
                 $hash = $matches[1];
                 $currentHash = Actions::genHash($modules, $settings);
 

--- a/src/Codeception/Subscriber/Console.php
+++ b/src/Codeception/Subscriber/Console.php
@@ -644,7 +644,7 @@ class Console implements EventSubscriberInterface
         } elseif ($this->isWin() && (PHP_SAPI === "cli")) {
             exec('mode con', $output);
             if (isset($output[4])) {
-                preg_match('/^ +.* +(\d+)$/', $output[4], $matches);
+                preg_match('#^ +.* +(\d+)$#', $output[4], $matches);
                 if (!empty($matches[1])) {
                     $this->width = (int) $matches[1];
                 }
@@ -663,7 +663,7 @@ class Console implements EventSubscriberInterface
         $prefix = ($this->output->isInteractive() && !$this->isDetailed($test) && $inProgress) ? '- ' : '';
 
         $testString = Descriptor::getTestAsString($test);
-        $testString = preg_replace('~^([^:]+):\s~', "<focus>$1{$this->chars['of']}</focus> ", $testString);
+        $testString = preg_replace('#^([^:]+):\s#', "<focus>$1{$this->chars['of']}</focus> ", $testString);
 
         $this
             ->message($testString)

--- a/src/Codeception/Subscriber/ErrorHandler.php
+++ b/src/Codeception/Subscriber/ErrorHandler.php
@@ -113,7 +113,7 @@ class ErrorHandler implements EventSubscriberInterface
         }
 
         $relativePath = codecept_relative_path($errFile);
-        throw new PHPUnitException("$errMsg at $relativePath:$errLine", $errNum);
+        throw new PHPUnitException("{$errMsg} at {$relativePath}:{$errLine}", $errNum);
     }
 
     public function shutdownHandler(): void
@@ -162,7 +162,7 @@ class ErrorHandler implements EventSubscriberInterface
                 && is_array($old)
                 && count($old) > 0
                 && is_object($old[0])
-                && get_class($old[0]) === 'Symfony\Component\Debug\ErrorHandler'
+                && $old[0] instanceof \Symfony\Component\Debug\ErrorHandler
             ) {
                 restore_error_handler();
             }

--- a/src/Codeception/Subscriber/ExtensionLoader.php
+++ b/src/Codeception/Subscriber/ExtensionLoader.php
@@ -31,7 +31,7 @@ class ExtensionLoader implements EventSubscriberInterface
     /**
      * @var array
      */
-    protected $config;
+    protected $config = [];
 
     /**
      * @var array
@@ -97,7 +97,6 @@ class ExtensionLoader implements EventSubscriberInterface
     }
 
     /**
-     * @param array $config
      * @return array<class-string, EventSubscriberInterface>
      * @throws ConfigurationException
      */

--- a/src/Codeception/Subscriber/PrepareTest.php
+++ b/src/Codeception/Subscriber/PrepareTest.php
@@ -40,7 +40,6 @@ class PrepareTest implements EventSubscriberInterface
 
         foreach ($prepareMethods as $method) {
 
-            /** @var \Codeception\Module $module **/
             if ($test instanceof Cest) {
                 $di->injectDependencies($test->getTestClass(), $method);
             }

--- a/src/Codeception/Suite.php
+++ b/src/Codeception/Suite.php
@@ -14,7 +14,7 @@ class Suite extends TestSuite
     /**
      * @var array
      */
-    protected $modules;
+    protected $modules = [];
     /**
      * @var string
      */
@@ -41,7 +41,6 @@ class Suite extends TestSuite
 
     /**
      * @param Dependent|SelfDescribing $test
-     * @return array
      */
     protected function getDependencies($test): array
     {

--- a/src/Codeception/SuiteManager.php
+++ b/src/Codeception/SuiteManager.php
@@ -60,6 +60,7 @@ class SuiteManager
      * @var string
      */
     protected $path = '';
+
     protected $printer = null;
 
     protected $env = null;
@@ -67,7 +68,7 @@ class SuiteManager
     /**
      * @var array
      */
-    protected $settings;
+    protected $settings = [];
 
     public function __construct(EventDispatcher $dispatcher, string $name, array $settings)
     {
@@ -123,7 +124,7 @@ class SuiteManager
     /**
      * @param TestInterface|DataProviderTestSuite $test
      */
-    protected function addToSuite($test): void
+    protected function addToSuite(\PHPUnit\Framework\Test $test): void
     {
         $this->configureTest($test);
 
@@ -152,9 +153,9 @@ class SuiteManager
     protected function createSuite(string $name): Suite
     {
         $suite = new Suite();
-        $suite->setBaseName(preg_replace('~\s.+$~', '', $name)); // replace everything after space (env name)
+        $suite->setBaseName(preg_replace('#\s.+$#', '', $name)); // replace everything after space (env name)
         if ($this->settings['namespace']) {
-            $name = $this->settings['namespace'] . ".$name";
+            $name = $this->settings['namespace'] . ".{$name}";
         }
         $suite->setName($name);
         if (isset($this->settings['backup_globals'])) {
@@ -210,11 +211,10 @@ class SuiteManager
             Notification::warning("Environments are not configured", Descriptor::getTestFullName($test));
             return;
         }
-        $availableEnvironments = array_keys($this->settings['env']);
         $listedEnvironments = explode(',', implode(',', $envs));
         foreach ($listedEnvironments as $env) {
-            if (!in_array($env, $availableEnvironments)) {
-                Notification::warning("Environment $env was not configured but used in test", Descriptor::getTestFullName($test));
+            if (!array_key_exists($env, $this->settings['env'])) {
+                Notification::warning("Environment {$env} was not configured but used in test", Descriptor::getTestFullName($test));
             }
         }
     }

--- a/src/Codeception/Template/Acceptance.php
+++ b/src/Codeception/Template/Acceptance.php
@@ -77,7 +77,7 @@ class LoginCest
 }
 EOF;
 
-    public function setup()
+    public function setup(): void
     {
         $this->checkInstalled();
         $this->say("Let's prepare Codeception for acceptance testing");

--- a/src/Codeception/Template/Api.php
+++ b/src/Codeception/Template/Api.php
@@ -53,7 +53,7 @@ class ApiCest
 EOF;
 
 
-    public function setup()
+    public function setup(): void
     {
         $this->checkInstalled();
         $this->say("Let's prepare Codeception for REST API testing");

--- a/src/Codeception/Template/Bootstrap.php
+++ b/src/Codeception/Template/Bootstrap.php
@@ -26,7 +26,7 @@ class Bootstrap extends InitTemplate
      */
     protected $envsDir = 'tests/_envs';
 
-    public function setup()
+    public function setup(): void
     {
         $this->checkInstalled($this->workDir);
 
@@ -94,7 +94,7 @@ class Bootstrap extends InitTemplate
 # Include one of framework modules (Symfony, Yii2, Laravel, Phalcon4) to use it
 # Remove this suite if you don't use frameworks
 
-actor: $actor{$this->actorSuffix}
+actor: {$actor}{$this->actorSuffix}
 modules:
     enabled:
         # add a framework module here
@@ -115,7 +115,7 @@ EOF;
 # Perform tests in browser using the WebDriver or PhpBrowser.
 # If you need both WebDriver and PHPBrowser tests - create a separate suite.
 
-actor: $actor{$this->actorSuffix}
+actor: {$actor}{$this->actorSuffix}
 modules:
     enabled:
         - PhpBrowser:
@@ -135,7 +135,7 @@ EOF;
 #
 # Suite for unit or integration tests.
 
-actor: $actor{$this->actorSuffix}
+actor: {$actor}{$this->actorSuffix}
 modules:
     enabled:
         - Asserts

--- a/src/Codeception/Template/Unit.php
+++ b/src/Codeception/Template/Unit.php
@@ -42,7 +42,7 @@ EOF;
 EOF;
 
 
-    public function setup()
+    public function setup(): void
     {
         $this->sayInfo('This will install Codeception for unit testing only');
         $this->say();

--- a/src/Codeception/Template/Upgrade4.php
+++ b/src/Codeception/Template/Upgrade4.php
@@ -18,7 +18,7 @@ class Upgrade4 extends InitTemplate
      */
     const DONATE_LINK = 'https://opencollective.com/codeception';
 
-    public function setup()
+    public function setup(): void
     {
         if (!$this->isInstalled()) {
             $this->sayWarning('Codeception is not installed in this dir.');

--- a/src/Codeception/Test/Cest.php
+++ b/src/Codeception/Test/Cest.php
@@ -83,8 +83,8 @@ class Cest extends Test implements
     public function getSpecFromMethod(): string
     {
         $text = $this->testMethod;
-        $text = preg_replace('/([A-Z]+)([A-Z][a-z])/', '\\1 \\2', $text);
-        $text = preg_replace('/([a-z\d])([A-Z])/', '\\1 \\2', $text);
+        $text = preg_replace('#([A-Z]+)([A-Z][a-z])#', '\\1 \\2', $text);
+        $text = preg_replace('#([a-z\d])([A-Z])#', '\\1 \\2', $text);
         return strtolower($text);
     }
 
@@ -206,7 +206,7 @@ class Cest extends Test implements
         $names = [];
         foreach ($this->getMetadata()->getDependencies() as $required) {
             if (strpos($required, ':') === false && method_exists($this->getTestClass(), $required)) {
-                $required = get_class($this->getTestClass()) . ":$required";
+                $required = get_class($this->getTestClass()) . ":{$required}";
             }
             $names[] = $required;
         }

--- a/src/Codeception/Test/Descriptor.php
+++ b/src/Codeception/Test/Descriptor.php
@@ -75,9 +75,9 @@ class Descriptor
     public static function getTestCaseNameAsString(string $testCaseName): string
     {
         $text = $testCaseName;
-        $text = preg_replace('/([A-Z]+)([A-Z][a-z])/', '\\1 \\2', $text);
-        $text = preg_replace('/([a-z\d])([A-Z])/', '\\1 \\2', $text);
-        $text = preg_replace('/^test /', '', $text);
+        $text = preg_replace('#([A-Z]+)([A-Z][a-z])#', '\\1 \\2', $text);
+        $text = preg_replace('#([a-z\d])([A-Z])#', '\\1 \\2', $text);
+        $text = preg_replace('#^test #', '', $text);
         $text = ucfirst(strtolower($text));
         return str_replace(['::', 'with data set'], [':', '|'], $text);
     }
@@ -100,7 +100,7 @@ class Descriptor
         }
         if ($testCase instanceof Descriptive) {
             $signature = $testCase->getSignature(); // cut everything before ":" from signature
-            return self::getTestFileName($testCase) . ':' . preg_replace('~^(.*?):~', '', $signature);
+            return self::getTestFileName($testCase) . ':' . preg_replace('#^(.*?):#', '', $signature);
         }
         if ($testCase instanceof TestCase) {
             return self::getTestFileName($testCase) . ':' . $testCase->getName(false);

--- a/src/Codeception/Test/Feature/ErrorLogger.php
+++ b/src/Codeception/Test/Feature/ErrorLogger.php
@@ -14,7 +14,7 @@ trait ErrorLogger
 
     public function errorLoggerEnd(string $status, float $time, Throwable $exception = null): void
     {
-        if (!$exception) {
+        if ($exception === null) {
             return;
         }
 

--- a/src/Codeception/Test/Gherkin.php
+++ b/src/Codeception/Test/Gherkin.php
@@ -144,7 +144,7 @@ class Gherkin extends Test implements ScenarioDriven, Reported
     private function contextAsString($context): string
     {
         if (is_array($context) && count($context) === 2) {
-            list($class, $method) = $context;
+            [$class, $method] = $context;
 
             if (is_string($class) && is_string($method)) {
                 return $class . ':' . $method;

--- a/src/Codeception/Test/Loader.php
+++ b/src/Codeception/Test/Loader.php
@@ -151,7 +151,6 @@ class Loader
         $finder = Finder::create()->files()->sortByName()->in($this->path)->followLinks();
 
         foreach ($this->formats as $format) {
-            /** @var Loader $format **/
             $formatFinder = clone($finder);
             $testFiles = $formatFinder->name($format->getPattern());
             foreach ($testFiles as $test) {

--- a/src/Codeception/Test/Loader/Cest.php
+++ b/src/Codeception/Test/Loader/Cest.php
@@ -13,7 +13,6 @@ use PHPUnit\Framework\DataProviderTestSuite;
 use ReflectionClass;
 use ReflectionException;
 use function array_map;
-use function count;
 use function get_class_methods;
 use function strlen;
 use function strpos;
@@ -62,7 +61,7 @@ class Cest implements LoaderInterface
 
                 // example Annotation
                 $rawExamples = Annotation::forMethod($unit, $method)->fetchAll('example');
-                if (count($rawExamples) > 0) {
+                if ($rawExamples !== []) {
                     $examples = array_map(
                         function ($v) {
                             return Annotation::arrayValue($v);

--- a/src/Codeception/Test/Loader/Gherkin.php
+++ b/src/Codeception/Test/Loader/Gherkin.php
@@ -75,7 +75,7 @@ class Gherkin implements LoaderInterface
     public function __construct($settings = [])
     {
         $this->settings = Configuration::mergeConfigs(self::$defaultSettings, $settings);
-        if (!class_exists('Behat\Gherkin\Keywords\ArrayKeywords')) {
+        if (!class_exists(\Behat\Gherkin\Keywords\ArrayKeywords::class)) {
             throw new TestParseException('Feature file can only be parsed with Behat\Gherkin library. Please install `behat/gherkin` with Composer');
         }
         $gherkin = new ReflectionClass(\Behat\Gherkin\Gherkin::class);
@@ -162,8 +162,8 @@ class Gherkin implements LoaderInterface
         if (strpos($pattern, '/') !== 0) {
             $pattern = preg_quote($pattern);
 
-            $pattern = preg_replace('~(\w+)\/(\w+)~', '(?:$1|$2)', $pattern); // or
-            $pattern = preg_replace('~\\\\\((\w)\\\\\)~', '$1?', $pattern); // (s)
+            $pattern = preg_replace('#(\w+)\/(\w+)#', '(?:$1|$2)', $pattern); // or
+            $pattern = preg_replace('#\\\\\((\w)\\\\\)#', '$1?', $pattern); // (s)
 
             $replacePattern = sprintf(
                 '(?|\"%s\"|%s)',
@@ -172,7 +172,7 @@ class Gherkin implements LoaderInterface
             ); // or matching numbers with optional $ or € chars
 
             // params converting from :param to match 11 and "aaa" and "aaa\"aaa"
-            $pattern = preg_replace('~"?\\\:(\w+)"?~', $replacePattern, $pattern);
+            $pattern = preg_replace('#"?\\\:(\w+)"?#', $replacePattern, $pattern);
             $pattern = "/^{$pattern}$/u";
             // validating this pattern is slow, so we skip it now
         }
@@ -193,7 +193,7 @@ class Gherkin implements LoaderInterface
     {
         $featureNode = $this->parser->parse(file_get_contents($filename), $filename);
 
-        if ($featureNode === null) {
+        if (!$featureNode instanceof \Behat\Gherkin\Node\FeatureNode) {
             return;
         }
 

--- a/src/Codeception/Test/Metadata.php
+++ b/src/Codeception/Test/Metadata.php
@@ -89,7 +89,6 @@ class Metadata
     }
 
     /**
-     * @param string|null $key
      * @return mixed
      */
     public function getCurrent(?string $key = null)

--- a/src/Codeception/Test/Unit.php
+++ b/src/Codeception/Test/Unit.php
@@ -97,7 +97,6 @@ class Unit extends TestCase implements
     /**
      * Returns current values
      *
-     * @param string|null $current
      * @return mixed
      */
     public function getCurrent(?string $current)

--- a/src/Codeception/Util/Annotation.php
+++ b/src/Codeception/Util/Annotation.php
@@ -51,7 +51,6 @@ class Annotation
      * Annotation::forClass('MyTestCase')->method('testData')->fetchAll('depends');
      * ```
      * @param object|string $class
-     * @return static
      */
     public static function forClass($class): Annotation
     {
@@ -68,8 +67,6 @@ class Annotation
 
     /**
      * @param object|string $class
-     * @param string $method
-     * @return Annotation
      */
     public static function forMethod($class, string $method): self
     {
@@ -156,12 +153,12 @@ class Annotation
 
         // json-style data format
         if (in_array($openingBrace, ['{', '['])) {
-            return json_decode($annotation, true);
+            return json_decode($annotation, true, 512, JSON_THROW_ON_ERROR);
         }
 
         // doctrine-style data format
         if ($openingBrace === '(') {
-            preg_match_all('~(\w+)\s*?=\s*?"(.*?)"\s*?[,)]~', $annotation, $matches, PREG_SET_ORDER);
+            preg_match_all('#(\w+)\s*?=\s*?"(.*?)"\s*?[,)]#', $annotation, $matches, PREG_SET_ORDER);
             $data = [];
             foreach ($matches as $item) {
                 $data[$item[1]] = $item[2];

--- a/src/Codeception/Util/ArrayContainsComparator.php
+++ b/src/Codeception/Util/ArrayContainsComparator.php
@@ -95,9 +95,6 @@ class ArrayContainsComparator
     }
 
     /**
-     * @param array $arr1
-     * @param array $arr2
-     *
      * @return array|bool|null
      */
     private function associativeArrayIntersect(array $arr1, array $arr2)

--- a/src/Codeception/Util/Fixtures.php
+++ b/src/Codeception/Util/Fixtures.php
@@ -18,6 +18,9 @@ use RuntimeException;
  */
 class Fixtures
 {
+    /**
+     * @var array
+     */
     protected static $fixtures = [];
 
     public static function add(string $name, $data): void

--- a/src/Codeception/Util/Locator.php
+++ b/src/Codeception/Util/Locator.php
@@ -56,8 +56,6 @@ class Locator
      * As a result the Locator will produce a mixed XPath value that will be used in fillField action.
      *
      * @static
-     * @param string $selector1
-     * @param string $selector2
      * @throws Exception
      */
     public static function combine(string $selector1, string $selector2): string
@@ -126,8 +124,7 @@ class Locator
     protected static function toXPath(string $selector): ?string
     {
         try {
-            $xpath = (new CssSelectorConverter())->toXPath($selector);
-            return $xpath;
+            return (new CssSelectorConverter())->toXPath($selector);
         } catch (ParseException $parseException) {
             if (self::isXPath($selector)) {
                 return $selector;
@@ -244,7 +241,7 @@ class Locator
      */
     public static function isClass(string $class): bool
     {
-        return (bool)preg_match('~^\.[\w\.\-\[\]\=\^\~\:]+$~', $class);
+        return (bool)preg_match('#^\.[\w\.\-\[\]\=\^\~\:]+$#', $class);
     }
 
     /**
@@ -282,7 +279,6 @@ class Locator
      *
      * @param string $element CSS or XPath locator
      * @param int|string $position xPath index
-     * @return string
      */
     public static function elementAt(string $element, $position): string
     {
@@ -336,7 +332,6 @@ class Locator
      * Transforms strict locator, \Facebook\WebDriver\WebDriverBy into a string representation
      *
      * @param string|array|WebDriverBy $selector
-     * @return string
      */
     public static function humanReadableString($selector): string
     {

--- a/src/Codeception/Util/Maybe.php
+++ b/src/Codeception/Util/Maybe.php
@@ -12,8 +12,6 @@ use function call_user_func_array;
 use function count;
 use function is_array;
 use function is_object;
-use function is_scalar;
-use function method_exists;
 use function property_exists;
 use function range;
 
@@ -78,10 +76,8 @@ class Maybe implements ArrayAccess, Iterator, JsonSerializable
             return new Maybe();
         }
 
-        if (is_object($this->val)) {
-            if (isset($this->val->{$key}) || property_exists($this->val, $key)) {
-                return $this->val->{$key};
-            }
+        if (is_object($this->val) && (isset($this->val->{$key}) || property_exists($this->val, $key))) {
+            return $this->val->{$key};
         }
 
         return $this->val->key;
@@ -154,13 +150,13 @@ class Maybe implements ArrayAccess, Iterator, JsonSerializable
         }
     }
 
-    public function __value()
+    public function value(): ?object
     {
         $val = $this->val;
         if (is_array($val)) {
             foreach ($val as $k => $v) {
                 if ($v instanceof self) {
-                    $v = $v->__value();
+                    $v = $v->value();
                 }
                 $val[$k] = $v;
             }
@@ -256,6 +252,6 @@ class Maybe implements ArrayAccess, Iterator, JsonSerializable
      */
     public function jsonSerialize()
     {
-        return $this->__value();
+        return $this->value();
     }
 }

--- a/src/Codeception/Util/PathResolver.php
+++ b/src/Codeception/Util/PathResolver.php
@@ -76,9 +76,6 @@ class PathResolver
      * FileSystem Case String Compare
      * compare two strings with the filesystem's case-sensitiveness
      *
-     * @param string $str1
-     * @param string $str2
-     * @param string $dirSep
      * @return int -1 / 0 / 1 for < / = / > respectively
      */
     private static function fsCaseStrCmp(string $str1, string $str2, string $dirSep = DIRECTORY_SEPARATOR): int
@@ -104,8 +101,6 @@ class PathResolver
      *         on the device or '' to indicate a path relative
      *         to the device's CWD
      *
-     * @param string $path
-     * @param string $dirSep
      * @return array<string, string>
      */
     private static function getPathAbsolutenessPrefix(string $path, string $dirSep = DIRECTORY_SEPARATOR): array

--- a/src/Codeception/Util/ReflectionHelper.php
+++ b/src/Codeception/Util/ReflectionHelper.php
@@ -8,6 +8,7 @@ use ReflectionException;
 use ReflectionMethod;
 use ReflectionParameter;
 use ReflectionProperty;
+use ReflectionType;
 use function array_filter;
 use function array_keys;
 use function array_map;
@@ -82,7 +83,7 @@ class ReflectionHelper
     public static function getClassFromParameter(ReflectionParameter $parameter): ?string
     {
         $type = $parameter->getType();
-        if ($type === null || $type->isBuiltin()) {
+        if (!$type instanceof ReflectionType || $type->isBuiltin()) {
             return null;
         }
         $typeString = $type->getName();
@@ -106,7 +107,7 @@ class ReflectionHelper
             if (method_exists($parameter, 'isDefaultValueConstant') && $parameter->isDefaultValueConstant()) {
                 $constName = $parameter->getDefaultValueConstantName();
                 if (false !== strpos($constName, '::')) {
-                    list($class, $const) = explode('::', $constName);
+                    [$class, $const] = explode('::', $constName);
                     if (in_array($class, ['self', 'static'])) {
                         $constName = '\\' . $parameter->getDeclaringClass()->getName() . '::' . $const;
                     } elseif (substr($class, 0, 1) !== '\\') {
@@ -150,7 +151,6 @@ class ReflectionHelper
      * PHP encode value
      *
      * @param mixed $value
-     * @return string
      */
     public static function phpEncodeValue($value): string
     {

--- a/src/Codeception/Util/ReflectionPropertyAccessor.php
+++ b/src/Codeception/Util/ReflectionPropertyAccessor.php
@@ -40,7 +40,7 @@ class ReflectionPropertyAccessor
     /**
      * @throws ReflectionException
      */
-    private function setPropertiesForClass(?object $obj, string $class, array $data): ?object
+    private function setPropertiesForClass(?object $obj, string $class, array $data): object
     {
         $reflectionClass = new ReflectionClass($class);
 

--- a/src/Codeception/Util/Template.php
+++ b/src/Codeception/Util/Template.php
@@ -16,9 +16,21 @@ use function str_replace;
  */
 class Template
 {
+    /**
+     * @var string
+     */
     protected $template;
+    /**
+     * @var array
+     */
     protected $vars = [];
+    /**
+     * @var string
+     */
     protected $placeholderStart;
+    /**
+     * @var string
+     */
     protected $placeholderEnd;
 
     public function __construct(string $template, string $placeholderStart = '{{', string $placeholderEnd = '}}')
@@ -40,7 +52,6 @@ class Template
     /**
      * Sets all template vars
      *
-     * @param array $vars
      */
     public function setVars(array $vars): void
     {

--- a/src/Codeception/Util/Uri.php
+++ b/src/Codeception/Util/Uri.php
@@ -58,7 +58,7 @@ class Uri
             if ((strpos($path, '/') !== 0) && !empty($path)) {
                 if ($basePath !== '') {
                     // if it ends with a slash, relative paths are below it
-                    if (preg_match('~/$~', $basePath)) {
+                    if (preg_match('#/$#', $basePath)) {
                         $path = $basePath . $path;
                     } else {
                         // remove double slashes

--- a/src/Codeception/Util/Xml.php
+++ b/src/Codeception/Util/Xml.php
@@ -10,14 +10,6 @@ use function is_array;
 
 class Xml
 {
-    /**
-     * @static
-     *
-     * @param DOMDocument $xml
-     * @param DOMNode $domNode
-     * @param array $array
-     * @return DOMDocument
-     */
     public static function arrayToXml(DOMDocument $xml, DOMNode $domNode, array $array = []): DOMDocument
     {
         foreach ($array as $el => $val) {
@@ -31,10 +23,7 @@ class Xml
     }
 
     /**
-     * @static
-     *
      * @param XmlBuilder|DOMDocument $xml
-     * @return DOMDocument
      */
     public static function toXml($xml): DOMDocument
     {

--- a/src/Codeception/Util/XmlBuilder.php
+++ b/src/Codeception/Util/XmlBuilder.php
@@ -99,7 +99,7 @@ class XmlBuilder
         return $this;
     }
 
-    public function val($val): self
+    public function val($val): void
     {
         $this->currentNode->nodeValue = $val;
     }
@@ -125,8 +125,6 @@ class XmlBuilder
     /**
      * Traverses to parent with $name
      *
-     * @param string $tag
-     * @return XmlBuilder
      * @throws Exception
      */
     public function parents(string $tag): self
@@ -135,7 +133,7 @@ class XmlBuilder
         $elFound = false;
         while ($traverseNode->parentNode) {
             $traverseNode = $traverseNode->parentNode;
-            if ($traverseNode->tagName == $tag) {
+            if ($traverseNode->tagName === $tag) {
                 $this->currentNode = $traverseNode;
                 $elFound = true;
                 break;

--- a/tests/unit/Codeception/Command/BaseCommandRunner.php
+++ b/tests/unit/Codeception/Command/BaseCommandRunner.php
@@ -2,8 +2,8 @@
 
 declare(strict_types=1);
 
-use Codeception\Stub;
 use Codeception\Application;
+use Codeception\Stub;
 use Symfony\Component\Console\Tester\CommandTester;
 
 class BaseCommandRunner extends \Codeception\PHPUnit\TestCase

--- a/tests/unit/Codeception/Coverage/FilterTest.php
+++ b/tests/unit/Codeception/Coverage/FilterTest.php
@@ -6,8 +6,6 @@ namespace Codeception\Coverage;
 
 use Codeception\Stub;
 use SebastianBergmann\CodeCoverage\CodeCoverage;
-use SebastianBergmann\CodeCoverage\Driver\Driver;
-
 use SebastianBergmann\CodeCoverage\Filter as CodeCoverageFilter;
 
 class FilterTest extends \Codeception\Test\Unit

--- a/tests/unit/Codeception/Lib/DiTest.php
+++ b/tests/unit/Codeception/Lib/DiTest.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Codeception\Lib;
 
+use Codeception\Exception\InjectionException;
+
 class DiTest extends \Codeception\Test\Unit
 {
     /**
@@ -18,7 +20,7 @@ class DiTest extends \Codeception\Test\Unit
 
     protected function injectionShouldFail(string $msg = '')
     {
-        $this->expectException(\Codeception\Exception\InjectionException::class);
+        $this->expectException(InjectionException::class);
         if ($msg !== '') {
             $this->expectExceptionMessage($msg);
         }
@@ -35,14 +37,14 @@ class DiTest extends \Codeception\Test\Unit
 
     public function testFailDependenciesInChain()
     {
-        require_once codecept_data_dir().'FailDependenciesInChain.php';
+        require_once codecept_data_dir() . 'FailDependenciesInChain.php';
         $this->injectionShouldFail('Failed to resolve dependency \'FailDependenciesInChain\AnotherClass\'');
         $this->di->instantiate('FailDependenciesInChain\IncorrectDependenciesClass');
     }
 
     public function testFailDependenciesNonExistent()
     {
-        require_once codecept_data_dir().'FailDependenciesNonExistent.php';
+        require_once codecept_data_dir() . 'FailDependenciesNonExistent.php';
         if (PHP_MAJOR_VERSION < 8) {
             $expectedExceptionMessage = 'Class FailDependenciesNonExistent\NonExistentClass does not exist';
         } else {
@@ -54,7 +56,7 @@ class DiTest extends \Codeception\Test\Unit
 
     public function testFailDependenciesPrimitiveParam()
     {
-        require_once codecept_data_dir().'FailDependenciesPrimitiveParam.php';
+        require_once codecept_data_dir() . 'FailDependenciesPrimitiveParam.php';
         $this->injectionShouldFail("Parameter 'required' must have default value");
         $this->di->instantiate('FailDependenciesPrimitiveParam\IncorrectDependenciesClass');
     }

--- a/tests/unit/Codeception/Lib/ModuleContainerTest.php
+++ b/tests/unit/Codeception/Lib/ModuleContainerTest.php
@@ -4,11 +4,10 @@ declare(strict_types=1);
 
 namespace Codeception\Lib;
 
-use Codeception\Exception\ModuleException;
 use Codeception\Lib\Interfaces\ConflictsWithModule;
 use Codeception\Lib\Interfaces\DependsOnModule;
-use Codeception\Test\Unit;
 use Codeception\Stub;
+use Codeception\Test\Unit;
 
 // @codingStandardsIgnoreFile
 class ModuleContainerTest extends Unit

--- a/tests/unit/Codeception/StepTest.php
+++ b/tests/unit/Codeception/StepTest.php
@@ -2,10 +2,10 @@
 
 declare(strict_types=1);
 
+use Codeception\Step;
 use Codeception\Step\Argument\FormattedOutput;
 use Codeception\Stub;
 use Facebook\WebDriver\WebDriverBy;
-use Codeception\Step;
 use PHPUnit\Framework\TestCase;
 
 class StepTest extends TestCase

--- a/tests/unit/Codeception/Util/AnnotationTest.php
+++ b/tests/unit/Codeception/Util/AnnotationTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-use \Codeception\Util\Annotation;
+use Codeception\Util\Annotation;
 
 /**
  * Class AnnotationTest

--- a/tests/unit/Codeception/Util/ReflectionHelperTest.php
+++ b/tests/unit/Codeception/Util/ReflectionHelperTest.php
@@ -84,18 +84,15 @@ class ReflectionHelperTest extends \Codeception\PHPUnit\TestCase
             ReflectionHelper::getClassFromParameter(new ReflectionParameter([$object, 'setDebug'], 0))
         );
 
-        $this->assertSame(
-            null,
+        $this->assertNull(
             ReflectionHelper::getClassFromParameter(new ReflectionParameter([$object, 'setDebug'], 1))
         );
 
-        $this->assertSame(
-            null,
+        $this->assertNull(
             ReflectionHelper::getClassFromParameter(new ReflectionParameter([$object, 'setDebug'], 'flavor'))
         );
 
-        $this->assertSame(
-            null,
+        $this->assertNull(
             ReflectionHelper::getClassFromParameter(new ReflectionParameter([$object, 'setInt'], 'i'))
         );
     }

--- a/tests/unit/Codeception/Util/StubTest.php
+++ b/tests/unit/Codeception/Util/StubTest.php
@@ -2,8 +2,8 @@
 
 declare(strict_types=1);
 
-use \Codeception\Stub;
-use \Codeception\Stub\Expected;
+use Codeception\Stub;
+use Codeception\Stub\Expected;
 
 class StubTest extends \Codeception\PHPUnit\TestCase
 {


### PR DESCRIPTION
With this PR I do a general review of my previous PRs, and I make sure to fix any inadvertently omitted changes, in addition to taking the opportunity to give *(the much desired)* consistency to the source code:

* Removed unnecessary typing docblocks
* Standardize `#` as PREG delimiter in regex
* Add `{}` to interpolate variables inside strings
* Stop using `list()` in favor of `[]`
* Add strict comparisons
* Add `JSON_THROW_ON_ERROR` to json functions where missing
* Initialize properties that do not get initial value in constructor, but are typed
* Type constants
* Use pre-increment and pre-decrement instead of increment and decrement
* Remove invalid type annotations
* Fix naming
* `assertNull` instead of `assertSame(null, ...)`

This is the last PR from me before the `5.0` release.