### PR TITLE
Explicitly require lib-innerbrowser as a dev dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,6 +33,7 @@
     "require-dev": {
         "vlucas/phpdotenv": "^4.0 | ^5.0",
         "symfony/process": ">=4.4 <6.0",
+        "codeception/lib-innerbrowser": "*@dev",
         "codeception/module-asserts": "*@dev",
         "codeception/module-cli": "*@dev",
         "codeception/module-db": "*@dev",


### PR DESCRIPTION
This is required so that the latest commit on the main branch is always downloaded instead of the latest stable version.