### PR TITLE
Fix duplicate test runs when codeception.yml and dist.yml are present…

### DIFF
--- a/src/Codeception/Configuration.php
+++ b/src/Codeception/Configuration.php
@@ -12,6 +12,8 @@ use Symfony\Component\Finder\SplFileInfo;
 use Symfony\Component\Yaml\Exception\ParseException;
 use Symfony\Component\Yaml\Yaml;
 
+use function array_unique;
+
 class Configuration
 {
     protected static $suites = [];
@@ -774,7 +776,7 @@ class Configuration
             $paths[] = codecept_relative_path($file->getPath());
         }
 
-        return $paths;
+        return array_unique($paths);
     }
 
     private static function prepareParams($settings)

--- a/tests/cli/IncludedCest.php
+++ b/tests/cli/IncludedCest.php
@@ -192,5 +192,20 @@ class IncludedCest
         $I->dontSeeInShellOutput('No tests executed');
         $I->seeInShellOutput('2 tests');
     }
-
+    
+    /**
+     * @param CliGuy $I
+     */
+    public function includedSuitesAreNotRunTwice (CliGuy $I) {
+    
+        $I->amInPath('tests/data/included_two_config_files');
+        $I->executeCommand('run');
+        
+        // It should be two tests.
+        $I->seeInShellOutput('FooTest');
+        $I->seeInShellOutput('BarTest');
+        $I->dontSeeInShellOutput('4 tests');
+        
+    }
+    
 }

--- a/tests/data/included_two_config_files/codeception.dist.yml
+++ b/tests/data/included_two_config_files/codeception.dist.yml
@@ -1,0 +1,4 @@
+include:
+  - packages/*
+paths:
+  output: _output

--- a/tests/data/included_two_config_files/packages/bar/codeception.dist.yml
+++ b/tests/data/included_two_config_files/packages/bar/codeception.dist.yml
@@ -1,0 +1,10 @@
+namespace: bar
+actor: Tester
+paths:
+  log: "_log"
+  tests: "tests"
+  data: "data"
+  support: "support"
+  output: "output"
+settings:
+  colors: false

--- a/tests/data/included_two_config_files/packages/bar/codeception.yml
+++ b/tests/data/included_two_config_files/packages/bar/codeception.yml
@@ -1,0 +1,1 @@
+# this config changes something from .dist.yml

--- a/tests/data/included_two_config_files/packages/bar/tests/unit.suite.yml
+++ b/tests/data/included_two_config_files/packages/bar/tests/unit.suite.yml
@@ -1,0 +1,1 @@
+namespace: bar\unit

--- a/tests/data/included_two_config_files/packages/bar/tests/unit/BarTest.php
+++ b/tests/data/included_two_config_files/packages/bar/tests/unit/BarTest.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace bar\unit;
+
+final class BarTest extends \PHPUnit\Framework\TestCase
+{
+    public function testBar()
+    {
+        $this->assertTrue(true);
+    }
+    
+}

--- a/tests/data/included_two_config_files/packages/foo/codeception.dist.yml
+++ b/tests/data/included_two_config_files/packages/foo/codeception.dist.yml
@@ -1,0 +1,10 @@
+namespace: foo
+actor: Tester
+paths:
+  log: "_log"
+  tests: "tests"
+  data: "data"
+  support: "support"
+  output: "output"
+settings:
+  colors: false

--- a/tests/data/included_two_config_files/packages/foo/codeception.yml
+++ b/tests/data/included_two_config_files/packages/foo/codeception.yml
@@ -1,0 +1,1 @@
+# this config changes something from .dist.yml

--- a/tests/data/included_two_config_files/packages/foo/tests/unit.suite.yml
+++ b/tests/data/included_two_config_files/packages/foo/tests/unit.suite.yml
@@ -1,0 +1,1 @@
+namespace: foo\unit

--- a/tests/data/included_two_config_files/packages/foo/tests/unit/FooTest.php
+++ b/tests/data/included_two_config_files/packages/foo/tests/unit/FooTest.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace foo\unit;
+
+final class FooTest extends \PHPUnit\Framework\TestCase
+{
+    public function testFoo()
+    {
+        $this->assertTrue(true);
+    }
+    
+}

--- a/tests/data/snapshots/tests/_data/Snapshot.NotAJsonSnapshot.xml
+++ b/tests/data/snapshots/tests/_data/Snapshot.NotAJsonSnapshot.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"></xs:schema>
 <note>
-    <to>Son</to>
-    <from>Vader</from>
-    <heading>Disclaimer</heading>
-    <body>I'm your father!</body>
+    <to>Tove</to>
+    <from>Jani</from>
+    <heading>Reminder</heading>
+    <body>Don't forget me this weekend!</body>
 </note>


### PR DESCRIPTION
This fixes #6285. 

The only change is source is adding array_unique before expanding and returning all wildcard includes.

Without this check including both a codeception.dist.yml and codeception.yml in an included directory will result in all tests being run twice.

There is also a new test case and confirming the fix.