### PR TITLE
Handle missing simplexml extension in ParamsLoader

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -51,6 +51,7 @@
         "phpunit/php-timer": "dev-master as 6.9.99"
     },
     "require-dev": {
+        "ext-simplexml": "*",
         "vlucas/phpdotenv": "^4.0 | ^5.0",
         "symfony/process": ">=4.4 <7.0",
         "codeception/lib-innerbrowser": "2.1.*@dev",
@@ -62,6 +63,7 @@
         "codeception/util-universalframework": "*@dev"
     },
     "suggest": {
+        "ext-simplexml": "For loading params from XML files",
         "hoa/console": "For interactive console functionality",
         "codeception/specify": "BDD-style code blocks",
         "codeception/verify": "BDD-style assertions",

--- a/src/Codeception/Lib/ParamsLoader.php
+++ b/src/Codeception/Lib/ParamsLoader.php
@@ -103,6 +103,10 @@ class ParamsLoader
 
     protected function loadXmlFile(): array
     {
+        if (!extension_loaded('simplexml')) {
+            throw new ConfigurationException('`simplexml` extension is required to parse .xml files.');
+        }
+
         $paramsToArray = function (SimpleXMLElement $params) use (&$paramsToArray): array {
             $a = [];
             foreach ($params as $param) {


### PR DESCRIPTION
* require-dev because `SimpleXMLElement` is used in tests
* suggest and check in `ParamsLoader` to print a friendly error when simplexml extension is not loaded