### PR TITLE
Fix W3C Warning for breadcrumbs: role="navigation" is unnecessary for…

### DIFF
--- a/ext/Recorder.php
+++ b/ext/Recorder.php
@@ -136,7 +136,7 @@ class Recorder extends \Codeception\Extension
 </head>
 <body>
     <!-- Navigation -->
-        <nav class="navbar navbar-expand-lg navbar-light bg-light" role="navigation">
+        <nav class="navbar navbar-expand-lg navbar-light bg-light">
         <div class="navbar-header">
             <a class="navbar-brand" href="../records.html"></span>Recorded Tests</a>
         </div>
@@ -216,7 +216,7 @@ EOF;
 </head>
 <body>
     <!-- Navigation -->
-    <nav class="navbar navbar-expand-lg navbar-light bg-light" role="navigation">
+    <nav class="navbar navbar-expand-lg navbar-light bg-light">
         <div class="navbar-header">
             <a class="navbar-brand" href="#">Recorded Tests
             </a>


### PR DESCRIPTION
… element nav

The nav tag has the ARIA  element role="navigation", but this is unnecessary for nav elements and will trigger an W3C Warning.