### PR TITLE
Abstract PHPUnit compatibility logic

### DIFF
--- a/src/Codeception/Coverage/PhpCodeCoverageFactory.php
+++ b/src/Codeception/Coverage/PhpCodeCoverageFactory.php
@@ -4,25 +4,23 @@ declare(strict_types=1);
 
 namespace Codeception\Coverage;
 
+use Codeception\PHPUnit\Compatibility\PHPUnit10;
 use PHPUnit\Runner\CodeCoverage as PHPUnitCodeCoverage;
 use SebastianBergmann\CodeCoverage\CodeCoverage;
 use SebastianBergmann\CodeCoverage\Driver\Driver;
 use SebastianBergmann\CodeCoverage\Filter as CodeCoverageFilter;
-use function method_exists;
 
 class PhpCodeCoverageFactory
 {
     public static function build(): CodeCoverage
     {
         $filter = new CodeCoverageFilter();
-        if (method_exists(PHPUnitCodeCoverage::class, 'activate')) {
-            // php-code-coverage 10
+        if (PHPUnit10::codeCoverageRunnerClassExists()) {
             if (!PHPUnitCodeCoverage::isActive()) {
                 PHPUnitCodeCoverage::activate($filter, false);
             }
             return PHPUnitCodeCoverage::instance();
         } else {
-            //php-code-coverage 9+
             $filter = new CodeCoverageFilter();
             $driver = Driver::forLineCoverage($filter);
 

--- a/src/Codeception/Coverage/Subscriber/Local.php
+++ b/src/Codeception/Coverage/Subscriber/Local.php
@@ -8,6 +8,7 @@ use Codeception\Coverage\SuiteSubscriber;
 use Codeception\Event\SuiteEvent;
 use Codeception\Events;
 use Codeception\Lib\Interfaces\Remote;
+use Codeception\PHPUnit\Compatibility\PHPUnit9;
 use PHPUnit\Runner\CodeCoverage as PHPUnitCodeCoverage;
 
 /**
@@ -51,11 +52,9 @@ class Local extends SuiteSubscriber
         }
         $testResult = $event->getResult();
 
-        if (method_exists($testResult, 'getCodeCoverage')) {
-            // PHPUnit 9
+        if (PHPUnit9::getCodeCoverageMethodExists($testResult)) {
             $codeCoverage = $testResult->getCodeCoverage();
         } else {
-            // PHPUnit 10
             $codeCoverage = PHPUnitCodeCoverage::instance();
             PHPUnitCodeCoverage::deactivate();
         }

--- a/src/Codeception/Coverage/SuiteSubscriber.php
+++ b/src/Codeception/Coverage/SuiteSubscriber.php
@@ -9,18 +9,17 @@ use Codeception\Coverage\Subscriber\Printer;
 use Codeception\Exception\ConfigurationException;
 use Codeception\Exception\ModuleException;
 use Codeception\Lib\Interfaces\Remote as RemoteInterface;
+use Codeception\PHPUnit\Compatibility\PHPUnit9;
 use Codeception\Stub;
 use Codeception\Subscriber\Shared\StaticEventsTrait;
 use Exception;
 use PHPUnit\Framework\CodeCoverageException;
 use PHPUnit\Framework\TestResult;
-use PHPUnit\Runner\CodeCoverage as RunnerCodeCoverage;
 use SebastianBergmann\CodeCoverage\CodeCoverage;
 use SebastianBergmann\CodeCoverage\Driver\Driver as CodeCoverageDriver;
 use SebastianBergmann\CodeCoverage\Filter as CodeCoverageFilter;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use function array_keys;
-use function method_exists;
 
 abstract class SuiteSubscriber implements EventSubscriberInterface
 {
@@ -129,8 +128,8 @@ abstract class SuiteSubscriber implements EventSubscriberInterface
     public function applyFilter(TestResult $result): void
     {
         $driver = Stub::makeEmpty(CodeCoverageDriver::class);
-        if (method_exists($result, 'setCodeCoverage')) {
-            // PHPUnit 9
+
+        if (PHPUnit9::setCodeCoverageMethodExists($result)) {
             $result->setCodeCoverage(new CodeCoverage($driver, new CodeCoverageFilter()));
         }
 
@@ -138,8 +137,7 @@ abstract class SuiteSubscriber implements EventSubscriberInterface
             ->whiteList($this->filters)
             ->blackList($this->filters);
 
-        if (method_exists($result, 'setCodeCoverage')) {
-            // PHPUnit 9
+        if (PHPUnit9::setCodeCoverageMethodExists($result)) {
             $result->setCodeCoverage($this->coverage);
         }
     }

--- a/src/Codeception/Test/Feature/CodeCoverage.php
+++ b/src/Codeception/Test/Feature/CodeCoverage.php
@@ -4,13 +4,13 @@ declare(strict_types=1);
 
 namespace Codeception\Test\Feature;
 
+use Codeception\PHPUnit\Compatibility\PHPUnit9;
 use Codeception\Test\Descriptor;
 use Codeception\Test\Interfaces\StrictCoverage;
 use Codeception\Test\Test as CodeceptTest;
-use SebastianBergmann\CodeCoverage\Exception as CodeCoverageException;
 use PHPUnit\Framework\TestResult;
 use PHPUnit\Runner\CodeCoverage as PHPUnitCoverage;
-use SebastianBergmann\CodeCoverage\Filter as CodeCoverageFilter;
+use SebastianBergmann\CodeCoverage\Exception as CodeCoverageException;
 
 trait CodeCoverage
 {
@@ -19,14 +19,12 @@ trait CodeCoverage
     public function codeCoverageStart(): void
     {
         $testResult = $this->getTestResultObject();
-        if (method_exists($testResult, 'getCodeCoverage')) {
-            // PHPUnit 9
+        if (PHPUnit9::getCodeCoverageMethodExists($testResult)) {
             $codeCoverage = $testResult->getCodeCoverage();
             if (!$codeCoverage) {
                 return;
             }
         } else {
-            // PHPUnit 10
             if (!PHPUnitCoverage::isActive()) {
                 return;
             }
@@ -39,14 +37,12 @@ trait CodeCoverage
     public function codeCoverageEnd(string $status, float $time): void
     {
         $testResult = $this->getTestResultObject();
-        if (method_exists($testResult, 'getCodeCoverage')) {
-            // PHPUnit 9
+        if (PHPUnit9::getCodeCoverageMethodExists($testResult)) {
             $codeCoverage = $testResult->getCodeCoverage();
             if (!$codeCoverage) {
                 return;
             }
         } else {
-            // PHPUnit 10
             if (!PHPUnitCoverage::isActive()) {
                 return;
             }

--- a/src/Codeception/Test/Test.php
+++ b/src/Codeception/Test/Test.php
@@ -4,20 +4,20 @@ declare(strict_types=1);
 
 namespace Codeception\Test;
 
+use Codeception\PHPUnit\Compatibility\PHPUnit9;
 use Codeception\TestInterface;
 use Codeception\Util\ReflectionHelper;
 use PHPUnit\Framework\AssertionFailedError;
 use PHPUnit\Framework\Exception;
 use PHPUnit\Framework\ExceptionWrapper;
 use PHPUnit\Framework\TestResult;
-use PHPUnit\Runner\Version;
 use SebastianBergmann\Timer\Timer;
 use Throwable;
 use function array_reverse;
 use function method_exists;
 
 // One way to implement different interfaces
-if (Version::series() < 10) {
+if (PHPUnit9::isCurrentVersion()) {
     require_once __DIR__ . '/TestWrapperPHPUnit9.php';
 } else {
     require_once __DIR__ . '/TestWrapperPHPUnit10.php';

--- a/src/PHPUnit/Compatibility/PHPUnit10.php
+++ b/src/PHPUnit/Compatibility/PHPUnit10.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Codeception\PHPUnit\Compatibility;
+
+use PHPUnit\Runner\CodeCoverage;
+use function method_exists;
+
+class PHPUnit10
+{
+    public static function codeCoverageRunnerClassExists(): bool
+    {
+        return class_exists(CodeCoverage::class);
+    }
+
+    public static function numberOfAssertionsPerformedMethodExists(object $test): bool
+    {
+        return method_exists($test, 'numberOfAssertionsPerformed');
+    }
+}

--- a/src/PHPUnit/Compatibility/PHPUnit9.php
+++ b/src/PHPUnit/Compatibility/PHPUnit9.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Codeception\PHPUnit\Compatibility;
 
 use PHPUnit\Runner\BaseTestRunner;
+use PHPUnit\Runner\Version;
 use function method_exists;
 
 class PHPUnit9
@@ -32,5 +33,10 @@ class PHPUnit9
     public static function setCodeCoverageMethodExists(object $testResult): bool
     {
         return method_exists($testResult, 'setCodeCoverage');
+    }
+
+    public static function isCurrentVersion(): bool
+    {
+        return Version::series() < 10;
     }
 }

--- a/src/PHPUnit/Compatibility/PHPUnit9.php
+++ b/src/PHPUnit/Compatibility/PHPUnit9.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Codeception\PHPUnit\Compatibility;
+
+use PHPUnit\Runner\BaseTestRunner;
+use function method_exists;
+
+class PHPUnit9
+{
+    public static function baseTestRunnerClassExists(): bool
+    {
+        return class_exists(BaseTestRunner::class);
+    }
+
+    public static function getCodeCoverageMethodExists(object $testResult): bool
+    {
+        return method_exists($testResult, 'getCodeCoverage');
+    }
+
+    public static function getTestResultObjectMethodExists(object $test): bool
+    {
+        return method_exists($test, 'getTestResultObject');
+    }
+
+    public static function removeListenerMethodExists(object $result): bool
+    {
+        return method_exists($result, 'removeListener');
+    }
+
+    public static function setCodeCoverageMethodExists(object $testResult): bool
+    {
+        return method_exists($testResult, 'setCodeCoverage');
+    }
+}

--- a/src/PHPUnit/NonFinal/JUnit.php
+++ b/src/PHPUnit/NonFinal/JUnit.php
@@ -9,6 +9,7 @@
  */
 namespace Codeception\PHPUnit\NonFinal;
 
+use Codeception\PHPUnit\Compatibility\PHPUnit10;
 use DOMDocument;
 use DOMElement;
 use PHPUnit\Framework\AssertionFailedError;
@@ -324,11 +325,9 @@ class JUnit extends Printer implements TestListener
     {
         $numAssertions = 0;
 
-        if (\method_exists($test, 'numberOfAssertionsPerformed')) {
-            // PHPUnit 10
+        if (PHPUnit10::numberOfAssertionsPerformedMethodExists($test)) {
             $numAssertions = $test->numberOfAssertionsPerformed();
         } else {
-            // PHPUnit 9
             $numAssertions = $test->getNumAssertions();
         }
 

--- a/src/PHPUnit/NonFinal/JUnit.php
+++ b/src/PHPUnit/NonFinal/JUnit.php
@@ -328,6 +328,7 @@ class JUnit extends Printer implements TestListener
         if (PHPUnit10::numberOfAssertionsPerformedMethodExists($test)) {
             $numAssertions = $test->numberOfAssertionsPerformed();
         } else {
+            // PHPUnit 9 or Cest or Cept or Gherkin
             $numAssertions = $test->getNumAssertions();
         }
 

--- a/src/PHPUnit/ResultPrinter.php
+++ b/src/PHPUnit/ResultPrinter.php
@@ -1,11 +1,10 @@
 <?php
 namespace Codeception\PHPUnit;
 
-use \PHPUnit\Framework\AssertionFailedError;
-use \PHPUnit\Framework\Test;
+use Codeception\PHPUnit\Compatibility\PHPUnit9;
 use PHPUnit\Framework\TestResult;
 use PHPUnit\Framework\TestStatus\TestStatus;
-use \PHPUnit\Runner\BaseTestRunner;
+use PHPUnit\Runner\BaseTestRunner;
 
 class ResultPrinter extends \PHPUnit\Util\TestDox\ResultPrinter
 {
@@ -18,11 +17,9 @@ class ResultPrinter extends \PHPUnit\Util\TestDox\ResultPrinter
      */
     public function addError(\PHPUnit\Framework\Test $test, \Throwable $e, float $time) : void
     {
-        if (class_exists(BaseTestRunner::class)) {
-            // PHPUnit 9
+        if (PHPUnit9::baseTestRunnerClassExists()) {
             $this->testStatus = BaseTestRunner::STATUS_ERROR;
         } else {
-            // PHPUnit 10
             $this->testStatus = TestStatus::error($e->getMessage());
         }
         $this->failed++;
@@ -37,11 +34,9 @@ class ResultPrinter extends \PHPUnit\Util\TestDox\ResultPrinter
      */
     public function addFailure(\PHPUnit\Framework\Test $test, \PHPUnit\Framework\AssertionFailedError $e, float $time) : void
     {
-        if (class_exists(BaseTestRunner::class)) {
-            // PHPUnit 9
+        if (PHPUnit9::baseTestRunnerClassExists()) {
             $this->testStatus = BaseTestRunner::STATUS_FAILURE;
         } else {
-            // PHPUnit 10
             $this->testStatus = TestStatus::failure($e->getMessage());
         }
         $this->failed++;
@@ -56,11 +51,9 @@ class ResultPrinter extends \PHPUnit\Util\TestDox\ResultPrinter
      */
     public function addWarning(\PHPUnit\Framework\Test $test, \PHPUnit\Framework\Warning $e, float $time): void
     {
-        if (class_exists(BaseTestRunner::class)) {
-            // PHPUnit 9
+        if (PHPUnit9::baseTestRunnerClassExists()) {
             $this->testStatus = BaseTestRunner::STATUS_WARNING;
         } else {
-            // PHPUnit 10
             $this->testStatus = TestStatus::warning($e->getMessage());
         }
         $this->warned++;
@@ -75,11 +68,9 @@ class ResultPrinter extends \PHPUnit\Util\TestDox\ResultPrinter
      */
     public function addIncompleteTest(\PHPUnit\Framework\Test $test, \Throwable $e, float $time) : void
     {
-        if (class_exists(BaseTestRunner::class)) {
-            // PHPUnit 9
+        if (PHPUnit9::baseTestRunnerClassExists()) {
             $this->testStatus = BaseTestRunner::STATUS_INCOMPLETE;
         } else {
-            // PHPUnit 10
             $this->testStatus = TestStatus::incomplete($e->getMessage());
         }
         $this->incomplete++;
@@ -96,11 +87,9 @@ class ResultPrinter extends \PHPUnit\Util\TestDox\ResultPrinter
      */
     public function addRiskyTest(\PHPUnit\Framework\Test $test, \Throwable $e, float $time) : void
     {
-        if (class_exists(BaseTestRunner::class)) {
-            // PHPUnit 9
+        if (PHPUnit9::baseTestRunnerClassExists()) {
             $this->testStatus = BaseTestRunner::STATUS_RISKY;
         } else {
-            // PHPUnit 10
             $this->testStatus = TestStatus::risky($e->getMessage());
         }
         $this->risky++;
@@ -115,11 +104,9 @@ class ResultPrinter extends \PHPUnit\Util\TestDox\ResultPrinter
      */
     public function addSkippedTest(\PHPUnit\Framework\Test $test, \Throwable $e, float $time) : void
     {
-        if (class_exists(BaseTestRunner::class)) {
-            // PHPUnit 9
+        if (PHPUnit9::baseTestRunnerClassExists()) {
             $this->testStatus = BaseTestRunner::STATUS_SKIPPED;
         } else {
-            // PHPUnit 10
             $this->testStatus = TestStatus::skipped($e->getMessage());
         }
         $this->skipped++;
@@ -127,11 +114,9 @@ class ResultPrinter extends \PHPUnit\Util\TestDox\ResultPrinter
 
     public function startTest(\PHPUnit\Framework\Test $test) : void
     {
-        if (class_exists(BaseTestRunner::class)) {
-            // PHPUnit 9
+        if (PHPUnit9::baseTestRunnerClassExists()) {
             $this->testStatus = BaseTestRunner::STATUS_PASSED;
         } else {
-            // PHPUnit 10
             $this->testStatus = TestStatus::success();
         }
     }

--- a/src/PHPUnit/ResultPrinter/HTML.php
+++ b/src/PHPUnit/ResultPrinter/HTML.php
@@ -1,6 +1,7 @@
 <?php
 namespace Codeception\PHPUnit\ResultPrinter;
 
+use Codeception\PHPUnit\Compatibility\PHPUnit9;
 use Codeception\PHPUnit\ResultPrinter as CodeceptionResultPrinter;
 use Codeception\Step;
 use Codeception\Step\Meta;
@@ -72,11 +73,9 @@ class HTML extends CodeceptionResultPrinter
     public function endTest(\PHPUnit\Framework\Test $test, float $time) : void
     {
         $steps = [];
-        if (class_exists(BaseTestRunner::class)) {
-            // PHPUnit 9
+        if (PHPUnit9::baseTestRunnerClassExists()) {
             $success = $this->testStatus == BaseTestRunner::STATUS_PASSED;
         } else {
-            // PHPUnit 10
             $success = $this->testStatus->isSuccess();
         }
         if ($success) {
@@ -88,9 +87,9 @@ class HTML extends CodeceptionResultPrinter
         }
         $this->timeTaken += $time;
 
-        if (class_exists(BaseTestRunner::class)) {
-            // PHPUnit 10
+        if (PHPUnit9::baseTestRunnerClassExists()) {
             switch ($this->testStatus) {
+                case BaseTestRunner::STATUS_ERROR:
                 case BaseTestRunner::STATUS_FAILURE:
                     $scenarioStatus = 'scenarioFailed';
                     break;
@@ -100,14 +99,10 @@ class HTML extends CodeceptionResultPrinter
                 case BaseTestRunner::STATUS_INCOMPLETE:
                     $scenarioStatus = 'scenarioIncomplete';
                     break;
-                case BaseTestRunner::STATUS_ERROR:
-                    $scenarioStatus = 'scenarioFailed';
-                    break;
                 default:
                     $scenarioStatus = 'scenarioSuccess';
             }
         } else {
-            // PHPUnit 10
             if ($this->testStatus->isSuccess()) {
                 $scenarioStatus = 'scenarioSuccess';
             } else if ($this->testStatus->isFailure() || $this->testStatus->isError()) {

--- a/src/PHPUnit/ResultPrinter/Report.php
+++ b/src/PHPUnit/ResultPrinter/Report.php
@@ -1,6 +1,7 @@
 <?php
 namespace Codeception\PHPUnit\ResultPrinter;
 
+use Codeception\PHPUnit\Compatibility\PHPUnit9;
 use Codeception\PHPUnit\ConsolePrinter;
 use Codeception\PHPUnit\ResultPrinter;
 use Codeception\Test\Descriptor;
@@ -15,32 +16,33 @@ class Report extends ResultPrinter implements ConsolePrinter
     public function endTest(\PHPUnit\Framework\Test $test, float $time) : void
     {
         $name = Descriptor::getTestAsString($test);
-        if (class_exists(BaseTestRunner::class)) {
-            // PHPUnit 9
+        if (PHPUnit9::baseTestRunnerClassExists()) {
             $success = $this->testStatus == BaseTestRunner::STATUS_PASSED;
         } else {
-            // PHPUnit 10
             $success = $this->testStatus->isSuccess();
         }
         if ($success) {
             $this->successful++;
         }
 
-        if (class_exists(BaseTestRunner::class)) {
-            // PHPUnit 9
-            if ($this->testStatus == \PHPUnit\Runner\BaseTestRunner::STATUS_FAILURE) {
-                $status = "\033[41;37mFAIL\033[0m";
-            } elseif ($this->testStatus == \PHPUnit\Runner\BaseTestRunner::STATUS_SKIPPED) {
-                $status = 'Skipped';
-            } elseif ($this->testStatus == \PHPUnit\Runner\BaseTestRunner::STATUS_INCOMPLETE) {
-                $status = 'Incomplete';
-            } elseif ($this->testStatus == \PHPUnit\Runner\BaseTestRunner::STATUS_ERROR) {
-                $status = 'ERROR';
-            } else {
-                $status = 'Ok';
+        if (PHPUnit9::baseTestRunnerClassExists()) {
+            switch ($this->testStatus) {
+                case BaseTestRunner::STATUS_ERROR:
+                    $status = 'ERROR';
+                    break;
+                case BaseTestRunner::STATUS_FAILURE:
+                    $status = "\033[41;37mFAIL\033[0m";
+                    break;
+                case BaseTestRunner::STATUS_SKIPPED:
+                    $status = 'Skipped';
+                    break;
+                case BaseTestRunner::STATUS_INCOMPLETE:
+                    $status = 'Incomplete';
+                    break;
+                default:
+                    $status = 'Ok';
             }
         } else {
-            // PHPUnit 10
             if ($this->testStatus->isFailure()) {
                 $status = "\033[41;37mFAIL\033[0m";
             } elseif ($this->testStatus->isSkipped()) {

--- a/src/PHPUnit/ResultPrinter/UI.php
+++ b/src/PHPUnit/ResultPrinter/UI.php
@@ -3,6 +3,7 @@ namespace Codeception\PHPUnit\ResultPrinter;
 
 use Codeception\Event\FailEvent;
 use Codeception\Events;
+use Codeception\PHPUnit\Compatibility\PHPUnit10;
 use Codeception\Test\Unit;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\EventDispatcher\EventDispatcher;
@@ -64,11 +65,9 @@ class UI extends \PHPUnit\TextUI\DefaultResultPrinter
     public function endTest(\PHPUnit\Framework\Test $test, float $time) : void
     {
         if ($test instanceof \PHPUnit\Framework\TestCase or $test instanceof \Codeception\Test\Test) {
-            if (method_exists($test, 'numberOfAssertionsPerformed')) {
-                // PHPUnit 10
+            if (PHPUnit10::numberOfAssertionsPerformedMethodExists($test)) {
                 $this->numAssertions += $test->numberOfAssertionsPerformed();
             } else {
-                // PHPUnit 9
                 $this->numAssertions += $test->getNumAssertions();
             }
         }

--- a/src/PHPUnit/Runner.php
+++ b/src/PHPUnit/Runner.php
@@ -3,6 +3,7 @@ namespace Codeception\PHPUnit;
 
 use Codeception\Configuration;
 use Codeception\Exception\ConfigurationException;
+use Codeception\PHPUnit\Compatibility\PHPUnit9;
 use ReflectionProperty;
 
 class Runner extends NonFinal\TestRunner
@@ -123,13 +124,11 @@ class Runner extends NonFinal\TestRunner
         $suite->run($result);
         unset($suite);
 
-        if (method_exists($result, 'removeListener')) {
-            // PHPUnit 9
+        if (PHPUnit9::removeListenerMethodExists($result)) {
             foreach ($arguments['listeners'] as $listener) {
                 $result->removeListener($listener);
             }
         } else {
-            // PHPUnit 10+
             $property = new ReflectionProperty($result, 'listeners');
             $property->setAccessible(true);
             $resultListeners = $property->getValue($result);

--- a/tests/data/claypit/tests/_data/MyReportPrinter.php
+++ b/tests/data/claypit/tests/_data/MyReportPrinter.php
@@ -9,8 +9,7 @@ class MyReportPrinter extends ResultPrinter implements ConsolePrinter
     {
         $name = \Codeception\Test\Descriptor::getTestAsString($test);
 
-        if (class_exists(BaseTestRunner::class)) {
-            // PHPUnit 9
+        if (\Codeception\PHPUnit\Compatibility\PHPUnit9::baseTestRunnerClassExists()) {
             if ($this->testStatus == BaseTestRunner::STATUS_FAILURE) {
                 $this->write('×');
             } elseif ($this->testStatus == BaseTestRunner::STATUS_SKIPPED) {
@@ -23,7 +22,6 @@ class MyReportPrinter extends ResultPrinter implements ConsolePrinter
                 $this->write('✔');
             }
         } else {
-            // PHPUnit 10
             if ($this->testStatus->isFailure()) {
                 $this->write('×');
             } elseif ($this->testStatus->isSkipped()) {


### PR DESCRIPTION
Benefits of doing something like this:

- There is no need to comment the code.
- The compatibility logic is in one place, it is easy to know *where* it is used and *which* of them there are.
- With fewer literals out there and there, typos are less likely to occur.

I'm not sure if that namespace (`Codeception\PHPUnit\Compatibility`) was the best to place something like this, but that is subject to change.