### PR TITLE
Improved shell usage

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -8,7 +8,13 @@ function codecept_debug($data)
     \Codeception\Util\Debug::debug($data);
 }
 
-function codecept_pause(array $vars = [])
+/**
+ * Executes interactive pause in ths place
+ *
+ * @param array $vars
+ * @return void
+ */
+function codecept_pause(array $vars = []): void
 {
     \Codeception\Util\Debug::pause($vars);
 }

--- a/functions.php
+++ b/functions.php
@@ -8,6 +8,11 @@ function codecept_debug($data)
     \Codeception\Util\Debug::debug($data);
 }
 
+function codecept_pause(array $vars = [])
+{
+    \Codeception\Util\Debug::pause($vars);
+}
+
 function codecept_root_dir($appendPath = '')
 {
     return \Codeception\Configuration::projectDir() . $appendPath;

--- a/src/Codeception/Lib/Actor/Shared/Pause.php
+++ b/src/Codeception/Lib/Actor/Shared/Pause.php
@@ -5,27 +5,26 @@ declare(strict_types=1);
 namespace Codeception\Lib\Actor\Shared;
 
 use Codeception\Command\Console;
+use Codeception\Lib\PauseShell;
 use Codeception\Util\Debug;
 use Psy\Shell;
 use Psy\Configuration;
 
 trait Pause
 {
-    public function pause(): void
+    public function pause(array $vars = []): void
     {
         if (!Debug::isEnabled()) {
             return;
         }
 
-        $logFile = '.pause.log';
-        $relativeLogFilePath = codecept_relative_path(codecept_output_dir($logFile));
-        $psyConf = new Configuration([
-            'prompt' => '>> ',
-            'startupMessage' => "<warning>Execution PAUSED</warning> use \$I-> to run commands.\nAll commands will be saved to $relativeLogFilePath"
-        ]);
-        $psyConf->setHistoryFile(codecept_output_dir($logFile));
-        $psy = new Shell($psyConf);
-        $psy->setScopeVariables(['I' => $this]);
+        $psy = (new PauseShell())
+            ->addMessage(' $I-> to launch commands')
+            ->addMessage(' $this-> to access current test')
+            ->getShell();
+
+        $vars['I'] = $this;
+        $psy->setScopeVariables($vars);
         $backtrace = debug_backtrace(DEBUG_BACKTRACE_PROVIDE_OBJECT, 2);
         if (!$backtrace[1]['object'] instanceof Console) {
             // set the scope of test class

--- a/src/Codeception/Lib/PauseShell.php
+++ b/src/Codeception/Lib/PauseShell.php
@@ -2,13 +2,12 @@
 
 namespace Codeception\Lib;
 
-use Codeception\Command\Console;
 use Psy\Shell;
 use Psy\Configuration;
 
 class PauseShell
 {
-    const LOG_FILE = '.pause.log';
+    public const LOG_FILE = '.pause.log';
     private Configuration $psyConf;
 
     public function __construct()
@@ -30,7 +29,6 @@ class PauseShell
 
     public function getShell(): Shell
     {
-        $psy = new Shell($this->psyConf);
-        return $psy;
+        return new Shell($this->psyConf);
     }
 }

--- a/src/Codeception/Lib/PauseShell.php
+++ b/src/Codeception/Lib/PauseShell.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Codeception\Lib;
+
+use Codeception\Command\Console;
+use Psy\Shell;
+use Psy\Configuration;
+
+class PauseShell
+{
+    const LOG_FILE = '.pause.log';
+    private Configuration $psyConf;
+
+    public function __construct()
+    {
+        $relativeLogFilePath = codecept_relative_path(codecept_output_dir(self::LOG_FILE));
+        $this->psyConf = new Configuration([
+            'prompt' => '>> ',
+            'startupMessage' => "<warning>Execution PAUSED</warning> All commands will be saved to $relativeLogFilePath"
+        ]);
+        $this->psyConf->setHistoryFile(codecept_output_dir(self::LOG_FILE));
+        $this->psyConf->setHistorySize(1000);
+    }
+
+    public function addMessage(string $message): self
+    {
+        $this->psyConf->setStartupMessage($this->psyConf->getStartupMessage() . "\n" . $message);
+        return $this;
+    }
+
+    public function getShell(): Shell
+    {
+        $psy = new Shell($this->psyConf);
+        return $psy;
+    }
+}

--- a/src/Codeception/Test/Unit.php
+++ b/src/Codeception/Test/Unit.php
@@ -96,10 +96,10 @@ class Unit extends TestCase implements
     /**
      * Starts interactive pause in this test
      *
-     * @param array $vars
+     * @param array<string, mixed> $vars
      * @return void
      */
-    public function pause(array $vars = [])
+    public function pause(array $vars = []): void
     {
         $psy = (new PauseShell())->getShell();
         $psy->setBoundObject($this);

--- a/src/Codeception/Test/Unit.php
+++ b/src/Codeception/Test/Unit.php
@@ -13,6 +13,7 @@ use Codeception\PHPUnit\TestCase;
 use Codeception\Scenario;
 use Codeception\Test\Feature\Stub;
 use Codeception\TestInterface;
+use Codeception\Util\Debug;
 use PHPUnit\Framework\TestResult;
 
 use function get_class;
@@ -101,6 +102,9 @@ class Unit extends TestCase implements
      */
     public function pause(array $vars = []): void
     {
+        if (!Debug::isEnabled()) {
+            return;
+        }
         $psy = (new PauseShell())->getShell();
         $psy->setBoundObject($this);
         $psy->setScopeVariables($vars);

--- a/src/Codeception/Test/Unit.php
+++ b/src/Codeception/Test/Unit.php
@@ -7,6 +7,7 @@ namespace Codeception\Test;
 use Codeception\Configuration;
 use Codeception\Exception\ModuleException;
 use Codeception\Lib\Di;
+use Codeception\Lib\PauseShell;
 use Codeception\Module;
 use Codeception\PHPUnit\TestCase;
 use Codeception\Scenario;
@@ -90,6 +91,20 @@ class Unit extends TestCase implements
             throw new ModuleException($module, "Module can't be accessed");
         }
         return $modules[$module];
+    }
+
+    /**
+     * Starts interactive pause in this test
+     *
+     * @param array $vars
+     * @return void
+     */
+    public function pause(array $vars = [])
+    {
+        $psy = (new PauseShell())->getShell();
+        $psy->setBoundObject($this);
+        $psy->setScopeVariables($vars);
+        $psy->run();
     }
 
     /**

--- a/src/Codeception/Util/Debug.php
+++ b/src/Codeception/Util/Debug.php
@@ -50,14 +50,21 @@ class Debug
         $psy = $pauseShell->getShell();
         $psy->setScopeVariables($vars);
         $backtrace = debug_backtrace(DEBUG_BACKTRACE_PROVIDE_OBJECT, 3);
-        if (isset($backtrace[1]['object'])) {
-            // set the scope of test class
+        foreach ($backtrace as $backtraceStep) {
+            $class = $backtraceStep['class'] ?? null;
+            $fn = $backtraceStep['class'] ?? null;
+            if ($class === Debug::class && $fn === 'pause') {
+                continue;
+            }
+            if ($fn === 'codecept_pause' && !$class) {
+                continue;
+            }
+            if (!isset($backtraceStep['object'])) {
+                continue;
+            }
             $pauseShell->addMessage('Use $this-> to access current object');
-            $psy->setBoundObject($backtrace[1]['object']);
-        } elseif (isset($backtrace[2]['object'])) {
-            // set the scope of test class
-            $pauseShell->addMessage('Use $this-> to access current object');
-            $psy->setBoundObject($backtrace[2]['object']);
+            $psy->setBoundObject($backtraceStep['object']);
+            break;
         }
         $psy->run();
     }

--- a/src/Codeception/Util/Debug.php
+++ b/src/Codeception/Util/Debug.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Codeception\Util;
 
+use Codeception\Command\Console;
 use Codeception\Lib\Console\Output;
 use Codeception\Lib\PauseShell;
 use Symfony\Component\Console\Helper\QuestionHelper;
@@ -45,8 +46,19 @@ class Debug
             return;
         }
 
-        $psy = (new PauseShell())->getShell();
+        $pauseShell = new PauseShell();
+        $psy = $pauseShell->getShell();
         $psy->setScopeVariables($vars);
+        $backtrace = debug_backtrace(DEBUG_BACKTRACE_PROVIDE_OBJECT, 3);
+        if (isset($backtrace[1]['object'])) {
+            // set the scope of test class
+            $pauseShell->addMessage('Use $this-> to access current object');
+            $psy->setBoundObject($backtrace[1]['object']);
+        } elseif (isset($backtrace[2]['object'])) {
+            // set the scope of test class
+            $pauseShell->addMessage('Use $this-> to access current object');
+            $psy->setBoundObject($backtrace[2]['object']);
+        }
         $psy->run();
     }
 

--- a/src/Codeception/Util/Debug.php
+++ b/src/Codeception/Util/Debug.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Codeception\Util;
 
 use Codeception\Lib\Console\Output;
+use Codeception\Lib\PauseShell;
 use Symfony\Component\Console\Helper\QuestionHelper;
 use Symfony\Component\Console\Input\ArgvInput;
 use Symfony\Component\Console\Question\ConfirmationQuestion;
@@ -36,6 +37,17 @@ class Debug
     public static function isEnabled(): bool
     {
         return (bool)self::$output;
+    }
+
+    public static function pause(array $vars = []): void
+    {
+        if (!self::isEnabled()) {
+            return;
+        }
+
+        $psy = (new PauseShell())->getShell();
+        $psy->setScopeVariables($vars);
+        $psy->run();
     }
 
     public static function confirm($question)


### PR DESCRIPTION
More pause options

* all shell settings moved to `Codecept\Lib\PauseShell`
* `codecept_pause()` function
* added `$this->pause()` for unit tests 
* all pause commands to receive `$vars` as array:

```php
codecept_pause(['user' => $user]);
$I->pause(['pageObject' => $pageObject]);
```

TODO: Documentation!