### PR TITLE
Add explicit return types to methods overriding Symfony methods, silencing deprecation warnings

### DIFF
--- a/src/Codeception/Application.php
+++ b/src/Codeception/Application.php
@@ -104,7 +104,7 @@ class Application extends BaseApplication
      *
      * @inheritDoc
      */
-    public function run(InputInterface $input = null, OutputInterface $output = null)
+    public function run(InputInterface $input = null, OutputInterface $output = null): int
     {
         if ($input === null) {
             $input = $this->getCoreArguments();

--- a/src/Codeception/Command/Bootstrap.php
+++ b/src/Codeception/Command/Bootstrap.php
@@ -41,12 +41,12 @@ class Bootstrap extends Command
         );
     }
 
-    public function getDescription()
+    public function getDescription(): string
     {
         return "Creates default test suites and generates all required files";
     }
 
-    public function execute(InputInterface $input, OutputInterface $output)
+    public function execute(InputInterface $input, OutputInterface $output): int
     {
         $bootstrap = new BootstrapTemplate($input, $output);
         if ($input->getArgument('path')) {

--- a/src/Codeception/Command/Build.php
+++ b/src/Codeception/Command/Build.php
@@ -28,19 +28,18 @@ class Build extends Command
      */
     protected $output;
 
-    public function getDescription()
+    public function getDescription(): string
     {
         return 'Generates base classes for all suites';
     }
 
-
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $this->output = $output;
         $this->buildActorsForConfig();
         return 0;
     }
-    
+
     private function buildActor(array $settings)
     {
         $actorGenerator = new ActorGenerator($settings);
@@ -48,7 +47,7 @@ class Build extends Command
             '<info>' . Configuration::config()['namespace'] . '\\' . $actorGenerator->getActorName()
             . "</info> includes modules: " . implode(', ', $actorGenerator->getModules())
         );
-        
+
         $content = $actorGenerator->produce();
 
         $file = $this->createDirectoryFor(
@@ -58,7 +57,7 @@ class Build extends Command
         $file .=  '.php';
         return $this->createFile($file, $content);
     }
-    
+
     private function buildActions(array $settings)
     {
         $actionsGenerator = new ActionsGenerator($settings);
@@ -87,17 +86,17 @@ class Build extends Command
             }
             $this->buildActions($settings);
             $actorBuilt = $this->buildActor($settings);
-            
+
             if ($actorBuilt) {
                 $this->output->writeln("{$settings['actor']}.php created.");
             }
         }
     }
-    
+
     protected function buildActorsForConfig($configFile = null)
     {
         $config = $this->getGlobalConfig($configFile);
-        
+
         $dir = Configuration::projectDir();
         $this->buildSuiteActors();
 

--- a/src/Codeception/Command/Console.php
+++ b/src/Codeception/Command/Console.php
@@ -46,12 +46,12 @@ class Console extends Command
         parent::configure();
     }
 
-    public function getDescription()
+    public function getDescription(): string
     {
         return 'Launches interactive test console';
     }
 
-    public function execute(InputInterface $input, OutputInterface $output)
+    public function execute(InputInterface $input, OutputInterface $output): int
     {
         $suiteName = $input->getArgument('suite');
         $this->output = $output;

--- a/src/Codeception/Command/GenerateCept.php
+++ b/src/Codeception/Command/GenerateCept.php
@@ -23,12 +23,12 @@ class GenerateCept extends Command
         ]);
     }
 
-    public function getDescription()
+    public function getDescription(): string
     {
         return 'Generates empty Cept file in suite';
     }
 
-    public function execute(InputInterface $input, OutputInterface $output)
+    public function execute(InputInterface $input, OutputInterface $output): int
     {
         $suite = $input->getArgument('suite');
         $filename = $input->getArgument('test');

--- a/src/Codeception/Command/GenerateCest.php
+++ b/src/Codeception/Command/GenerateCest.php
@@ -29,12 +29,12 @@ class GenerateCest extends Command
         ]);
     }
 
-    public function getDescription()
+    public function getDescription(): string
     {
         return 'Generates empty Cest file in suite';
     }
 
