### PR TITLE
Encode non-string parameters in configuration files

### DIFF
--- a/src/Codeception/Configuration.php
+++ b/src/Codeception/Configuration.php
@@ -408,17 +408,18 @@ class Configuration
     protected static function getConfFromContents(string $contents, string $filename = '(.yml)'): array
     {
         if (self::$params) {
-            $template = new Template($contents, '%', '%');
-            $vars = [];
-            foreach (self::$params as $key => $value) {
-                if (is_string($value)) {
-                    $vars[$key] = $value;
-                } else {
-                    $vars[$key] = json_encode($value, JSON_THROW_ON_ERROR);
-                }
-            }
-            $template->setVars($vars);
-            $contents = $template->produce();
+            // replace '%var%' with encoded value
+            $singleQuoteTemplate = new Template($contents, "'%", "%'", 'json_encode');
+            $singleQuoteTemplate->setVars(self::$params);
+            $contents = $singleQuoteTemplate->produce();
+            // replace "%var%" with encoded value
+            $doubleQuoteTemplate = new Template($contents, '"%', '%"', 'json_encode');
+            $doubleQuoteTemplate->setVars(self::$params);
+            $contents = $doubleQuoteTemplate->produce();
+            // replace %var% with string value as is
+            $plainTemplate = new Template($contents, '%', '%');
+            $plainTemplate->setVars(self::$params);
+            $contents = $plainTemplate->produce();
         }
 
         try {

--- a/src/Codeception/Configuration.php
+++ b/src/Codeception/Configuration.php
@@ -409,7 +409,15 @@ class Configuration
     {
         if (self::$params) {
             $template = new Template($contents, '%', '%');
-            $template->setVars(self::$params);
+            $vars = [];
+            foreach (self::$params as $key => $value) {
+                if (is_string($value)) {
+                    $vars[$key] = $value;
+                } else {
+                    $vars[$key] = json_encode($value, JSON_THROW_ON_ERROR);
+                }
+            }
+            $template->setVars($vars);
             $contents = $template->produce();
         }
 

--- a/tests/cli/ConfigParamsCest.php
+++ b/tests/cli/ConfigParamsCest.php
@@ -7,28 +7,35 @@ final class ConfigParamsCest
     public function checkYamlParamsPassed(CliGuy $I)
     {
         $I->amInPath('tests/data/params');
-        $I->executeCommand('run -c codeception_yaml.yml');
+        $I->executeCommand('run -c codeception_yaml.yml dummy DummyCept');
+        $I->seeInShellOutput('OK (1 test');
+    }
+
+    public function checkArrayAndIntegerYamlParamsPassed(CliGuy $I)
+    {
+        $I->amInPath('tests/data/params');
+        $I->executeCommand('run -c codeception_yaml.yml dummy YamlCept');
         $I->seeInShellOutput('OK (1 test');
     }
 
     public function checkDotEnvParamsPassed(CliGuy $I)
     {
         $I->amInPath('tests/data/params');
-        $I->executeCommand('run -c codeception_dotenv.yml');
+        $I->executeCommand('run -c codeception_dotenv.yml dummy DummyCept');
         $I->seeInShellOutput('OK (1 test');
     }
 
     public function checkComplexDotEnvParamsPassed(CliGuy $I)
     {
         $I->amInPath('tests/data/params');
-        $I->executeCommand('run -c codeception_dotenv2.yml');
+        $I->executeCommand('run -c codeception_dotenv2.yml dummy DummyCept');
         $I->seeInShellOutput('OK (1 test');
     }
 
     public function checkEnvParamsPassed(CliGuy $I)
     {
         $I->amInPath('tests/data/params');
-        $I->executeCommand('run --no-exit');
+        $I->executeCommand('run --no-exit dummy DummyCept');
         $I->seeInShellOutput('FAILURES');
         $I->seeInShellOutput("Failed asserting that an array contains 'val1'");
     }
@@ -36,14 +43,14 @@ final class ConfigParamsCest
     public function checkParamsPassedInSelf(CliGuy $I)
     {
         $I->amInPath('tests/data/params');
-        $I->executeCommand('run -c codeception_self.yml');
+        $I->executeCommand('run -c codeception_self.yml dummy DummyCept');
         $I->seeInShellOutput('OK (1 test');
     }
 
     public function checkXmlParamsPassed(CliGuy $I)
     {
         $I->amInPath('tests/data/params');
-        $I->executeCommand('run -c codeception_xml.yml');
+        $I->executeCommand('run -c codeception_xml.yml dummy DummyCept');
         $I->seeInShellOutput('OK (1 test');
     }
 }

--- a/tests/cli/ConfigParamsCest.php
+++ b/tests/cli/ConfigParamsCest.php
@@ -7,35 +7,28 @@ final class ConfigParamsCest
     public function checkYamlParamsPassed(CliGuy $I)
     {
         $I->amInPath('tests/data/params');
-        $I->executeCommand('run -c codeception_yaml.yml dummy DummyCept');
-        $I->seeInShellOutput('OK (1 test');
-    }
-
-    public function checkArrayAndIntegerYamlParamsPassed(CliGuy $I)
-    {
-        $I->amInPath('tests/data/params');
-        $I->executeCommand('run -c codeception_yaml.yml dummy YamlCept');
+        $I->executeCommand('run -c codeception_yaml.yml dummy');
         $I->seeInShellOutput('OK (1 test');
     }
 
     public function checkDotEnvParamsPassed(CliGuy $I)
     {
         $I->amInPath('tests/data/params');
-        $I->executeCommand('run -c codeception_dotenv.yml dummy DummyCept');
+        $I->executeCommand('run -c codeception_dotenv.yml dummy');
         $I->seeInShellOutput('OK (1 test');
     }
 
     public function checkComplexDotEnvParamsPassed(CliGuy $I)
     {
         $I->amInPath('tests/data/params');
-        $I->executeCommand('run -c codeception_dotenv2.yml dummy DummyCept');
+        $I->executeCommand('run -c codeception_dotenv2.yml dummy');
         $I->seeInShellOutput('OK (1 test');
     }
 
     public function checkEnvParamsPassed(CliGuy $I)
     {
         $I->amInPath('tests/data/params');
-        $I->executeCommand('run --no-exit dummy DummyCept');
+        $I->executeCommand('run --no-exit dummy');
         $I->seeInShellOutput('FAILURES');
         $I->seeInShellOutput("Failed asserting that an array contains 'val1'");
     }
@@ -43,14 +36,21 @@ final class ConfigParamsCest
     public function checkParamsPassedInSelf(CliGuy $I)
     {
         $I->amInPath('tests/data/params');
-        $I->executeCommand('run -c codeception_self.yml dummy DummyCept');
+        $I->executeCommand('run -c codeception_self.yml dummy');
         $I->seeInShellOutput('OK (1 test');
     }
 
     public function checkXmlParamsPassed(CliGuy $I)
     {
         $I->amInPath('tests/data/params');
-        $I->executeCommand('run -c codeception_xml.yml dummy DummyCept');
+        $I->executeCommand('run -c codeception_xml.yml dummy');
+        $I->seeInShellOutput('OK (1 test');
+    }
+
+    public function checkNonStringParamsAreEncodedProperly(CliGuy $I)
+    {
+        $I->amInPath('tests/data/params');
+        $I->executeCommand('run -c codeception_yaml.yml complex');
         $I->seeInShellOutput('OK (1 test');
     }
 }

--- a/tests/data/params/params.yml
+++ b/tests/data/params/params.yml
@@ -1,3 +1,8 @@
 parameters:
     KEY1: val1
     KEY2: val2
+    KEY3: 1
+    KEY4:
+        - foo
+        - bar
+        - baz

--- a/tests/data/params/tests/_support/ComplexTester.php
+++ b/tests/data/params/tests/_support/ComplexTester.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Inherited Methods
+ * @method void wantToTest($text)
+ * @method void wantTo($text)
+ * @method void execute($callable)
+ * @method void expectTo($prediction)
+ * @method void expect($prediction)
+ * @method void amGoingTo($argumentation)
+ * @method void am($role)
+ * @method void lookForwardTo($achieveValue)
+ * @method void comment($description)
+ * @method void pause($vars = [])
+ *
+ * @SuppressWarnings(PHPMD)
+*/
+class ComplexTester extends \Codeception\Actor
+{
+    use _generated\ComplexTesterActions;
+
+    /**
+     * Define custom actions here
+     */
+}

--- a/tests/data/params/tests/_support/Helper/Dummy.php
+++ b/tests/data/params/tests/_support/Helper/Dummy.php
@@ -22,4 +22,9 @@ class Dummy extends \Codeception\Module
         $this->assertContains('val1', $vars);
         $this->assertContains('val2', $vars);
     }
