### PR TITLE
Replace symfony console constants with integers

### DIFF
--- a/src/Codeception/Command/Bootstrap.php
+++ b/src/Codeception/Command/Bootstrap.php
@@ -55,6 +55,6 @@ class Bootstrap extends Command
             $bootstrap->initDir($input->getArgument('path'));
         }
         $bootstrap->setup();
-        return Command::SUCCESS;
+        return 0;
     }
 }

--- a/src/Codeception/Command/Build.php
+++ b/src/Codeception/Command/Build.php
@@ -38,7 +38,7 @@ class Build extends Command
     {
         $this->output = $output;
         $this->buildActorsForConfig();
-        return Command::SUCCESS;
+        return 0;
     }
 
     private function buildActor(array $settings): bool

--- a/src/Codeception/Command/Clean.php
+++ b/src/Codeception/Command/Clean.php
@@ -30,7 +30,7 @@ class Clean extends Command
         $projectDir = Configuration::projectDir();
         $this->cleanProjectsRecursively($output, $projectDir);
         $output->writeln("Done");
-        return Command::SUCCESS;
+        return 0;
     }
 
     private function cleanProjectsRecursively(OutputInterface $output, string $projectDir): void

--- a/src/Codeception/Command/Completion.php
+++ b/src/Codeception/Command/Completion.php
@@ -71,7 +71,7 @@ class Completion extends CompletionCommand
         }
 
         parent::execute($input, $output);
-        return Command::SUCCESS;
+        return 0;
     }
 
     protected function createDefinition(): SymfonyInputDefinition

--- a/src/Codeception/Command/CompletionFallback.php
+++ b/src/Codeception/Command/CompletionFallback.php
@@ -31,6 +31,6 @@ END);
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $output->writeln("Install optional <comment>stecman/symfony-console-completion</comment>");
-        return Command::SUCCESS;
+        return 0;
     }
 }

--- a/src/Codeception/Command/ConfigValidate.php
+++ b/src/Codeception/Command/ConfigValidate.php
@@ -72,7 +72,7 @@ class ConfigValidate extends Command
             $output->writeln("<info>{$suite} Suite Config</info>:\n");
             $output->writeln($this->formatOutput($config));
 
-            return Command::SUCCESS;
+            return 0;
         }
 
         $output->write("Validating global config... ");
@@ -103,7 +103,7 @@ class ConfigValidate extends Command
         }
 
         $output->writeln("Execute <info>codecept config:validate [<suite>]</info> to see config for a suite");
-        return Command::SUCCESS;
+        return 0;
     }
 
     protected function formatOutput($config): ?string

--- a/src/Codeception/Command/Console.php
+++ b/src/Codeception/Command/Console.php
@@ -124,7 +124,7 @@ class Console extends Command
         $eventDispatcher->dispatch(new SuiteEvent($this->suite), Events::SUITE_AFTER);
 
         $output->writeln("<info>Bye-bye!</info>");
-        return Command::SUCCESS;
+        return 0;
     }
 
     protected function listenToSignals(): void

--- a/src/Codeception/Command/DryRun.php
+++ b/src/Codeception/Command/DryRun.php
@@ -96,7 +96,7 @@ class DryRun extends Command
             }
         }
         $eventDispatcher->dispatch(new SuiteEvent($suiteManager->getSuite()), Events::SUITE_AFTER);
-        return Command::SUCCESS;
+        return 0;
     }
 
     protected function matchTestFromFilename($filename, $testsPath)

--- a/src/Codeception/Command/GenerateCest.php
+++ b/src/Codeception/Command/GenerateCest.php
@@ -52,16 +52,16 @@ class GenerateCest extends Command
 
         if (file_exists($filename)) {
             $output->writeln("<error>Test {$filename} already exists</error>");
-            return Command::FAILURE;
+            return 1;
         }
         $cest = new CestGenerator($class, $config);
         $res = $this->createFile($filename, $cest->produce());
         if (!$res) {
             $output->writeln("<error>Test {$filename} already exists</error>");
-            return Command::FAILURE;
+            return 1;
         }
 
         $output->writeln("<info>Test was created in {$filename}</info>");
