### PR TITLE
4.1 Remove dead DataProviderTestSuite code

### DIFF
--- a/src/Codeception/Command/DryRun.php
+++ b/src/Codeception/Command/DryRun.php
@@ -85,13 +85,6 @@ class DryRun extends Command
         $this->dispatch($dispatcher, Events::SUITE_INIT, new SuiteEvent($suiteManager->getSuite(), null, $settings));
         $this->dispatch($dispatcher, Events::SUITE_BEFORE, new SuiteEvent($suiteManager->getSuite(), null, $settings));
         foreach ($tests as $test) {
-            if ($test instanceof \PHPUnit\Framework\DataProviderTestSuite) {
-                foreach ($test as $t) {
-                    if ($t instanceof Test) {
-                        $this->dryRunTest($output, $dispatcher, $t);
-                    }
-                }
-            }
             if ($test instanceof Test and $test instanceof ScenarioDriven) {
                 $this->dryRunTest($output, $dispatcher, $test);
             }

--- a/src/Codeception/Lib/GroupManager.php
+++ b/src/Codeception/Lib/GroupManager.php
@@ -149,13 +149,6 @@ class GroupManager
         if ($test instanceof \PHPUnit\Framework\TestCase) {
             $groups = array_merge($groups, \PHPUnit\Util\Test::getGroups(get_class($test), $test->getName(false)));
         }
-        if ($test instanceof \PHPUnit\Framework\DataProviderTestSuite) {
-            $firstTest = $test->testAt(0);
-            if ($firstTest != false && $firstTest instanceof TestInterface) {
-                $groups = array_merge($groups, $firstTest->getMetadata()->getGroups());
-                $filename = Descriptor::getTestFileName($firstTest);
-            }
-        }
 
         foreach ($this->testsInGroups as $group => $tests) {
             foreach ($tests as $testPattern) {
@@ -168,14 +161,6 @@ class GroupManager
                 if ($test instanceof Gherkin
                     && mb_strtolower($filename . ':' . $test->getMetadata()->getFeature()) === mb_strtolower($testPattern)) {
                     $groups[] = $group;
-                }
-                if ($test instanceof \PHPUnit\Framework\DataProviderTestSuite) {
-                    $firstTest = $test->testAt(0);
-                    if ($firstTest != false && $firstTest instanceof TestInterface) {
-                        if (strpos($filename . ':' . $firstTest->getName(false), $testPattern) === 0) {
-                            $groups[] = $group;
-                        }
-                    }
                 }
             }
         }

--- a/src/Codeception/Subscriber/BeforeAfterTest.php
+++ b/src/Codeception/Subscriber/BeforeAfterTest.php
@@ -22,11 +22,6 @@ class BeforeAfterTest implements EventSubscriberInterface
     {
         foreach ($e->getSuite()->tests() as $test) {
             /** @var $test \PHPUnit\Framework\Test  * */
-            if ($test instanceof \PHPUnit\Framework\DataProviderTestSuite) {
-                $potentialTestClass = strstr($test->getName(), '::', true);
-                $this->hooks[$potentialTestClass] = \PHPUnit\Util\Test::getHookMethods($potentialTestClass);
-            }
-
             $testClass = get_class($test);
             $this->hooks[$testClass] = \PHPUnit\Util\Test::getHookMethods($testClass);
         }

--- a/tests/cli/DryRunCest.php
+++ b/tests/cli/DryRunCest.php
@@ -10,6 +10,8 @@ class DryRunCest
     {
         $I->executeCommand('dry-run scenario ExamplesCest --no-ansi');
         $I->seeInShellOutput('ExamplesCest: Files exists annotation');
+        $I->seeInShellOutput('I see file found "scenario.suite.yml"');
+        $I->seeInShellOutput('I see file found "dummy.suite.yml"');
     }
 
     public function runFeature(CliGuy $I)


### PR DESCRIPTION
These conditions used wrong class name since release of PHPUnit 6.0, so this code was is effectively dead for 4 years.
I fixed conditions in #6136 but now I think that it was a wrong way to handle this issue.

The only place where Codeception creates DataProviderTestSuite is in [Test\Loader\Cest](https://github.com/Codeception/Codeception/blob/4.1.18/src/Codeception/Test/Loader/Cest.php#L79) but dry-run command does not receive it.

I think that DataProviderTest Suite is handled well by [Test\Loader\Unit](https://github.com/Codeception/Codeception/blob/4.1.18/src/Codeception/Test/Loader/Unit.php#L63-L68) and [Codeception\SuiteManager](https://github.com/Codeception/Codeception/blob/4.1.18/src/Codeception/SuiteManager.php#L114-L119)