-    public function execute(InputInterface $input, OutputInterface $output)
+    public function execute(InputInterface $input, OutputInterface $output): int
     {
         $suite = $input->getArgument('suite');
         $class = $input->getArgument('class');

--- a/src/Codeception/Command/GenerateHelper.php
+++ b/src/Codeception/Command/GenerateHelper.php
@@ -27,12 +27,12 @@ class GenerateHelper extends Command
         ]);
     }
 
-    public function getDescription()
+    public function getDescription(): string
     {
         return 'Generates new helper';
     }
 
-    public function execute(InputInterface $input, OutputInterface $output)
+    public function execute(InputInterface $input, OutputInterface $output): int
     {
         $name = ucfirst($input->getArgument('name'));
         $config = $this->getGlobalConfig();

--- a/src/Codeception/Command/GenerateScenarios.php
+++ b/src/Codeception/Command/GenerateScenarios.php
@@ -35,12 +35,12 @@ class GenerateScenarios extends Command
         parent::configure();
     }
 
-    public function getDescription()
+    public function getDescription(): string
     {
         return 'Generates text representation for all scenarios';
     }
 
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $suite = $input->getArgument('suite');
 

--- a/src/Codeception/Command/GenerateSuite.php
+++ b/src/Codeception/Command/GenerateSuite.php
@@ -34,12 +34,12 @@ class GenerateSuite extends Command
         ]);
     }
 
-    public function getDescription()
+    public function getDescription(): string
     {
         return 'Generates new test suite';
     }
 
-    public function execute(InputInterface $input, OutputInterface $output)
+    public function execute(InputInterface $input, OutputInterface $output): int
     {
         $this->addStyles($output);
         $suite = $input->getArgument('suite');

--- a/src/Codeception/Command/GenerateTest.php
+++ b/src/Codeception/Command/GenerateTest.php
@@ -29,12 +29,12 @@ class GenerateTest extends Command
         parent::configure();
     }
 
-    public function getDescription()
+    public function getDescription(): string
     {
         return 'Generates empty unit test file in suite';
     }
 
-    public function execute(InputInterface $input, OutputInterface $output)
+    public function execute(InputInterface $input, OutputInterface $output): int
     {
         $suite = $input->getArgument('suite');
         $class = $input->getArgument('class');

--- a/src/Codeception/Command/Init.php
+++ b/src/Codeception/Command/Init.php
@@ -24,12 +24,12 @@ class Init extends Command
         );
     }
 
-    public function getDescription()
+    public function getDescription(): string
     {
         return "Creates test suites by a template";
     }
 
-    public function execute(InputInterface $input, OutputInterface $output)
+    public function execute(InputInterface $input, OutputInterface $output): int
     {
         $template = $input->getArgument('template');
 

--- a/src/Codeception/Command/Run.php
+++ b/src/Codeception/Command/Run.php
@@ -228,7 +228,7 @@ class Run extends Command
         parent::configure();
     }
 
-    public function getDescription()
+    public function getDescription(): string
     {
         return 'Runs the test suites';
     }

--- a/src/Codeception/Extension.php
+++ b/src/Codeception/Extension.php
@@ -32,8 +32,7 @@ abstract class Extension implements EventSubscriberInterface
         $this->_initialize();
     }
 
