### PR TITLE
Added the ability to configure additional paths for suite

### DIFF
--- a/src/Codeception/Configuration.php
+++ b/src/Codeception/Configuration.php
@@ -359,7 +359,21 @@ class Configuration
         $settings['path'] = self::$dir . DIRECTORY_SEPARATOR . $config['paths']['tests']
             . DIRECTORY_SEPARATOR . $settings['path'] . DIRECTORY_SEPARATOR;
 
+        if (!isset($settings['additional_paths']) || !is_array($settings['additional_paths'])) {
+            $settings['additional_paths'] = [];
+        }
 
+        foreach ($settings['additional_paths'] as $key => $path) {
+            if (!is_string($path)) {
+                unset($settings['additional_paths'][$key]);
+            }
+
+            $preparePath = str_replace('/', DIRECTORY_SEPARATOR, $path);
+
+            $settings['additional_paths'][$key] = self::$dir . DIRECTORY_SEPARATOR . $preparePath;
+        }
+
+        $settings['additional_paths'] = array_values($settings['additional_paths']);
 
         return $settings;
     }

--- a/src/Codeception/SuiteManager.php
+++ b/src/Codeception/SuiteManager.php
@@ -51,6 +51,7 @@ class SuiteManager
     protected $tests = [];
     protected $debug = false;
     protected $path = '';
+    protected $additionalPaths = [];
     protected $printer = null;
 
     protected $env = null;
@@ -62,6 +63,7 @@ class SuiteManager
         $this->dispatcher = $dispatcher;
         $this->di = new Di();
         $this->path = $settings['path'];
+        $this->additionalPaths = isset($settings['additional_paths']) ? $settings['additional_paths'] : [];
         $this->groupManager = new GroupManager($settings['groups']);
         $this->moduleContainer = new ModuleContainer($this->di, $settings);
 

--- a/src/Codeception/Test/Loader.php
+++ b/src/Codeception/Test/Loader.php
@@ -43,10 +43,12 @@ class Loader
     protected $formats = [];
     protected $tests = [];
     protected $path;
+    protected $additionalPaths;
 
     public function __construct(array $suiteSettings)
     {
         $this->path = $suiteSettings['path'];
+        $this->additionalPaths = isset($suiteSettings['additional_paths']) ? $suiteSettings['additional_paths'] : [];
         $this->formats = [
             new CeptLoader(),
             new CestLoader(),
@@ -128,7 +130,12 @@ class Loader
             return $this->loadTest($fileName);
         }
 
-        $finder = Finder::create()->files()->sortByName()->in($this->path)->followLinks();
+        $paths = array_merge(
+            [$this->path],
+            $this->additionalPaths
+        );
+
+        $finder = Finder::create()->files()->sortByName()->in($paths)->followLinks();
 
         foreach ($this->formats as $format) {
             /** @var $format Loader  **/


### PR DESCRIPTION
Added the ability to configure additional paths for suite.

This allows you to focus tests closer to your code.

Example tests/codeception/unit.suite.dist.yml:

```
actor: UnitTester
bootstrap: _bootstrap.php
modules:
    enabled:
        - Asserts
        - \tests\codeception\Helper\Unit
        - Mockery
additional_paths:
    - src/backend/Model/*/*/Tests/

```

Example test file \App\Model\DeliveryDate\Calculator\Tests\MyTest:

```
<?php

declare(strict_types=1);

namespace App\Model\DeliveryDate\Calculator\Tests;

class MyTest extends \Codeception\Test\Unit
{
    public function testWithoutOrderCertificate(): void
    {
        $this->assertFalse(false);
    }
}

```

Example running test:

```
$ docker-compose run --rm php-cli vendor/bin/codecept run unit src/backend/Model/DeliveryDate/Calculator/Tests/MyTest.php

Codeception PHP Testing Framework v4.1.22
Powered by PHPUnit 9.5.10 by Sebastian Bergmann and contributors.

Tests\codeception.unit Tests (1) --------------------------------------------------------------------------------------------------------------------------------------------------
✔ MyTest: Without order certificate (0.00s)
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------


Time: 00:00.026, Memory: 27.76 MB

OK (1 test, 1 assertion)
```

----

Tried adding tests but the current ones are broken. I would be glad to get help writing them.