### PR TITLE
Make dry-run command compatible with symfony/console 5.3

### DIFF
--- a/src/Codeception/Command/DryRun.php
+++ b/src/Codeception/Command/DryRun.php
@@ -68,7 +68,7 @@ class DryRun extends Command
 
         $dispatcher = new EventDispatcher();
         $dispatcher->addSubscriber(new ConsolePrinter([
-            'colors' => !$input->getOption('no-ansi'),
+            'colors'    => (!$input->hasParameterOption('--no-ansi') xor $input->hasParameterOption('ansi')),
             'steps'     => true,
             'verbosity' => OutputInterface::VERBOSITY_VERBOSE,
         ]));


### PR DESCRIPTION
Symfony/console 5.3 introduced negatable options, so `--no-ansi` option no longer exists.

It makes `dry-run` command fail with ` The "no-ansi" option does not exist.` error.

I fixed it by copying no-ansi logic from [run command](https://github.com/Codeception/Codeception/blob/4.1.20/src/Codeception/Command/Run.php#L303).