### PR TITLE
Replaces outdated short URL for the bootstrap config option

### DIFF
--- a/src/Codeception/Configuration.php
+++ b/src/Codeception/Configuration.php
@@ -256,7 +256,7 @@ class Configuration
 
         if ($config['settings']['bootstrap']) {
             $bootstrap = self::$config['settings']['bootstrap'];
-            Notification::deprecate("'settings: bootstrap: $bootstrap' option is deprecated! Replace it with: 'bootstrap: $bootstrap' (not under settings section).\nSee: https://codeception.com/docs/reference/Configuration");
+            Notification::deprecate("'settings: bootstrap: $bootstrap' option is deprecated! Replace it with: 'bootstrap: $bootstrap' (not under settings section). See: https://codeception.com/docs/reference/Configuration");
             try {
                 self::loadBootstrap($bootstrap, self::testsDir());
             } catch (ConfigurationException $exception) {

--- a/src/Codeception/Configuration.php
+++ b/src/Codeception/Configuration.php
@@ -256,7 +256,7 @@ class Configuration
 
         if ($config['settings']['bootstrap']) {
             $bootstrap = self::$config['settings']['bootstrap'];
-            Notification::deprecate("'settings: bootstrap: $bootstrap' option is deprecated! Replace it with: 'bootstrap: $bootstrap' (not under settings section). See https://bit.ly/2YrRzVc ");
+            Notification::deprecate("'settings: bootstrap: $bootstrap' option is deprecated! Replace it with: 'bootstrap: $bootstrap' (not under settings section).\nSee: https://codeception.com/docs/reference/Configuration");
             try {
                 self::loadBootstrap($bootstrap, self::testsDir());
             } catch (ConfigurationException $exception) {


### PR DESCRIPTION
Addresses #6270.

I was looking for a URL shortener that I could use, but apparently all of the big ones require you to sign up for an account nowadays. I also wasn't sure if it would be accepted since I don't know if any of these services let you change the target URL after a short URL's created, so I figured I'd just put the full link in there.

At first I was going to compensate for the length by breaking it out onto a new line, but from what I can tell the package Codeception uses for CLI output already handles this if I'm not mistaken.

If that's not the case and/or a short URL would be better, let me know and I'll update it.