+
+    public function seeVarEquals($name, $value)
+    {
+        $this->assertEquals($this->config['vars'][$name], $value);
+    }
 }

--- a/tests/data/params/tests/_support/Helper/Dummy.php
+++ b/tests/data/params/tests/_support/Helper/Dummy.php
@@ -23,8 +23,8 @@ class Dummy extends \Codeception\Module
         $this->assertContains('val2', $vars);
     }
 
-    public function seeVarEquals($name, $value)
+    public function seeVarEquals(int $position, $value)
     {
-        $this->assertEquals($this->config['vars'][$name], $value);
+        $this->assertSame($value, $this->config['vars'][$position]);
     }
 }

--- a/tests/data/params/tests/complex.suite.yml
+++ b/tests/data/params/tests/complex.suite.yml
@@ -1,0 +1,5 @@
+actor: ComplexTester
+modules:
+    enabled:
+        - \Helper\Dummy:
+              vars: ["%KEY3%", '%KEY4%', "%KEY4%", "%KEY4.1%"]

--- a/tests/data/params/tests/complex/YamlCept.php
+++ b/tests/data/params/tests/complex/YamlCept.php
@@ -1,0 +1,8 @@
+<?php
+
+$I = new DummyTester($scenario);
+
+$I->seeVarEquals(0, 1);
+$I->seeVarEquals(1, ['foo', 'bar', 'baz']);
+$I->seeVarEquals(2, ['foo', 'bar', 'baz']);
+$I->seeVarEquals(3, 'bar');

