### PR TITLE
4.1 Generate actions with intersection types

### DIFF
--- a/src/Codeception/Lib/Generator/Actions.php
+++ b/src/Codeception/Lib/Generator/Actions.php
@@ -240,7 +240,16 @@ EOF;
     {
         if ($type instanceof \ReflectionUnionType) {
             $types = $type->getTypes();
-            return implode('|', $types);
+            return implode(
+                '|',
+                array_map([$this, 'stringifyNamedType'], $types)
+            );
+        } elseif ($type instanceof \ReflectionIntersectionType) {
+            $types = $type->getTypes();
+            return implode(
+                '&',
+                array_map([$this, 'stringifyNamedType'], $types)
+            );
         }
 
         if (PHP_VERSION_ID < 70100) {
@@ -249,8 +258,26 @@ EOF;
             $returnTypeString = $type->getName();
         }
         return sprintf(
-            '%s%s%s',
+            '%s%s',
             (PHP_VERSION_ID >= 70100 && $type->allowsNull() && $returnTypeString !== 'mixed') ? '?' : '',
+            $this->stringifyNamedType($type)
+        );
+    }
+
+    /**
+     * @param \ReflectionNamedType|\ReflectionType $type
+     * @return string
+     * @todo param is only \ReflectionNamedType in Codeception 5
+     */
+    private function stringifyNamedType($type)
+    {
+        if (PHP_VERSION_ID < 70100) {
+            $returnTypeString = (string)$type;
+        } else {
+            $returnTypeString = $type->getName();
+        }
+        return sprintf(
+            '%s%s',
             $type->isBuiltin() ? '' : '\\',
             $returnTypeString
         );

--- a/tests/cli/BuildCest.php
+++ b/tests/cli/BuildCest.php
@@ -77,6 +77,27 @@ class BuildCest
         $I->seeFileFound('CliGuyActions.php', 'tests/support/_generated');
         $I->seeInThisFile('public function grabFromOutput(array|string $param): string|int');
     }
+
+    public function generatedIntersectReturnTypeOnPhp81(CliGuy $I, Scenario $scenario)
+    {
+        if (PHP_VERSION_ID < 80100) {
+            $scenario->skip('Does not work in PHP < 8.1');
+        }
+
+        $I->wantToTest('generate action with intersect return type');
+
+        $cliHelperContents = file_get_contents(codecept_root_dir('tests/support/CliHelper.php'));
+        $cliHelperContents = str_replace('public function grabFromOutput($regex)', 'public function grabFromOutput(CliHelper&\ArrayObject $param): CliHelper&\ArrayObject', $cliHelperContents);
+        file_put_contents(codecept_root_dir('tests/support/CliHelper.php'), $cliHelperContents);
+
+        $I->runShellCommand('php codecept build');
+        $I->seeInShellOutput('generated successfully');
+        $I->seeInSupportDir('CliGuy.php');
+        $I->seeInThisFile('class CliGuy extends \Codeception\Actor');
+        $I->seeInThisFile('use _generated\CliGuyActions');
+        $I->seeFileFound('CliGuyActions.php', 'tests/support/_generated');
+        $I->seeInThisFile('public function grabFromOutput(\Codeception\Module\CliHelper&\ArrayObject $param): \Codeception\Module\CliHelper&\ArrayObject');
+    }
     
     public function noReturnForVoidType(CliGuy $I, Scenario $scenario)
     {


### PR DESCRIPTION
Intersection types were introduced in PHP 8.1 - `Interface1 & Interface2`. See https://php.watch/versions/8.1/intersection-types for more information.

This change allows to use intersection types as action parameter and return type.

Also I fixed class names used in union and intersection types.
Before this change class names used union types were generated without leading backslash and were relating to `_generated` namespace.