### PR TITLE
Deprecating `GenerateCept`

### DIFF
--- a/src/Codeception/Command/GenerateCept.php
+++ b/src/Codeception/Command/GenerateCept.php
@@ -8,12 +8,7 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
 /**
- * Generates Cept (scenario-driven test) file:
- *
- * * `codecept generate:cept suite Login`
- * * `codecept g:cept suite subdir/subdir/testnameCept.php`
- * * `codecept g:cept suite LoginCept -c path/to/project`
- *
+ * @deprecated
  */
 class GenerateCept extends Command
 {


### PR DESCRIPTION
The Cept format has been deprecated some 4 years ago https://github.com/Codeception/Codeception/issues/3976 - so I think it's about time to start thinking about ways to actually remove it from the codebase :-)
I deleted the explanation in order to remove the commands from https://codeception.com/docs/reference/Commands.html