### PR TITLE
Standardize "@example.com" as domain in documentation

### DIFF
--- a/src/Codeception/Lib/Interfaces/Web.php
+++ b/src/Codeception/Lib/Interfaces/Web.php
@@ -690,7 +690,7 @@ interface Web
      * ``` php
      * <?php
      * $I->fillField("//input[@type='text']", "Hello World!");
-     * $I->fillField(['name' => 'email'], 'jon@mail.com');
+     * $I->fillField(['name' => 'email'], 'jon@example.com');
      * ?>
      * ```
      *


### PR DESCRIPTION
See https://github.com/Codeception/module-symfony/pull/124#issuecomment-800233544