### PR TITLE
Fixed wildcard matching of group files

### DIFF
--- a/src/Codeception/Lib/GroupManager.php
+++ b/src/Codeception/Lib/GroupManager.php
@@ -56,14 +56,15 @@ class GroupManager
                 ->sortByName()
                 ->in($path);
 
-            $i = 1;
-
-
             foreach ($files as $file) {
                 /** @var SplFileInfo $file * */
-                $this->configuredGroups[str_replace('*', $i, $group)] = dirname($pattern).DIRECTORY_SEPARATOR.$file->getRelativePathname();
-                $i++;
+                $prefix = str_replace('*', '', $group);
+                $pathPrefix = str_replace('*', '', basename($pattern));
+                $groupName = $prefix . str_replace($pathPrefix, '', $file->getRelativePathname());
+
+                $this->configuredGroups[$groupName] = dirname($pattern) . DIRECTORY_SEPARATOR . $file->getRelativePathname();
             }
+
             unset($this->configuredGroups[$group]);
         }
     }

--- a/tests/data/group_manager_test/group_chunk_1_1
+++ b/tests/data/group_manager_test/group_chunk_1_1
@@ -1,0 +1,1 @@
+tests/data/group_manager_test/UserTest.php

--- a/tests/data/group_manager_test/group_chunk_1_2
+++ b/tests/data/group_manager_test/group_chunk_1_2
@@ -1,0 +1,1 @@
+tests/data/group_manager_test/PostTest.php

--- a/tests/unit/Codeception/Lib/GroupManagerTest.php
+++ b/tests/unit/Codeception/Lib/GroupManagerTest.php
@@ -76,11 +76,23 @@ class GroupManagerTest extends \Codeception\Test\Unit
         $this->assertContains('group_2', $this->manager->groupsForTest($test2));
     }
 
+
+    public function testGroupsByPatternWithMultipleDigits()
+    {
+        $this->manager = new GroupManager(['group_chunk_*' => 'tests/data/group_manager_test/group_chunk_*']);
+        $test1 = $this->makeTestCase('tests/data/group_manager_test/UserTest.php');
+        $test2 = $this->makeTestCase('tests/data/group_manager_test/PostTest.php');
+
+        $this->assertContains('group_chunk_1_1', $this->manager->groupsForTest($test1));
+        $this->assertContains('group_chunk_1_2', $this->manager->groupsForTest($test2));
+    }
+
     public function testGroupsByDifferentPattern()
     {
         $this->manager = new GroupManager(['g_*' => 'tests/data/group_manager_test/group_*']);
         $test1 = $this->makeTestCase('tests/data/group_manager_test/UserTest.php');
         $test2 = $this->makeTestCase('tests/data/group_manager_test/PostTest.php');
+        codecept_debug($this->manager->groupsForTest($test1));
         $this->assertContains('g_1', $this->manager->groupsForTest($test1));
         $this->assertContains('g_2', $this->manager->groupsForTest($test2));
     }

--- a/tests/unit/Codeception/Lib/GroupManagerTest.php
+++ b/tests/unit/Codeception/Lib/GroupManagerTest.php
@@ -92,7 +92,7 @@ class GroupManagerTest extends \Codeception\Test\Unit
         $this->manager = new GroupManager(['g_*' => 'tests/data/group_manager_test/group_*']);
         $test1 = $this->makeTestCase('tests/data/group_manager_test/UserTest.php');
         $test2 = $this->makeTestCase('tests/data/group_manager_test/PostTest.php');
-        codecept_debug($this->manager->groupsForTest($test1));
+
         $this->assertContains('g_1', $this->manager->groupsForTest($test1));
         $this->assertContains('g_2', $this->manager->groupsForTest($test2));
     }


### PR DESCRIPTION
Replaces #6300 

This fixes using group manager to import groups from files by wildcard pattern.

```
#insude codeception.yml
groups:
    group_*: tests/_data/group_*
```

**Previous behavior**: `tests/_data/group_*` pattern found only files `group_1`, `group_2`, but NOT `group_awesome`, `group_1_1` etc.

This behavior was incorrect as it didn't match all from a wildcard and limited results to `group_\d+`

**Current behavior**: `tests/_data/group_*` pattern finds all group* files in directory: `group_1`, `group_1_1`, etc
