### PR TITLE
Added --shard, --grep, --filter options

### DIFF
--- a/src/Codeception/Codecept.php
+++ b/src/Codeception/Codecept.php
@@ -69,6 +69,7 @@ class Codecept
         'groups'             => null,
         'excludeGroups'      => null,
         'filter'             => null,
+        'shard'              => null,
         'env'                => null,
         'fail-fast'          => 0,
         'ansi'               => true,
@@ -273,6 +274,7 @@ class Codecept
 
     public function runSuite(array $settings, string $suite, string $test = null): TestResult
     {
+        $settings['shard'] = $this->options['shard'];
         $suiteManager = new SuiteManager($this->dispatcher, $suite, $settings);
         $suiteManager->initialize();
         srand($this->options['seed']);

--- a/src/Codeception/Command/Run.php
+++ b/src/Codeception/Command/Run.php
@@ -423,7 +423,6 @@ class Run extends Command
         }
 
         if (!$this->options['silent'] && $config['settings']['shuffle']) {
-
             $this->output->writeln(
                 "[SEED] <info>" . $userOptions['seed'] . "</info>"
             );
@@ -461,9 +460,10 @@ class Run extends Command
             );
         }
 
-            if (!$input->getOption('no-exit') && !$this->codecept->getResult()->wasSuccessfulIgnoringWarnings()) {
+        if (!$input->getOption('no-exit') && !$this->codecept->getResult()->wasSuccessfulIgnoringWarnings()) {
             exit(1);
         }
+
         return 0;
     }
 

--- a/src/Codeception/Command/Run.php
+++ b/src/Codeception/Command/Run.php
@@ -410,7 +410,7 @@ class Run extends Command
 
         if (isset($userOptions['filter']) && $filter) {
             throw new InvalidOptionException("--filter and --grep can't be used with a test name");
-        } elseif($filter) {
+        } elseif ($filter) {
             $userOptions['filter'] = $filter;
         }
 

--- a/src/Codeception/Command/Run.php
+++ b/src/Codeception/Command/Run.php
@@ -410,13 +410,13 @@ class Run extends Command
 
         if (isset($userOptions['filter']) && $filter) {
             throw new InvalidOptionException("--filter and --grep can't be used with a test name");
-        } else {
+        } elseif($filter) {
             $userOptions['filter'] = $filter;
         }
 
         if ($this->options['shard']) {
             $this->output->writeln(
-                "[SHARD ${userOptions['shard']}] <info>Running subset of tests</info>"
+                "[Shard ${userOptions['shard']}] <info>Running subset of tests</info>"
             );
             // disable shuffle for sharding
             $config['settings']['shuffle'] = false;
@@ -424,7 +424,7 @@ class Run extends Command
 
         if (!$this->options['silent'] && $config['settings']['shuffle']) {
             $this->output->writeln(
-                "[SEED] <info>" . $userOptions['seed'] . "</info>"
+                "[Seed] <info>" . $userOptions['seed'] . "</info>"
             );
         }
 
@@ -456,7 +456,7 @@ class Run extends Command
 
         if ($this->options['shard']) {
             $this->output->writeln(
-                "[SHARD ${userOptions['shard']}] <info>Merge this result with other shards to see the complete report</info>"
+                "[Shard ${userOptions['shard']}] <info>Merge this result with other shards to see the complete report</info>"
             );
         }
 

--- a/src/Codeception/Test/Loader.php
+++ b/src/Codeception/Test/Loader.php
@@ -87,17 +87,19 @@ class Loader
                 throw new ConfigurationException("Shard must be set as --shard=CURRENT/TOTAL where CURRENT and TOTAL are number. For instance: --shard=1/3");
             }
 
-            list($shard, $totalShards) = explode('/', $this->shard);
+            [$shard, $totalShards] = explode('/', $this->shard);
+
+            if ($shard < 1) {
+                throw new ConfigurationException("Incorrect shard index. Use 1/$totalShards to start the first shard.");
+            }
 
             if ($totalShards < $shard) {
                 throw new ConfigurationException("Total shards are less than current shard.");
             }
 
             $chunks = $this->splitTestsIntoChunks($totalShards);
-            if (!isset($chunks[$shard - 1])) {
-                return [];
-            }
-            return $chunks[$shard - 1];
+
+            return $chunks[$shard - 1] ?? [];
         }
         return $this->tests;
     }

--- a/src/Codeception/Test/Loader.php
+++ b/src/Codeception/Test/Loader.php
@@ -104,7 +104,7 @@ class Loader
         return $this->tests;
     }
 
-    private function splitTestsIntoChunks($chunks)
+    private function splitTestsIntoChunks(array $chunks): array
     {
         return array_chunk($this->tests, intval(ceil(sizeof($this->tests) / $chunks)));
     }

--- a/src/Codeception/Test/Loader.php
+++ b/src/Codeception/Test/Loader.php
@@ -84,17 +84,17 @@ class Loader
         if ($this->shard) {
             $this->shard = trim($this->shard);
             if (!preg_match('~^\d+\/\d+$~', $this->shard)) {
-                throw new ConfigurationException("Shard must be set as --shard=CURRENT/TOTAL where CURRENT and TOTAL are number. For instance: --shard=1/3");
+                throw new ConfigurationException('Shard must be set as --shard=CURRENT/TOTAL where CURRENT and TOTAL are number. For instance: --shard=1/3');
             }
 
             [$shard, $totalShards] = explode('/', $this->shard);
 
             if ($shard < 1) {
-                throw new ConfigurationException("Incorrect shard index. Use 1/$totalShards to start the first shard.");
+                throw new ConfigurationException("Incorrect shard index. Use 1/{$totalShards} to start the first shard");
             }
 
             if ($totalShards < $shard) {
-                throw new ConfigurationException("Total shards are less than current shard.");
+                throw new ConfigurationException('Total shards are less than current shard');
             }
 
             $chunks = $this->splitTestsIntoChunks($totalShards);

--- a/src/Codeception/Test/Loader.php
+++ b/src/Codeception/Test/Loader.php
@@ -92,9 +92,11 @@ class Loader
             if ($totalShards < $shard) {
                 throw new ConfigurationException("Total shards are less than current shard.");
             }
-            
+
             $chunks = $this->splitTestsIntoChunks($totalShards);
-            if (!isset($chunks[$shard - 1])) return [];
+            if (!isset($chunks[$shard - 1])) {
+                return [];
+            }
             return $chunks[$shard - 1];
         }
         return $this->tests;

