### PR TITLE
Code Coverage of PHP files only

### DIFF
--- a/src/Codeception/Coverage/Filter.php
+++ b/src/Codeception/Coverage/Filter.php
@@ -167,6 +167,9 @@ class Filter
         $fileOrDir = str_replace('\\', '/', $pattern);
         $parts = explode('/', $fileOrDir);
         $file = array_pop($parts);
+        if ($file === '*') {
+            $file = '*.php';
+        }
         $finder->name($file);
         if (count($parts)) {
             $last_path = array_pop($parts);

--- a/tests/unit/Codeception/Coverage/FilterTest.php
+++ b/tests/unit/Codeception/Coverage/FilterTest.php
@@ -31,7 +31,7 @@ class FilterTest extends \Codeception\Test\Unit
                         'src/Codeception/Codecept.php'
                     ],
                     'exclude' => [
-                        'tests/unit/CodeGuy.php'
+                        'tests/support/CodeGuy.php'
                     ]
                 ]
             ]
@@ -42,20 +42,26 @@ class FilterTest extends \Codeception\Test\Unit
         $this->assertFalse($fileFilter->$filterMethod(codecept_root_dir('tests/unit/C3Test.php')));
         $this->assertFalse($fileFilter->$filterMethod(codecept_root_dir('src/Codeception/Codecept.php')));
         $this->assertTrue($fileFilter->$filterMethod(codecept_root_dir('vendor/guzzlehttp/guzzle/src/Client.php')));
-        $this->assertTrue($fileFilter->$filterMethod(codecept_root_dir('tests/unit/CodeGuy.php')));
+        $this->assertTrue($fileFilter->$filterMethod(codecept_root_dir('tests/support/CodeGuy.php')));
+        $this->assertTrue(
+            $fileFilter->$filterMethod(
+                codecept_root_dir('tests/unit.suite.yml','tests/unit.suite.yml appears in whitelist')
+            ),
+            'tests/unit.suite.yml appears in file list'
+        );
     }
 
     public function testShortcutFilter()
     {
         $config = ['coverage' => [
             'include' => ['tests/*'],
-            'exclude' => ['tests/unit/CodeGuy.php']
+            'exclude' => ['tests/support/CodeGuy.php']
         ]];
         $this->filter->whiteList($config);
         $fileFilter = $this->filter->getFilter();
         $filterMethod = $this->getFilterMethod();
         $this->assertFalse($fileFilter->$filterMethod(codecept_root_dir('tests/unit/C3Test.php')));
-        $this->assertTrue($fileFilter->$filterMethod(codecept_root_dir('tests/unit/CodeGuy.php')));
+        $this->assertTrue($fileFilter->$filterMethod(codecept_root_dir('tests/support/CodeGuy.php')));
     }
 
     /**


### PR DESCRIPTION
[Code Coverage documentation](https://codeception.com/docs/11-Codecoverage#Configuration) gives examples for file patters ending with `*`.

```yml
coverage:
    enabled: true
    include:
        - app/*
    exclude:
        - app/cache/*
```

Recently [it was brought to my attention](https://stackoverflow.com/questions/69443881/include-exclude-files-for-remote-coverage-in-codeception) that such rule adds non-PHP files to code coverage report too.
I tested it myself and got feature files, yaml files and everything in tests/_output directory added to code coverage report.

![image](https://user-images.githubusercontent.com/395992/137674966-01018bf8-1222-4582-9ed9-7c6d39b6e5f0.png)


So I made this simple patch to change `/*` to `/*.php`.
Alternatively users could use `- app/*.php` in their include list, but it is better to have sane defaults.

If someone thinks that this is a breaking change, it could be merged to 5.0 branch instead.

