### PR TITLE
Improve dependency to symfony event dispatcher

### DIFF
--- a/shim.php
+++ b/shim.php
@@ -37,7 +37,7 @@ namespace {
     class_alias('Codeception\TestInterface', 'Codeception\TestCase');
 
     //Compatibility with Symfony 5
-    if (!class_exists('Symfony\Component\EventDispatcher\Event') && class_exists('Symfony\Contracts\EventDispatcher\Event')) {
-        class_alias('Symfony\Contracts\EventDispatcher\Event', 'Symfony\Component\EventDispatcher\Event');
+    if (!class_exists('Symfony\Contracts\EventDispatcher\Event') && class_exists('Symfony\Component\EventDispatcher\Event')) {
+        class_alias('Symfony\Component\EventDispatcher\Event', 'Symfony\Contracts\EventDispatcher\Event');
     }
 }

--- a/src/Codeception/Event/DispatcherWrapper.php
+++ b/src/Codeception/Event/DispatcherWrapper.php
@@ -2,8 +2,8 @@
 
 namespace Codeception\Event;
 
-use Symfony\Component\EventDispatcher\Event;
 use Symfony\Component\EventDispatcher\EventDispatcher;
+use Symfony\Contracts\EventDispatcher\Event;
 use Symfony\Contracts\EventDispatcher\EventDispatcherInterface as ContractsEventDispatcherInterface;
 
 trait DispatcherWrapper

--- a/src/Codeception/Event/PrintResultEvent.php
+++ b/src/Codeception/Event/PrintResultEvent.php
@@ -1,7 +1,7 @@
 <?php
 namespace Codeception\Event;
 
-use Symfony\Component\EventDispatcher\Event;
+use Symfony\Contracts\EventDispatcher\Event;
 
 class PrintResultEvent extends Event
 {

--- a/src/Codeception/Event/StepEvent.php
+++ b/src/Codeception/Event/StepEvent.php
@@ -3,7 +3,7 @@ namespace Codeception\Event;
 
 use Codeception\Step;
 use Codeception\TestInterface;
-use Symfony\Component\EventDispatcher\Event;
+use Symfony\Contracts\EventDispatcher\Event;
 
 class StepEvent extends Event
 {

--- a/src/Codeception/Event/SuiteEvent.php
+++ b/src/Codeception/Event/SuiteEvent.php
@@ -2,7 +2,7 @@
 namespace Codeception\Event;
 
 use Codeception\Suite;
-use Symfony\Component\EventDispatcher\Event;
+use Symfony\Contracts\EventDispatcher\Event;
 
 class SuiteEvent extends Event
 {

--- a/src/Codeception/Event/TestEvent.php
+++ b/src/Codeception/Event/TestEvent.php
@@ -1,7 +1,7 @@
 <?php
 namespace Codeception\Event;
 
-use Symfony\Component\EventDispatcher\Event;
+use Symfony\Contracts\EventDispatcher\Event;
 
 class TestEvent extends Event
 {


### PR DESCRIPTION
https://github.com/Codeception/Codeception/pull/5766/commits/15ba342b6511d0557435182d815690aa6b8e6aef
introduced a change for symfony 5 compatibility by creating an alias for a new class.

While the project still uses the old class namespace with a symfony version > 5 this old namespace is always an alias to the new class.

The problem with creating this alias is, that it may have some other implications in other libraries.  

Take the symfony/messenger for example and the class SendMessageMiddleware
(LTS - https://github.com/symfony/messenger/blob/5.4/Middleware/SendMessageMiddleware.php). They design the backward compatibility the other way around.

By creating this alias, it traps the package that it is in legacy mode, but it is not.

So better replace the usage of `Symfony\Component\EventDispatcher\Event` with `Symfony\Contracts\EventDispatcher\Event` and use the alias the other way around to be backward compatible. In case this backward support is dropped, only the alias has to been removed.
