### PR TITLE
Update codebase to PHP 7.4

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -79,6 +79,7 @@ jobs:
         run: php codecept run -c vendor/codeception/module-filesystem/
 
       - name: Run module-db sqlite tests
+        if: matrix.php != '8.1'
         run: php codecept run -c vendor/codeception/module-db/ unit :Sqlite
 
       - name: Run module-phpbrowser tests
@@ -136,6 +137,7 @@ jobs:
         run: composer install --prefer-dist --no-interaction --no-progress --optimize-autoloader --ansi
 
       - name: Run tests cli
+        if: matrix.php != '8.1'
         run: php codecept run cli --skip-group coverage
         
       - name: Run tests unit

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        php: ["7.3", "7.4", "8.0"]
+        php: ['7.4', '8.0', '8.1']
 
     steps:
       - name: Checkout
@@ -58,15 +58,15 @@ jobs:
       - name: Test that failing test really fails
         run: if php codecept run -c tests/data/claypit/ scenario FailedCept -vvv; then echo "Test hasn't failed"; false; fi;
 
-      - name: Run tests without code coverage on PHP 7.3, 7.4
-        if: matrix.php == '7.3' || matrix.php == '7.4'
+      - name: Run tests without code coverage on PHP 8.0
+        if: matrix.php == '8.0'
         run: |
           php -S 127.0.0.1:8008 -t tests/data/app >/dev/null 2>&1 &
           php codecept build
           php codecept run cli,unit
 
-      - name: Run tests with code coverage on PHP 7.2, 8.0
-        if: matrix.php == '7.2' || matrix.php == '8.0'
+      - name: Run tests with code coverage on PHP 7.4, 8.1
+        if: matrix.php == '7.4' || matrix.php == '8.1'
         run: |
           php -S 127.0.0.1:8008 -t tests/data/app -d pcov.directory=$(pwd)/tests/data/app >/dev/null 2>&1 &
           php codecept build
