### PR TITLE
Fix loading .env file overwriting existing variables

### DIFF
--- a/src/Codeception/Lib/ParamsLoader.php
+++ b/src/Codeception/Lib/ParamsLoader.php
@@ -120,6 +120,7 @@ class ParamsLoader
                 $repository = \Dotenv\Repository\RepositoryBuilder::createWithNoAdapters()
                     ->addAdapter(\Dotenv\Repository\Adapter\EnvConstAdapter::class)
                     ->addAdapter(\Dotenv\Repository\Adapter\ServerConstAdapter::class)
+                    ->immutable()
                     ->make();
                 $dotEnv = \Dotenv\Dotenv::create($repository, codecept_root_dir(), $this->paramStorage);
             } elseif (class_exists('Dotenv\Repository\RepositoryBuilder')) {


### PR DESCRIPTION
The v5 branch of phpdotenv is missing the `immutable` flag, changing the behavior used with v4. It is now overwriting existing environment variables with the same name.

From the docs:
![image](https://user-images.githubusercontent.com/2145319/152346129-71468690-b185-4333-8506-6c6bf64f91fc.png)

This is preventing the following use case:

```yml
# codeception.yml
params:
  - .env # Use dev defaults from file
  - env # But prefer values set on the environment, e.g. in CI
```

This does not work, because when loading the `.env` file, the environment variables we would load in the second step were already modified.