### PR TITLE
Fix exclude list in coverage filter

### DIFF
--- a/src/Codeception/Coverage/Filter.php
+++ b/src/Codeception/Coverage/Filter.php
@@ -67,7 +67,7 @@ class Filter
                 foreach ($finder as $file) {
                     if (method_exists($filter, 'addFileToWhitelist')) {
                         //php-code-coverage 8 or older
-                        $filter->addFileToWhitelist($file);
+                        $filter->addFileToWhitelist((string)$file);
                     } else {
                         //php-code-coverage 9+
                         $filter->includeFile((string)$file);
@@ -89,10 +89,10 @@ class Filter
                     foreach ($finder as $file) {
                         if (method_exists($filter, 'removeFileFromWhitelist')) {
                             //php-code-coverage 8 or older
-                            $filter->removeFileFromWhitelist($file);
+                            $filter->removeFileFromWhitelist((string)$file);
                         } else {
                             //php-code-coverage 9+
-                            $filter->excludeFile($file);
+                            $filter->excludeFile((string)$file);
                         }
                     }
                 } catch (DirectoryNotFoundException) {


### PR DESCRIPTION
https://github.com/Codeception/Codeception/pull/6092 started to use `declare(strict_types=1)`.

`symfony/finder` does not return the file paths as string but as instance of `SplFileInfo`.

This leads to the following exception when using exclude lists containing wildcards:

```
> vendor/bin/codecept run api --colors --coverage coverage_api.cov
Codeception PHP Testing Framework v5.0.0-RC1 https://helpukrainewin.org/
Powered by PHPUnit 9.5.19 #StandWithUkraine
Fatal error: Uncaught TypeError: SebastianBergmann\CodeCoverage\Filter::excludeFile(): Argument #1 ($filename) must be of type string, Symfony\Component\Finder\SplFileInfo given, called in /builds/robot/base/robot-pub/vendor/codeception/codeception/src/Codeception/Coverage/Filter.php on line 95 and defined in /builds/robot/base/robot-pub/vendor/phpunit/php-code-coverage/src/Filter.php:65
```

This MR just adds an explicit cast to `string` which should solve the issue.