### PR TITLE
Populate $_ENV when loading .env with Symfony/DotEnv

### DIFF
--- a/src/Codeception/Lib/ParamsLoader.php
+++ b/src/Codeception/Lib/ParamsLoader.php
@@ -121,7 +121,10 @@ class ParamsLoader
 
         // symfony/dotenv
         if (class_exists(SymfonyDotenv::class)) {
-            return (new SymfonyDotenv())->parse(file_get_contents($this->paramsFile), $this->paramsFile);
+            $symfonyDotEnv = new SymfonyDotenv();
+            $values = $symfonyDotEnv->parse(file_get_contents($this->paramsFile), $this->paramsFile);
+            $symfonyDotEnv->populate($values, true);
+            return $values;
         }
 
         throw new ConfigurationException(


### PR DESCRIPTION
As suggested in https://github.com/Codeception/Codeception/pull/6393#discussion_r829284908

Could not think of a reasonable way to test this - PhpDotenv seems to always take priority