### PR TITLE
Fix message about deprecated in build-stage

### DIFF
--- a/src/Codeception/Command/Shared/FileSystem.php
+++ b/src/Codeception/Command/Shared/FileSystem.php
@@ -43,7 +43,7 @@ trait FileSystem
         return preg_replace("~$suffix$~", '', $classname);
     }
 
-    protected function createFile($filename, $contents, $force = false, $flags = null)
+    protected function createFile($filename, $contents, $force = false, $flags = 0)
     {
         if (file_exists($filename) && !$force) {
             return false;


### PR DESCRIPTION
Hi!

When you build suites in PHP 8.1, you have a message: 
```
vendor/bin/codecept build
Building Actor classes for suites: acceptance, functional, unit
 -> AcceptanceTesterActions.php generated successfully. 71 methods added

Deprecated: file_put_contents(): Passing null to parameter #3 ($flags) of type int is deprecated in /var/www/core/vendor/codeception/codeception/src/Codeception/Command/Shared/FileSystem.php on line 51
```

This pull request fixed it. I changed the default value of flags in the method 'FileSystem::createFile()'.