### PR TITLE
Fix incorrect $answer type declaration in InitTemplate

### DIFF
--- a/src/Codeception/InitTemplate.php
+++ b/src/Codeception/InitTemplate.php
@@ -97,7 +97,7 @@ abstract class InitTemplate
      *
      * @return mixed|string
      */
-    protected function ask(string $question, bool|array $answer = null): mixed
+    protected function ask(string $question, string|bool|array $answer = null): mixed
     {
         $question = "? {$question}";
         $dialog = new QuestionHelper();
@@ -109,7 +109,7 @@ abstract class InitTemplate
             $question .= " (y/n) ";
             return $dialog->ask($this->input, $this->output, new ConfirmationQuestion($question, $answer));
         }
-        if ($answer) {
+        if (is_string($answer)) {
             $question .= " <info>({$answer})</info>";
         }
         return $dialog->ask($this->input, $this->output, new Question("{$question} ", $answer));


### PR DESCRIPTION
I think the type declaration here is incorrect, which is causing commands like `codecept init acceptance` to break:

```
Fatal error: Uncaught TypeError: Codeception\InitTemplate::ask(): Argument #2 ($answer) must be of type array|bool|null, string given, called in vendor/codeception/codeception/src/Codeception/Template/Acceptance.php on line 86 and defined in vendor/codeception/codeception/src/Codeception/InitTemplate.php:100
Stack trace:
#0 vendor/codeception/codeception/src/Codeception/Template/Acceptance.php(86): Codeception\InitTemplate->ask('Where tests wil...', 'tests')
#1 vendor/codeception/codeception/src/Codeception/Command/Init.php(58): Codeception\Template\Acceptance->setup()
#2 vendor/symfony/console/Command/Command.php(298): Codeception\Command\Init->execute(Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
#3 vendor/symfony/console/Application.php(1015): Symfony\Component\Console\Command\Command->run(Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
#4 vendor/symfony/console/Application.php(299): Symfony\Component\Console\Application->doRunCommand(Object(Codeception\Command\Init), Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
#5 vendor/symfony/console/Application.php(171): Symfony\Component\Console\Application->doRun(Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
#6 vendor/codeception/codeception/src/Codeception/Application.php(112): Symfony\Component\Console\Application->run(Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
#7 vendor/codeception/codeception/app.php(45): Codeception\Application->run()
#8 vendor/codeception/codeception/app.php(46): {closure}()
#9 vendor/codeception/codeception/codecept(7): require('/var/www/vhosts...')
#10 vendor/bin/codecept(117): include('/var/www/vhosts...')
#11 {main}
  thrown in vendor/codeception/codeception/src/Codeception/InitTemplate.php on line 100
```

You can see an example of where the `ask()` method is passed a string `$answer` here: https://github.com/Codeception/Codeception/blob/5.0/src/Codeception/Template/Acceptance.php#L86

I've added `string` to the type declaration and adjusted the conditional in the method itself. It looks like the [issue got introduced when upgrading to PHP 8.0](https://github.com/Codeception/Codeception/commit/3900f8da535b9e4dfb8f252663e9047d4efc353f#diff-bde6b4867b1e363fec051a411c4454ff88164bc1eb3eee31aef508ca0c1b81c5R98).