### PR TITLE
Fix ActiveRecord::haveRecord

### DIFF
--- a/src/Codeception/Lib/Interfaces/ActiveRecord.php
+++ b/src/Codeception/Lib/Interfaces/ActiveRecord.php
@@ -4,7 +4,7 @@ namespace Codeception\Lib\Interfaces;
 
 interface ActiveRecord extends ORM
 {
-    public function haveRecord(string $model, array $attributes = []): void;
+    public function haveRecord(string $model, array $attributes = []);
 
     public function seeRecord(string $model, array $attributes = []): void;
 


### PR DESCRIPTION
`haveRecord` [returns](https://github.com/Codeception/module-laravel/blob/f32a941a06e57bb06d2e485da11b191f38bec659/src/Codeception/Module/Laravel.php#L908) an `int` or an Eloquent model in Laravel module, so it shouldn't be typed to `: void`.