### PR TITLE
CI: Run tests against PHPUnit 10

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,7 +28,7 @@ jobs:
         run: phpcs tests/ --standard=tests/phpcs.xml
 
   linux:
-    name: PHP ${{ matrix.php }}-${{ matrix.os }}
+    name: PHP ${{ matrix.php }}-${{ matrix.os }}-${{ matrix.mode }}
 
     env:
       extensions: curl, mbstring, openssl, pdo, pdo_sqlite
@@ -42,6 +42,7 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         php: ['8.0', '8.1']
+        mode: ['stable', 'experimental']
 
     steps:
       - name: Checkout
@@ -63,9 +64,9 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ${{ env.COMPOSER_CACHE_DIR }}
-          key: php${{ matrix.php }}-composer-${{ hashFiles('**/composer.json') }}
+          key: php${{ matrix.php }}-${{ matrix.mode }}-composer-${{ hashFiles('**/composer.json') }}
           restore-keys: |
-            php${{ matrix.php }}-composer-
+            php${{ matrix.php }}-${{ matrix.mode }}-composer-
 
       - name: Update composer
         run: composer self-update
@@ -73,27 +74,32 @@ jobs:
       - name: Validate composer.json
         run: composer validate
 
+      - name: Install latest versions of dependencies in stable mode
+        if: matrix.mode == 'stable'
+        run: composer update --prefer-source --no-interaction --no-progress --optimize-autoloader --ansi
 
-      - name: Composer install lowest versions of dependencies on PHP 8.0
-        if: matrix.php == '8.0'
+      - name: Composer install lowest versions of dependencies on PHP 8.0 in experimental mode
+        if: matrix.php == '8.0' && matrix.mode == 'experimental'
         run: composer update --prefer-source --prefer-lowest --no-interaction --no-progress --optimize-autoloader --ansi
 
-      - name: Composer install highest versions of dependencies on PHP 8.1
-        if: matrix.php == '8.1'
-        run: composer update --prefer-source --no-interaction --no-progress --optimize-autoloader --ansi
+      - name: Composer install PHPUnit 10 on PHP 8.1 in experimental mode
+        if: matrix.php == '8.1' && matrix.mode == 'experimental'
+        run: |
+          composer config minimum-stability dev
+          composer require phpunit/phpunit:"10.0.x-dev" phpunit/php-code-coverage:"10.0.x-dev" phpunit/php-text-template:"3.0.x-dev" sebastian/diff:"5.0.x-dev" --no-update
+          composer update --prefer-source --no-interaction --no-progress --optimize-autoloader --ansi
 
       - name: Test that failing test really fails
         run: if php codecept run -c tests/data/claypit/ scenario FailedCept -vvv; then echo "Test hasn't failed"; false; fi;
 
-      - name: Run tests without code coverage on PHP 8.0
-        if: matrix.php == '8.0'
-        run: |
-          php -S 127.0.0.1:8008 -t tests/data/app >/dev/null 2>&1 &
-          php codecept build
-          php codecept run cli,unit
+#      - name: Run tests without code coverage on PHP 8.0
+#        if: matrix.php == '8.0'
+#        run: |
+#          php -S 127.0.0.1:8008 -t tests/data/app >/dev/null 2>&1 &
+#          php codecept build
+#          php codecept run cli,unit
 
-      - name: Run tests with code coverage on PHP 8.1
-        if: matrix.php == '8.1'
+      - name: Run tests
         run: |
           php -S 127.0.0.1:8008 -t tests/data/app -d pcov.directory=$(pwd)/tests/data/app >/dev/null 2>&1 &
           php codecept build
@@ -106,7 +112,6 @@ jobs:
         run: php codecept run -c vendor/codeception/module-filesystem/
 
       - name: Run module-db sqlite tests
-        if: matrix.php != '8.1'
         run: php codecept run -c vendor/codeception/module-db/ unit :Sqlite
 
       - name: Run module-phpbrowser tests


### PR DESCRIPTION
PHPUnit 10 will require PHP 8.1.

I will double the number of test builds to 4:
1. Latest stable versions of all dependencies on PHP 8.0
2. Latest stable versions of all dependencies on PHP 8.1
3. Lowest supported version of all dependencies on PHP 8.0
4. PHPUnit 10 on PHP 8.1