@@ -101,7 +101,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [windows-latest]
-        php: ["7.3", "7.4", "8.0"]
+        php: ['7.4', '8.0', '8.1']
 
     steps:
       - name: Checkout

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     "minimum-stability": "RC",
 
     "require": {
-        "php": ">=7.3.0 <9.0",
+        "php": "^7.4 | ^8.0",
         "ext-curl": "*",
         "ext-json": "*",
         "ext-mbstring": "*",

--- a/ext/DotReporter.php
+++ b/ext/DotReporter.php
@@ -7,7 +7,7 @@ namespace Codeception\Extension;
 use Codeception\Event\FailEvent;
 use Codeception\Events;
 use Codeception\Extension;
-use Codeception\Subscriber\Console;
+use Codeception\Subscriber\Console as CodeceptConsole;
 
 /**
  * DotReporter provides less verbose output for test execution.
@@ -42,32 +42,21 @@ use Codeception\Subscriber\Console;
  */
 class DotReporter extends Extension
 {
-    /**
-     * @var Console
-     */
-    protected $standardReporter;
-    /**
-     * @var array
-     */
-    protected $errors = [];
-    /**
-     * @var array
-     */
-    protected $failures = [];
-    /**
-     * @var int
-     */
-    protected $width = 10;
-    /**
-     * @var int
-     */
-    protected $currentPos = 0;
+    protected ?CodeceptConsole $standardReporter = null;
+
+    protected array $errors = [];
+
+    protected array $failures = [];
+
+    protected int $width = 10;
+
+    protected int $currentPos = 0;
 
     public function _initialize(): void
     {
         $this->options['silent'] = false; // turn on printing for this extension
         $this->_reconfigure(['settings' => ['silent' => true]]); // turn off printing for everything else
-        $this->standardReporter = new Console($this->options);
+        $this->standardReporter = new CodeceptConsole($this->options);
         $this->width = $this->standardReporter->detectWidth();
     }
 
@@ -76,7 +65,7 @@ class DotReporter extends Extension
      *
      * @var array<string, string>
      */
-    public static $events = [
+    public static array $events = [
         Events::SUITE_BEFORE => 'beforeSuite',
         Events::TEST_SUCCESS => 'success',
         Events::TEST_FAIL    => 'fail',

--- a/ext/Logger.php
+++ b/ext/Logger.php
@@ -48,7 +48,7 @@ class Logger extends Extension
     /**
      * @var array<string, string>
      */
-    public static $events = [
+    public static array $events = [
         Events::SUITE_BEFORE    => 'beforeSuite',
         Events::TEST_BEFORE     => 'beforeTest',
         Events::TEST_AFTER      => 'afterTest',
@@ -60,25 +60,16 @@ class Logger extends Extension
         Events::TEST_SKIPPED    => 'testSkipped',
     ];
 
-    /**
-     * @var RotatingFileHandler
-     */
-    protected $logHandler;
+    protected ?RotatingFileHandler $logHandler = null;
 
-    /**
-     * @var \Monolog\Logger
-     */
-    protected static $logger;
+    protected static ?\Monolog\Logger $logger = null;
 
-    /**
-     * @var string
-     */
-    protected $path;
+    protected ?string $path = null;
 
     /**
      * @var array<string, int>
      */
-    protected $config = ['max_files' => 3];
+    protected array $config = ['max_files' => 3];
 
     public function _initialize(): void
     {

--- a/ext/Recorder.php
+++ b/ext/Recorder.php
@@ -8,6 +8,7 @@ use Codeception\Event\StepEvent;
 use Codeception\Event\TestEvent;
 use Codeception\Events;
 use Codeception\Exception\ExtensionException;
+use Codeception\Extension;
 use Codeception\Lib\Interfaces\ScreenshotSaver;
 use Codeception\Module\WebDriver;
 use Codeception\Step;
@@ -17,6 +18,7 @@ use Codeception\Util\Template;
 use DateTime;
 use DirectoryIterator;
 use Exception;
+use Symfony\Contracts\EventDispatcher\Event;
 use function array_diff;
 use function array_key_exists;
 use function array_keys;
@@ -25,7 +27,6 @@ use function array_unique;
 use function basename;
 use function codecept_output_dir;
 use function codecept_relative_path;
-use function count;
 use function dirname;
 use function file_put_contents;
 use function in_array;
@@ -98,10 +99,9 @@ use function uniqid;
  * ```
  *
  */
-class Recorder extends \Codeception\Extension
+class Recorder extends Extension
 {
-    /** @var array */
-    protected $config = [
+    protected array $config = [
         'delete_successful'    => true,
         'module'               => 'WebDriver',
         'template'             => null,
@@ -114,8 +114,7 @@ class Recorder extends \Codeception\Extension
         'include_microseconds' => false,
     ];
 
-    /** @var string */
-    protected $template = <<<EOF
+    protected string $template = <<<EOF
 <!DOCTYPE html>
 <html lang="en">
 <head>
@@ -228,13 +227,11 @@ class Recorder extends \Codeception\Extension
 </html>
 EOF;
 
-    /** @var string */
-    protected $indicatorTemplate = <<<EOF
+    protected string $indicatorTemplate = <<<EOF
 <li data-target="#steps" data-slide-to="{{step}}" class="{{isActive}}"></li>
 EOF;
 
-    /** @var string */
-    protected $indexTemplate = <<<EOF
+    protected string $indexTemplate = <<<EOF
 <!DOCTYPE html>
 <html lang="en">
 <head>
@@ -264,8 +261,7 @@ EOF;
 
 EOF;
 
-    /** @var string */
-    protected $slidesTemplate = <<<EOF
+    protected string $slidesTemplate = <<<EOF
 <div class="carousel-item {{isActive}}">
     <img class="mx-auto d-block mh-100" src="{{image}}">
     <div class="carousel-caption {{isError}}">
@@ -275,8 +271,7 @@ EOF;
 </div>
 EOF;
 
-    /** @var array */
-    public static $events = [
+    public static array $events = [
         Events::SUITE_BEFORE => 'beforeSuite',
         Events::SUITE_AFTER  => 'afterSuite',
         Events::TEST_BEFORE  => 'before',
@@ -286,44 +281,31 @@ EOF;
         Events::STEP_AFTER   => 'afterStep',
     ];
 
-    /** @var WebDriver|null */
-    protected $webDriverModule;
+    protected ?\Codeception\Module $webDriverModule = null;
 
-    /** @var string */
-    protected $dir;
+    protected ?string $dir = null;
 
-    /** @var array */
-    protected $slides = [];
+    protected array $slides = [];
 
-    /** @var int */
-    protected $stepNum = 0;
+    protected int $stepNum = 0;
 
-    /** @var string */
-    protected $seed;
+    protected ?string $seed = null;
 
-    /** @var array */
-    protected $seeds = [];
+    protected array $seeds = [];
 
-    /** @var array */
-    protected $recordedTests = [];
+    protected array $recordedTests = [];
 
-    /** @var array */
-    protected $skipRecording = [];
+    protected array $skipRecording = [];
 
-    /** @var array */
-    protected $errorMessages = [];
+    protected array $errorMessages = [];
 
-    /** @var bool */
-    protected $colors = false;
+    protected bool $colors = false;
 
-    /** @var bool */
-    protected $ansi = false;
+    protected bool $ansi = false;
 
-    /** @var array */
-    protected $timeStamps = [];
+    protected array $timeStamps = [];
 
-    /** @var string */
-    private $dateFormat;
+    private ?string $dateFormat = null;
 
     public function beforeSuite(): void
     {
@@ -631,9 +613,8 @@ EOF;
 
     /**
      * @param StepEvent|TestEvent $event
-     * @return string
      */
-    private function getTestName($event): string
+    private function getTestName(Event $event): string
     {
         return basename($event->getTest()->getMetadata()->getFilename()) . '_' . preg_replace('/[^A-Za-z0-9\-\_]/', '_', $event->getTest()->getMetadata()->getName());
     }

--- a/ext/RunBefore.php
+++ b/ext/RunBefore.php
@@ -42,20 +42,16 @@ use function sleep;
  */
 class RunBefore extends Extension
 {
-    /**
-     * @var array
-     */
-    protected $config = [];
+    protected array $config = [];
 
     /**
      * @var array<string, string>
      */
-    protected static $events = [
+    protected static array $events = [
         Events::SUITE_BEFORE => 'runBefore'
     ];
 
-    /** @var array[] */
-    private $processes = [];
+    private array $processes = [];
 
     public function _initialize(): void
     {

--- a/ext/RunFailed.php
+++ b/ext/RunFailed.php
@@ -47,12 +47,12 @@ class RunFailed extends Extension
     /**
      * @var array<string, string>
      */
-    public static $events = [
+    public static array $events = [
         Events::RESULT_PRINT_AFTER => 'saveFailed'
     ];
 
     /** @var string filename/groupname for failed tests */
-    protected $group = 'failed';
+    protected string $group = 'failed';
 
     public function _initialize(): void
     {

--- a/ext/RunProcess.php
+++ b/ext/RunProcess.php
@@ -60,12 +60,12 @@ class RunProcess extends Extension
     /**
      * @var array<string, int>
      */
-    protected $config = ['sleep' => 0];
+    protected array $config = ['sleep' => 0];
 
     /**
      * @var array<string, string>
      */
-    protected static $events = [
+    protected static array $events = [
         Events::SUITE_BEFORE => 'runProcess',
         Events::SUITE_AFTER => 'stopProcess'
     ];
@@ -73,7 +73,7 @@ class RunProcess extends Extension
     /**
      * @var Process[]
      */
-    private $processes = [];
+    private array $processes = [];
 
     public function _initialize(): void
     {
@@ -108,7 +108,7 @@ class RunProcess extends Extension
     public function stopProcess(): void
     {
         foreach (array_reverse($this->processes) as $process) {
-            /** @var $process Process  **/
+            /** @var Process $process */
             if (!$process->isRunning()) {
                 continue;
             }

--- a/ext/SimpleReporter.php
+++ b/ext/SimpleReporter.php
@@ -26,7 +26,7 @@ class SimpleReporter extends Extension
      *
      * @var array<string, string>
      */
-    public static $events = [
+    public static array $events = [
         Events::SUITE_BEFORE => 'beforeSuite',
         Events::TEST_END     => 'after',
         Events::TEST_SUCCESS => 'success',

--- a/src/Codeception/Actor.php
+++ b/src/Codeception/Actor.php
@@ -15,10 +15,7 @@ abstract class Actor
     use Comment;
     use Pause;
 
-    /**
-     * @var Scenario
-     */
-    protected $scenario;
+    protected Scenario $scenario;
 
     public function __construct(Scenario $scenario)
     {
@@ -49,7 +46,7 @@ abstract class Actor
     /**
      * Lazy-execution given anonymous function
      */
-    public function execute(Closure $callable): Actor
+    public function execute(Closure $callable): self
     {
         $this->scenario->addStep(new Executor($callable, []));
         $callable();

--- a/src/Codeception/Application.php
+++ b/src/Codeception/Application.php
@@ -16,10 +16,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class Application extends BaseApplication
 {
-    /**
-     * @var SymfonyArgvInput|null
-     */
-    protected $coreArguments = null;
+    protected ?SymfonyArgvInput $coreArguments = null;
 
     /**
      * Register commands from config file
@@ -46,7 +43,7 @@ class Application extends BaseApplication
 
     public function renderExceptionWrapper(Exception $exception, OutputInterface $output): void
     {
-        if (method_exists(\Symfony\Component\Console\Application::class, 'renderException')) {
+        if (method_exists(BaseApplication::class, 'renderException')) {
             //Symfony 5
             parent::renderException($exception, $output);
         } else {

--- a/src/Codeception/Codecept.php
+++ b/src/Codeception/Codecept.php
@@ -34,30 +34,15 @@ class Codecept
      */
     const VERSION = '5.0.0';
 
-    /**
-     * @var Runner
-     */
-    protected $runner;
+    protected ?Runner $runner = null;
 
-    /**
-     * @var TestResult
-     */
-    protected $result;
+    protected TestResult $result;
 
-    /**
-     * @var EventDispatcher
-     */
-    protected $dispatcher;
+    protected EventDispatcher $dispatcher;
 
-    /**
-     * @var ExtensionLoader
-     */
-    protected $extensionLoader;
+    protected ExtensionLoader $extensionLoader;
 
-    /**
-     * @var array
-     */
-    protected $options = [
+    protected array $options = [
         'silent'          => false,
         'debug'           => false,
         'steps'           => false,
@@ -86,15 +71,9 @@ class Codecept
         'quiet'           => false,
     ];
 
-    /**
-     * @var array
-     */
-    protected $config = [];
+    protected array $config = [];
 
-    /**
-     * @var array
-     */
-    protected $extensions = [];
+    protected array $extensions = [];
 
     public function __construct(array $options = [])
     {

--- a/src/Codeception/Command/Bootstrap.php
+++ b/src/Codeception/Command/Bootstrap.php
@@ -55,6 +55,6 @@ class Bootstrap extends Command
             $bootstrap->initDir($input->getArgument('path'));
         }
         $bootstrap->setup();
-        return 0;
+        return Command::SUCCESS;
     }
 }

--- a/src/Codeception/Command/Build.php
+++ b/src/Codeception/Command/Build.php
@@ -9,7 +9,7 @@ use Codeception\Lib\Generator\Actions as ActionsGenerator;
 use Codeception\Lib\Generator\Actor as ActorGenerator;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
-use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Output\OutputInterface as SymfonyOutputInterface;
 use function implode;
 
 /**
@@ -25,27 +25,20 @@ class Build extends Command
     use Shared\ConfigTrait;
     use Shared\FileSystemTrait;
 
-    /**
-     * @var string
-     */
-    protected $inheritedMethodTemplate = ' * @method void %s(%s)';
+    protected string $inheritedMethodTemplate = ' * @method void %s(%s)';
 
-    /**
-     * @var OutputInterface
-     */
-    protected $output;
+    protected ?SymfonyOutputInterface $output = null;
 
     public function getDescription(): string
     {
         return 'Generates base classes for all suites';
     }
 
-
-    protected function execute(InputInterface $input, OutputInterface $output): int
+    protected function execute(InputInterface $input, SymfonyOutputInterface $output): int
     {
         $this->output = $output;
         $this->buildActorsForConfig();
-        return 0;
+        return Command::SUCCESS;
     }
 
     private function buildActor(array $settings): bool
@@ -74,7 +67,6 @@ class Build extends Command
             " -> {$settings['actor']}Actions.php generated successfully. "
             . $actionsGenerator->getNumMethods() . " methods added"
         );
-
 
         $file = $this->createDirectoryFor(Configuration::supportDir() . '_generated', $settings['actor']);
         $file .= $this->getShortClassName($settings['actor']) . 'Actions.php';

--- a/src/Codeception/Command/Clean.php
+++ b/src/Codeception/Command/Clean.php
@@ -30,7 +30,7 @@ class Clean extends Command
         $projectDir = Configuration::projectDir();
         $this->cleanProjectsRecursively($output, $projectDir);
         $output->writeln("Done");
-        return 0;
+        return Command::SUCCESS;
     }
 
     private function cleanProjectsRecursively(OutputInterface $output, string $projectDir): void

--- a/src/Codeception/Command/Completion.php
+++ b/src/Codeception/Command/Completion.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Codeception\Command;
 
-if (!class_exists(\Stecman\Component\Symfony\Console\BashCompletion\Completion::class)) {
+if (!class_exists(ConsoleCompletion::class)) {
     echo "Please install `stecman/symfony-console-completion\n` to enable auto completion";
     return;
 }
@@ -15,13 +15,14 @@ use Stecman\Component\Symfony\Console\BashCompletion\Completion\CompletionInterf
 use Stecman\Component\Symfony\Console\BashCompletion\Completion\ShellPathCompletion;
 use Stecman\Component\Symfony\Console\BashCompletion\CompletionCommand;
 use Stecman\Component\Symfony\Console\BashCompletion\CompletionHandler;
+use Symfony\Component\Console\Input\InputDefinition as SymfonyInputDefinition;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
 class Completion extends CompletionCommand
 {
-    protected function configureCompletion(CompletionHandler $handler)
+    protected function configureCompletion(CompletionHandler $handler): void
     {
         // Can't set for all commands, because it wouldn't work well with generate:suite
         $suiteCommands = [
@@ -71,10 +72,10 @@ class Completion extends CompletionCommand
         }
 
         parent::execute($input, $output);
-        return 0;
+        return Command::SUCCESS;
     }
 
-    protected function createDefinition()
+    protected function createDefinition(): SymfonyInputDefinition
     {
         $definition = parent::createDefinition();
         $definition->addOption(new InputOption(

--- a/src/Codeception/Command/CompletionFallback.php
+++ b/src/Codeception/Command/CompletionFallback.php
@@ -30,6 +30,6 @@ END);
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $output->writeln("Install optional <comment>stecman/symfony-console-completion</comment>");
-        return 0;
+        return Command::SUCCESS;
     }
 }

--- a/src/Codeception/Command/ConfigValidate.php
+++ b/src/Codeception/Command/ConfigValidate.php
@@ -72,7 +72,7 @@ class ConfigValidate extends Command
             $output->writeln("<info>{$suite} Suite Config</info>:\n");
             $output->writeln($this->formatOutput($config));
 
-            return 0;
+            return Command::SUCCESS;
         }
 
         $output->write("Validating global config... ");
@@ -102,14 +102,13 @@ class ConfigValidate extends Command
             $output->writeln('Ok');
         }
 
-
         $output->writeln("Execute <info>codecept config:validate [<suite>]</info> to see config for a suite");
-        return 0;
+        return Command::SUCCESS;
     }
 
     protected function formatOutput($config): ?string
     {
         $output = print_r($config, true);
-        return preg_replace('#\[(.*?)\] =>#', "<fg=yellow>$1</fg=yellow> =>", $output);
+        return preg_replace('#\[(.*?)] =>#', "<fg=yellow>$1</fg=yellow> =>", $output);
     }
 }

--- a/src/Codeception/Command/Console.php
+++ b/src/Codeception/Command/Console.php
@@ -33,26 +33,18 @@ use function pcntl_signal;
  */
 class Console extends Command
 {
-    /**
-     * @var Cept|null
-     */
-    protected $test;
-    /**
-     * @var Codecept|null
-     */
-    protected $codecept;
-    /**
-     * @var Suite|null
-     */
-    protected $suite;
-    /**
-     * @var OutputInterface|null
-     */
-    protected $output;
+    protected ?Cept $test = null;
+
+    protected ?Codecept $codecept = null;
+
+    protected ?Suite $suite = null;
+
+    protected ?OutputInterface $output = null;
+
     /**
      * @var string[]
      */
-    protected $actions = [];
+    protected array $actions = [];
 
     protected function configure(): void
     {
@@ -132,7 +124,7 @@ class Console extends Command
         $eventDispatcher->dispatch(new SuiteEvent($this->suite), Events::SUITE_AFTER);
 
         $output->writeln("<info>Bye-bye!</info>");
-        return 0;
+        return Command::SUCCESS;
     }
 
     protected function listenToSignals(): void

--- a/src/Codeception/Command/DryRun.php
+++ b/src/Codeception/Command/DryRun.php
@@ -97,7 +97,7 @@ class DryRun extends Command
             }
         }
         $eventDispatcher->dispatch(new SuiteEvent($suiteManager->getSuite()), Events::SUITE_AFTER);
-        return 0;
+        return Command::SUCCESS;
     }
 
     protected function matchTestFromFilename($filename, $testsPath)

--- a/src/Codeception/Command/GenerateCept.php
+++ b/src/Codeception/Command/GenerateCept.php
@@ -47,9 +47,9 @@ class GenerateCept extends Command
         $res = $this->createFile($fullPath, $cept->produce());
         if (!$res) {
             $output->writeln("<error>Test {$filename} already exists</error>");
-            return 1;
+            return Command::FAILURE;
         }
         $output->writeln("<info>Test was created in {$fullPath}</info>");
-        return 0;
+        return Command::SUCCESS;
     }
 }

--- a/src/Codeception/Command/GenerateCest.php
+++ b/src/Codeception/Command/GenerateCest.php
@@ -52,16 +52,16 @@ class GenerateCest extends Command
 
         if (file_exists($filename)) {
             $output->writeln("<error>Test {$filename} already exists</error>");
-            return 1;
+            return Command::FAILURE;
         }
         $cest = new CestGenerator($class, $config);
         $res = $this->createFile($filename, $cest->produce());
         if (!$res) {
             $output->writeln("<error>Test {$filename} already exists</error>");
-            return 1;
+            return Command::FAILURE;
         }
 
         $output->writeln("<info>Test was created in {$filename}</info>");
-        return 0;
+        return Command::SUCCESS;
     }
 }

--- a/src/Codeception/Command/GenerateEnvironment.php
+++ b/src/Codeception/Command/GenerateEnvironment.php
@@ -54,10 +54,10 @@ class GenerateEnvironment extends Command
 
         if ($saved) {
             $output->writeln("<info>{$env} config was created in {$relativePath}/{$file}</info>");
-            return 0;
+            return Command::SUCCESS;
         } else {
             $output->writeln("<error>File {$relativePath}/{$file} already exists</error>");
-            return 1;
+            return Command::FAILURE;
         }
     }
 }

--- a/src/Codeception/Command/GenerateFeature.php
+++ b/src/Codeception/Command/GenerateFeature.php
@@ -57,9 +57,9 @@ class GenerateFeature extends Command
         $res = $this->createFile($fullPath, $feature->produce());
         if (!$res) {
             $output->writeln("<error>Feature {$filename} already exists</error>");
-            return 1;
+            return Command::FAILURE;
         }
         $output->writeln("<info>Feature was created in {$fullPath}</info>");
-        return 0;
+        return Command::SUCCESS;
     }
 }

--- a/src/Codeception/Command/GenerateGroup.php
+++ b/src/Codeception/Command/GenerateGroup.php
@@ -49,13 +49,13 @@ class GenerateGroup extends Command
 
         if (!$res) {
             $output->writeln("<error>Group {$filename} already exists</error>");
-            return 1;
+            return Command::FAILURE;
         }
 
         $output->writeln("<info>Group extension was created in {$filename}</info>");
         $output->writeln(
             'To use this group extension, include it to "extensions" option of global Codeception config.'
         );
-        return 0;
+        return Command::SUCCESS;
     }
 }

--- a/src/Codeception/Command/GenerateHelper.php
+++ b/src/Codeception/Command/GenerateHelper.php
@@ -47,10 +47,10 @@ class GenerateHelper extends Command
         $res = $this->createFile($filename, (new Helper($name, $config['namespace']))->produce());
         if ($res) {
             $output->writeln("<info>Helper {$filename} created</info>");
-            return 0;
+            return Command::SUCCESS;
         } else {
             $output->writeln("<error>Error creating helper {$filename}</error>");
-            return 1;
+            return Command::FAILURE;
         }
     }
 }

--- a/src/Codeception/Command/GeneratePageObject.php
+++ b/src/Codeception/Command/GeneratePageObject.php
@@ -68,9 +68,9 @@ class GeneratePageObject extends Command
 
         if (!$res) {
             $output->writeln("<error>PageObject {$filename} already exists</error>");
-            return 1;
+            return Command::FAILURE;
         }
         $output->writeln("<info>PageObject was created in {$filename}</info>");
-        return 0;
+        return Command::SUCCESS;
     }
 }

--- a/src/Codeception/Command/GenerateScenarios.php
+++ b/src/Codeception/Command/GenerateScenarios.php
@@ -109,7 +109,7 @@ class GenerateScenarios extends Command
         if ($input->getOption('single-file')) {
             $this->createFile($path . $this->formatExtension($format), $this->decorate($scenarios, $format), true);
         }
-        return 0;
+        return Command::SUCCESS;
     }
 
     protected function decorate(string $text, string $format): string

--- a/src/Codeception/Command/GenerateSnapshot.php
+++ b/src/Codeception/Command/GenerateSnapshot.php
@@ -69,9 +69,9 @@ class GenerateSnapshot extends Command
 
         if (!$res) {
             $output->writeln("<error>Snapshot {$filename} already exists</error>");
-            return 1;
+            return Command::FAILURE;
         }
         $output->writeln("<info>Snapshot was created in {$filename}</info>");
-        return 0;
+        return Command::SUCCESS;
     }
 }

--- a/src/Codeception/Command/GenerateStepObject.php
+++ b/src/Codeception/Command/GenerateStepObject.php
@@ -72,9 +72,9 @@ class GenerateStepObject extends Command
 
         if (!$res) {
             $output->writeln("<error>StepObject {$filename} already exists</error>");
-            return 1;
+            return Command::FAILURE;
         }
         $output->writeln("<info>StepObject was created in {$filename}</info>");
-        return 0;
+        return Command::SUCCESS;
     }
 }

--- a/src/Codeception/Command/GenerateSuite.php
+++ b/src/Codeception/Command/GenerateSuite.php
@@ -54,7 +54,7 @@ class GenerateSuite extends Command
 
         if ($this->containsInvalidCharacters($suite)) {
             $output->writeln("<error>Suite name '{$suite}' contains invalid characters. ([A-Za-z0-9_]).</error>");
-            return 1;
+            return Command::FAILURE;
         }
 
         $config = $this->getGlobalConfig();
@@ -132,7 +132,7 @@ EOF;
         $output->writeln("3. Run tests of this suite with <bold>codecept run {$suite}</bold> command");
 
         $output->writeln("<info>Suite {$suite} generated</info>");
-        return 0;
+        return Command::SUCCESS;
     }
 
     private function containsInvalidCharacters(string $suite): bool

--- a/src/Codeception/Command/GenerateTest.php
+++ b/src/Codeception/Command/GenerateTest.php
@@ -56,9 +56,9 @@ class GenerateTest extends Command
 
         if (!$res) {
             $output->writeln("<error>Test {$filename} already exists</error>");
-            return 1;
+            return Command::FAILURE;
         }
         $output->writeln("<info>Test was created in {$filename}</info>");
-        return 0;
+        return Command::SUCCESS;
     }
 }

--- a/src/Codeception/Command/GherkinSnippets.php
+++ b/src/Codeception/Command/GherkinSnippets.php
@@ -57,7 +57,7 @@ class GherkinSnippets extends Command
         $snippets = $generator->getSnippets();
         if (empty($snippets)) {
             $output->writeln("<notice> All Gherkin steps are defined. Exiting... </notice>");
-            return 0;
+            return Command::SUCCESS;
         }
         $output->writeln("<comment> Snippets found in: </comment>");
 
@@ -73,6 +73,6 @@ class GherkinSnippets extends Command
         $output->writeln("<info> ----------------------------------------- </info>");
         $output->writeln(sprintf(' <bold>%d</bold> snippets proposed', count($snippets)));
         $output->writeln("<notice> Copy generated snippets to {$config['actor']} or a specific Gherkin context </notice>");
-        return 0;
+        return Command::SUCCESS;
     }
 }

--- a/src/Codeception/Command/GherkinSteps.php
+++ b/src/Codeception/Command/GherkinSteps.php
@@ -70,6 +70,6 @@ class GherkinSteps extends Command
         if (!isset($table)) {
             $output->writeln("No steps are defined, start creating them by running <bold>gherkin:snippets</bold>");
         }
-        return 0;
+        return Command::SUCCESS;
     }
 }

--- a/src/Codeception/Command/Init.php
+++ b/src/Codeception/Command/Init.php
@@ -55,6 +55,6 @@ class Init extends Command
             $initProcess->initDir($path);
         }
         $initProcess->setup();
-        return 0;
+        return Command::SUCCESS;
     }
 }

--- a/src/Codeception/Command/Run.php
+++ b/src/Codeception/Command/Run.php
@@ -122,28 +122,21 @@ use function substr_replace;
 class Run extends Command
 {
     use Shared\ConfigTrait;
-    /**
-     * @var Codecept
-     */
-    protected $codecept;
+
+    protected ?Codecept $codecept = null;
 
     /**
-     * @var integer of executed suites
+     * @var int Executed suites
      */
-    protected $executed = 0;
+    protected int $executed = 0;
 
-    /**
-     * @var array of options (command run)
-     */
-    protected $options = [];
+    protected array $options = [];
 
-    /**
-     * @var OutputInterface
-     */
-    protected $output;
+    protected ?OutputInterface $output = null;
 
     /**
      * Sets Run arguments
+     *
      * @throws SymfonyConsoleInvalidArgumentException
      */
     protected function configure(): void
@@ -439,7 +432,7 @@ class Run extends Command
         if (!$input->getOption('no-exit') && !$this->codecept->getResult()->wasSuccessful()) {
             exit(1);
         }
-        return 0;
+        return Command::SUCCESS;
     }
 
     protected function matchSingleTest($suite, $config): ?array

--- a/src/Codeception/Command/SelfUpdate.php
+++ b/src/Codeception/Command/SelfUpdate.php
@@ -37,9 +37,8 @@ class SelfUpdate extends Command
 
     /**
      * Holds the current script filename.
-     * @var string
      */
-    protected $filename;
+    protected string $filename;
 
     /**
      * {@inheritdoc}
@@ -102,9 +101,9 @@ class SelfUpdate extends Command
                     $e->getMessage()
                 )
             );
-            return 1;
+            return Command::FAILURE;
         }
 
-        return 0;
+        return Command::SUCCESS;
     }
 }

--- a/src/Codeception/Command/Shared/ConfigTrait.php
+++ b/src/Codeception/Command/Shared/ConfigTrait.php
@@ -20,16 +20,19 @@ use function ucfirst;
 
 trait ConfigTrait
 {
-    protected function getSuiteConfig($suite): array
+    protected function getSuiteConfig(string $suite): array
     {
         return Configuration::suiteSettings($suite, $this->getGlobalConfig());
     }
 
-    protected function getGlobalConfig($conf = null): array
+    protected function getGlobalConfig(string $conf = null): array
     {
         return Configuration::config($conf);
     }
 
+    /**
+     * @return string[]
+     */
     protected function getSuites($conf = null): array
     {
         return Configuration::suites();

--- a/src/Codeception/Configuration.php
+++ b/src/Codeception/Configuration.php
@@ -26,59 +26,53 @@ class Configuration
     /**
      * @var string[]
      */
-    protected static $suites = [];
+    protected static array $suites = [];
 
     /**
-     * @var array Current configuration
+     * @var array|null Current configuration
      */
-    protected static $config = null;
+    protected static ?array $config = null;
 
     /**
      * @var array environmental files configuration cache
      */
-    protected static $envConfig = [];
+    protected static array $envConfig = [];
 
     /**
-     * @var string Directory containing main configuration file.
+     * @var string|false|null Directory containing main configuration file.
      * @see self::projectDir()
      */
     protected static $dir = null;
 
     /**
-     * @var string Current project output directory.
+     * @var string|null Current project output directory.
      */
-    protected static $outputDir = null;
+    protected static ?string $outputDir = null;
 
     /**
-     * @var string Current project data directory. This directory is used to hold
+     * @var string|null Current project data directory. This directory is used to hold
      * sql dumps and other things needed for current project tests.
      */
-    protected static $dataDir = null;
+    protected static ?string $dataDir = null;
 
     /**
-     * @var string Directory with test support files like Actors, Helpers, PageObjects, etc
+     * @var string|null Directory with test support files like Actors, Helpers, PageObjects, etc
      */
-    protected static $supportDir = null;
+    protected static ?string $supportDir = null;
 
     /**
-     * @var string Directory containing environment configuration files.
+     * @var string|null Directory containing environment configuration files.
      */
-    protected static $envsDir = null;
+    protected static ?string $envsDir = null;
 
     /**
-     * @var string Directory containing tests and suites of the current project.
+     * @var string|null Directory containing tests and suites of the current project.
      */
-    protected static $testsDir = null;
+    protected static ?string $testsDir = null;
 
-    /**
-     * @var bool
-     */
-    public static $lock = false;
+    public static bool $lock = false;
 
-    /**
-     * @var array Default config
-     */
-    public static $defaultConfig = [
+    public static array $defaultConfig = [
         'actor_suffix'=> 'Tester',
         'namespace'  => '',
         'include'    => [],
@@ -116,10 +110,7 @@ class Configuration
         'gherkin'    => []
     ];
 
-    /**
-     * @var array
-     */
-    public static $defaultSuiteSettings = [
+    public static array $defaultSuiteSettings = [
         'actor'       => null,
         'class_name'  => null, // Codeception <2.3 compatibility
         'modules'     => [
@@ -141,10 +132,7 @@ class Configuration
         'error_level' => 'E_ALL & ~E_STRICT & ~E_DEPRECATED',
     ];
 
-    /**
-     * @var array|null
-     */
-    protected static $params;
+    protected static ?array $params = null;
 
     /**
      * Loads global config file which is `codeception.yml` by default.
@@ -294,7 +282,6 @@ class Configuration
             ? $bootstrap
             : rtrim($path, DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR . $bootstrap;
 
-
         if (!file_exists($bootstrap)) {
             throw new ConfigurationException("Bootstrap file {$bootstrap} can't be loaded");
         }
@@ -373,14 +360,14 @@ class Configuration
             . DIRECTORY_SEPARATOR . $settings['path'] . DIRECTORY_SEPARATOR;
 
 
-
         return $settings;
     }
 
     /**
      * Loads environments configuration from set directory
      *
-     * @param string $path path to the directory
+     * @param string $path Path to the directory
+     * @return array<string, array>
      */
     protected static function loadEnvConfigs(string $path): array
     {
@@ -455,8 +442,7 @@ class Configuration
     /**
      * Loads configuration from Yaml file or returns given value if the file doesn't exist
      *
-     * @param string $filename filename
-     * @param array|null $nonExistentValue value used if filename is not found
+     * @param array|null $nonExistentValue Value used if filename is not found
      * @throws ConfigurationException
      */
     protected static function getConfFromFile(string $filename, ?array $nonExistentValue = []): ?array
@@ -479,15 +465,13 @@ class Configuration
     /**
      * Return list of enabled modules according suite config.
      *
-     * @param array $settings suite settings
+     * @param array $settings Suite settings
      */
     public static function modules(array $settings): array
     {
         return array_filter(
             array_map(
-                function ($m) {
-                    return is_array($m) ? key($m) : $m;
-                },
+                fn($m) => is_array($m) ? key($m) : $m,
                 $settings['modules']['enabled'],
                 array_keys($settings['modules']['enabled'])
             ),
@@ -577,7 +561,6 @@ class Configuration
     {
         return self::$dir . DIRECTORY_SEPARATOR;
     }
-
 
     /**
      * Returns path to tests directory
@@ -727,10 +710,11 @@ class Configuration
      * Returns the expanded paths or the original if not a wildcard.
      *
      * @throws ConfigurationException
+     * @return string[]
      */
     protected static function expandWildcardsFor(string $include): array
     {
-        if (1 !== preg_match('#[\?\.\*]#', $include)) {
+        if (1 !== preg_match('#[?.*]#', $include)) {
             return [$include,];
         }
 

--- a/src/Codeception/Coverage/Filter.php
+++ b/src/Codeception/Coverage/Filter.php
@@ -20,20 +20,11 @@ use function strpos;
 
 class Filter
 {
-    /**
-     * @var CodeCoverage|null
-     */
-    protected $phpCodeCoverage = null;
+    protected ?CodeCoverage $phpCodeCoverage = null;
 
-    /**
-     * @var Filter
-     */
-    protected static $c3;
+    protected static ?Filter $c3 = null;
 
-    /**
-     * @var \SebastianBergmann\CodeCoverage\Filter|null
-     */
-    protected $filter = null;
+    protected ?\SebastianBergmann\CodeCoverage\Filter $filter = null;
 
     public function __construct(CodeCoverage $phpCoverage)
     {

--- a/src/Codeception/Coverage/Subscriber/Local.php
+++ b/src/Codeception/Coverage/Subscriber/Local.php
@@ -18,15 +18,12 @@ class Local extends SuiteSubscriber
     /**
      * @var array<string, string>
      */
-    public static $events = [
+    public static array $events = [
         Events::SUITE_BEFORE => 'beforeSuite',
         Events::SUITE_AFTER  => 'afterSuite',
     ];
 
-    /**
-     * @var Remote
-     */
-    protected $module;
+    protected ?Remote $module = null;
 
     protected function isEnabled(): bool
     {

--- a/src/Codeception/Coverage/Subscriber/LocalServer.php
+++ b/src/Codeception/Coverage/Subscriber/LocalServer.php
@@ -74,29 +74,21 @@ class LocalServer extends SuiteSubscriber
      */
     const COVERAGE_COOKIE_ERROR = 'CODECEPTION_CODECOVERAGE_ERROR';
 
-    /**
-     * @var string
-     */
-    protected $suiteName = '';
-    /**
-     * @var array
-     */
-    protected $c3Access = [
+    protected string $suiteName = '';
+
+    protected array $c3Access = [
         'http' => [
             'method' => "GET",
             'header' => ''
         ]
     ];
 
-    /**
-     * @var WebInterface
-     */
-    protected $module;
+    protected ?WebInterface $module = null;
 
     /**
      * @var array<string, string>
      */
-    public static $events = [
+    public static array $events = [
         Events::SUITE_BEFORE => 'beforeSuite',
         Events::TEST_BEFORE  => 'beforeTest',
         Events::STEP_AFTER   => 'afterStep',
@@ -159,7 +151,7 @@ class LocalServer extends SuiteSubscriber
 
         $retries = 5;
         while (!file_exists($coverageFile) && --$retries >= 0) {
-            $seconds = (int) 0.5 * 1000000; // 0.5 sec
+            $seconds = (int) 0.5 * 1_000_000; // 0.5 sec
             usleep($seconds);
         }
 
@@ -221,9 +213,7 @@ class LocalServer extends SuiteSubscriber
 
         $okHeaders = array_filter(
             $http_response_header,
-            function ($h) {
-                return preg_match('#^HTTP(.*?)\s200#', $h);
-            }
+            fn($h) => preg_match('#^HTTP(.*?)\s200#', $h)
         );
         if (empty($okHeaders)) {
             throw new RemoteException("Request was not successful. See response header: " . $http_response_header[0]);

--- a/src/Codeception/Coverage/Subscriber/Printer.php
+++ b/src/Codeception/Coverage/Subscriber/Printer.php
@@ -34,14 +34,11 @@ class Printer implements EventSubscriberInterface
     /**
      * @var array<string, string>
      */
-    public static $events = [
+    public static array $events = [
         Events::RESULT_PRINT_AFTER => 'printResult'
     ];
 
-    /**
-     * @var array
-     */
-    protected $settings = [
+    protected array $settings = [
         'enabled'           => true,
         'low_limit'         => 35,
         'high_limit'        => 70,
@@ -49,22 +46,13 @@ class Printer implements EventSubscriberInterface
         'show_only_summary' => false
     ];
 
-    /**
-     * @var CodeCoverage
-     */
-    public static $coverage;
-    /**
-     * @var array
-     */
-    protected $options = [];
-    /**
-     * @var string
-     */
-    protected $logDir;
-    /**
-     * @var array
-     */
-    protected $destination = [];
+    public static CodeCoverage $coverage;
+
+    protected array $options = [];
+
+    protected string $logDir;
+
+    protected array $destination = [];
 
     public function __construct(array $options)
     {

--- a/src/Codeception/Coverage/SuiteSubscriber.php
+++ b/src/Codeception/Coverage/SuiteSubscriber.php
@@ -25,10 +25,7 @@ abstract class SuiteSubscriber implements EventSubscriberInterface
 {
     use StaticEventsTrait;
 
-    /**
-     * @var array
-     */
-    protected $defaultSettings = [
+    protected array $defaultSettings = [
         'enabled'        => false,
         'remote'         => false,
         'local'          => false,
@@ -39,34 +36,20 @@ abstract class SuiteSubscriber implements EventSubscriberInterface
         'work_dir'       => null,
         'cookie_domain'  => null,
     ];
-    /**
-     * @var array
-     */
-    protected $settings = [];
-    /**
-     * @var array
-     */
-    protected $filters = [];
-    /**
-     * @var array
-     */
-    protected $modules = [];
-    /**
-     * @var CodeCoverage|null
-     */
-    protected $coverage;
-    /**
-     * @var string
-     */
-    protected $logDir;
-    /**
-     * @var array
-     */
-    protected $options = [];
-    /**
-     * @var array
-     */
-    public static $events = [];
+
+    protected array $settings = [];
+
+    protected array $filters = [];
+
+    protected array $modules = [];
+
+    protected ?CodeCoverage $coverage = null;
+
+    protected string $logDir;
+
+    protected array $options = [];
+
+    public static array $events = [];
 
     abstract protected function isEnabled();
 

--- a/src/Codeception/Event/FailEvent.php
+++ b/src/Codeception/Event/FailEvent.php
@@ -9,15 +9,9 @@ use Throwable;
 
 class FailEvent extends TestEvent
 {
-    /**
-     * @var Throwable
-     */
-    protected $fail;
+    protected Throwable $fail;
 
-    /**
-     * @var int
-     */
-    protected $count;
+    protected int $count;
 
     public function __construct(PHPUnitTest $test, ?float $time, Throwable $e, int $count = 0)
     {

--- a/src/Codeception/Event/PrintResultEvent.php
+++ b/src/Codeception/Event/PrintResultEvent.php
@@ -10,15 +10,9 @@ use Symfony\Contracts\EventDispatcher\Event;
 
 class PrintResultEvent extends Event
 {
-    /**
-     * @var TestResult
-     */
-    protected $result;
+    protected TestResult $result;
 
-    /**
-     * @var Printer
-     */
-    protected $printer;
+    protected Printer $printer;
 
     public function __construct(TestResult $testResult, Printer $printer)
     {

--- a/src/Codeception/Event/StepEvent.php
+++ b/src/Codeception/Event/StepEvent.php
@@ -10,15 +10,9 @@ use Symfony\Contracts\EventDispatcher\Event;
 
 class StepEvent extends Event
 {
-    /**
-     * @var Step
-     */
-    protected $step;
+    protected Step $step;
 
-    /**
-     * @var TestInterface
-     */
-    protected $test;
+    protected TestInterface $test;
 
     public function __construct(TestInterface $test, Step $step)
     {

--- a/src/Codeception/Event/SuiteEvent.php
+++ b/src/Codeception/Event/SuiteEvent.php
@@ -10,20 +10,11 @@ use Symfony\Contracts\EventDispatcher\Event;
 
 class SuiteEvent extends Event
 {
-    /**
-     * @var TestSuite
-     */
-    protected $suite;
+    protected TestSuite $suite;
 
-    /**
-     * @var TestResult
-     */
-    protected $result;
+    protected ?TestResult $result;
 
-    /**
-     * @var array
-     */
-    protected $settings = [];
+    protected array $settings;
 
     public function __construct(
         TestSuite $testSuite,

--- a/src/Codeception/Event/TestEvent.php
+++ b/src/Codeception/Event/TestEvent.php
@@ -9,15 +9,9 @@ use Symfony\Contracts\EventDispatcher\Event;
 
 class TestEvent extends Event
 {
-    /**
-     * @var PHPUnitTest
-     */
-    protected $test;
+    protected PHPUnitTest $test;
 
-    /**
-     * @var float Time taken
-     */
-    protected $time;
+    protected ?float $time; // Time taken
 
     public function __construct(PHPUnitTest $test, ?float $time = 0)
     {
@@ -30,10 +24,7 @@ class TestEvent extends Event
         return $this->time;
     }
 
-    /**
-     * @return \Codeception\TestInterface
-     */
-    public function getTest()
+    public function getTest(): PHPUnitTest
     {
         return $this->test;
     }

--- a/src/Codeception/Events.php
+++ b/src/Codeception/Events.php
@@ -122,14 +122,12 @@ final class Events
      */
     const TEST_SKIPPED = 'test.skipped';
 
-
     /**
      * The event listener method receives a {@link \Codeception\Event\FailEvent} instance.
      *
      * @var string
      */
     const TEST_WARNING = 'test.warning';
-
 
     /**
      * The event listener method receives a {@link \Codeception\Event\TestEvent} instance.

--- a/src/Codeception/Example.php
+++ b/src/Codeception/Example.php
@@ -13,6 +13,9 @@ use Traversable;
 
 class Example implements ArrayAccess, Countable, IteratorAggregate
 {
+    /**
+     * @var mixed
+     */
     protected $data;
 
     public function __construct($data)
@@ -25,7 +28,7 @@ class Example implements ArrayAccess, Countable, IteratorAggregate
      *
      * @link http://php.net/manual/en/arrayaccess.offsetexists.php
      * @param mixed $offset <p>An offset to check for.</p>
-     * @return boolean true on success or false on failure.
+     * @return bool true on success or false on failure.
      * The return value will be casted to boolean if non-boolean was returned.
      */
     public function offsetExists($offset): bool

--- a/src/Codeception/Exception/ExtensionException.php
+++ b/src/Codeception/Exception/ExtensionException.php
@@ -14,7 +14,6 @@ class ExtensionException extends Exception
      * ExtensionException constructor.
      *
      * @param object|string $extension
-     * @param Exception|null $previous
      */
     public function __construct($extension, string $message, Exception $previous = null)
     {

--- a/src/Codeception/Exception/ModuleConfigException.php
+++ b/src/Codeception/Exception/ModuleConfigException.php
@@ -16,7 +16,6 @@ class ModuleConfigException extends Exception
      * ModuleConfigException constructor.
      *
      * @param object|string $module
-     * @param Exception|null $previous
      */
     public function __construct($module, string $message, Exception $previous = null)
     {

--- a/src/Codeception/Exception/ModuleException.php
+++ b/src/Codeception/Exception/ModuleException.php
@@ -12,10 +12,7 @@ use function str_replace;
 
 class ModuleException extends Exception
 {
-    /**
-     * @var string
-     */
-    protected $module;
+    protected string $module;
 
     /**
      * ModuleException constructor.

--- a/src/Codeception/Exception/TestParseException.php
+++ b/src/Codeception/Exception/TestParseException.php
@@ -8,7 +8,7 @@ use Exception;
 
 class TestParseException extends Exception
 {
-    public function __construct(string $fileName, string $errors = null, ?int $line = null)
+    public function __construct(string $fileName, string $errors = null, int $line = null)
     {
         $this->message = "Couldn't parse test '{$fileName}'";
         if ($line !== null) {

--- a/src/Codeception/InitTemplate.php
+++ b/src/Codeception/InitTemplate.php
@@ -47,30 +47,15 @@ abstract class InitTemplate
      */
     const GIT_IGNORE = '.gitignore';
 
-    /**
-     * @var string
-     */
-    protected $namespace = '';
+    protected string $namespace = '';
 
-    /**
-     * @var string
-     */
-    protected $actorSuffix = 'Tester';
+    protected string $actorSuffix = 'Tester';
 
-    /**
-     * @var string
-     */
-    protected $workDir = '.';
+    protected string $workDir = '.';
 
-    /**
-     * @var InputInterface
-     */
-    protected $input;
+    protected InputInterface $input;
 
-    /**
-     * @var OutputInterface
-     */
-    protected $output;
+    protected OutputInterface $output;
 
     public function __construct(InputInterface $input, OutputInterface $output)
     {

--- a/src/Codeception/Lib/Actor/Shared/Friend.php
+++ b/src/Codeception/Lib/Actor/Shared/Friend.php
@@ -9,10 +9,7 @@ use Codeception\Scenario;
 
 trait Friend
 {
-    /**
-     * @var array
-     */
-    protected $friends = [];
+    protected array $friends = [];
 
     abstract protected function getScenario(): Scenario;
 

--- a/src/Codeception/Lib/Actor/Shared/Retry.php
+++ b/src/Codeception/Lib/Actor/Shared/Retry.php
@@ -6,14 +6,9 @@ namespace Codeception\Lib\Actor\Shared;
 
 trait Retry
 {
-    /**
-     * @var int
-     */
-    protected $retryNum = 1;
-    /**
-     * @var int
-     */
-    protected $retryInterval = 100;
+    protected int $retryNum = 1;
+
+    protected int $retryInterval = 100;
 
     /**
      * Configure number of retries and initial interval.

--- a/src/Codeception/Lib/Connector/Shared/PhpSuperGlobalsConverter.php
+++ b/src/Codeception/Lib/Connector/Shared/PhpSuperGlobalsConverter.php
@@ -73,9 +73,7 @@ trait PhpSuperGlobalsConverter
                      * to ['tmp_name' => ['a' => '/tmp/test.txt'] ]
                      */
                     $innerInfo = array_map(
-                        function ($v) use ($innerName) {
-                            return [$innerName => $v];
-                        },
+                        fn($v) => [$innerName => $v],
                         $innerInfo
                     );
 

--- a/src/Codeception/Lib/Console/Message.php
+++ b/src/Codeception/Lib/Console/Message.php
@@ -8,14 +8,9 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class Message
 {
-    /**
-     * @var Output|null
-     */
-    protected $output;
-    /**
-     * @var string
-     */
-    protected $message;
+    protected ?Output $output;
+
+    protected string $message;
 
     public function __construct(string $message, Output $output = null)
     {

--- a/src/Codeception/Lib/Console/MessageFactory.php
+++ b/src/Codeception/Lib/Console/MessageFactory.php
@@ -8,19 +8,11 @@ use SebastianBergmann\Comparator\ComparisonFailure;
 
 class MessageFactory
 {
-    /**
-     * @var DiffFactory
-     */
-    protected $diffFactory;
-    /**
-     * @var Output
-     */
-    private $output;
+    protected DiffFactory $diffFactory;
 
-    /**
-     * @var Colorizer
-     */
-    protected $colorizer;
+    private Output $output;
+
+    protected Colorizer $colorizer;
 
     public function __construct(Output $output)
     {

--- a/src/Codeception/Lib/Console/Output.php
+++ b/src/Codeception/Lib/Console/Output.php
@@ -15,26 +15,17 @@ class Output extends ConsoleOutput
     /**
      * @var array<string, int|bool>
      */
-    protected $config = [
+    protected array $config = [
         'colors'      => true,
         'verbosity'   => self::VERBOSITY_NORMAL,
         'interactive' => true
     ];
 
-    /**
-     * @var SymfonyFormatterHelper
-     */
-    public $formatHelper;
+    public SymfonyFormatterHelper $formatHelper;
 
-    /**
-     * @var bool
-     */
-    public $waitForDebugOutput = true;
+    public bool $waitForDebugOutput = true;
 
-    /**
-     * @var bool
-     */
-    protected $isInteractive = false;
+    protected bool $isInteractive = false;
 
     public function __construct(array $config)
     {
@@ -59,7 +50,6 @@ class Output extends ConsoleOutput
         $formatter->setStyle('info', new OutputFormatterStyle('green'));
 
         $this->formatHelper = new SymfonyFormatterHelper();
-
 
         parent::__construct($this->config['verbosity'], $this->config['colors'], $formatter);
     }

--- a/src/Codeception/Lib/Console/ReplHistory.php
+++ b/src/Codeception/Lib/Console/ReplHistory.php
@@ -6,17 +6,11 @@ namespace Codeception\Lib\Console;
 
 class ReplHistory
 {
-    protected $outputFile;
+    protected string $outputFile;
 
-    /**
-     * @var array
-     */
-    protected $stashedCommands = [];
+    protected array $stashedCommands = [];
 
-    /**
-     * @var ReplHistory
-     */
-    protected static $instance;
+    protected static ?self $instance = null;
 
     private function __construct()
     {

--- a/src/Codeception/Lib/Di.php
+++ b/src/Codeception/Lib/Di.php
@@ -22,12 +22,9 @@ class Di
     /**
      * @var object[]
      */
-    protected $container = [];
+    protected array $container = [];
 
-    /**
-     * @var Di
-     */
-    protected $fallback;
+    protected ?Di $fallback = null;
 
     public function __construct(Di $fallback = null)
     {
@@ -50,13 +47,12 @@ class Di
      * @param string $injectMethodName Method which will be invoked after object creation;
      *                                 Resolved dependencies will be passed to it as arguments
      * @throws InjectionException|ReflectionException
-     * @return null|object
      */
     public function instantiate(
         string $className,
         array $constructorArgs = null,
         string $injectMethodName = self::DEFAULT_INJECT_METHOD_NAME
-    ) {
+    ): ?object {
         // normalize namespace
         $className = ltrim($className, '\\');
 

--- a/src/Codeception/Lib/Friend.php
+++ b/src/Codeception/Lib/Friend.php
@@ -10,31 +10,20 @@ use Codeception\Lib\Interfaces\MultiSession;
 
 class Friend
 {
-    /**
-     * @var string
-     */
-    protected $name;
-    /**
-     * @var Actor
-     */
-    protected $actor;
-    /**
-     * @var array
-     */
-    protected $data = [];
-    /**
-     * @var array|null
-     */
-    protected $multiSessionModules = [];
+    protected string $name;
+
+    protected Actor $actor;
+
+    protected array $data = [];
+
+    protected array $multiSessionModules = [];
 
     public function __construct(string $name, Actor $actor, array $modules = [])
     {
         $this->name = $name;
         $this->actor = $actor;
 
-        $this->multiSessionModules = array_filter($modules, function ($m) {
-            return $m instanceof MultiSession;
-        });
+        $this->multiSessionModules = array_filter($modules, fn($m): bool => $m instanceof MultiSession);
 
         if (empty($this->multiSessionModules)) {
             throw new TestRuntimeException("No multisession modules used. Can't instantiate friend");

--- a/src/Codeception/Lib/Generator/Actions.php
+++ b/src/Codeception/Lib/Generator/Actions.php
@@ -8,6 +8,7 @@ use Codeception\Codecept;
 use Codeception\Configuration;
 use Codeception\Lib\Di;
 use Codeception\Lib\ModuleContainer;
+use Codeception\Step\GeneratedStep;
 use Codeception\Util\ReflectionHelper;
 use Codeception\Util\Template;
 use Exception;
@@ -15,23 +16,15 @@ use ReflectionClass;
 use ReflectionException;
 use ReflectionMethod;
 use ReflectionType;
+use ReflectionUnionType;
 
 class Actions
 {
-    /**
-     * @var Di
-     */
-    public $di;
+    public Di $di;
 
-    /**
-     * @var ModuleContainer
-     */
-    public $moduleContainer;
+    public ModuleContainer $moduleContainer;
 
-    /**
-     * @var string
-     */
-    protected $template = <<<EOF
+    protected string $template = <<<EOF
 <?php  //[STAMP] {{hash}}
 namespace {{namespace}}_generated;
 
@@ -51,10 +44,7 @@ trait {{name}}Actions
 
 EOF;
 
-    /**
-     * @var string
-     */
-    protected $methodTemplate = <<<EOF
+    protected string $methodTemplate = <<<EOF
 
     /**
      * [!] Method is generated. Documentation taken from corresponding module.
@@ -67,35 +57,20 @@ EOF;
     }
 EOF;
 
-    /**
-     * @var string
-     */
-    protected $name;
+    protected string $name;
+
+    protected array $settings = [];
+
+    protected array $modules = [];
+
+    protected array $actions = [];
+
+    protected int $numMethods = 0;
 
     /**
-     * @var array
+     * @var GeneratedStep[]
      */
-    protected $settings = [];
-
-    /**
-     * @var array
-     */
-    protected $modules = [];
-
-    /**
-     * @var array
-     */
-    protected $actions = [];
-
-    /**
-     * @var int
-     */
-    protected $numMethods = 0;
-
-    /**
-     * @var array GeneratedStep[]
-     */
-    protected $generatedSteps = [];
+    protected array $generatedSteps = [];
 
     public function __construct(array $settings)
     {
@@ -112,7 +87,6 @@ EOF;
 
         $this->generatedSteps = (array) $settings['step_decorators'];
     }
-
 
     public function produce(): string
     {
@@ -263,7 +237,7 @@ EOF;
 
     private function stringifyType(ReflectionType $type): string
     {
-        if ($type instanceof \ReflectionUnionType) {
+        if ($type instanceof ReflectionUnionType) {
             $types = $type->getTypes();
             return implode('|', $types);
         }

--- a/src/Codeception/Lib/Generator/Actor.php
+++ b/src/Codeception/Lib/Generator/Actor.php
@@ -15,20 +15,11 @@ use ReflectionMethod;
 
 class Actor
 {
-    /**
-     * @var Di
-     */
-    public $di;
+    public Di $di;
 
-    /**
-     * @var ModuleContainer
-     */
-    public $moduleContainer;
+    public ModuleContainer $moduleContainer;
 
-    /**
-     * @var string
-     */
-    protected $template = <<<EOF
+    protected string $template = <<<EOF
 <?php
 
 declare(strict_types=1);
@@ -51,25 +42,13 @@ class {{actor}} extends \Codeception\Actor
 
 EOF;
 
-    /**
-     * @var string
-     */
-    protected $inheritedMethodTemplate = ' * @method {{return}} {{method}}({{params}})';
+    protected string $inheritedMethodTemplate = ' * @method {{return}} {{method}}({{params}})';
 
-    /**
-     * @var array
-     */
-    protected $settings = [];
+    protected array $settings = [];
 
-    /**
-     * @var array
-     */
-    protected $modules = [];
+    protected array $modules = [];
 
-    /**
-     * @var array
-     */
-    protected $actions = [];
+    protected array $actions = [];
 
     public function __construct(array $settings)
     {

--- a/src/Codeception/Lib/Generator/Cept.php
+++ b/src/Codeception/Lib/Generator/Cept.php
@@ -9,20 +9,14 @@ use Codeception\Util\Template;
 
 class Cept
 {
-    /**
-     * @var string
-     */
-    protected $template = <<<EOF
+    protected string $template = <<<EOF
 <?php {{use}}
 \$I = new {{actor}}(\$scenario);
 \$I->wantTo('perform actions and see result');
 
 EOF;
 
-    /**
-     * @var array
-     */
-    protected $settings = [];
+    protected array $settings = [];
 
     public function __construct(array $settings)
     {

--- a/src/Codeception/Lib/Generator/Cest.php
+++ b/src/Codeception/Lib/Generator/Cest.php
@@ -14,10 +14,7 @@ class Cest
     use Classname;
     use Namespaces;
 
-    /**
-     * @var string
-     */
-    protected $template = <<<EOF
+    protected string $template = <<<EOF
 <?php
 {{namespace}}
 class {{name}}Cest
@@ -34,15 +31,9 @@ class {{name}}Cest
 
 EOF;
 
-    /**
-     * @var array
-     */
-    protected $settings = [];
+    protected array $settings = [];
 
-    /**
-     * @var string
-     */
-    protected $name;
+    protected ?string $name;
 
     public function __construct(string $className, array $settings)
     {

--- a/src/Codeception/Lib/Generator/Feature.php
+++ b/src/Codeception/Lib/Generator/Feature.php
@@ -8,10 +8,7 @@ use Codeception\Util\Template;
 
 class Feature
 {
-    /**
-     * @var string
-     */
-    protected $template = <<<EOF
+    protected string $template = <<<EOF
 Feature: {{name}}
   In order to ...
   As a ...
@@ -21,10 +18,7 @@ Feature: {{name}}
 
 EOF;
 
-    /**
-     * @var string
-     */
-    protected $name;
+    protected string $name;
 
     public function __construct(string $name)
     {

--- a/src/Codeception/Lib/Generator/GherkinSnippets.php
+++ b/src/Codeception/Lib/Generator/GherkinSnippets.php
@@ -11,10 +11,7 @@ use Symfony\Component\Finder\Finder;
 
 class GherkinSnippets
 {
-    /**
-     * @var string
-     */
-    protected $template = <<<EOF
+    protected string $template = <<<EOF
     /**
      * @{{type}} {{text}}
      */
@@ -28,15 +25,17 @@ EOF;
     /**
      * @var string[]
      */
-    protected $snippets = [];
+    protected array $snippets = [];
+
     /**
      * @var string[]
      */
-    protected $processed = [];
+    protected array $processed = [];
+
     /**
      * @var string[]
      */
-    protected $features = [];
+    protected array $features = [];
 
     public function __construct(array $settings, $test = null)
     {
@@ -102,7 +101,7 @@ EOF;
         $pattern = $step->getText();
 
         // match numbers (not in quotes)
-        if (preg_match_all('#([\d\.])(?=([^"]*"[^"]*")*[^"]*$)#', $pattern, $matches)) {
+        if (preg_match_all('#([\d.])(?=([^"]*"[^"]*")*[^"]*$)#', $pattern, $matches)) {
             foreach ($matches[1] as $num => $param) {
                 ++$num;
                 $args[] = '$num' . $num;

--- a/src/Codeception/Lib/Generator/Group.php
+++ b/src/Codeception/Lib/Generator/Group.php
@@ -13,10 +13,7 @@ class Group
     use Namespaces;
     use Classname;
 
-    /**
-     * @var string
-     */
-    protected $template = <<<EOF
+    protected string $template = <<<EOF
 <?php
 
 declare(strict_types=1);
@@ -49,20 +46,11 @@ class {{class}} extends \Codeception\Platform\Group
 
 EOF;
 
-    /**
-     * @var string
-     */
-    protected $name;
+    protected string $name;
 
-    /**
-     * @var string
-     */
-    protected $namespace;
+    protected string $namespace;
 
-    /**
-     * @var array
-     */
-    protected $settings = [];
+    protected array $settings = [];
 
     public function __construct(array $settings, string $name)
     {

--- a/src/Codeception/Lib/Generator/Helper.php
+++ b/src/Codeception/Lib/Generator/Helper.php
@@ -11,10 +11,7 @@ class Helper
 {
     use Namespaces;
 
-    /**
-     * @var string
-     */
-    protected $template = <<<EOF
+    protected string $template = <<<EOF
 <?php
 
 declare(strict_types=1);
@@ -29,15 +26,9 @@ class {{name}} extends \\Codeception\\Module
 
 EOF;
 
-    /**
-     * @var string
-     */
-    protected $namespace;
+    protected string $namespace;
 
-    /**
-     * @var string
-     */
-    protected $name;
+    protected string $name;
 
     public function __construct(string $name, string $namespace = '')
     {

--- a/src/Codeception/Lib/Generator/PageObject.php
+++ b/src/Codeception/Lib/Generator/PageObject.php
@@ -13,10 +13,7 @@ class PageObject
     use Namespaces;
     use Classname;
 
-    /**
-     * @var string
-     */
-    protected $template = <<<EOF
+    protected string $template = <<<EOF
 <?php
 
 declare(strict_types=1);
@@ -49,10 +46,7 @@ class {{class}}
 
 EOF;
 
-    /**
-     * @var string
-     */
-    protected $actionsTemplate = <<<EOF
+    protected string $actionsTemplate = <<<EOF
     /**
      * @var \\{{actorClass}};
      */
@@ -65,25 +59,13 @@ EOF;
 
 EOF;
 
-    /**
-     * @var string
-     */
-    protected $actions = '';
+    protected string $actions = '';
 
-    /**
-     * @var array
-     */
-    protected $settings = [];
+    protected array $settings = [];
 
-    /**
-     * @var string
-     */
-    protected $name;
+    protected string $name;
 
-    /**
-     * @var string
-     */
-    protected $namespace;
+    protected string $namespace;
 
     public function __construct(array $settings, string $name)
     {

--- a/src/Codeception/Lib/Generator/Shared/Classname.php
+++ b/src/Codeception/Lib/Generator/Shared/Classname.php
@@ -6,7 +6,7 @@ namespace Codeception\Lib\Generator\Shared;
 
 trait Classname
 {
-    protected function removeSuffix(string $classname, string $suffix)
+    protected function removeSuffix(string $classname, string $suffix): string
     {
         $classname = preg_replace('#\.php$#', '', $classname);
         return preg_replace("#{$suffix}$#", '', $classname);

--- a/src/Codeception/Lib/Generator/Snapshot.php
+++ b/src/Codeception/Lib/Generator/Snapshot.php
@@ -11,10 +11,7 @@ class Snapshot
 {
     use Namespaces;
 
-    /**
-     * @var string
-     */
-    protected $template = <<<EOF
+    protected string $template = <<<EOF
 <?php
 
 declare(strict_types=1);
@@ -33,10 +30,7 @@ class {{name}} extends \\Codeception\\Snapshot
 }
 EOF;
 
-    /**
-     * @var string
-     */
-    protected $actionsTemplate = <<<EOF
+    protected string $actionsTemplate = <<<EOF
     /**
      * @var \\{{actorClass}};
      */
@@ -48,20 +42,11 @@ EOF;
     }
 EOF;
 
-    /**
-     * @var string
-     */
-    protected $namespace;
+    protected string $namespace;
 
-    /**
-     * @var string
-     */
-    protected $name;
+    protected string $name;
 
-    /**
-     * @var array
-     */
-    protected $settings = [];
+    protected array $settings = [];
 
     public function __construct(array $settings, string $name)
     {

--- a/src/Codeception/Lib/Generator/StepObject.php
+++ b/src/Codeception/Lib/Generator/StepObject.php
@@ -14,10 +14,7 @@ class StepObject
     use Namespaces;
     use Classname;
 
-    /**
-     * @var string
-     */
-    protected $template = <<<EOF
+    protected string $template = <<<EOF
 <?php
 
 declare(strict_types=1);
@@ -30,10 +27,7 @@ class {{name}} extends {{actorClass}}
 }
 EOF;
 
-    /**
-     * @var string
-     */
-    protected $actionTemplate = <<<EOF
+    protected string $actionTemplate = <<<EOF
 
     public function {{action}}()
     {
@@ -42,25 +36,13 @@ EOF;
 
 EOF;
 
-    /**
-     * @var array
-     */
-    protected $settings = [];
+    protected array $settings = [];
 
-    /**
-     * @var string
-     */
-    protected $name;
+    protected string $name;
 
-    /**
-     * @var string
-     */
-    protected $actions = '';
+    protected string $actions = '';
 
-    /**
-     * @var string
-     */
-    public $namespace;
+    public string $namespace;
 
     public function __construct(array $settings, string $name)
     {

--- a/src/Codeception/Lib/Generator/Test.php
+++ b/src/Codeception/Lib/Generator/Test.php
@@ -14,10 +14,7 @@ class Test
     use Namespaces;
     use Classname;
 
-    /**
-     * @var string
-     */
-    protected $template = <<<EOF
+    protected string $template = <<<EOF
 <?php
 {{namespace}}
 class {{name}}Test extends \Codeception\Test\Unit
@@ -39,10 +36,7 @@ class {{name}}Test extends \Codeception\Test\Unit
 }
 EOF;
 
-    /**
-     * @var string
-     */
-    protected $testerTemplate = <<<EOF
+    protected string $testerTemplate = <<<EOF
     /**
      * @var \{{actorClass}}
      */
@@ -50,15 +44,9 @@ EOF;
     
 EOF;
 
-    /**
-     * @var array
-     */
-    protected $settings = [];
+    protected array $settings = [];
 
-    /**
-     * @var string
-     */
-    protected $name;
+    protected ?string $name;
 
     public function __construct(array $settings, string $name)
     {

--- a/src/Codeception/Lib/GroupManager.php
+++ b/src/Codeception/Lib/GroupManager.php
@@ -23,12 +23,9 @@ class GroupManager
     /**
      * @var string[]
      */
-    protected $configuredGroups = [];
+    protected array $configuredGroups = [];
 
-    /**
-     * @var mixed[][]
-     */
-    protected $testsInGroups = [];
+    protected array $testsInGroups = [];
 
     /**
      * @param string[] $groups
@@ -64,7 +61,7 @@ class GroupManager
 
             $i = 1;
             foreach ($files as $file) {
-                /** @var SplFileInfo $file * */
+                /** @var SplFileInfo $file */
                 $this->configuredGroups[str_replace('*', (string)$i, $group)] = dirname($pattern) . DIRECTORY_SEPARATOR . $file->getRelativePathname();
                 ++$i;
             }

--- a/src/Codeception/Lib/ModuleContainer.php
+++ b/src/Codeception/Lib/ModuleContainer.php
@@ -31,14 +31,14 @@ class ModuleContainer
     const MODULE_NAMESPACE = '\\Codeception\\Module\\';
 
     /**
-     * @var integer
+     * @var int
      */
     const MAXIMUM_LEVENSHTEIN_DISTANCE = 5;
 
     /**
      * @var array<string, string>
      */
-    public static $packages = [
+    public static array $packages = [
         'AMQP' => 'codeception/module-amqp',
         'Apc' => 'codeception/module-apc',
         'Asserts' => 'codeception/module-asserts',
@@ -66,31 +66,15 @@ class ModuleContainer
         'ZF2' => 'codeception/module-zf2',
     ];
 
-    /**
-     * @var array
-     */
-    private $config = [];
+    private array $config;
 
-    /**
-     * @var Di
-     */
-    private $di;
+    private Di $di;
 
-    /**
-     * @var array
-     */
-    private $modules = [];
+    private array $modules = [];
 
-    /**
-     * @var array
-     */
-    private $active = [];
+    private array $active = [];
 
-    /**
-     * @var array
-     */
-    private $actions = [];
-
+    private array $actions = [];
 
     public function __construct(Di $di, array $config)
     {
@@ -130,7 +114,7 @@ class ModuleContainer
             // Explicitly setting $config to null skips this validation.
             $config = null;
         }
-        $this->modules[$moduleName] = $this->di->instantiate($moduleClass, [$this, $config], (string)false);
+        $this->modules[$moduleName] = $this->di->instantiate($moduleClass, [$this, $config], 'false');
 
         $module = $this->modules[$moduleName];
 
@@ -191,7 +175,7 @@ class ModuleContainer
     /**
      * Should a method be included as an action?
      */
-    private function includeMethodAsAction(Module $module, ReflectionMethod $method, ?array $configuredParts = null): bool
+    private function includeMethodAsAction(Module $module, ReflectionMethod $method, array $configuredParts = null): bool
     {
         // Filter out excluded actions
         if ($module::$excludeActions && in_array($method->name, $module::$excludeActions)) {
@@ -299,7 +283,7 @@ class ModuleContainer
     /**
      * Get the module for an action.
      *
-     * @return Module|null
+     * @var Module|null
      */
     public function moduleForAction(string $action)
     {
@@ -352,9 +336,7 @@ class ModuleContainer
             throw new ModuleException($module, 'Module requires method _inject to be defined to accept dependencies');
         }
 
-        $dependencies = array_map(function ($dependency) {
-            return $this->create($dependency, false);
-        }, $this->getConfiguredDependencies($moduleName));
+        $dependencies = array_map(fn($dependency): ?object => $this->create($dependency, false), $this->getConfiguredDependencies($moduleName));
 
         call_user_func_array([$module, '_inject'], $dependencies);
     }

--- a/src/Codeception/Lib/Notification.php
+++ b/src/Codeception/Lib/Notification.php
@@ -9,7 +9,7 @@ class Notification
     /**
      * @var string[]
      */
-    protected static $messages = [];
+    protected static array $messages = [];
 
     public static function warning(string $message, string $location): void
     {

--- a/src/Codeception/Lib/ParamsLoader.php
+++ b/src/Codeception/Lib/ParamsLoader.php
@@ -19,10 +19,8 @@ class ParamsLoader
      * @var array|string|null
      */
     protected $paramStorage;
-    /**
-     * @var string|null
-     */
-    protected $paramsFile;
+
+    protected ?string $paramsFile = null;
 
     /**
      * @param array|string $paramStorage
@@ -73,6 +71,9 @@ class ParamsLoader
         throw new ConfigurationException("Params can't be loaded from `{$paramStorage}`.");
     }
 
+    /**
+     * @return array|string|null
+     */
     public function loadArray()
     {
         return $this->paramStorage;

--- a/src/Codeception/Lib/Parser.php
+++ b/src/Codeception/Lib/Parser.php
@@ -14,18 +14,11 @@ use ParseError;
 
 class Parser
 {
-    /**
-     * @var Scenario
-     */
-    protected $scenario;
-    /**
-     * @var Metadata
-     */
-    protected $metadata;
-    /**
-     * @var string
-     */
-    protected $code;
+    protected Scenario $scenario;
+
+    protected Metadata $metadata;
+
+    protected string $code;
 
     public function __construct(Scenario $scenario, Metadata $metadata)
     {
@@ -179,22 +172,21 @@ class Parser
 
     protected function stripComments(string $code): string
     {
-        $code = preg_replace('#\/\/.*?$#m', '', $code); // remove inline comments
-        $code = preg_replace('#\/*\*.*?\*\/#ms', '', $code);
-        return $code; // remove block comment
+        $code = preg_replace('#//.*?$#m', '', $code); // remove inline comments
+        return preg_replace('#/*\*.*?\*/#ms', '', $code); // remove block comment
     }
 
     protected function matchComments(string $code): string
     {
         $matches = [];
         $comments = '';
-        $hasLineComment = preg_match_all('#\/\/(.*?)$#m', $code, $matches);
+        $hasLineComment = preg_match_all('#//(.*?)$#m', $code, $matches);
         if ($hasLineComment) {
             foreach ($matches[1] as $line) {
                 $comments .= $line."\n";
             }
         }
-        $hasBlockComment = preg_match('#\/*\*(.*?)\*\/#ms', $code, $matches);
+        $hasBlockComment = preg_match('#/*\*(.*?)\*/#ms', $code, $matches);
         if ($hasBlockComment) {
             $comments .= $matches[1]."\n";
         }

--- a/src/Codeception/Scenario.php
+++ b/src/Codeception/Scenario.php
@@ -16,30 +16,15 @@ use PHPUnit\Framework\SkippedTestError;
 
 class Scenario
 {
-    /**
-     * @var TestInterface
-     */
-    protected $test;
+    protected TestInterface $test;
 
-    /**
-     * @var Metadata
-     */
-    protected $metadata;
+    protected Metadata $metadata;
 
-    /**
-     * @var array
-     */
-    protected $steps = [];
+    protected array $steps = [];
 
-    /**
-     * @var string
-     */
-    protected $feature;
+    protected string $feature;
 
-    /**
-     * @var Meta|null
-     */
-    protected $metaStep;
+    protected ?Meta $metaStep = null;
 
     public function __construct(TestInterface $test)
     {

--- a/src/Codeception/Snapshot.php
+++ b/src/Codeception/Snapshot.php
@@ -13,35 +13,20 @@ abstract class Snapshot
 {
     use Asserts;
 
-    /**
-     * @var string|null
-     */
-    protected $fileName;
+    protected ?string $fileName = null;
 
     /**
-     * @var null
+     * @var string|false
      */
     protected $dataSet;
 
-    /**
-     * @var bool|null
-     */
-    protected $refresh;
+    protected ?bool $refresh = null;
 
-    /**
-     * @var bool
-     */
-    protected $showDiff = false;
+    protected bool $showDiff = false;
 
-    /**
-     * @var bool
-     */
-    protected $saveAsJson = true;
+    protected bool $saveAsJson = true;
 
-    /**
-     * @var string
-     */
-    protected $extension = 'json';
+    protected string $extension = 'json';
 
     /**
      * Should return data from current test run

--- a/src/Codeception/Step.php
+++ b/src/Codeception/Step.php
@@ -25,52 +25,26 @@ abstract class Step
      */
     const STACK_POSITION = 3;
 
-    /**
-     * @var string
-     */
-    protected $action;
+    protected string $action;
 
-    /**
-     * @var array
-     */
-    protected $arguments = [];
+    protected array $arguments;
 
-    protected $debugOutput;
-
-    /**
-     * @var bool
-     */
-    public $executed = false;
+    public bool $executed = false;
 
     /**
      * @var string|int|null
      */
     protected $line = null;
 
-    /**
-     * @var string|null
-     */
-    protected $file = null;
+    protected ?string $file = null;
 
-    /**
-     * @var string
-     */
-    protected $prefix = 'I';
+    protected string $prefix = 'I';
 
-    /**
-     * @var MetaStep|null
-     */
-    protected $metaStep = null;
+    protected ?MetaStep $metaStep = null;
 
-    /**
-     * @var bool
-     */
-    protected $failed = false;
+    protected bool $failed = false;
 
-    /**
-     * @var bool
-     */
-    protected $isTry = false;
+    protected bool $isTry = false;
 
     public function __construct(string $action, array $arguments = [])
     {
@@ -145,7 +119,7 @@ abstract class Step
 
         if ($totalLength > $maxLength && $maxLength > 0) {
             //sort arguments from shortest to longest
-            uasort($arguments, function ($arg1, $arg2) {
+            uasort($arguments, function ($arg1, $arg2): int {
                 $length1 = mb_strlen($arg1, 'utf-8');
                 $length2 = mb_strlen($arg2, 'utf-8');
                 if ($length1 === $length2) {
@@ -283,7 +257,6 @@ abstract class Step
     }
 
     /**
-     * @param ModuleContainer|null $container
      * @return mixed
      */
     public function run(ModuleContainer $container = null)
@@ -319,7 +292,7 @@ abstract class Step
      */
     protected function addMetaStep(array $step, array $stack): void
     {
-        if (($this->isTestFile($this->file)) || ($step['class'] == \Codeception\Scenario::class)) {
+        if (($this->isTestFile($this->file)) || ($step['class'] == Scenario::class)) {
             return;
         }
 
@@ -338,13 +311,11 @@ abstract class Step
             }
 
             // in case arguments were passed by reference, copy args array to ensure dereference.  array_values() does not dereference values
-            $this->metaStep = new Step\Meta($step['function'], array_map(function ($i) {
-                return $i;
-            }, array_values($step['args'])));
+            $this->metaStep = new Step\Meta($step['function'], array_map(fn($i) => $i, array_values($step['args'])));
             $this->metaStep->setTraceInfo($step['file'], $step['line']);
 
             // page objects or other classes should not be included with "I"
-            if (!in_array(\Codeception\Actor::class, class_parents($step['class']))) {
+            if (!in_array(Actor::class, class_parents($step['class']))) {
                 if (isset($step['object'])) {
                     $this->metaStep->setPrefix(get_class($step['object']) . ':');
                     return;

--- a/src/Codeception/Step/Argument/PasswordArgument.php
+++ b/src/Codeception/Step/Argument/PasswordArgument.php
@@ -6,10 +6,7 @@ namespace Codeception\Step\Argument;
 
 class PasswordArgument implements FormattedOutput
 {
-    /**
-     * @var string
-     */
-    private $password;
+    private string $password;
 
     public function __construct(string $password)
     {

--- a/src/Codeception/Step/Executor.php
+++ b/src/Codeception/Step/Executor.php
@@ -10,10 +10,7 @@ use Codeception\Step as CodeceptionStep;
 
 class Executor extends CodeceptionStep
 {
-    /**
-     * @var Closure
-     */
-    protected $callable;
+    protected Closure $callable;
 
     public function __construct(Closure $callable, array $arguments = [])
     {

--- a/src/Codeception/Step/Retry.php
+++ b/src/Codeception/Step/Retry.php
@@ -14,10 +14,7 @@ use function usleep;
 
 class Retry extends Assertion implements GeneratedStep
 {
-    /**
-     * @var string
-     */
-    protected static $methodTemplate = <<<EOF
+    protected static string $methodTemplate = <<<EOF
 
     /**
      * [!] Method is generated.
@@ -35,14 +32,9 @@ class Retry extends Assertion implements GeneratedStep
     }
 EOF;
 
-    /**
-     * @var int
-     */
-    private $retryNum;
-    /**
-     * @var int
-     */
-    private $retryInterval;
+    private int $retryNum;
+
+    private int $retryInterval;
 
     public function __construct($action, array $arguments, int $retryNum, int $retryInterval)
     {

--- a/src/Codeception/Subscriber/AutoRebuild.php
+++ b/src/Codeception/Subscriber/AutoRebuild.php
@@ -26,7 +26,7 @@ class AutoRebuild implements EventSubscriberInterface
     /**
      * @var array<string, string>
      */
-    protected static $events = [
+    protected static array $events = [
         Events::SUITE_INIT => 'updateActor'
     ];
 
@@ -53,7 +53,7 @@ class AutoRebuild implements EventSubscriberInterface
         $handle = @fopen($actorActionsFile, "r");
         if ($handle && is_writable($actorActionsFile)) {
             $line = @fgets($handle);
-            if (preg_match('#\[STAMP\] ([a-f0-9]*)#', $line, $matches)) {
+            if (preg_match('#\[STAMP] ([a-f0-9]*)#', $line, $matches)) {
                 $hash = $matches[1];
                 $currentHash = Actions::genHash($modules, $settings);
 

--- a/src/Codeception/Subscriber/BeforeAfterTest.php
+++ b/src/Codeception/Subscriber/BeforeAfterTest.php
@@ -19,19 +19,14 @@ class BeforeAfterTest implements EventSubscriberInterface
     /**
      * @var array<string, string|int[]|string[]>
      */
-    protected static $events = [
+    protected static array $events = [
         Events::SUITE_BEFORE => 'beforeClass',
         Events::SUITE_AFTER  => ['afterClass', 100]
     ];
 
-    /**
-     * @var array
-     */
-    protected $hooks = [];
-    /**
-     * @var array
-     */
-    protected $startedTests = [];
+    protected array $hooks = [];
+
+    protected array $startedTests = [];
 
     public function beforeClass(SuiteEvent $event): void
     {

--- a/src/Codeception/Subscriber/Bootstrap.php
+++ b/src/Codeception/Subscriber/Bootstrap.php
@@ -16,7 +16,7 @@ class Bootstrap implements EventSubscriberInterface
     /**
      * @var array<string, string>
      */
-    protected static $events = [
+    protected static array $events = [
         Events::SUITE_INIT => 'loadBootstrap',
     ];
 

--- a/src/Codeception/Subscriber/Console.php
+++ b/src/Codeception/Subscriber/Console.php
@@ -17,6 +17,7 @@ use Codeception\Lib\Notification;
 use Codeception\Step;
 use Codeception\Step\Comment;
 use Codeception\Step\ConditionalAssertion;
+use Codeception\Step\Meta;
 use Codeception\Suite;
 use Codeception\Test\Descriptor;
 use Codeception\Test\Interfaces\ScenarioDriven;
@@ -62,7 +63,7 @@ class Console implements EventSubscriberInterface
     /**
      * @var array<string, string>
      */
-    protected static $events = [
+    protected static array $events = [
         Events::SUITE_BEFORE       => 'beforeSuite',
         Events::SUITE_AFTER        => 'afterSuite',
         Events::TEST_START         => 'startTest',
@@ -79,81 +80,56 @@ class Console implements EventSubscriberInterface
         Events::RESULT_PRINT_AFTER => 'afterResult',
     ];
 
-    /**
-     * @var Step
-     */
-    protected $metaStep;
+    protected ?Meta $metaStep = null;
 
-    /**
-     * @var Message
-     */
-    protected $message;
-    /**
-     * @var bool
-     */
-    protected $steps = true;
-    /**
-     * @var bool
-     */
-    protected $debug = false;
-    /**
-     * @var bool
-     */
-    protected $ansi = true;
-    /**
-     * @var bool
-     */
-    protected $silent = false;
-    /**
-     * @var bool
-     */
-    protected $lastTestFailed = false;
-    /**
-     * @var TestInterface|null
-     */
-    protected $printedTest;
-    /**
-     * @var bool
-     */
-    protected $rawStackTrace = false;
-    /**
-     * @var int
-     */
-    protected $traceLength = 5;
-    /**
-     * @var int
-     */
-    protected $width;
+    protected ?Message $message;
 
-    /**
-     * @var OutputInterface
-     */
-    protected $output;
+    protected bool $steps = true;
+
+    protected bool $debug = false;
+
+    protected bool $ansi = true;
+
+    protected bool $silent = false;
+
+    protected bool $lastTestFailed = false;
+
+    protected ?SelfDescribing $printedTest = null;
+
+    protected bool $rawStackTrace = false;
+
+    protected int $traceLength = 5;
+
+    protected ?int $width = null;
+
+    protected OutputInterface $output;
+
     /**
      * @var ConditionalAssertion[]
      */
-    protected $conditionalFails = [];
+    protected array $conditionalFails = [];
+
     /**
      * @var Step[]
      */
-    protected $failedStep = [];
+    protected array $failedStep = [];
+
     /**
      * @var string[]
      */
-    protected $reports = [];
-    /**
-     * @var string
-     */
-    protected $namespace = '';
+    protected array $reports = [];
+
+    protected string $namespace = '';
+
     /**
      * @var array<string, string>
      */
-    protected $chars = ['success' => '+', 'fail' => 'x', 'of' => ':'];
+    protected array $chars = ['success' => '+', 'fail' => 'x', 'of' => ':'];
 
     /**
      * @var array<string, int|bool|null>
      */
-    protected $options = [
+    protected array $options = [
         'debug'         => false,
         'ansi'          => false,
         'steps'         => true,
@@ -164,10 +140,7 @@ class Console implements EventSubscriberInterface
         'no-artifacts'  => false,
     ];
 
-    /**
-     * @var MessageFactory
-     */
-    protected $messageFactory;
+    protected MessageFactory $messageFactory;
 
     public function __construct(array $options)
     {
@@ -217,9 +190,7 @@ class Console implements EventSubscriberInterface
                 implode(
                     ', ',
                     array_map(
-                        function ($module) {
-                            return $module->_getName();
-                        },
+                        fn($module) => $module->_getName(),
                         $event->getSuite()->getModules()
                     )
                 )
@@ -591,9 +562,7 @@ class Console implements EventSubscriberInterface
         $this->message("\nScenario Steps:\n")->style('comment')->writeln();
 
         foreach ($trace as $step) {
-            /**
-             * @var $step Step
-             */
+            /** @var Step $step */
             if (!$step->__toString()) {
                 continue;
             }

--- a/src/Codeception/Subscriber/Dependencies.php
+++ b/src/Codeception/Subscriber/Dependencies.php
@@ -20,7 +20,7 @@ class Dependencies implements EventSubscriberInterface
     /**
      * @var array<string, string>
      */
-    protected static $events = [
+    protected static array $events = [
         Events::TEST_START => 'testStart',
         Events::TEST_SUCCESS => 'testSuccess'
     ];
@@ -28,7 +28,7 @@ class Dependencies implements EventSubscriberInterface
     /**
      * @var string[]
      */
-    protected $successfulTests = [];
+    protected array $successfulTests = [];
 
     public function testStart(TestEvent $event): void
     {

--- a/src/Codeception/Subscriber/ErrorHandler.php
+++ b/src/Codeception/Subscriber/ErrorHandler.php
@@ -31,7 +31,7 @@ class ErrorHandler implements EventSubscriberInterface
     /**
      * @var array<string, string>
      */
-    protected static $events = [
+    protected static array $events = [
         Events::SUITE_BEFORE => 'handle',
         Events::SUITE_AFTER  => 'onFinish'
     ];
@@ -39,32 +39,26 @@ class ErrorHandler implements EventSubscriberInterface
     /**
      * @var bool $stopped to keep shutdownHandler from possible looping.
      */
-    private $stopped = false;
+    private bool $stopped = false;
 
     /**
      * @var bool $initialized to avoid double error handler substitution
      */
-    private $initialized = false;
+    private bool $initialized = false;
 
-    /**
-     * @var bool
-     */
-    private $deprecationsInstalled = false;
+    private bool $deprecationsInstalled = false;
 
     /**
      * @var callable|null
      */
     private $oldHandler;
 
-    /**
-     * @var bool
-     */
-    private $suiteFinished = false;
+    private bool $suiteFinished = false;
 
     /**
-     * @var int stores bitmask for errors
+     * @var int Stores bitmask for errors
      */
-    private $errorLevel;
+    private int $errorLevel;
 
     public function __construct()
     {

--- a/src/Codeception/Subscriber/ExtensionLoader.php
+++ b/src/Codeception/Subscriber/ExtensionLoader.php
@@ -23,35 +23,20 @@ class ExtensionLoader implements EventSubscriberInterface
     /**
      * @var array<string, string>
      */
-    protected static $events = [
+    protected static array $events = [
         Events::MODULE_INIT => 'registerSuiteExtensions',
         Events::SUITE_AFTER  => 'stopSuiteExtensions'
     ];
 
-    /**
-     * @var array
-     */
-    protected $config = [];
+    protected array $config = [];
 
-    /**
-     * @var array
-     */
-    protected $options = [];
+    protected array $options = [];
 
-    /**
-     * @var array
-     */
-    protected $globalExtensions = [];
+    protected array $globalExtensions = [];
 
-    /**
-     * @var array
-     */
-    protected $suiteExtensions = [];
+    protected array $suiteExtensions = [];
 
-    /**
-     * @var EventDispatcher
-     */
-    protected $dispatcher;
+    protected EventDispatcher $dispatcher;
 
     public function __construct(EventDispatcher $eventDispatcher)
     {

--- a/src/Codeception/Subscriber/FailFast.php
+++ b/src/Codeception/Subscriber/FailFast.php
@@ -15,7 +15,7 @@ class FailFast implements EventSubscriberInterface
     /**
      * @var array<string, string>
      */
-    protected static $events = [
+    protected static array $events = [
         Events::SUITE_BEFORE => 'stopOnFail',
     ];
 

--- a/src/Codeception/Subscriber/GracefulTermination.php
+++ b/src/Codeception/Subscriber/GracefulTermination.php
@@ -24,10 +24,7 @@ class GracefulTermination implements EventSubscriberInterface
      */
     const ASYNC_SIGNAL_HANDLING_FUNC = 'pcntl_async_signals';
 
-    /**
-     * @var SuiteEvent
-     */
-    protected $suiteEvent;
+    protected ?SuiteEvent $suiteEvent = null;
 
     public function handleSuite(SuiteEvent $event): void
     {

--- a/src/Codeception/Subscriber/Module.php
+++ b/src/Codeception/Subscriber/Module.php
@@ -21,7 +21,7 @@ class Module implements EventSubscriberInterface
     /**
      * @var array<string, string>
      */
-    protected static $events = [
+    protected static array $events = [
         Events::TEST_BEFORE  => 'before',
         Events::TEST_AFTER   => 'after',
         Events::STEP_BEFORE  => 'beforeStep',
@@ -33,7 +33,7 @@ class Module implements EventSubscriberInterface
     ];
 
     /** @var \Codeception\Module[] */
-    protected $modules = [];
+    protected array $modules = [];
 
     /**
      * @param \Codeception\Module[] $modules

--- a/src/Codeception/Subscriber/PrepareTest.php
+++ b/src/Codeception/Subscriber/PrepareTest.php
@@ -18,19 +18,16 @@ class PrepareTest implements EventSubscriberInterface
     /**
      * @var array<string, string>
      */
-    protected static $events = [
+    protected static array $events = [
         Events::TEST_BEFORE => 'prepare',
     ];
 
-    /**
-     * @var array
-     */
-    protected $modules = [];
+    protected array $modules = [];
 
     public function prepare(TestEvent $event): void
     {
         $test = $event->getTest();
-        /** @var $di Di  **/
+        /** @var Di $di */
         $prepareMethods = $test->getMetadata()->getParam('prepare');
 
         if (!$prepareMethods) {

--- a/src/Codeception/Suite.php
+++ b/src/Codeception/Suite.php
@@ -11,14 +11,9 @@ use PHPUnit\Framework\TestSuite;
 
 class Suite extends TestSuite
 {
-    /**
-     * @var array
-     */
-    protected $modules = [];
-    /**
-     * @var string
-     */
-    protected $baseName;
+    protected array $modules = [];
+
+    protected ?string $baseName = null;
 
     public function reorderDependencies(): void
     {

--- a/src/Codeception/SuiteManager.php
+++ b/src/Codeception/SuiteManager.php
@@ -14,45 +14,23 @@ use Codeception\Test\Loader;
 use PHPUnit\Framework\DataProviderTestSuite;
 use PHPUnit\Framework\Test as PHPUnitTest;
 use PHPUnit\Framework\TestResult;
-use PHPUnit\Framework\TestSuite;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 
 class SuiteManager
 {
-    /**
-     * @var TestSuite
-     */
-    protected $suite = null;
+    protected ?Suite $suite = null;
 
-    /**
-     * @var EventDispatcher|null
-     */
-    protected $dispatcher = null;
+    protected ?EventDispatcher $dispatcher = null;
 
-    /**
-     * @var GroupManager
-     */
-    protected $groupManager;
+    protected GroupManager $groupManager;
 
-    /**
-     * @var ModuleContainer
-     */
-    protected $moduleContainer;
+    protected ModuleContainer $moduleContainer;
 
-    /**
-     * @var Di
-     */
-    protected $di;
+    protected Di $di;
 
-    /**
-     * @var string
-     */
-    protected $env = '';
+    protected string $env = '';
 
-    /**
-     * @var array
-     */
-    protected $settings = [];
+    protected array $settings = [];
 
     public function __construct(EventDispatcher $dispatcher, string $name, array $settings)
     {
@@ -151,7 +129,6 @@ class SuiteManager
         $suite->setModules($this->moduleContainer->all());
         return $suite;
     }
-
 
     public function run(PHPUnit\Runner $runner, TestResult $result, array $options): void
     {

--- a/src/Codeception/Template/Acceptance.php
+++ b/src/Codeception/Template/Acceptance.php
@@ -10,10 +10,7 @@ use Symfony\Component\Yaml\Yaml;
 
 class Acceptance extends InitTemplate
 {
-    /**
-     * @var string
-     */
-    protected $configTemplate = <<<EOF
+    protected string $configTemplate = <<<EOF
 # suite config
 suites:
     acceptance:
@@ -53,10 +50,7 @@ settings:
     lint: true
 EOF;
 
-    /**
-     * @var string
-     */
-    protected $firstTest = <<<EOF
+    protected string $firstTest = <<<EOF
 <?php
 class LoginCest 
 {    
@@ -77,12 +71,12 @@ class LoginCest
 }
 EOF;
 
-    public function setup(): void
+    public function setup()
     {
         $this->checkInstalled();
         $this->say("Let's prepare Codeception for acceptance testing");
         $this->say("Create your tests and run them in real browser");
-        $this->say("");
+        $this->say('');
 
         $dir = $this->ask("Where tests will be stored?", 'tests');
 

--- a/src/Codeception/Template/Api.php
+++ b/src/Codeception/Template/Api.php
@@ -5,15 +5,13 @@ declare(strict_types=1);
 namespace Codeception\Template;
 
 use Codeception\InitTemplate;
+use Codeception\Module\PhpBrowser;
 use Codeception\Util\Template;
 use Symfony\Component\Yaml\Yaml;
 
 class Api extends InitTemplate
 {
-    /**
-     * @var string
-     */
-    protected $configTemplate = <<<EOF
+    protected string $configTemplate = <<<EOF
 # suite config
 suites:
     api:
@@ -36,10 +34,7 @@ settings:
     lint: true
 EOF;
 
-    /**
-     * @var string
-     */
-    protected $firstTest = <<<EOF
+    protected string $firstTest = <<<EOF
 <?php
 class ApiCest 
 {    
@@ -52,18 +47,17 @@ class ApiCest
 }
 EOF;
 
-
-    public function setup(): void
+    public function setup()
     {
         $this->checkInstalled();
         $this->say("Let's prepare Codeception for REST API testing");
-        $this->say("");
+        $this->say('');
 
         $dir = $this->ask("Where tests will be stored?", 'tests');
 
         $url = $this->ask("Start url for tests", "http://localhost/api");
 
-        if (!class_exists('\\Codeception\\Module\\REST') || !class_exists(\Codeception\Module\PhpBrowser::class)) {
+        if (!class_exists('\\Codeception\\Module\\REST') || !class_exists(PhpBrowser::class)) {
             $this->addModulesToComposer(['REST', 'PhpBrowser']);
         }
 
@@ -89,11 +83,9 @@ EOF;
         $this->createHelper('Api', $supportDir);
         $this->createActor('ApiTester', $supportDir, Yaml::parse($configFile)['suites']['api']);
 
-
         $this->sayInfo("Created global config codeception.yml inside the root directory");
         $this->createFile($dir . DIRECTORY_SEPARATOR . 'ApiCest.php', $this->firstTest);
         $this->sayInfo("Created a demo test ApiCest.php");
-
 
         $this->say();
         $this->saySuccess("INSTALLATION COMPLETE");

--- a/src/Codeception/Template/Bootstrap.php
+++ b/src/Codeception/Template/Bootstrap.php
@@ -4,29 +4,23 @@ declare(strict_types=1);
 
 namespace Codeception\Template;
 
+use Codeception\Extension\RunFailed;
 use Codeception\InitTemplate;
+use Codeception\Module\Asserts;
+use Codeception\Module\PhpBrowser;
 use Symfony\Component\Yaml\Yaml;
 
 class Bootstrap extends InitTemplate
 {
-    /**
-     * @var string
-     */
-    protected $supportDir = 'tests/_support';
-    /**
-     * @var string
-     */
-    protected $outputDir = 'tests/_output';
-    /**
-     * @var string
-     */
-    protected $dataDir = 'tests/_data';
-    /**
-     * @var string
-     */
-    protected $envsDir = 'tests/_envs';
+    protected string $supportDir = 'tests/_support';
 
-    public function setup(): void
+    protected string $outputDir = 'tests/_output';
+
+    protected string $dataDir = 'tests/_data';
+
+    protected string $envsDir = 'tests/_envs';
+
+    public function setup()
     {
         $this->checkInstalled($this->workDir);
 
@@ -52,7 +46,7 @@ class Bootstrap extends InitTemplate
             return;
         }
 
-        if (!class_exists(\Codeception\Module\Asserts::class) || !class_exists(\Codeception\Module\PhpBrowser::class)) {
+        if (!class_exists(Asserts::class) || !class_exists(PhpBrowser::class)) {
             $this->addModulesToComposer(['PhpBrowser', 'Asserts']);
         }
 
@@ -159,7 +153,7 @@ EOF;
             ],
             'actor_suffix' => 'Tester',
             'extensions' => [
-                'enabled' => [\Codeception\Extension\RunFailed::class]
+                'enabled' => [RunFailed::class]
             ]
         ];
 

--- a/src/Codeception/Template/Unit.php
+++ b/src/Codeception/Template/Unit.php
@@ -5,15 +5,13 @@ declare(strict_types=1);
 namespace Codeception\Template;
 
 use Codeception\InitTemplate;
+use Codeception\Module\Asserts;
 use Codeception\Util\Template;
 use Symfony\Component\Yaml\Yaml;
 
 class Unit extends InitTemplate
 {
-    /**
-     * @var string
-     */
-    protected $configTemplate = <<<EOF
+    protected string $configTemplate = <<<EOF
 suites:
     unit:
         path: .
@@ -29,10 +27,7 @@ paths:
      
 EOF;
 
-    /**
-     * @var string
-     */
-    protected $testerAndModules = <<<EOF
+    protected string $testerAndModules = <<<EOF
         actor: UnitTester
         modules:
             enabled:
@@ -41,8 +36,7 @@ EOF;
         step_decorators: ~ 
 EOF;
 
-
-    public function setup(): void
+    public function setup()
     {
         $this->sayInfo('This will install Codeception for unit testing only');
         $this->say();
@@ -72,7 +66,7 @@ EOF;
 
         $this->createFile('codeception.yml', $configFile);
 
-        if (!class_exists(\Codeception\Module\Asserts::class)) {
+        if (!class_exists(Asserts::class)) {
             $this->addModulesToComposer(['Asserts']);
         }
 

--- a/src/Codeception/Template/Upgrade4.php
+++ b/src/Codeception/Template/Upgrade4.php
@@ -6,6 +6,7 @@ namespace Codeception\Template;
 
 use Codeception\Configuration;
 use Codeception\InitTemplate;
+use Exception;
 
 class Upgrade4 extends InitTemplate
 {
@@ -18,7 +19,7 @@ class Upgrade4 extends InitTemplate
      */
     const DONATE_LINK = 'https://opencollective.com/codeception';
 
-    public function setup(): void
+    public function setup()
     {
         if (!$this->isInstalled()) {
             $this->sayWarning('Codeception is not installed in this dir.');
@@ -46,7 +47,7 @@ class Upgrade4 extends InitTemplate
             $this->sayError("No suites found in current config.");
             $this->sayWarning('If you use sub-configs with `include` option, run this script on subconfigs:');
             $this->sayWarning('Example: php vendor/bin/codecept init upgrade4 -c backend/');
-            throw new \Exception("No suites found, can't upgrade");
+            throw new Exception("No suites found, can't upgrade");
         }
         foreach (Configuration::suites() as $suite) {
             $suiteConfig = Configuration::suiteSettings($suite, $config);
@@ -75,7 +76,7 @@ class Upgrade4 extends InitTemplate
     {
         try {
             $this->checkInstalled();
-        } catch (\Exception $e) {
+        } catch (Exception $e) {
             return true;
         }
         return false;

--- a/src/Codeception/Test/Cept.php
+++ b/src/Codeception/Test/Cept.php
@@ -20,10 +20,7 @@ class Cept extends Test implements Interfaces\Plain, Interfaces\ScenarioDriven, 
 {
     use Feature\ScenarioLoader;
 
-    /**
-     * @var Parser
-     */
-    protected $parser;
+    protected Parser $parser;
 
     public function __construct(string $name, string $file)
     {

--- a/src/Codeception/Test/Cest.php
+++ b/src/Codeception/Test/Cest.php
@@ -37,16 +37,19 @@ class Cest extends Test implements
     Interfaces\StrictCoverage
 {
     use Feature\ScenarioLoader;
-    /**
-     * @var Parser
-     */
-    protected $parser;
-    protected $testClassInstance;
-    /**
-     * @var string
-     */
-    protected $testMethod;
 
+    protected Parser $parser;
+
+    /**
+     * @var object|string
+     */
+    protected $testClassInstance;
+
+    protected string $testMethod;
+
+    /**
+     * @param object|string $testClass
+     */
     public function __construct($testClass, string $methodName, string $fileName)
     {
         $metadata = new Metadata();

--- a/src/Codeception/Test/Feature/AssertionCounter.php
+++ b/src/Codeception/Test/Feature/AssertionCounter.php
@@ -8,10 +8,7 @@ use PHPUnit\Framework\Assert;
 
 trait AssertionCounter
 {
-    /**
-     * @var int
-     */
-    protected $numAssertions = 0;
+    protected int $numAssertions = 0;
 
     public function getNumAssertions(): int
     {

--- a/src/Codeception/Test/Feature/MetadataCollector.php
+++ b/src/Codeception/Test/Feature/MetadataCollector.php
@@ -8,10 +8,7 @@ use Codeception\Test\Metadata;
 
 trait MetadataCollector
 {
-    /**
-     * @var Metadata
-     */
-    private $metadata;
+    private Metadata $metadata;
 
     protected function setMetadata(Metadata $metadata): void
     {

--- a/src/Codeception/Test/Feature/ScenarioLoader.php
+++ b/src/Codeception/Test/Feature/ScenarioLoader.php
@@ -10,10 +10,7 @@ use Codeception\Test\Metadata;
 
 trait ScenarioLoader
 {
-    /**
-     * @var Scenario
-     */
-    private $scenario;
+    private Scenario $scenario;
 
     abstract public function getMetadata(): Metadata;
 

--- a/src/Codeception/Test/Gherkin.php
+++ b/src/Codeception/Test/Gherkin.php
@@ -32,25 +32,13 @@ use function var_export;
 
 class Gherkin extends Test implements ScenarioDriven, Reported
 {
-    /**
-     * @var array
-     */
-    protected $steps = [];
+    protected array $steps = [];
 
-    /**
-     * @var FeatureNode
-     */
-    protected $featureNode;
+    protected FeatureNode $featureNode;
 
-    /**
-     * @var ScenarioNode
-     */
-    protected $scenarioNode;
+    protected ScenarioInterface $scenarioNode;
 
-    /**
-     * @var Scenario
-     */
-    protected $scenario;
+    protected Scenario $scenario;
 
     public function __construct(FeatureNode $featureNode, ScenarioInterface $scenarioNode, array $steps = [])
     {
@@ -196,7 +184,7 @@ class Gherkin extends Test implements ScenarioDriven, Reported
 
     protected function makeContexts(): void
     {
-        /** @var Di $di **/
+        /** @var Di $di */
         $di = $this->getMetadata()->getService('di');
         $di->set($this->getScenario());
 
@@ -257,6 +245,8 @@ class Gherkin extends Test implements ScenarioDriven, Reported
 
     /**
      * Field values for XML reports
+     *
+     * @return array<string, string>
      */
     public function getReportFields(): array
     {

--- a/src/Codeception/Test/Loader.php
+++ b/src/Codeception/Test/Loader.php
@@ -53,15 +53,11 @@ class Loader
     /**
      * @var LoaderInterface[]
      */
-    protected $formats = [];
-    /**
-     * @var array
-     */
-    protected $tests = [];
-    /**
-     * @var string
-     */
-    protected $path;
+    protected array $formats = [];
+
+    protected array $tests = [];
+
+    protected ?string $path = null;
 
     public function __construct(array $suiteSettings)
     {
@@ -123,7 +119,7 @@ class Loader
         $path = $this->makePath($path);
 
         foreach ($this->formats as $format) {
-            /** @var Loader $format **/
+            /** @var Loader $format */
             if (preg_match($format->getPattern(), $path)) {
                 $format->loadTests($path);
                 $this->tests = $format->getTests();

--- a/src/Codeception/Test/Loader/Cept.php
+++ b/src/Codeception/Test/Loader/Cept.php
@@ -12,7 +12,7 @@ class Cept implements LoaderInterface
     /**
      * @var CeptFormat[]
      */
-    protected $tests = [];
+    protected array $tests = [];
 
     public function getPattern(): string
     {

--- a/src/Codeception/Test/Loader/Cest.php
+++ b/src/Codeception/Test/Loader/Cest.php
@@ -23,7 +23,7 @@ class Cest implements LoaderInterface
     /**
      * @var DataProviderTestSuite[]|CestFormat[]
      */
-    protected $tests = [];
+    protected array $tests = [];
 
     /**
      * @return DataProviderTestSuite[]|CestFormat[]
@@ -63,9 +63,7 @@ class Cest implements LoaderInterface
                 $rawExamples = Annotation::forMethod($unit, $method)->fetchAll('example');
                 if ($rawExamples !== []) {
                     $examples = array_map(
-                        function ($v): ?array {
-                            return Annotation::arrayValue($v);
-                        },
+                        fn($v): ?array => Annotation::arrayValue($v),
                         $rawExamples
                     );
                 }

--- a/src/Codeception/Test/Loader/Unit.php
+++ b/src/Codeception/Test/Loader/Unit.php
@@ -17,10 +17,7 @@ use function get_class;
 
 class Unit implements LoaderInterface
 {
-    /**
-     * @var array
-     */
-    protected $tests = [];
+    protected array $tests = [];
 
     public function getPattern(): string
     {

--- a/src/Codeception/Test/Metadata.php
+++ b/src/Codeception/Test/Metadata.php
@@ -12,24 +12,15 @@ use function array_unique;
 
 class Metadata
 {
-    /**
-     * @var string
-     */
-    protected $name;
-    /**
-     * @var string
-     */
-    protected $filename;
-    /**
-     * @var string
-     */
-    protected $feature = '';
-    protected $index;
+    protected ?string $name = null;
 
-    /**
-     * @var array
-     */
-    protected $params = [
+    protected ?string $filename = null;
+
+    protected string $feature = '';
+
+    protected ?int $index = null;
+
+    protected array $params = [
         'env' => [],
         'group' => [],
         'depends' => [],
@@ -37,18 +28,11 @@ class Metadata
         'incomplete' => null
     ];
 
-    /**
-     * @var array
-     */
-    protected $current = [];
-    /**
-     * @var array
-     */
-    protected $services = [];
-    /**
-     * @var array
-     */
-    protected $reports = [];
+    protected array $current = [];
+
+    protected array $services = [];
+
+    protected array $reports = [];
 
     public function getEnv(): array
     {
@@ -126,12 +110,12 @@ class Metadata
         return $this->filename;
     }
 
-    public function setIndex($index): void
+    public function setIndex(int $index): void
     {
         $this->index = $index;
     }
 
-    public function getIndex()
+    public function getIndex(): ?int
     {
         return $this->index;
     }
@@ -188,10 +172,9 @@ class Metadata
     }
 
     /**
-     * Returns test params like: env, group, skip, incomplete, etc
+     * Returns test params like: env, group, skip, incomplete, etc.
      * Can return by annotation or return all if no key passed
      *
-     * @param string|null $key
      * @return mixed
      */
     public function getParam(string $key = null)

--- a/src/Codeception/Test/Test.php
+++ b/src/Codeception/Test/Test.php
@@ -33,21 +33,14 @@ abstract class Test implements TestInterface, Interfaces\Descriptive
     use Feature\MetadataCollector;
     use Feature\IgnoreIfMetadataBlocked;
 
-    /**
-     * @var TestResult|null
-     */
-    private $testResult;
-    /**
-     * @var bool
-     */
-    private $ignored = false;
+    private ?TestResult $testResult = null;
+
+    private bool $ignored = false;
 
     /**
      * Enabled traits with methods to be called before and after the test.
-     *
-     * @var array
      */
-    protected $hooks = [
+    protected array $hooks = [
       'ignoreIfMetadataBlocked',
       'codeCoverage',
       'assertionCounter',
@@ -80,8 +73,6 @@ abstract class Test implements TestInterface, Interfaces\Descriptive
 
     /**
      * Test representation
-     *
-     * @return mixed
      */
     abstract public function toString(): string;
 

--- a/src/Codeception/Test/Unit.php
+++ b/src/Codeception/Test/Unit.php
@@ -27,10 +27,7 @@ class Unit extends TestCase implements
 {
     use Stub;
 
-    /**
-     * @var Metadata
-     */
-    private $metadata;
+    private ?Metadata $metadata = null;
 
     public function getMetadata(): Metadata
     {
@@ -52,7 +49,7 @@ class Unit extends TestCase implements
             return;
         }
 
-        /** @var Di $di **/
+        /** @var Di $di */
         $di = $this->getMetadata()->getService('di');
         $di->set(new Scenario($this));
 

--- a/src/Codeception/Util/ActionSequence.php
+++ b/src/Codeception/Util/ActionSequence.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Codeception\Util;
 
+use Closure;
 use Codeception\Step\Action;
 use Exception;
 use function call_user_func_array;
@@ -28,7 +29,7 @@ use function str_replace;
  * @method $this dontSeeElement($selector, $attributes = [])
  * @method $this click($link, $context = null)
  * @method $this wait($timeout)
- * @method $this waitForElementChange($element, \Closure $callback, $timeout = 30)
+ * @method $this waitForElementChange($element, Closure $callback, $timeout = 30)
  * @method $this waitForElement($element, $timeout = 10)
  * @method $this waitForElementVisible($element, $timeout = 10)
  * @method $this waitForElementNotVisible($element, $timeout = 10)
@@ -56,7 +57,7 @@ class ActionSequence
     /**
      * @var Action[]
      */
-    protected $actions = [];
+    protected array $actions = [];
 
     /**
      * Creates an instance

--- a/src/Codeception/Util/Annotation.php
+++ b/src/Codeception/Util/Annotation.php
@@ -6,6 +6,7 @@ namespace Codeception\Util;
 
 use ReflectionClass;
 use ReflectionMethod;
+use Reflector;
 use function get_class;
 use function in_array;
 use function is_object;
@@ -24,20 +25,16 @@ class Annotation
     /**
      * @var ReflectionClass[]
      */
-    protected static $reflectedClasses = [];
-    /**
-     * @var string
-     */
-    protected static $regex = '/@%s(?:[ \t]*(.*?))?[ \t]*(?:\*\/)?\r?$/m';
-    protected static $lastReflected = null;
-    /**
-     * @var ReflectionClass
-     */
-    protected $reflectedClass;
+    protected static array $reflectedClasses = [];
+
+    protected static string $regex = '/@%s(?:[ \t]*(.*?))?[ \t]*(?:\*\/)?\r?$/m';
+
+    protected ReflectionClass $reflectedClass;
+
     /**
      * @var ReflectionClass|ReflectionMethod
      */
-    protected $currentReflectedItem;
+    protected Reflector $currentReflectedItem;
 
     /**
      * Grabs annotation values.
@@ -52,7 +49,7 @@ class Annotation
      * ```
      * @param object|string $class
      */
-    public static function forClass($class): Annotation
+    public static function forClass($class): self
     {
         if (is_object($class)) {
             $class = get_class($class);
@@ -101,7 +98,6 @@ class Annotation
         }
         return $annotations;
     }
-
 
     public function __construct(ReflectionClass $reflectionClass)
     {

--- a/src/Codeception/Util/ArrayContainsComparator.php
+++ b/src/Codeception/Util/ArrayContainsComparator.php
@@ -14,10 +14,7 @@ use function range;
 
 class ArrayContainsComparator
 {
-    /**
-     * @var array
-     */
-    protected $haystack = [];
+    protected array $haystack;
 
     public function __construct(array $haystack)
     {

--- a/src/Codeception/Util/Autoload.php
+++ b/src/Codeception/Util/Autoload.php
@@ -17,16 +17,13 @@ use function trim;
  */
 class Autoload
 {
-    /**
-     * @var bool
-     */
-    protected static $registered = false;
+    protected static bool $registered = false;
+
     /**
      * An associative array where the key is a namespace prefix and the value
      * is an array of base directories for classes in that namespace.
-     * @var array
      */
-    protected static $map = [];
+    protected static array $map = [];
 
     private function __construct()
     {
@@ -129,7 +126,7 @@ class Autoload
      *
      * @param string $prefix The namespace prefix.
      * @param string $relativeClass The relative class name.
-     * @return bool|string Boolean false if no mapped file can be loaded, or the name of the mapped file that was loaded.
+     * @return string|false Boolean false if no mapped file can be loaded, or the name of the mapped file that was loaded.
      */
     protected static function loadMappedFile(string $prefix, string $relativeClass)
     {

--- a/src/Codeception/Util/Debug.php
+++ b/src/Codeception/Util/Debug.php
@@ -15,10 +15,7 @@ use Symfony\Component\Console\Question\ConfirmationQuestion;
  */
 class Debug
 {
-    /**
-     * @var Output null
-     */
-    protected static $output = null;
+    protected static ?Output $output = null;
 
     public static function setOutput(Output $output): void
     {

--- a/src/Codeception/Util/Fixtures.php
+++ b/src/Codeception/Util/Fixtures.php
@@ -18,10 +18,7 @@ use RuntimeException;
  */
 class Fixtures
 {
-    /**
-     * @var array
-     */
-    protected static $fixtures = [];
+    protected static array $fixtures = [];
 
     public static function add(string $name, $data): void
     {

--- a/src/Codeception/Util/Locator.php
+++ b/src/Codeception/Util/Locator.php
@@ -226,7 +226,7 @@ class Locator
      */
     public static function isID(string $id): bool
     {
-        return (bool)preg_match('~^#[\w\.\-\[\]\=\^\~\:]+$~', $id);
+        return (bool)preg_match('~^#[\w.\-\[\]=^\~:]+$~', $id);
     }
 
     /**
@@ -241,7 +241,7 @@ class Locator
      */
     public static function isClass(string $class): bool
     {
-        return (bool)preg_match('#^\.[\w\.\-\[\]\=\^\~\:]+$#', $class);
+        return (bool)preg_match('#^\.[\w.\-\[\]=^~:]+$#', $class);
     }
 
     /**

--- a/src/Codeception/Util/Maybe.php
+++ b/src/Codeception/Util/Maybe.php
@@ -33,18 +33,14 @@ use function range;
  */
 class Maybe implements ArrayAccess, Iterator, JsonSerializable
 {
-    /**
-     * @var int
-     */
-    protected $position = 0;
+    protected int $position = 0;
+
     /**
      * @var mixed
      */
     protected $val = null;
-    /**
-     * @var null
-     */
-    protected $assocArray = null;
+
+    protected ?bool $assocArray = null;
 
     /**
      * @param mixed $val

--- a/src/Codeception/Util/ReflectionHelper.php
+++ b/src/Codeception/Util/ReflectionHelper.php
@@ -39,7 +39,7 @@ class ReflectionHelper
      * @return mixed
      * @throws ReflectionException
      */
-    public static function readPrivateProperty(object $object, string $property, ?string $class = null)
+    public static function readPrivateProperty(object $object, string $property, string $class = null)
     {
         if (is_null($class)) {
             $class = $object;
@@ -57,7 +57,7 @@ class ReflectionHelper
      * @return mixed
      * @throws ReflectionException
      */
-    public static function invokePrivateMethod(object $object, string $method, array $args = [], ?string $class = null)
+    public static function invokePrivateMethod(object $object, string $method, array $args = [], string $class = null)
     {
         if (is_null($class)) {
             $class = $object;
@@ -170,22 +170,17 @@ class ReflectionHelper
      */
     public static function phpEncodeArray(array $array): string
     {
-        $isPlainArray = function (array $value): bool {
-            return (($value === [])
-                || (
-                    (array_keys($value) === range(0, count($value) - 1))
-                    && ([] === array_filter(array_keys($value), 'is_string')))
-            );
-        };
+        $isPlainArray = fn(array $value): bool => ($value === [])
+            || (
+                (array_keys($value) === range(0, count($value) - 1))
+                && ([] === array_filter(array_keys($value), 'is_string')));
 
         if ($isPlainArray($array)) {
             return '[' . implode(', ', array_map([self::class, 'phpEncodeValue'], $array)) . ']';
         }
 
         $values = array_map(
-            function ($key) use ($array): string {
-                return self::phpEncodeValue($key) . ' => ' . self::phpEncodeValue($array[$key]);
-            },
+            fn($key): string => self::phpEncodeValue($key) . ' => ' . self::phpEncodeValue($array[$key]),
             array_keys($array)
         );
 

--- a/src/Codeception/Util/ReflectionPropertyAccessor.php
+++ b/src/Codeception/Util/ReflectionPropertyAccessor.php
@@ -88,7 +88,7 @@ class ReflectionPropertyAccessor
     /**
      * @throws ReflectionException
      */
-    public function createWithProperties(string $class, array $data): ?object
+    public function createWithProperties(string $class, array $data): object
     {
         $obj = null;
         do {

--- a/src/Codeception/Util/Shared/Namespaces.php
+++ b/src/Codeception/Util/Shared/Namespaces.php
@@ -13,7 +13,10 @@ use function str_replace;
 
 trait Namespaces
 {
-    protected function breakParts(string $class)
+    /**
+     * @return string[]
+     */
+    protected function breakParts(string $class): array
     {
         // removing leading slashes and dots first
         $class = str_replace('/', '\\', ltrim($class, './\\'));
@@ -41,7 +44,7 @@ trait Namespaces
         return "namespace {$str};\n";
     }
 
-    protected function getNamespaces(string $class)
+    protected function getNamespaces(string $class): array
     {
         $namespaces = $this->breakParts($class);
         array_pop($namespaces);

--- a/src/Codeception/Util/Template.php
+++ b/src/Codeception/Util/Template.php
@@ -16,22 +16,10 @@ use function str_replace;
  */
 class Template
 {
-    /**
-     * @var string
-     */
-    protected $template;
-    /**
-     * @var array
-     */
-    protected $vars = [];
-    /**
-     * @var string
-     */
-    protected $placeholderStart;
-    /**
-     * @var string
-     */
-    protected $placeholderEnd;
+    protected string $template;
+    protected array $vars = [];
+    protected string $placeholderStart;
+    protected string $placeholderEnd;
 
     public function __construct(string $template, string $placeholderStart = '{{', string $placeholderEnd = '}}')
     {
@@ -51,7 +39,6 @@ class Template
 
     /**
      * Sets all template vars
-     *
      */
     public function setVars(array $vars): void
     {

--- a/src/Codeception/Util/XmlBuilder.php
+++ b/src/Codeception/Util/XmlBuilder.php
@@ -72,15 +72,9 @@ use Exception;
  */
 class XmlBuilder
 {
-    /**
-     * @var DOMDocument
-     */
-    protected $dom;
+    protected DOMDocument $dom;
 
-    /**
-     * @var DOMElement
-     */
-    protected $currentNode;
+    protected DOMElement $currentNode;
 
     public function __construct()
     {


### PR DESCRIPTION
This PR does not include the update to PHP 7.4 of the Codeception `/tests` folder.

It was necessary to disable the `db` and `cli` tests for PHP 8.1 on Windows as they failed even without making any changes.

Last but not least, I am skipping updating the following files:

- `src/Codeception/Extension.php`
- `src/Codeception/Module.php`

Since to get a correct build I would need updates to all modules and extensions as well.