### PR TITLE
Fix type error when there is no matching test

### DIFF
--- a/src/Codeception/Suite.php
+++ b/src/Codeception/Suite.php
@@ -51,7 +51,7 @@ class Suite extends TestSuite
         $tests = [];
         foreach ($test->fetchDependencies() as $requiredTestName) {
             $required = $this->findMatchedTest($requiredTestName);
-            if (!$required) {
+            if ($required === null) {
                 continue;
             }
             $tests = array_merge($tests, $this->getDependencies($required));
@@ -60,7 +60,7 @@ class Suite extends TestSuite
         return $tests;
     }
 
-    protected function findMatchedTest(string $testSignature): SelfDescribing
+    protected function findMatchedTest(string $testSignature): ?SelfDescribing
     {
         /** @var SelfDescribing $test */
         foreach ($this->tests as $test) {
@@ -69,6 +69,8 @@ class Suite extends TestSuite
                 return $test;
             }
         }
+
+        return null;
     }
 
     public function getModules(): array


### PR DESCRIPTION
This error happened to me while working on another branch:

> $ ./codecept run tests/cli/ConfigNoActorCest.php:runSuitesWithoutActor
> Codeception PHP Testing Framework v5.0.0
> Powered by PHPUnit 10.0-g2bc4a059f by Sebastian Bergmann and contributors.
> [Seed] 820860849
> PHP Fatal error:  Uncaught TypeError: Codeception\Suite::findMatchedTest(): Return value must be of type PHPUnit\Framework\SelfDescribing, none returned in /.../Codeception/src/Codeception/Suite.php:72
> Stack trace:
> #0 /.../Codeception/src/Codeception/Suite.php(53): Codeception\Suite->findMatchedTest()
> #1 /.../Codeception/src/Codeception/Suite.php(27): Codeception\Suite->getDependencies()
> #2 /.../Codeception/src/Codeception/SuiteManager.php(120): Codeception\Suite->reorderDependencies()
