### PR TITLE
[Codecept5] Updated types for Extension class properties

### DIFF
--- a/ext/RunProcess.php
+++ b/ext/RunProcess.php
@@ -58,7 +58,7 @@ use function sleep;
 class RunProcess extends Extension
 {
     /**
-     * @var array<string, int>
+     * @var array<int|string, mixed>
      */
     protected array $config = ['sleep' => 0];
 

--- a/src/Codeception/Extension.php
+++ b/src/Codeception/Extension.php
@@ -25,16 +25,16 @@ use function is_array;
 abstract class Extension implements EventSubscriberInterface
 {
     /**
-     * @var array
+     * @var array<int|string, mixed>
      */
-    protected $config = [];
+    protected array $config = [];
 
     protected Output $output;
 
     protected array $globalConfig = [];
 
     /**
-     * @var Array<string,Module>
+     * @var array<string, Module>
      */
     private array $modules = [];
 

--- a/tests/data/claypit/tests/_support/SuiteExtension.php
+++ b/tests/data/claypit/tests/_support/SuiteExtension.php
@@ -16,7 +16,7 @@ class SuiteExtension extends Extension
     ];
 
     /** @var array */
-    protected $config = ['config1' => 'novalue', 'config2' => 'novalue'];
+    protected array $config = ['config1' => 'novalue', 'config2' => 'novalue'];
 
     public function beforeSuite(SuiteEvent $e )
     {


### PR DESCRIPTION
Minor typed property and docblock fixes for the `Extension` and `RunProcess` extension classes.