--- a/tests/data/params/tests/dummy.suite.yml
+++ b/tests/data/params/tests/dummy.suite.yml
@@ -2,5 +2,5 @@ actor: DummyTester
 modules:
     enabled:
         - \Helper\Dummy:
-            vars: ["%KEY1%", "%KEY2%"]
+            vars: [%KEY1%, %KEY2%]
             path: "%PATH%"

--- a/tests/data/params/tests/dummy.suite.yml
+++ b/tests/data/params/tests/dummy.suite.yml
@@ -2,5 +2,5 @@ actor: DummyTester
 modules:
     enabled:
         - \Helper\Dummy:
-            vars: [%KEY1%, %KEY2%]
+            vars: ["%KEY1%", '%KEY2%', '%KEY3%', '%KEY4%']
             path: "%PATH%"

--- a/tests/data/params/tests/dummy/YamlCept.php
+++ b/tests/data/params/tests/dummy/YamlCept.php
@@ -1,0 +1,7 @@
+<?php
+
+$I = new DummyTester($scenario);
+
+$I->seeVarEquals('KEY3', 1);
+$I->seeVarEquals('KEY4', ['foo', 'bar', 'baz']);
+

--- a/tests/data/params/tests/dummy/YamlCept.php
+++ b/tests/data/params/tests/dummy/YamlCept.php
@@ -1,7 +1,0 @@
-<?php
-
-$I = new DummyTester($scenario);
-
-$I->seeVarEquals('KEY3', 1);
-$I->seeVarEquals('KEY4', ['foo', 'bar', 'baz']);
-


### PR DESCRIPTION
This change allows to use non-string values in parameterized configuration files.
Most importantly objects and arrays, but also integers, floats and booleans.

Because unquoted placeholder `%var%` is not a valid value in Yaml format, this change will replace quoted placeholders with unquoted values,   e.g .  `param: "%var%"` will be rendered as `param: false`

Fixes #6408 
Fixes #5223