### PR TITLE
Added optional value to fail-fast option

### DIFF
--- a/src/Codeception/Codecept.php
+++ b/src/Codeception/Codecept.php
@@ -133,7 +133,7 @@ class Codecept
             $this->dispatcher->addSubscriber(new Subscriber\Console($this->options));
         }
         if ($this->options['fail-fast']) {
-            $this->dispatcher->addSubscriber(new Subscriber\FailFast());
+            $this->dispatcher->addSubscriber(new Subscriber\FailFast($this->options['fail-fast']));
         }
 
         if ($this->options['coverage']) {

--- a/src/Codeception/Command/Run.php
+++ b/src/Codeception/Command/Run.php
@@ -81,7 +81,7 @@ use Symfony\Component\Console\Output\OutputInterface;
  *  --skip (-s)           Skip selected suites (multiple values allowed)
  *  --skip-group (-x)     Skip selected groups (multiple values allowed)
  *  --env                 Run tests in selected environments. (multiple values allowed, environments can be merged with ',')
- *  --fail-fast (-f)      Stop after first failure
+ *  --fail-fast (-f)      Stop after nth failure (defaults to 1)
  *  --no-rebuild          Do not rebuild actor classes on start
  *  --help (-h)           Display this help message.
  *  --quiet (-q)          Do not output any message. Almost the same as `--silent`
@@ -213,7 +213,7 @@ class Run extends Command
                 InputOption::VALUE_IS_ARRAY | InputOption::VALUE_REQUIRED,
                 'Run tests in selected environments.'
             ),
-            new InputOption('fail-fast', 'f', InputOption::VALUE_NONE, 'Stop after first failure'),
+            new InputOption('fail-fast', 'f', InputOption::VALUE_OPTIONAL, 'Stop after nth failure'),
             new InputOption('no-rebuild', '', InputOption::VALUE_NONE, 'Do not rebuild actor classes on start'),
             new InputOption(
                 'seed',
@@ -324,6 +324,10 @@ class Run extends Command
         }
         if (!$userOptions['ansi'] && $input->getOption('colors')) {
             $userOptions['colors'] = true; // turn on colors even in non-ansi mode if strictly passed
+        }
+        // array key will exist if fail-fast option is used
+        if (array_key_exists('fail-fast', $userOptions)) {
+            $userOptions['fail-fast'] = (int) $this->options['fail-fast'] ?: 1;
         }
 
         $suite = $input->getArgument('suite');

--- a/src/Codeception/Subscriber/FailFast.php
+++ b/src/Codeception/Subscriber/FailFast.php
@@ -2,6 +2,7 @@
 namespace Codeception\Subscriber;
 
 use Codeception\Event\SuiteEvent;
+use Codeception\Event\TestEvent;
 use Codeception\Events;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
@@ -10,12 +11,33 @@ class FailFast implements EventSubscriberInterface
     use Shared\StaticEvents;
 
     public static $events = [
-        Events::SUITE_BEFORE => 'stopOnFail',
+        Events::TEST_FAIL => 'stopOnFail',
+        Events::TEST_ERROR => 'stopOnFail',
+        Events::SUITE_BEFORE => 'cacheSuite'
     ];
 
-    public function stopOnFail(SuiteEvent $e)
+    private $failureCount = 0;
+
+    private $stopFailureCount;
+
+    private $suiteCache;
+
+    public function __construct($stopFailureCount)
     {
-        $e->getResult()->stopOnError(true);
-        $e->getResult()->stopOnFailure(true);
+        $this->stopFailureCount = (int) $stopFailureCount;
+    }
+
+    public function cacheSuite(SuiteEvent $e)
+    {
+        $this->suiteCache = $e->getResult();
+    }
+
+    public function stopOnFail(TestEvent $e)
+    {
+        $this->failureCount++;
+
+        if ($this->failureCount >= $this->stopFailureCount) {
+            $this->suiteCache->stop();
+        }
     }
 }

--- a/tests/cli/RunCest.php
+++ b/tests/cli/RunCest.php
@@ -296,7 +296,7 @@ class RunCest
         $I->seeInShellOutput("OK");
     }
 
-    public function runTestWithFailFast(\CliGuy $I)
+    public function runTestWithFailFastDefault(\CliGuy $I)
     {
         $I->executeCommand('run unit --skip-group error --no-exit');
         $I->seeInShellOutput('FailingTest: Me');
@@ -304,6 +304,14 @@ class RunCest
         $I->executeCommand('run unit --fail-fast --skip-group error --no-exit');
         $I->seeInShellOutput('There was 1 failure');
         $I->dontSeeInShellOutput("PassingTest: Me");
+    }
+
+    public function runTestWithFailFastCustom(\CliGuy $I)
+    {
+        $I->executeCommand('run unit tests/unit/FailingTest.php --fail-fast=2 --no-exit');
+        $I->seeInShellOutput('There were 2 failures');
+        $I->executeCommand('run unit tests/unit/FailingTest.php --no-exit');
+        $I->seeInShellOutput('There were 3 failures');
     }
 
     public function runWithCustomOutputPath(\CliGuy $I)

