### PR TITLE
Fix E_DEPRECATED warnings in Example class on PHP 8.1

### DIFF
--- a/src/Codeception/Example.php
+++ b/src/Codeception/Example.php
@@ -12,6 +12,7 @@ class Example implements \ArrayAccess, \Countable, \IteratorAggregate
         $this->data = $data;
     }
 
+    #[\ReturnTypeWillChange]
     /**
      * Whether a offset exists
      * @link http://php.net/manual/en/arrayaccess.offsetexists.php
@@ -29,6 +30,7 @@ class Example implements \ArrayAccess, \Countable, \IteratorAggregate
         return array_key_exists($offset, $this->data);
     }
 
+    #[\ReturnTypeWillChange]
     /**
      * Offset to retrieve
      * @link http://php.net/manual/en/arrayaccess.offsetget.php
@@ -46,6 +48,7 @@ class Example implements \ArrayAccess, \Countable, \IteratorAggregate
         return $this->data[$offset];
     }
 
+    #[\ReturnTypeWillChange]
     /**
      * Offset to set
      * @link http://php.net/manual/en/arrayaccess.offsetset.php
@@ -63,6 +66,7 @@ class Example implements \ArrayAccess, \Countable, \IteratorAggregate
         $this->data[$offset] = $value;
     }
 
+    #[\ReturnTypeWillChange]
     /**
      * Offset to unset
      * @link http://php.net/manual/en/arrayaccess.offsetunset.php
@@ -77,6 +81,7 @@ class Example implements \ArrayAccess, \Countable, \IteratorAggregate
         unset($this->data[$offset]);
     }
 
+    #[\ReturnTypeWillChange]
     /**
      * Count elements of an object
      * @link http://php.net/manual/en/countable.count.php
@@ -91,6 +96,7 @@ class Example implements \ArrayAccess, \Countable, \IteratorAggregate
         return count($this->data);
     }
 
+    #[\ReturnTypeWillChange]
     /**
      * Retrieve an external iterator
      * @link http://php.net/manual/en/iteratoraggregate.getiterator.php


### PR DESCRIPTION
Fixes https://github.com/Codeception/Codeception/issues/6291