-        return Command::SUCCESS;
+        return 0;
     }
 }

--- a/src/Codeception/Command/GenerateEnvironment.php
+++ b/src/Codeception/Command/GenerateEnvironment.php
@@ -54,10 +54,10 @@ class GenerateEnvironment extends Command
 
         if ($saved) {
             $output->writeln("<info>{$env} config was created in {$relativePath}/{$file}</info>");
-            return Command::SUCCESS;
+            return 0;
         } else {
             $output->writeln("<error>File {$relativePath}/{$file} already exists</error>");
-            return Command::FAILURE;
+            return 1;
         }
     }
 }

--- a/src/Codeception/Command/GenerateFeature.php
+++ b/src/Codeception/Command/GenerateFeature.php
@@ -57,9 +57,9 @@ class GenerateFeature extends Command
         $res = $this->createFile($fullPath, $feature->produce());
         if (!$res) {
             $output->writeln("<error>Feature {$filename} already exists</error>");
-            return Command::FAILURE;
+            return 1;
         }
         $output->writeln("<info>Feature was created in {$fullPath}</info>");
-        return Command::SUCCESS;
+        return 0;
     }
 }

--- a/src/Codeception/Command/GenerateGroup.php
+++ b/src/Codeception/Command/GenerateGroup.php
@@ -49,13 +49,13 @@ class GenerateGroup extends Command
 
         if (!$res) {
             $output->writeln("<error>Group {$filename} already exists</error>");
-            return Command::FAILURE;
+            return 1;
         }
 
         $output->writeln("<info>Group extension was created in {$filename}</info>");
         $output->writeln(
             'To use this group extension, include it to "extensions" option of global Codeception config.'
         );
-        return Command::SUCCESS;
+        return 0;
     }
 }

--- a/src/Codeception/Command/GenerateHelper.php
+++ b/src/Codeception/Command/GenerateHelper.php
@@ -47,10 +47,10 @@ class GenerateHelper extends Command
         $res = $this->createFile($filename, (new Helper($name, $config['namespace']))->produce());
         if ($res) {
             $output->writeln("<info>Helper {$filename} created</info>");
-            return Command::SUCCESS;
+            return 0;
         } else {
             $output->writeln("<error>Error creating helper {$filename}</error>");
-            return Command::FAILURE;
+            return 1;
         }
     }
 }

--- a/src/Codeception/Command/GeneratePageObject.php
+++ b/src/Codeception/Command/GeneratePageObject.php
@@ -68,9 +68,9 @@ class GeneratePageObject extends Command
 
         if (!$res) {
             $output->writeln("<error>PageObject {$filename} already exists</error>");
-            return Command::FAILURE;
+            return 1;
         }
         $output->writeln("<info>PageObject was created in {$filename}</info>");
-        return Command::SUCCESS;
+        return 0;
     }
 }

--- a/src/Codeception/Command/GenerateScenarios.php
+++ b/src/Codeception/Command/GenerateScenarios.php
@@ -109,7 +109,7 @@ class GenerateScenarios extends Command
         if ($input->getOption('single-file')) {
             $this->createFile($path . $this->formatExtension($format), $this->decorate($scenarios, $format), true);
         }
-        return Command::SUCCESS;
+        return 0;
     }
 
     protected function decorate(string $text, string $format): string

--- a/src/Codeception/Command/GenerateSnapshot.php
+++ b/src/Codeception/Command/GenerateSnapshot.php
@@ -69,9 +69,9 @@ class GenerateSnapshot extends Command
 
         if (!$res) {
             $output->writeln("<error>Snapshot {$filename} already exists</error>");
-            return Command::FAILURE;
+            return 1;
         }
         $output->writeln("<info>Snapshot was created in {$filename}</info>");
-        return Command::SUCCESS;
+        return 0;
     }
 }

--- a/src/Codeception/Command/GenerateStepObject.php
+++ b/src/Codeception/Command/GenerateStepObject.php
@@ -72,9 +72,9 @@ class GenerateStepObject extends Command
 
         if (!$res) {
             $output->writeln("<error>StepObject {$filename} already exists</error>");
-            return Command::FAILURE;
+            return 1;
         }
         $output->writeln("<info>StepObject was created in {$filename}</info>");