--- a/src/Codeception/Test/Loader.php
+++ b/src/Codeception/Test/Loader.php
@@ -97,14 +97,14 @@ class Loader
                 throw new ConfigurationException('Total shards are less than current shard');
             }
 
-            $chunks = $this->splitTestsIntoChunks($totalShards);
+            $chunks = $this->splitTestsIntoChunks((int)$totalShards);
 
             return $chunks[$shard - 1] ?? [];
         }
         return $this->tests;
     }
 
-    private function splitTestsIntoChunks(array $chunks): array
+    private function splitTestsIntoChunks(int $chunks): array
     {
         return array_chunk($this->tests, intval(ceil(sizeof($this->tests) / $chunks)));
     }

--- a/tests/cli/RunCest.php
+++ b/tests/cli/RunCest.php
@@ -706,6 +706,50 @@ EOF
         $I->seeInShellOutput("OK (");
     }
 
+    public function runTestsWithGrep(CliGuy $I)
+    {
+        $I->executeCommand('run dummy --grep Another --no-ansi');
+        $I->dontSeeInShellOutput('GroupEventsCest');
+        $I->seeInShellOutput('AnotherCest');
+
+        $I->executeCommand('run dummy --grep Optimistic --no-ansi');
+        $I->seeInShellOutput('OK (1 test');
+    }
+
+    public function runTestsWithFilter(CliGuy $I)
+    {
+        $I->executeCommand('run dummy --filter Another --no-ansi');
+        $I->dontSeeInShellOutput('GroupEventsCest');
+        $I->seeInShellOutput('AnotherCest');
+    }
+
+    public function runTestsByShards(CliGuy $I)
+    {
+        $I->executeCommand('run dummy --shard=1/3 --no-ansi');
+        $I->seeInShellOutput('OK (2 tests');
+        $I->seeInShellOutput('[SHARD 1/3');
+        preg_match_all('~\+\s(\w+:\s[\w\s]+)~', $I->grabShellOutput(), $matches);
+        $tests1 = $matches[1];
+
+        $I->executeCommand('run dummy --shard=2/3');
+        $I->seeInShellOutput('OK (2 tests');
+        $I->seeInShellOutput('[SHARD 2/3');
+
+        preg_match_all('~\+\s(\w+:\s[\w\s]+)~', $I->grabShellOutput(), $matches);
+        $tests2 = $matches[1];
+
+        $I->executeCommand('run dummy --shard=3/3');
+        $I->seeInShellOutput('OK (2 tests');
+        $I->seeInShellOutput('[SHARD 3/3');
+
+        preg_match_all('~\+\s(\w+:\s[\w\s]+)~', $I->grabShellOutput(), $matches);
+        $tests3 = $matches[1];
+
+        $I->assertEmpty(array_intersect($tests1, $tests2), 'same tests in shards');
+        $I->assertEmpty(array_intersect($tests2, $tests3), 'same tests in shards');
+        $I->assertEmpty(array_intersect($tests1, $tests3), 'same tests in shards');
+    }
+
     /**
      * @group reports
      *

--- a/tests/cli/RunCest.php
+++ b/tests/cli/RunCest.php
@@ -727,20 +727,20 @@ EOF
     {
         $I->executeCommand('run dummy --shard=1/3 --no-ansi');
         $I->seeInShellOutput('OK (2 tests');
-        $I->seeInShellOutput('[SHARD 1/3');
+        $I->seeInShellOutput('[Shard 1/3');
         preg_match_all('~\+\s(\w+:\s[\w\s]+)~', $I->grabShellOutput(), $matches);
         $tests1 = $matches[1];
 
         $I->executeCommand('run dummy --shard=2/3');
         $I->seeInShellOutput('OK (2 tests');
-        $I->seeInShellOutput('[SHARD 2/3');
+        $I->seeInShellOutput('[Shard 2/3');
 
         preg_match_all('~\+\s(\w+:\s[\w\s]+)~', $I->grabShellOutput(), $matches);
         $tests2 = $matches[1];
 
         $I->executeCommand('run dummy --shard=3/3');
         $I->seeInShellOutput('OK (2 tests');
-        $I->seeInShellOutput('[SHARD 3/3');
+        $I->seeInShellOutput('[Shard 3/3');
 
         preg_match_all('~\+\s(\w+:\s[\w\s]+)~', $I->grabShellOutput(), $matches);
         $tests3 = $matches[1];


### PR DESCRIPTION
Introduced `--shard` option to execute non-intersecting subsets of tests. This allows parallelizing tests for multiple agents. The use case is slow-running browser tests that might be executed on different machines. Using shards you can easily split tests by machines and execute them independently. This feature does not aggregate reports from agents, however this can be achieved with robo-paratest.

To split tests for 3 agents call a command per agent:

```
codecept run --shard 1/3
codecept run --shard 2/3
codecept run --shard 3/3
```

Also, as a side-effect, this PR adds `--filter` and `--grep` options which I got used to while working on CodeceptJS

P.S. Updated Parallel testing guide coming soon when this is merged