-
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents(): array
     {
         if (!isset(static::$events)) {
             return [Events::SUITE_INIT => 'receiveModuleContainer'];

--- a/src/Codeception/GroupObject.php
+++ b/src/Codeception/GroupObject.php
@@ -15,7 +15,7 @@ abstract class GroupObject extends Extension
     {
     }
 
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents(): array
     {
         $inheritedEvents = parent::getSubscribedEvents();
         $events = [];

--- a/src/Codeception/Subscriber/GracefulTermination.php
+++ b/src/Codeception/Subscriber/GracefulTermination.php
@@ -44,7 +44,7 @@ class GracefulTermination implements EventSubscriberInterface
         );
     }
 
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents(): array
     {
         if (!function_exists(self::SIGNAL_FUNC)) {
             return [];

--- a/src/Codeception/Subscriber/Shared/StaticEvents.php
+++ b/src/Codeception/Subscriber/Shared/StaticEvents.php
@@ -3,7 +3,7 @@ namespace Codeception\Subscriber\Shared;
 
 trait StaticEvents
 {
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents(): array
     {
         return static::$events;
     }


### PR DESCRIPTION
This greatly reduces the number of deprecation warnings I get running with Symfony 5.4.2

Some deprecation warnings remain, but it seems they come from different repositories, so I'm not sure which. 

The ones relating to PHPUnit seemed more intrusive, so I figured I'd leave those.

Old output:
```
Remaining indirect deprecation notices (62)

  1x: Method "Symfony\Component\EventDispatcher\EventSubscriberInterface::getSubscribedEvents()" might add "array" as a native return type declaration in the future. Do the same in implementation "Codeception\Extension" now to avoid errors or add an explicit @return annotation to suppress this message.
    1x in Application::run from Codeception

  1x: Method "Symfony\Component\EventDispatcher\EventSubscriberInterface::getSubscribedEvents()" might add "array" as a native return type declaration in the future. Do the same in implementation "Codeception\GroupObject" now to avoid errors or add an explicit @return annotation to suppress this message.
    1x in Application::run from Codeception

  1x: Method "Symfony\Component\Console\Application::run()" might add "int" as a native return type declaration in the future. Do the same in child class "Codeception\Application" now to avoid errors or add an explicit @return annotation to suppress this message.
    1x in Application::run from Codeception

  1x: Method "Symfony\Component\Console\Command\Command::getDescription()" might add "string" as a native return type declaration in the future. Do the same in child class "Codeception\Command\Build" now to avoid errors or add an explicit @return annotation to suppress this message.
    1x in Application::run from Codeception

  1x: Method "Symfony\Component\Console\Command\Command::execute()" might add "int" as a native return type declaration in the future. Do the same in child class "Codeception\Command\Build" now to avoid errors or add an explicit @return annotation to suppress this message.
    1x in Application::run from Codeception

  1x: Method "Symfony\Component\Console\Command\Command::getDescription()" might add "string" as a native return type declaration in the future. Do the same in child class "Codeception\Command\Run" now to avoid errors or add an explicit @return annotation to suppress this message.
    1x in Application::run from Codeception

  1x: Method "Symfony\Component\Console\Command\Command::getDescription()" might add "string" as a native return type declaration in the future. Do the same in child class "Codeception\Command\Init" now to avoid errors or add an explicit @return annotation to suppress this message.
    1x in Application::run from Codeception

  1x: Method "Symfony\Component\Console\Command\Command::execute()" might add "int" as a native return type declaration in the future. Do the same in child class "Codeception\Command\Init" now to avoid errors or add an explicit @return annotation to suppress this message.
    1x in Application::run from Codeception

  1x: Method "Symfony\Component\Console\Command\Command::getDescription()" might add "string" as a native return type declaration in the future. Do the same in child class "Codeception\Command\Console" now to avoid errors or add an explicit @return annotation to suppress this message.
    1x in Application::run from Codeception

  1x: Method "Symfony\Component\Console\Command\Command::execute()" might add "int" as a native return type declaration in the future. Do the same in child class "Codeception\Command\Console" now to avoid errors or add an explicit @return annotation to suppress this message.
    1x in Application::run from Codeception

  1x: Method "Symfony\Component\Console\Command\Command::getDescription()" might add "string" as a native return type declaration in the future. Do the same in child class "Codeception\Command\Bootstrap" now to avoid errors or add an explicit @return annotation to suppress this message.
    1x in Application::run from Codeception

  1x: Method "Symfony\Component\Console\Command\Command::execute()" might add "int" as a native return type declaration in the future. Do the same in child class "Codeception\Command\Bootstrap" now to avoid errors or add an explicit @return annotation to suppress this message.
    1x in Application::run from Codeception

  1x: Method "Symfony\Component\Console\Command\Command::getDescription()" might add "string" as a native return type declaration in the future. Do the same in child class "Codeception\Command\GenerateCept" now to avoid errors or add an explicit @return annotation to suppress this message.
    1x in Application::run from Codeception

  1x: Method "Symfony\Component\Console\Command\Command::execute()" might add "int" as a native return type declaration in the future. Do the same in child class "Codeception\Command\GenerateCept" now to avoid errors or add an explicit @return annotation to suppress this message.
    1x in Application::run from Codeception

  1x: Method "Symfony\Component\Console\Command\Command::getDescription()" might add "string" as a native return type declaration in the future. Do the same in child class "Codeception\Command\GenerateCest" now to avoid errors or add an explicit @return annotation to suppress this message.
    1x in Application::run from Codeception

  1x: Method "Symfony\Component\Console\Command\Command::execute()" might add "int" as a native return type declaration in the future. Do the same in child class "Codeception\Command\GenerateCest" now to avoid errors or add an explicit @return annotation to suppress this message.
    1x in Application::run from Codeception

  1x: Method "Symfony\Component\Console\Command\Command::getDescription()" might add "string" as a native return type declaration in the future. Do the same in child class "Codeception\Command\GenerateTest" now to avoid errors or add an explicit @return annotation to suppress this message.
    1x in Application::run from Codeception

  1x: Method "Symfony\Component\Console\Command\Command::execute()" might add "int" as a native return type declaration in the future. Do the same in child class "Codeception\Command\GenerateTest" now to avoid errors or add an explicit @return annotation to suppress this message.
    1x in Application::run from Codeception

  1x: Method "Symfony\Component\Console\Command\Command::getDescription()" might add "string" as a native return type declaration in the future. Do the same in child class "Codeception\Command\GenerateSuite" now to avoid errors or add an explicit @return annotation to suppress this message.
    1x in Application::run from Codeception

  1x: Method "Symfony\Component\Console\Command\Command::execute()" might add "int" as a native return type declaration in the future. Do the same in child class "Codeception\Command\GenerateSuite" now to avoid errors or add an explicit @return annotation to suppress this message.
    1x in Application::run from Codeception

  1x: Method "Symfony\Component\Console\Command\Command::getDescription()" might add "string" as a native return type declaration in the future. Do the same in child class "Codeception\Command\GenerateHelper" now to avoid errors or add an explicit @return annotation to suppress this message.
    1x in Application::run from Codeception

  1x: Method "Symfony\Component\Console\Command\Command::execute()" might add "int" as a native return type declaration in the future. Do the same in child class "Codeception\Command\GenerateHelper" now to avoid errors or add an explicit @return annotation to suppress this message.
    1x in Application::run from Codeception

  1x: Method "Symfony\Component\Console\Command\Command::getDescription()" might add "string" as a native return type declaration in the future. Do the same in child class "Codeception\Command\GenerateScenarios" now to avoid errors or add an explicit @return annotation to suppress this message.
    1x in Application::run from Codeception

  1x: Method "Symfony\Component\Console\Command\Command::execute()" might add "int" as a native return type declaration in the future. Do the same in child class "Codeception\Command\GenerateScenarios" now to avoid errors or add an explicit @return annotation to suppress this message.
    1x in Application::run from Codeception

  1x: Method "Symfony\Component\Console\Command\Command::getDescription()" might add "string" as a native return type declaration in the future. Do the same in child class "Codeception\Command\Clean" now to avoid errors or add an explicit @return annotation to suppress this message.
    1x in Application::run from Codeception

  1x: Method "Symfony\Component\Console\Command\Command::execute()" might add "int" as a native return type declaration in the future. Do the same in child class "Codeception\Command\Clean" now to avoid errors or add an explicit @return annotation to suppress this message.
    1x in Application::run from Codeception

  1x: Method "Symfony\Component\Console\Command\Command::getDescription()" might add "string" as a native return type declaration in the future. Do the same in child class "Codeception\Command\GenerateGroup" now to avoid errors or add an explicit @return annotation to suppress this message.
    1x in Application::run from Codeception

  1x: Method "Symfony\Component\Console\Command\Command::execute()" might add "int" as a native return type declaration in the future. Do the same in child class "Codeception\Command\GenerateGroup" now to avoid errors or add an explicit @return annotation to suppress this message.
    1x in Application::run from Codeception

  1x: Method "Symfony\Component\Console\Command\Command::getDescription()" might add "string" as a native return type declaration in the future. Do the same in child class "Codeception\Command\GeneratePageObject" now to avoid errors or add an explicit @return annotation to suppress this message.
    1x in Application::run from Codeception

  1x: Method "Symfony\Component\Console\Command\Command::execute()" might add "int" as a native return type declaration in the future. Do the same in child class "Codeception\Command\GeneratePageObject" now to avoid errors or add an explicit @return annotation to suppress this message.
    1x in Application::run from Codeception

  1x: Method "Symfony\Component\Console\Command\Command::getDescription()" might add "string" as a native return type declaration in the future. Do the same in child class "Codeception\Command\GenerateStepObject" now to avoid errors or add an explicit @return annotation to suppress this message.
    1x in Application::run from Codeception

  1x: Method "Symfony\Component\Console\Command\Command::execute()" might add "int" as a native return type declaration in the future. Do the same in child class "Codeception\Command\GenerateStepObject" now to avoid errors or add an explicit @return annotation to suppress this message.
    1x in Application::run from Codeception

  1x: Method "Symfony\Component\Console\Command\Command::getDescription()" might add "string" as a native return type declaration in the future. Do the same in child class "Codeception\Command\GenerateSnapshot" now to avoid errors or add an explicit @return annotation to suppress this message.
    1x in Application::run from Codeception

  1x: Method "Symfony\Component\Console\Command\Command::execute()" might add "int" as a native return type declaration in the future. Do the same in child class "Codeception\Command\GenerateSnapshot" now to avoid errors or add an explicit @return annotation to suppress this message.
    1x in Application::run from Codeception

  1x: Method "Symfony\Component\Console\Command\Command::getDescription()" might add "string" as a native return type declaration in the future. Do the same in child class "Codeception\Command\GenerateEnvironment" now to avoid errors or add an explicit @return annotation to suppress this message.
    1x in Application::run from Codeception

  1x: Method "Symfony\Component\Console\Command\Command::execute()" might add "int" as a native return type declaration in the future. Do the same in child class "Codeception\Command\GenerateEnvironment" now to avoid errors or add an explicit @return annotation to suppress this message.
    1x in Application::run from Codeception

  1x: Method "Symfony\Component\Console\Command\Command::getDescription()" might add "string" as a native return type declaration in the future. Do the same in child class "Codeception\Command\GenerateFeature" now to avoid errors or add an explicit @return annotation to suppress this message.
    1x in Application::run from Codeception

  1x: Method "Symfony\Component\Console\Command\Command::execute()" might add "int" as a native return type declaration in the future. Do the same in child class "Codeception\Command\GenerateFeature" now to avoid errors or add an explicit @return annotation to suppress this message.
    1x in Application::run from Codeception

  1x: Method "Symfony\Component\Console\Command\Command::getDescription()" might add "string" as a native return type declaration in the future. Do the same in child class "Codeception\Command\GherkinSnippets" now to avoid errors or add an explicit @return annotation to suppress this message.
    1x in Application::run from Codeception

  1x: Method "Symfony\Component\Console\Command\Command::execute()" might add "int" as a native return type declaration in the future. Do the same in child class "Codeception\Command\GherkinSnippets" now to avoid errors or add an explicit @return annotation to suppress this message.
    1x in Application::run from Codeception

  1x: Method "Symfony\Component\Console\Command\Command::getDescription()" might add "string" as a native return type declaration in the future. Do the same in child class "Codeception\Command\GherkinSteps" now to avoid errors or add an explicit @return annotation to suppress this message.
    1x in Application::run from Codeception

  1x: Method "Symfony\Component\Console\Command\Command::execute()" might add "int" as a native return type declaration in the future. Do the same in child class "Codeception\Command\GherkinSteps" now to avoid errors or add an explicit @return annotation to suppress this message.
    1x in Application::run from Codeception

  1x: Method "Symfony\Component\Console\Command\Command::getDescription()" might add "string" as a native return type declaration in the future. Do the same in child class "Codeception\Command\DryRun" now to avoid errors or add an explicit @return annotation to suppress this message.
    1x in Application::run from Codeception

  1x: Method "Symfony\Component\Console\Command\Command::execute()" might add "int" as a native return type declaration in the future. Do the same in child class "Codeception\Command\DryRun" now to avoid errors or add an explicit @return annotation to suppress this message.
    1x in Application::run from Codeception

  1x: Method "Symfony\Component\Console\Command\Command::getDescription()" might add "string" as a native return type declaration in the future. Do the same in child class "Codeception\Command\ConfigValidate" now to avoid errors or add an explicit @return annotation to suppress this message.
    1x in Application::run from Codeception

  1x: Method "Symfony\Component\Console\Command\Command::execute()" might add "int" as a native return type declaration in the future. Do the same in child class "Codeception\Command\ConfigValidate" now to avoid errors or add an explicit @return annotation to suppress this message.
    1x in Application::run from Codeception

  1x: Method "Symfony\Component\Console\Command\Command::execute()" might add "int" as a native return type declaration in the future. Do the same in child class "Codeception\Command\CompletionFallback" now to avoid errors or add an explicit @return annotation to suppress this message.
    1x in Application::run from Codeception

  1x: Method "Symfony\Component\EventDispatcher\EventSubscriberInterface::getSubscribedEvents()" might add "array" as a native return type declaration in the future. Do the same in implementation "Codeception\Subscriber\ExtensionLoader" now to avoid errors or add an explicit @return annotation to suppress this message.
    1x in Application::run from Codeception

  1x: Method "Symfony\Component\EventDispatcher\EventSubscriberInterface::getSubscribedEvents()" might add "array" as a native return type declaration in the future. Do the same in implementation "Codeception\Subscriber\GracefulTermination" now to avoid errors or add an explicit @return annotation to suppress this message.
    1x in Application::run from Codeception

  1x: Method "Symfony\Component\EventDispatcher\EventSubscriberInterface::getSubscribedEvents()" might add "array" as a native return type declaration in the future. Do the same in implementation "Codeception\Subscriber\ErrorHandler" now to avoid errors or add an explicit @return annotation to suppress this message.
    1x in Application::run from Codeception

  1x: Method "Symfony\Component\EventDispatcher\EventSubscriberInterface::getSubscribedEvents()" might add "array" as a native return type declaration in the future. Do the same in implementation "Codeception\Subscriber\Dependencies" now to avoid errors or add an explicit @return annotation to suppress this message.
    1x in Application::run from Codeception

  1x: Method "Symfony\Component\EventDispatcher\EventSubscriberInterface::getSubscribedEvents()" might add "array" as a native return type declaration in the future. Do the same in implementation "Codeception\Subscriber\Bootstrap" now to avoid errors or add an explicit @return annotation to suppress this message.
    1x in Application::run from Codeception

  1x: Method "Symfony\Component\EventDispatcher\EventSubscriberInterface::getSubscribedEvents()" might add "array" as a native return type declaration in the future. Do the same in implementation "Codeception\Subscriber\PrepareTest" now to avoid errors or add an explicit @return annotation to suppress this message.
    1x in Application::run from Codeception

  1x: Method "Symfony\Component\EventDispatcher\EventSubscriberInterface::getSubscribedEvents()" might add "array" as a native return type declaration in the future. Do the same in implementation "Codeception\Subscriber\Module" now to avoid errors or add an explicit @return annotation to suppress this message.
    1x in Application::run from Codeception

  1x: Method "Symfony\Component\EventDispatcher\EventSubscriberInterface::getSubscribedEvents()" might add "array" as a native return type declaration in the future. Do the same in implementation "Codeception\Subscriber\BeforeAfterTest" now to avoid errors or add an explicit @return annotation to suppress this message.
    1x in Application::run from Codeception

  1x: Method "Symfony\Component\EventDispatcher\EventSubscriberInterface::getSubscribedEvents()" might add "array" as a native return type declaration in the future. Do the same in implementation "Codeception\Subscriber\AutoRebuild" now to avoid errors or add an explicit @return annotation to suppress this message.
    1x in Application::run from Codeception

  1x: Method "Symfony\Component\EventDispatcher\EventSubscriberInterface::getSubscribedEvents()" might add "array" as a native return type declaration in the future. Do the same in implementation "Codeception\Subscriber\Console" now to avoid errors or add an explicit @return annotation to suppress this message.
    1x in Application::run from Codeception

  1x: The "Codeception\PHPUnit\Listener" class implements "PHPUnit\Framework\TestListener" that is deprecated Use the `TestHook` interfaces instead.
    1x in Application::run from Codeception

  1x: The "PHPUnit\TextUI\DefaultResultPrinter" class is considered internal This class is not covered by the backward compatibility promise for PHPUnit. It may change without further notice. You should not use it from "Codeception\PHPUnit\ResultPrinter\UI".
    1x in Application::run from Codeception

  1x: The "PHPUnit\Runner\BaseTestRunner" class is considered internal This class is not covered by the backward compatibility promise for PHPUnit. It may change without further notice. You should not use it from "Codeception\PHPUnit\NonFinal\TestRunner".
    1x in Application::run from Codeception

  1x: The "PHPUnit\Framework\TestSuite" class is considered internal This class is not covered by the backward compatibility promise for PHPUnit. It may change without further notice. You should not use it from "Codeception\Suite".
    1x in Application::run from Codeception

  1x: Method "Symfony\Component\BrowserKit\AbstractBrowser::doRequest()" might add "object" as a native return type declaration in the future. Do the same in child class "Codeception\Lib\Connector\Guzzle" now to avoid errors or add an explicit @return annotation to suppress this message.
    1x in Application::run from Codeception
```

New output:

```
Remaining indirect deprecation notices (28)

  1x: Method "Symfony\Component\Console\Command\Command::getDescription()" might add "string" as a native return type declaration in the future. Do the same in child class "Codeception\Command\Clean" now to avoid errors or add an explicit @return annotation to suppress this message.
    1x in Application::run from Codeception

  1x: Method "Symfony\Component\Console\Command\Command::execute()" might add "int" as a native return type declaration in the future. Do the same in child class "Codeception\Command\Clean" now to avoid errors or add an explicit @return annotation to suppress this message.
    1x in Application::run from Codeception

  1x: Method "Symfony\Component\Console\Command\Command::getDescription()" might add "string" as a native return type declaration in the future. Do the same in child class "Codeception\Command\GenerateGroup" now to avoid errors or add an explicit @return annotation to suppress this message.
    1x in Application::run from Codeception

  1x: Method "Symfony\Component\Console\Command\Command::execute()" might add "int" as a native return type declaration in the future. Do the same in child class "Codeception\Command\GenerateGroup" now to avoid errors or add an explicit @return annotation to suppress this message.
    1x in Application::run from Codeception

  1x: Method "Symfony\Component\Console\Command\Command::getDescription()" might add "string" as a native return type declaration in the future. Do the same in child class "Codeception\Command\GeneratePageObject" now to avoid errors or add an explicit @return annotation to suppress this message.
    1x in Application::run from Codeception

  1x: Method "Symfony\Component\Console\Command\Command::execute()" might add "int" as a native return type declaration in the future. Do the same in child class "Codeception\Command\GeneratePageObject" now to avoid errors or add an explicit @return annotation to suppress this message.
    1x in Application::run from Codeception

  1x: Method "Symfony\Component\Console\Command\Command::getDescription()" might add "string" as a native return type declaration in the future. Do the same in child class "Codeception\Command\GenerateStepObject" now to avoid errors or add an explicit @return annotation to suppress this message.
    1x in Application::run from Codeception

  1x: Method "Symfony\Component\Console\Command\Command::execute()" might add "int" as a native return type declaration in the future. Do the same in child class "Codeception\Command\GenerateStepObject" now to avoid errors or add an explicit @return annotation to suppress this message.
    1x in Application::run from Codeception

  1x: Method "Symfony\Component\Console\Command\Command::getDescription()" might add "string" as a native return type declaration in the future. Do the same in child class "Codeception\Command\GenerateSnapshot" now to avoid errors or add an explicit @return annotation to suppress this message.
    1x in Application::run from Codeception

  1x: Method "Symfony\Component\Console\Command\Command::execute()" might add "int" as a native return type declaration in the future. Do the same in child class "Codeception\Command\GenerateSnapshot" now to avoid errors or add an explicit @return annotation to suppress this message.
    1x in Application::run from Codeception

  1x: Method "Symfony\Component\Console\Command\Command::getDescription()" might add "string" as a native return type declaration in the future. Do the same in child class "Codeception\Command\GenerateEnvironment" now to avoid errors or add an explicit @return annotation to suppress this message.
    1x in Application::run from Codeception

  1x: Method "Symfony\Component\Console\Command\Command::execute()" might add "int" as a native return type declaration in the future. Do the same in child class "Codeception\Command\GenerateEnvironment" now to avoid errors or add an explicit @return annotation to suppress this message.
    1x in Application::run from Codeception

  1x: Method "Symfony\Component\Console\Command\Command::getDescription()" might add "string" as a native return type declaration in the future. Do the same in child class "Codeception\Command\GenerateFeature" now to avoid errors or add an explicit @return annotation to suppress this message.
    1x in Application::run from Codeception

  1x: Method "Symfony\Component\Console\Command\Command::execute()" might add "int" as a native return type declaration in the future. Do the same in child class "Codeception\Command\GenerateFeature" now to avoid errors or add an explicit @return annotation to suppress this message.
    1x in Application::run from Codeception

  1x: Method "Symfony\Component\Console\Command\Command::getDescription()" might add "string" as a native return type declaration in the future. Do the same in child class "Codeception\Command\GherkinSnippets" now to avoid errors or add an explicit @return annotation to suppress this message.
    1x in Application::run from Codeception

  1x: Method "Symfony\Component\Console\Command\Command::execute()" might add "int" as a native return type declaration in the future. Do the same in child class "Codeception\Command\GherkinSnippets" now to avoid errors or add an explicit @return annotation to suppress this message.
    1x in Application::run from Codeception

  1x: Method "Symfony\Component\Console\Command\Command::getDescription()" might add "string" as a native return type declaration in the future. Do the same in child class "Codeception\Command\GherkinSteps" now to avoid errors or add an explicit @return annotation to suppress this message.
    1x in Application::run from Codeception

  1x: Method "Symfony\Component\Console\Command\Command::execute()" might add "int" as a native return type declaration in the future. Do the same in child class "Codeception\Command\GherkinSteps" now to avoid errors or add an explicit @return annotation to suppress this message.
    1x in Application::run from Codeception

  1x: Method "Symfony\Component\Console\Command\Command::getDescription()" might add "string" as a native return type declaration in the future. Do the same in child class "Codeception\Command\DryRun" now to avoid errors or add an explicit @return annotation to suppress this message.
    1x in Application::run from Codeception

  1x: Method "Symfony\Component\Console\Command\Command::execute()" might add "int" as a native return type declaration in the future. Do the same in child class "Codeception\Command\DryRun" now to avoid errors or add an explicit @return annotation to suppress this message.
    1x in Application::run from Codeception

  1x: Method "Symfony\Component\Console\Command\Command::getDescription()" might add "string" as a native return type declaration in the future. Do the same in child class "Codeception\Command\ConfigValidate" now to avoid errors or add an explicit @return annotation to suppress this message.
    1x in Application::run from Codeception

  1x: Method "Symfony\Component\Console\Command\Command::execute()" might add "int" as a native return type declaration in the future. Do the same in child class "Codeception\Command\ConfigValidate" now to avoid errors or add an explicit @return annotation to suppress this message.
    1x in Application::run from Codeception

  1x: Method "Symfony\Component\Console\Command\Command::execute()" might add "int" as a native return type declaration in the future. Do the same in child class "Codeception\Command\CompletionFallback" now to avoid errors or add an explicit @return annotation to suppress this message.
    1x in Application::run from Codeception

  1x: The "Codeception\PHPUnit\Listener" class implements "PHPUnit\Framework\TestListener" that is deprecated Use the `TestHook` interfaces instead.
    1x in Application::run from Codeception

  1x: The "PHPUnit\TextUI\DefaultResultPrinter" class is considered internal This class is not covered by the backward compatibility promise for PHPUnit. It may change without further notice. You should not use it from "Codeception\PHPUnit\ResultPrinter\UI".
    1x in Application::run from Codeception

  1x: The "PHPUnit\Runner\BaseTestRunner" class is considered internal This class is not covered by the backward compatibility promise for PHPUnit. It may change without further notice. You should not use it from "Codeception\PHPUnit\NonFinal\TestRunner".
    1x in Application::run from Codeception

  1x: The "PHPUnit\Framework\TestSuite" class is considered internal This class is not covered by the backward compatibility promise for PHPUnit. It may change without further notice. You should not use it from "Codeception\Suite".
    1x in Application::run from Codeception

  1x: Method "Symfony\Component\BrowserKit\AbstractBrowser::doRequest()" might add "object" as a native return type declaration in the future. Do the same in child class "Codeception\Lib\Connector\Guzzle" now to avoid errors or add an explicit @return annotation to suppress this message.
    1x in Application::run from Codeception
```