-        return Command::SUCCESS;
+        return 0;
     }
 }

--- a/src/Codeception/Command/GenerateSuite.php
+++ b/src/Codeception/Command/GenerateSuite.php
@@ -54,7 +54,7 @@ class GenerateSuite extends Command
 
         if ($this->containsInvalidCharacters($suite)) {
             $output->writeln("<error>Suite name '{$suite}' contains invalid characters. ([A-Za-z0-9_]).</error>");
-            return Command::FAILURE;
+            return 1;
         }
 
         $config = $this->getGlobalConfig();
@@ -132,7 +132,7 @@ EOF;
         $output->writeln("3. Run tests of this suite with <bold>codecept run {$suite}</bold> command");
 
         $output->writeln("<info>Suite {$suite} generated</info>");
-        return Command::SUCCESS;
+        return 0;
     }
 
     private function containsInvalidCharacters(string $suite): bool

--- a/src/Codeception/Command/GenerateTest.php
+++ b/src/Codeception/Command/GenerateTest.php
@@ -56,9 +56,9 @@ class GenerateTest extends Command
 
         if (!$res) {
             $output->writeln("<error>Test {$filename} already exists</error>");
-            return Command::FAILURE;
+            return 1;
         }
         $output->writeln("<info>Test was created in {$filename}</info>");
-        return Command::SUCCESS;
+        return 0;
     }
 }

--- a/src/Codeception/Command/GherkinSnippets.php
+++ b/src/Codeception/Command/GherkinSnippets.php
@@ -57,7 +57,7 @@ class GherkinSnippets extends Command
         $snippets = $generator->getSnippets();
         if (empty($snippets)) {
             $output->writeln("<notice> All Gherkin steps are defined. Exiting... </notice>");
-            return Command::SUCCESS;
+            return 0;
         }
         $output->writeln("<comment> Snippets found in: </comment>");
 
@@ -73,6 +73,6 @@ class GherkinSnippets extends Command
         $output->writeln("<info> ----------------------------------------- </info>");
         $output->writeln(sprintf(' <bold>%d</bold> snippets proposed', count($snippets)));
         $output->writeln("<notice> Copy generated snippets to {$config['actor']} or a specific Gherkin context </notice>");
-        return Command::SUCCESS;
+        return 0;
     }
 }

--- a/src/Codeception/Command/GherkinSteps.php
+++ b/src/Codeception/Command/GherkinSteps.php
@@ -70,6 +70,6 @@ class GherkinSteps extends Command
         if (!isset($table)) {
             $output->writeln("No steps are defined, start creating them by running <bold>gherkin:snippets</bold>");
         }
-        return Command::SUCCESS;
+        return 0;
     }
 }

--- a/src/Codeception/Command/Init.php
+++ b/src/Codeception/Command/Init.php
@@ -55,6 +55,6 @@ class Init extends Command
             $initProcess->initDir($path);
         }
         $initProcess->setup();
-        return Command::SUCCESS;
+        return 0;
     }
 }

--- a/src/Codeception/Command/Run.php
+++ b/src/Codeception/Command/Run.php
@@ -433,7 +433,7 @@ class Run extends Command
         if (!$input->getOption('no-exit') && !$this->codecept->getResult()->wasSuccessfulIgnoringWarnings()) {
             exit(1);
         }
-        return Command::SUCCESS;
+        return 0;
     }
 
     protected function matchSingleTest($suite, $config): ?array

--- a/src/Codeception/Command/SelfUpdate.php
+++ b/src/Codeception/Command/SelfUpdate.php
@@ -101,9 +101,9 @@ class SelfUpdate extends Command
                     $e->getMessage()
                 )
             );
-            return Command::FAILURE;
+            return 1;
         }
 
-        return Command::SUCCESS;
+        return 0;
     }
 }


### PR DESCRIPTION
These constants were added in Symfony 5.1 and Codeception 5 allows 4.4 onwards.