### PR TITLE
Return params from env file without modifying superglobals

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -52,7 +52,7 @@
     },
     "require-dev": {
         "ext-simplexml": "*",
-        "vlucas/phpdotenv": "^5.0",
+        "vlucas/phpdotenv": "^5.1",
         "symfony/process": ">=4.4 <7.0",
         "symfony/dotenv": ">=4.4 <7.0",
         "codeception/lib-innerbrowser": "*@dev",

--- a/composer.json
+++ b/composer.json
@@ -54,6 +54,7 @@
         "ext-simplexml": "*",
         "vlucas/phpdotenv": "^4.0 | ^5.0",
         "symfony/process": ">=4.4 <7.0",
+        "symfony/dotenv": "^6.0",
         "codeception/lib-innerbrowser": "*@dev",
         "codeception/module-asserts": "*@dev",
         "codeception/module-cli": "*@dev",
@@ -69,6 +70,8 @@
     },
     "suggest": {
         "ext-simplexml": "For loading params from XML files",
+        "vlucas/phpdotenv": "For loading params from .env files",
+        "symfony/dotenv": "For loading params from .env files",
         "hoa/console": "For interactive console functionality",
         "codeception/specify": "BDD-style code blocks",
         "codeception/verify": "BDD-style assertions",

--- a/composer.json
+++ b/composer.json
@@ -52,7 +52,7 @@
     },
     "require-dev": {
         "ext-simplexml": "*",
-        "vlucas/phpdotenv": "^4.0 | ^5.0",
+        "vlucas/phpdotenv": "^5.0",
         "symfony/process": ">=4.4 <7.0",
         "symfony/dotenv": "^6.0",
         "codeception/lib-innerbrowser": "*@dev",

--- a/composer.json
+++ b/composer.json
@@ -54,7 +54,7 @@
         "ext-simplexml": "*",
         "vlucas/phpdotenv": "^5.0",
         "symfony/process": ">=4.4 <7.0",
-        "symfony/dotenv": "^6.0",
+        "symfony/dotenv": ">=4.4 <7.0",
         "codeception/lib-innerbrowser": "*@dev",
         "codeception/module-asserts": "*@dev",
         "codeception/module-cli": "*@dev",

--- a/src/Codeception/Lib/ParamsLoader.php
+++ b/src/Codeception/Lib/ParamsLoader.php
@@ -116,7 +116,7 @@ class ParamsLoader
     {
         // vlucas/phpdotenv
         if (class_exists(PhpDotenv::class)) {
-            return PhpDotenv::createArrayBacked(codecept_root_dir(), $this->paramStorage)->load();
+            return PhpDotenv::parse(file_get_contents($this->paramsFile));
         }
 
         // symfony/dotenv

--- a/src/Codeception/Lib/ParamsLoader.php
+++ b/src/Codeception/Lib/ParamsLoader.php
@@ -116,29 +116,15 @@ class ParamsLoader
 
     protected function loadDotEnvFile(): array
     {
-        if (class_exists(RepositoryBuilder::class)) {
-            if (method_exists(RepositoryBuilder::class, 'createWithNoAdapters')) {
-                //dotenv v5
-                $repository = RepositoryBuilder::createWithNoAdapters()
-                    ->addAdapter(EnvConstAdapter::class)
-                    ->addAdapter(ServerConstAdapter::class)
-                    ->make();
-            } else {
-                //dotenv v4
-                $repository = RepositoryBuilder::create()
-                    ->withReaders([new ServerConstAdapter()])
-                    ->immutable()
-                    ->make();
-            }
-            $dotEnv = Dotenv::create($repository, codecept_root_dir(), $this->paramStorage);
-            $dotEnv->load();
-            return $_SERVER;
+        if (!class_exists(Dotenv::class)) {
+            throw new ConfigurationException(
+                "`vlucas/phpdotenv` library is required to parse .env files.\n" .
+                "Please install it via composer: composer require vlucas/phpdotenv"
+            );
         }
 
-        throw new ConfigurationException(
-            "`vlucas/phpdotenv` library is required to parse .env files.\n" .
-            "Please install it via composer: composer require vlucas/phpdotenv"
-        );
+        // Dotenv v5 & v4
+        return Dotenv::createArrayBacked(codecept_root_dir(), $this->paramStorage)->load();
     }
 
     protected function loadEnvironmentVars(): array


### PR DESCRIPTION
I noticed that in contrast to the other ways to load params (php, yml, xml etc), when loading from `.env` files there is a side-effect that modifies the `$_ENV` and `$_SERVER` superglobals. While this is usually what you want in the most common use-case for `phpdotenv`, in this case it is a bit odd, as `.env` files are merely used as another input format to load and merge Codeception params. That it also messes around with the values read from the real environment is unexpected.

The piece if code I used to parse the `.env` file into an array is supported in both v4 and v5 of `phpdotenv`.

I based this on the 5.0 branch as it is a breaking change. I also created a bugfix PR for 4.x that fixes environment variables being overwritten but does not remove the side-effect (#6347).