### PR TITLE
Add more code coverage settings

### DIFF
--- a/src/Codeception/Coverage/SuiteSubscriber.php
+++ b/src/Codeception/Coverage/SuiteSubscriber.php
@@ -21,16 +21,19 @@ abstract class SuiteSubscriber implements EventSubscriberInterface
     use StaticEventsTrait;
 
     protected array $defaultSettings = [
-        'enabled'        => false,
-        'remote'         => false,
-        'local'          => false,
-        'xdebug_session' => 'codeception',
-        'remote_config'  => null,
-        'show_uncovered' => false,
-        'c3_url'         => null,
-        'work_dir'       => null,
-        'cookie_domain'  => null,
-        'path_coverage'  => false,
+        'enabled'                      => false,
+        'remote'                       => false,
+        'local'                        => false,
+        'xdebug_session'               => 'codeception',
+        'remote_config'                => null,
+        'show_uncovered'               => false,
+        'c3_url'                       => null,
+        'work_dir'                     => null,
+        'cookie_domain'                => null,
+        'path_coverage'                => false,
+        'strict_covers_annotation'     => false,
+        'ignore_deprecated_code'       => false,
+        'disable_code_coverage_ignore' => false,
     ];
 
     protected array $settings = [];
@@ -79,6 +82,22 @@ abstract class SuiteSubscriber implements EventSubscriberInterface
             if (isset($settings['coverage'][$key])) {
                 $this->settings[$key] = $settings['coverage'][$key];
             }
+        }
+
+        if ($this->settings['strict_covers_annotation']) {
+            $this->coverage->enableCheckForUnintentionallyCoveredCode();
+        }
+
+        if ($this->settings['ignore_deprecated_code']) {
+            $this->coverage->ignoreDeprecatedCode();
+        } else {
+            $this->coverage->doNotIgnoreDeprecatedCode();
+        }
+
+        if ($this->settings['disable_code_coverage_ignore']) {
+            $this->coverage->disableAnnotationsForIgnoringCode();
+        } else {
+            $this->coverage->enableAnnotationsForIgnoringCode();
         }
 
         if ($this->settings['show_uncovered']) {


### PR DESCRIPTION
We had a few feature requests to add some code coverage setting and a few attempts to add these settings to Codeception.

I reviewed configuration options of PHPCodeCoverage library and added 3 missing settings:

* strict_covers_annotation - marks test as risky if it has `@covers` annotation but executes some other code
* ignore_deprecated_code - doesn't collect code coverage for code having `@deprecated` annotation
* disable_code_coverage_ignore - ignores `@codeCoverageIgnore`, `@codeCoverageIgnoreStart` and `@codeCoverageIgnoreEnd` annotations

The only setting I left out is coverage_cache_directory, see https://github.com/sebastianbergmann/phpunit/blob/master/src/TextUI/TestRunner.php#L245-L277

Closes #6258
Replaces #5874 
Replaces #5922