### PR TITLE
Adding clickable `editorUrl` from `codeception.yml`

### DIFF
--- a/src/Codeception/Step.php
+++ b/src/Codeception/Step.php
@@ -79,10 +79,17 @@ abstract class Step
         return $this->action;
     }
 
-    public function getLine()
+    public function getFilePath()
     {
-        if ($this->line && $this->file) {
-            return codecept_relative_path($this->file) . ':' . $this->line;
+        if ($this->file) {
+            return codecept_relative_path($this->file);
+        }
+    }
+
+    public function getLineNumber()
+    {
+        if ($this->line) {
+            return $this->line;
         }
     }
 

--- a/src/Codeception/Step.php
+++ b/src/Codeception/Step.php
@@ -79,6 +79,16 @@ abstract class Step
         return $this->action;
     }
 
+    /**
+     * @deprecated To be removed in Codeception 5.0
+     */
+    public function getLine()
+    {
+        if ($this->line && $this->file) {
+            return codecept_relative_path($this->file) . ':' . $this->line;
+        }
+    }
+
     public function getFilePath()
     {
         if ($this->file) {

--- a/src/Codeception/Subscriber/Console.php
+++ b/src/Codeception/Subscriber/Console.php
@@ -367,7 +367,9 @@ class Console implements EventSubscriberInterface
                     $line = $trace['line'];
                 }
             }
-            $message = str_replace(['%%file%%', '%%line%%'], [$filePath, $line], $this->options['editorUrl']);
+            if ($line > 1) {
+                $message = str_replace(['%%file%%', '%%line%%'], [$filePath, $line], $this->options['editorUrl']);
+            }
         } else {
             $message = codecept_relative_path(Descriptor::getTestFullName($failedTest));
         }

--- a/src/Codeception/Subscriber/Console.php
+++ b/src/Codeception/Subscriber/Console.php
@@ -358,18 +358,15 @@ class Console implements EventSubscriberInterface
         $this->output->writeln('');
 
         // Clickable `editorUrl`:
-        if (isset($this->options['editorUrl']) && is_string($this->options['editorUrl'])) {
+        if (isset($this->options['editorUrl']) and is_string($this->options['editorUrl'])) {
             $filePath = codecept_absolute_path(Descriptor::getTestFileName($failedTest));
-            $message = str_replace('%%file%%', $filePath, $this->options['editorUrl']);
             $line = 1;
             foreach ($fail->getTrace() as $trace) {
                 if (isset($trace['file']) and $filePath === $trace['file'] and isset($trace['line'])) {
                     $line = $trace['line'];
                 }
             }
-            if ($line > 1) {
-                $message = str_replace(['%%file%%', '%%line%%'], [$filePath, $line], $this->options['editorUrl']);
-            }
+            $message = str_replace(['%%file%%', '%%line%%'], [$filePath, $line], $this->options['editorUrl']);
         } else {
             $message = codecept_relative_path(Descriptor::getTestFullName($failedTest));
         }
@@ -509,7 +506,14 @@ class Console implements EventSubscriberInterface
                 $message->writeln();
                 continue;
             }
-            $message->append($step['file'] . ':' . $step['line']);
+
+            // Clickable `editorUrl`:
+            if (isset($this->options['editorUrl']) and is_string($this->options['editorUrl'])) {
+                $lineString = str_replace(['%%file%%', '%%line%%'], [$step['file'], $step['line']], $this->options['editorUrl']);
+            } else {
+                $lineString = $step['file'] . ':' . $step['line'];
+            }
+            $message->append($lineString);
             $message->writeln();
         }
 
@@ -553,9 +557,17 @@ class Console implements EventSubscriberInterface
                 $message->style('bold');
             }
 
