### PR TITLE
Action generator: Handle mixed type correctly

### DIFF
--- a/src/Codeception/Lib/Generator/Actions.php
+++ b/src/Codeception/Lib/Generator/Actions.php
@@ -250,7 +250,7 @@ EOF;
         }
         return sprintf(
             '%s%s%s',
-            (PHP_VERSION_ID >= 70100 && $type->allowsNull()) ? '?' : '',
+            (PHP_VERSION_ID >= 70100 && $type->allowsNull() && $returnTypeString !== 'mixed') ? '?' : '',
             $type->isBuiltin() ? '' : '\\',
             $returnTypeString
         );

--- a/tests/cli/BuildCest.php
+++ b/tests/cli/BuildCest.php
@@ -135,4 +135,22 @@ class BuildCest
         $I->seeFileFound('CliGuyActions.php', 'tests/support/_generated');
         $I->seeInThisFile('public function seeDirFound(?\Directory $dir = NULL): ?bool');
     }
+
+    public function generateMixedParametersOnPHP80AndLater(CliGuy $I, Scenario $scenario)
+    {
+        if (PHP_VERSION_ID < 80000) {
+            $scenario->skip('Does not work in PHP < 8.0');
+        }
+        $cliHelperContents = file_get_contents(codecept_root_dir('tests/support/CliHelper.php'));
+        $cliHelperContents = str_replace('public function seeDirFound($dir)', 'public function seeDirFound(mixed $dir = null): mixed', $cliHelperContents);
+        file_put_contents(codecept_root_dir('tests/support/CliHelper.php'), $cliHelperContents);
+
+        $I->runShellCommand('php codecept build');
+        $I->seeInShellOutput('generated successfully');
+        $I->seeInSupportDir('CliGuy.php');
+        $I->seeInThisFile('class CliGuy extends \Codeception\Actor');
+        $I->seeInThisFile('use _generated\CliGuyActions');
+        $I->seeFileFound('CliGuyActions.php', 'tests/support/_generated');
+        $I->seeInThisFile('public function seeDirFound(mixed $dir = NULL): mixed');
+    }
 }


### PR DESCRIPTION
Before this change, action generator generated `?mixed`.

Fixes #6317