### PR TITLE
CI: Prefer lowest versions of dependencies on PHP 8.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,8 +53,14 @@ jobs:
       - name: Validate composer.json
         run: composer validate
 
-      - name: Composer install
-        run: composer install --prefer-source --no-interaction --no-progress --optimize-autoloader --ansi
+
+      - name: Composer install lowest versions of dependencies on PHP 8.0
+        if: matrix.php == '8.0'
+        run: composer update --prefer-source --prefer-lowest --no-interaction --no-progress --optimize-autoloader --ansi
+
+      - name: Composer install highest versions of dependencies on PHP 8.1
+        if: matrix.php == '8.1'
+        run: composer update --prefer-source --no-interaction --no-progress --optimize-autoloader --ansi
 
       - name: Test that failing test really fails
         run: if php codecept run -c tests/data/claypit/ scenario FailedCept -vvv; then echo "Test hasn't failed"; false; fi;


### PR DESCRIPTION
It will help to ensure that we didn't break compatibility with older versions of dependencies