### PR TITLE
Added api step decoration

### DIFF
--- a/src/Codeception/Template/Api.php
+++ b/src/Codeception/Template/Api.php
@@ -19,6 +19,8 @@ suites:
                 - REST:
                     url: {{url}}
                     depends: PhpBrowser
+        step_decorators:
+            - \Codeception\Step\AsJson
 
 paths:
     tests: {{baseDir}}


### PR DESCRIPTION
Since REST module 1.4.1 it is possible to use `AsJson` suffix to send JSON requests:

```php
$user = $I->sendPostAsJson('user', ['id' => 1]);
codecept_debug($user['id'])
$I->assertEquals(1, $user['id'])
```