--- a/tests/cli/RunCest.php
+++ b/tests/cli/RunCest.php
@@ -298,19 +298,19 @@ class RunCest
 
     public function runTestWithFailFastDefault(\CliGuy $I)
     {
-        $I->executeCommand('run unit --skip-group error --no-exit');
+        $I->executeCommand('run unit --skip-group error --skip-group multiple-fail --no-exit');
         $I->seeInShellOutput('FailingTest: Me');
         $I->seeInShellOutput("PassingTest: Me");
-        $I->executeCommand('run unit --fail-fast --skip-group error --no-exit');
+        $I->executeCommand('run unit --fail-fast --skip-group error --skip-group multiple-fail --no-exit');
         $I->seeInShellOutput('There was 1 failure');
         $I->dontSeeInShellOutput("PassingTest: Me");
     }
 
     public function runTestWithFailFastCustom(\CliGuy $I)
     {
-        $I->executeCommand('run unit tests/unit/FailingTest.php --fail-fast=2 --no-exit');
+        $I->executeCommand('run unit MultipleFailingTest.php --fail-fast=2 --no-exit');
         $I->seeInShellOutput('There were 2 failures');
-        $I->executeCommand('run unit tests/unit/FailingTest.php --no-exit');
+        $I->executeCommand('run unit MultipleFailingTest.php --no-exit');
         $I->seeInShellOutput('There were 3 failures');
     }
 

--- a/tests/data/claypit/tests/unit/FailingTest.php
+++ b/tests/data/claypit/tests/unit/FailingTest.php
@@ -7,4 +7,13 @@ class FailingTest extends \PHPUnit\Framework\TestCase
         $this->assertFalse(true);
     }
 
+    public function testMeTwo()
+    {
+        $this->assertFalse(true);
+    }
+
+    public function testMeThree()
+    {
+        $this->assertFalse(true);
+    }
 }

--- a/tests/data/claypit/tests/unit/FailingTest.php
+++ b/tests/data/claypit/tests/unit/FailingTest.php
@@ -6,14 +6,4 @@ class FailingTest extends \PHPUnit\Framework\TestCase
     {
         $this->assertFalse(true);
     }
-
-    public function testMeTwo()
-    {
-        $this->assertFalse(true);
-    }
-
-    public function testMeThree()
-    {
-        $this->assertFalse(true);
-    }
 }

--- a/tests/data/claypit/tests/unit/MultipleFailingTest.php
+++ b/tests/data/claypit/tests/unit/MultipleFailingTest.php
@@ -1,0 +1,22 @@
+<?php
+
+/**
+ * @group multiple-fail
+ */
+class MultipleFailingTest extends \PHPUnit\Framework\TestCase
+{
+    public function testMe()
+    {
+        $this->assertFalse(true);
+    }
+
+    public function testMeTwo()
+    {
+        $this->assertFalse(true);
+    }
+
+    public function testMeThree()
+    {
+        $this->assertFalse(true);
+    }
+}

--- a/tests/unit/Codeception/SuiteManagerTest.php
+++ b/tests/unit/Codeception/SuiteManagerTest.php
@@ -30,7 +30,7 @@ class SuiteManagerTest extends \Codeception\PHPUnit\TestCase
         $settings = \Codeception\Configuration::$defaultSuiteSettings;
         $settings['actor'] = 'CodeGuy';
         $this->suiteman = new \Codeception\SuiteManager($this->dispatcher, 'suite', $settings);
-        
+
         $printer = \Codeception\Util\Stub::makeEmpty('PHPUnit\TextUI\ResultPrinter');
         $this->runner = new \Codeception\PHPUnit\Runner;
         $this->runner->setPrinter($printer);
@@ -60,6 +60,10 @@ class SuiteManagerTest extends \Codeception\PHPUnit\TestCase
      */
     public function testFewTests()
     {
+        if (version_compare(phpversion(), '8.1', '>=') && PHP_OS_FAMILY === 'Windows') {
+            $this->markTestSkipped("Temporary disabled for windows php version 8.1 and greater.");
+        }
+
         $file = \Codeception\Configuration::dataDir().'SimpleCest.php';
 
         $this->suiteman->loadTests($file);


### PR DESCRIPTION
https://github.com/Codeception/Codeception/issues/6152

First time working with this code base. This appears to work, although ran into a few issues.
1. Not super happy about having to cache the suite object in order to potentially stop it later. Is there some form of a container present for a better way to access this?
2. Had to be a bit hacky around the failure tests. Ended out just making a separate test class/group for multiple failures.
3. I could not get 5 of the `RemoteWith...` tests to pass locally. However, I don't think this is related to my changes.
  
Aside that, let me know if any requested changes or bugs found. Intent was to keep this working with boolean values as well for `fail-fast`, in terms of the existing configuration files.


Not sure if this falls into the "merge into 4.1" or "merge into master" category, defaulting to 4.1 for the time being. Let me know if it should be changed to master.