### PR TITLE
Use stricter types in Configuration

### DIFF
--- a/src/Codeception/Codecept.php
+++ b/src/Codeception/Codecept.php
@@ -254,7 +254,9 @@ class Codecept
                     }
 
                     // Merge configuration consecutively with already build configuration
-                    $suiteEnvConfig = Configuration::mergeConfigs($suiteEnvConfig, $config['env'][$currentEnv]);
+                    if (is_array($config['env'][$currentEnv])) {
+                        $suiteEnvConfig = Configuration::mergeConfigs($suiteEnvConfig, $config['env'][$currentEnv]);
+                    }
                     $envConfigs[]   = $currentEnv;
                 }
             }

--- a/src/Codeception/InitTemplate.php
+++ b/src/Codeception/InitTemplate.php
@@ -207,6 +207,7 @@ abstract class InitTemplate
     /**
      * Create an Actor class and generate actions for it.
      * Requires a suite config as array in 3rd parameter.
+     * @param array<string, mixed> $suiteConfig
      */
     protected function createActor(string $name, string $directory, array $suiteConfig): void
     {

--- a/src/Codeception/Lib/ModuleContainer.php
+++ b/src/Codeception/Lib/ModuleContainer.php
@@ -436,7 +436,11 @@ class ModuleContainer
 
             $enabledModuleName = key($enabledModuleConfig);
             if ($enabledModuleName === $moduleName) {
-                return Configuration::mergeConfigs(reset($enabledModuleConfig), $config);
+                $moduleConfig = reset($enabledModuleConfig);
+                if (!is_array($moduleConfig)) {
+                    return $config;
+                }
+                return Configuration::mergeConfigs($moduleConfig, $config);
             }
         }
 

--- a/src/Codeception/Subscriber/Console.php
+++ b/src/Codeception/Subscriber/Console.php
@@ -153,6 +153,9 @@ class Console implements EventSubscriberInterface
 
     private bool $firstDefectType = true;
 
+    /**
+     * @param array<string, mixed> $options
+     */
     public function __construct(array $options)
     {
         $this->timer = new Timer();

--- a/src/Codeception/Subscriber/Deprecation.php
+++ b/src/Codeception/Subscriber/Deprecation.php
@@ -24,6 +24,9 @@ class Deprecation implements EventSubscriberInterface
 
     private Output $output;
 
+    /**
+     * @param array<string, mixed> $options
+     */
     public function __construct(array $options)
     {
         $this->output = new Output($options);

--- a/src/Codeception/Subscriber/ExtensionLoader.php
+++ b/src/Codeception/Subscriber/ExtensionLoader.php
@@ -28,12 +28,24 @@ class ExtensionLoader implements EventSubscriberInterface
         Events::SUITE_AFTER => 'stopSuiteExtensions'
     ];
 
+    /**
+     * @var array<string, mixed>
+     */
     protected array $config = [];
 
+    /**
+     * @var array<string, mixed>
+     */
     protected array $options = [];
 
+    /**
+     * @var array<class-string, EventSubscriberInterface>
+     */
     protected array $globalExtensions = [];
 
+    /**
+     * @var array<class-string, EventSubscriberInterface>
+     */
     protected array $suiteExtensions = [];
 
     public function __construct(protected EventDispatcher $dispatcher)
@@ -41,6 +53,10 @@ class ExtensionLoader implements EventSubscriberInterface
         $this->config = Configuration::config();
     }
 
+    /**
+     * @param array<string, mixed> $options
+     * @throws ConfigurationException
+     */
     public function bootGlobalExtensions(array $options): void
     {
         $this->options = $options;
@@ -79,6 +95,7 @@ class ExtensionLoader implements EventSubscriberInterface
     }
 
     /**
+     * @param array<string, mixed> $config
      * @return array<class-string, EventSubscriberInterface>
      * @throws ConfigurationException
      */
@@ -109,6 +126,10 @@ class ExtensionLoader implements EventSubscriberInterface
         return $extensions;
     }
 
+    /**
+     * @param array<string, mixed> $config
+     * @return array<string, mixed>
+     */
     private function getExtensionConfig(string $extension, array $config): array
     {
         $extensionConfig = $config['extensions']['config'][$extension] ?? [];
@@ -128,7 +149,11 @@ class ExtensionLoader implements EventSubscriberInterface
 
             $enabledExtension = key($enabledExtensionsConfig);
             if ($enabledExtension === $extension) {
-                return Configuration::mergeConfigs(reset($enabledExtensionsConfig), $extensionConfig);
+                $enabledExtensionConfig = reset($enabledExtensionsConfig);
+                if (!is_array($enabledExtensionConfig)) {
+                    return $extensionConfig;
+                }
+                return Configuration::mergeConfigs($enabledExtensionConfig, $extensionConfig);
             }
         }
 

--- a/src/Codeception/Test/Loader/Gherkin.php
+++ b/src/Codeception/Test/Loader/Gherkin.php
@@ -63,7 +63,11 @@ class Gherkin implements LoaderInterface
 
     protected array $steps = [];
 
-    public function __construct($settings = [])
+    /**
+     * @param array<string, mixed> $settings
+     * @throws TestParseException
+     */
+    public function __construct(array $settings = [])
     {
         $this->settings = Configuration::mergeConfigs(self::$defaultSettings, $settings);
         if (!class_exists(GherkinKeywords::class)) {


### PR DESCRIPTION
`Configuration::mergeConfig` only deals with arrays now.

Added some `@param array<string, mixed>` annotations to pass phpstan level 6.