### PR TITLE
Deleting copyright and "team" link

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -98,6 +98,3 @@ The documentation source files can be found at https://github.com/Codeception/co
 
 ## License
 MIT
-
-(c) [Codeception Team](http://codeception.com/credits)
-2011-2021


### PR DESCRIPTION
What's the benefit of having this info here that needs to be updated every year? (latest: @Arhell at https://github.com/Codeception/Codeception/pull/6282)
Also: What is https://codeception.com/credits about at all? Can we delete this? Anybody interested in the team will certainly find https://github.com/Codeception/Codeception/graphs/contributors ;-)
@DavertMik I know what you're probably saying ("marekting" :-) - so my question is: When was this page last updated? ;-)