-            $line = $step->getLine();
-            if ($line and (!$step instanceof Comment)) {
-                $message->append(" at <info>$line</info>");
+            if (!$step instanceof Comment) {
+                $filePath = $step->getFilePath();
+                if ($filePath) {
+                    // Clickable `editorUrl`:
+                    if (isset($this->options['editorUrl']) and is_string($this->options['editorUrl'])) {
+                        $lineString = str_replace(['%%file%%', '%%line%%'], [codecept_absolute_path($step->getFilePath()), $step->getLineNumber()], $this->options['editorUrl']);
+                    } else {
+                        $lineString = $step->getFilePath() . ':' . $step->getLineNumber();
+                    }
+                }
+                $message->append(" at <info>$lineString</info>");
             }
 
             $stepNumber--;

--- a/src/Codeception/Subscriber/Console.php
+++ b/src/Codeception/Subscriber/Console.php
@@ -358,7 +358,7 @@ class Console implements EventSubscriberInterface
         $this->output->writeln('');
 
         // Clickable `editorUrl`:
-        if (isset($this->options['editorUrl']) and is_string($this->options['editorUrl'])) {
+        if (isset($this->options['editorUrl']) && is_string($this->options['editorUrl'])) {
             $filePath = codecept_absolute_path(Descriptor::getTestFileName($failedTest));
             $line = 1;
             foreach ($fail->getTrace() as $trace) {

--- a/src/Codeception/Subscriber/Console.php
+++ b/src/Codeception/Subscriber/Console.php
@@ -561,7 +561,7 @@ class Console implements EventSubscriberInterface
                 $filePath = $step->getFilePath();
                 if ($filePath) {
                     // Clickable `editorUrl`:
-                    if (isset($this->options['editorUrl']) and is_string($this->options['editorUrl'])) {
+                    if (isset($this->options['editorUrl']) && is_string($this->options['editorUrl'])) {
                         $lineString = str_replace(['%%file%%', '%%line%%'], [codecept_absolute_path($step->getFilePath()), $step->getLineNumber()], $this->options['editorUrl']);
                     } else {
                         $lineString = $step->getFilePath() . ':' . $step->getLineNumber();

--- a/src/Codeception/Subscriber/Console.php
+++ b/src/Codeception/Subscriber/Console.php
@@ -566,8 +566,8 @@ class Console implements EventSubscriberInterface
                     } else {
                         $lineString = $step->getFilePath() . ':' . $step->getLineNumber();
                     }
+                    $message->append(" at <info>$lineString</info>");
                 }
-                $message->append(" at <info>$lineString</info>");
             }
 
             $stepNumber--;

--- a/src/Codeception/Subscriber/Console.php
+++ b/src/Codeception/Subscriber/Console.php
@@ -358,7 +358,7 @@ class Console implements EventSubscriberInterface
         $this->output->writeln('');
 
         // Clickable `editorUrl`:
-        if (isset($this->options['editorUrl']) and is_string($this->options['editorUrl'])) {
+        if (isset($this->options['editorUrl']) && is_string($this->options['editorUrl'])) {
             $filePath = codecept_absolute_path(Descriptor::getTestFileName($failedTest));
             $message = str_replace('%%file%%', $filePath, $this->options['editorUrl']);
             $line = 1;

--- a/src/Codeception/Subscriber/Console.php
+++ b/src/Codeception/Subscriber/Console.php
@@ -356,8 +356,23 @@ class Console implements EventSubscriberInterface
         $this->output->write($e->getCount() . ") ");
         $this->writeCurrentTest($failedTest, false);
         $this->output->writeln('');
+
+        // Clickable `editorUrl`:
+        if (isset($this->options['editorUrl']) and is_string($this->options['editorUrl'])) {
+            $filePath = codecept_absolute_path(Descriptor::getTestFileName($failedTest));
+            $message = str_replace('%%file%%', $filePath, $this->options['editorUrl']);
+            $line = 0;
+            foreach ($fail->getTrace() as $trace) {
+                if (isset($trace['file']) and $filePath === $trace['file'] and isset($trace['line'])) {
+                    $line = $trace['line'];
+                }
+            }
+            $message = str_replace(['%%file%%', '%%line%%'], [$filePath, $line], $this->options['editorUrl']);
+        } else {
+            $message = codecept_relative_path(Descriptor::getTestFullName($failedTest));
+        }
         $this->message("<error> Test </error> ")
-            ->append(codecept_relative_path(Descriptor::getTestFullName($failedTest)))
+            ->append($message)
             ->write();
 
         if ($failedTest instanceof ScenarioDriven) {

--- a/src/Codeception/Subscriber/Console.php
+++ b/src/Codeception/Subscriber/Console.php
@@ -362,7 +362,7 @@ class Console implements EventSubscriberInterface
             $filePath = codecept_absolute_path(Descriptor::getTestFileName($failedTest));
             $line = 1;
             foreach ($fail->getTrace() as $trace) {
-                if (isset($trace['file']) and $filePath === $trace['file'] and isset($trace['line'])) {
+                if (isset($trace['file']) && $filePath === $trace['file'] && isset($trace['line'])) {
                     $line = $trace['line'];
                 }
             }

--- a/src/Codeception/Subscriber/Console.php
+++ b/src/Codeception/Subscriber/Console.php
@@ -508,7 +508,7 @@ class Console implements EventSubscriberInterface
             }
 
             // Clickable `editorUrl`:
-            if (isset($this->options['editorUrl']) and is_string($this->options['editorUrl'])) {
+            if (isset($this->options['editorUrl']) && is_string($this->options['editorUrl'])) {
                 $lineString = str_replace(['%%file%%', '%%line%%'], [$step['file'], $step['line']], $this->options['editorUrl']);
             } else {
                 $lineString = $step['file'] . ':' . $step['line'];

--- a/src/Codeception/Subscriber/Console.php
+++ b/src/Codeception/Subscriber/Console.php
@@ -361,7 +361,7 @@ class Console implements EventSubscriberInterface
         if (isset($this->options['editorUrl']) and is_string($this->options['editorUrl'])) {
             $filePath = codecept_absolute_path(Descriptor::getTestFileName($failedTest));
             $message = str_replace('%%file%%', $filePath, $this->options['editorUrl']);
-            $line = 0;
+            $line = 1;
             foreach ($fail->getTrace() as $trace) {
                 if (isset($trace['file']) and $filePath === $trace['file'] and isset($trace['line'])) {
                     $line = $trace['line'];

--- a/src/Codeception/Subscriber/Console.php
+++ b/src/Codeception/Subscriber/Console.php
@@ -165,7 +165,7 @@ class Console implements EventSubscriberInterface
         $this->printedTest = $test;
         $this->message = null;
 
-        if (!$this->output->isInteractive() and !$this->isDetailed($test)) {
+        if (!$this->output->isInteractive() && !$this->isDetailed($test)) {
             return;
         }
         $this->writeCurrentTest($test);
@@ -207,7 +207,7 @@ class Console implements EventSubscriberInterface
     public function afterResult(PrintResultEvent $event)
     {
         $result = $event->getResult();
-        if ($result->skippedCount() + $result->notImplementedCount() > 0 and $this->options['verbosity'] < OutputInterface::VERBOSITY_VERBOSE) {
+        if ($result->skippedCount() + $result->notImplementedCount() > 0 && $this->options['verbosity'] < OutputInterface::VERBOSITY_VERBOSE) {
             $this->output->writeln("run with `-v` to get more info about skipped or incomplete tests");
         }
         foreach ($this->reports as $message) {
@@ -303,7 +303,7 @@ class Console implements EventSubscriberInterface
             return;
         }
         $metaStep = $e->getStep()->getMetaStep();
-        if ($metaStep and $this->metaStep != $metaStep) {
+        if ($metaStep && $this->metaStep != $metaStep) {
             $this->message(' ' . $metaStep->getPrefix())
                 ->style('bold')
                 ->append($metaStep->__toString())
@@ -316,7 +316,7 @@ class Console implements EventSubscriberInterface
 
     private function printStep(Step $step)
     {
-        if ($step instanceof Comment and $step->__toString() == '') {
+        if ($step instanceof Comment && $step->__toString() == '') {
             return; // don't print empty comments
         }
         $msg = $this->message(' ');
@@ -616,7 +616,7 @@ class Console implements EventSubscriberInterface
      */
     protected function writeCurrentTest(\PHPUnit\Framework\SelfDescribing $test, $inProgress = true)
     {
-        $prefix = ($this->output->isInteractive() and !$this->isDetailed($test) and $inProgress) ? '- ' : '';
+        $prefix = ($this->output->isInteractive() && !$this->isDetailed($test) && $inProgress) ? '- ' : '';
 
         $testString = Descriptor::getTestAsString($test);
         $testString = preg_replace('~^([^:]+):\s~', "<focus>$1{$this->chars['of']}</focus> ", $testString);


### PR DESCRIPTION
Closes https://github.com/Codeception/Codeception/issues/6259

* I followed the syntax of https://phpstan.org/user-guide/output-format#opening-file-in-an-editor even though we wouldn't need the second `%` here. (This is due to some phpstan internals, the code ultimately reads `\str_replace(['%file%', '%line%'], ...`).
But I'd say having an *identical* `editorUrl` syntax between Codeception and phpstan by far outweighs the "cost" of some unneeded `%` characters... ;-)

* `$line = 0;` is a fallback in case the trace iteration doesn't work out. I'm guessing that putting 1 for the line is better than leaving it empty.