### PR TITLE
Reduce the memory consumption by forcing PHP to release the unused memory

### DIFF
--- a/src/Codeception/Lib/Parser.php
+++ b/src/Codeception/Lib/Parser.php
@@ -170,6 +170,9 @@ class Parser
             }
         }
 
+        $tokens = null;
+        gc_mem_caches();
+
         return $classes;
     }
 


### PR DESCRIPTION
At our company we run our codeception tests in parallel using multiple processes.
When 50 Codeception processes run in parallel the memory consumption of a single Codeception process starts to matter. We noticed that some of our Cests consume 40MB of RAM while others consume 80MB (run on Ubuntu 20.04, PHP 7.4.3 and Centos 7, PHP 7.4.14). 

I profiled our tests to find how can I reduce their memory footprint. I found that the source of the problem lies in a single call to token_get_all() in the \Codeception\Lib\Parser::getClassesFromFile() function.

It seems this is a well known issue:

https://bugs.php.net/bug.php?id=71375

On large files the result of token_get_all() can consume dozens of megabytes of RAM, but even after result got out of scope PHP doesn't return the consumed memory to the OS.

I added lines:
```
$tokens = null; 
gc_mem_caches();
``` 
to the end of the \Codeception\Lib\Parser::getClassesFromFile() function to force PHP to return the cached memory. It reduced the memory consumption of our parallel run by 1GB.

Though \Codeception\SuiteManager::loadTests() looks like a better place for the gc_mem_caches() call: 
```
public function loadTests($path = null)
{
    $testLoader = new Loader($this->settings);
    $testLoader->loadTests($path);
    gc_mem_caches();
```
for some unknown reason a call to gc_mem_caches() in \Codeception\SuiteManager::loadTests() releases less memory for some Cests than the same call at the end of \Codeception\Lib\Parser::getClassesFromFile() (700MB vs 1GB in the case of our parallel run).