### PR TITLE
Adding options `chars_success` and `chars_fail`

### DIFF
--- a/src/Codeception/Subscriber/Console.php
+++ b/src/Codeception/Subscriber/Console.php
@@ -107,6 +107,13 @@ class Console implements EventSubscriberInterface
             $this->chars['success'] = '✔';
             $this->chars['fail'] = '✖';
         }
+        
+        if (is_string($this->options['chars_success'])) {
+            $this->chars['success'] = $this->options['chars_success'];
+        }
+        if (is_string($this->options['chars_fail'])) {
+            $this->chars['fail'] = $this->options['chars_fail'];
+        }
 
         foreach (['html', 'xml', 'phpunit-xml', 'tap', 'json'] as $report) {
             if (!$this->options[$report]) {

--- a/src/Codeception/Subscriber/Console.php
+++ b/src/Codeception/Subscriber/Console.php
@@ -107,7 +107,8 @@ class Console implements EventSubscriberInterface
             $this->chars['success'] = '✔';
             $this->chars['fail'] = '✖';
         }
-        
+
+        // Allow custom "success" and "fail" characters:
         if (is_string($this->options['chars_success'])) {
             $this->chars['success'] = $this->options['chars_success'];
         }


### PR DESCRIPTION
There's still no real solution for https://github.com/Codeception/Codeception/issues/6029, so in fact I'm manually changing the characters in my `vendor` directory after each Codeception release ;-)

So now I was finally looking for a more durable solution. And since this was really easy to implement, I'm suggesting: Let's allow people to just use *any* character!