### PR TITLE
Fix DotReporter output

### DIFF
--- a/ext/DotReporter.php
+++ b/ext/DotReporter.php
@@ -55,7 +55,6 @@ class DotReporter extends Extension
 
     public function _initialize(): void
     {
-        $this->options['silent'] = false; // turn on printing for this extension
         $this->_reconfigure(['settings' => ['silent' => true]]); // turn off printing for everything else
         $this->standardReporter = new CodeceptConsole($this->options);
         $this->width = $this->standardReporter->detectWidth();
@@ -78,7 +77,7 @@ class DotReporter extends Extension
 
     public function beforeSuite(): void
     {
-        $this->writeln('');
+        $this->output->writeln('');
     }
 
     public function success(): void
@@ -104,7 +103,7 @@ class DotReporter extends Extension
     protected function printChar(string $char): void
     {
         if ($this->currentPos >= $this->width) {
-            $this->writeln('');
+            $this->output->writeln('');
             $this->currentPos = 0;
         }
         $this->write($char);
@@ -118,6 +117,8 @@ class DotReporter extends Extension
 
     public function afterResult(PrintResultEvent $event): void
     {
+        $this->output->writeln('');
+        $this->output->writeln('');
         $this->standardReporter->afterResult($event);
     }
 }

--- a/ext/DotReporter.php
+++ b/ext/DotReporter.php
@@ -6,6 +6,7 @@ namespace Codeception\Extension;
 
 use Codeception\Event\FailEvent;
 use Codeception\Event\PrintResultEvent;
+use Codeception\Event\TestEvent;
 use Codeception\Events;
 use Codeception\Extension;
 use Codeception\Subscriber\Console as CodeceptConsole;
@@ -71,6 +72,7 @@ class DotReporter extends Extension
         Events::TEST_FAIL    => 'fail',
         Events::TEST_ERROR   => 'error',
         Events::TEST_SKIPPED => 'skipped',
+        Events::TEST_AFTER   => 'afterTest',
         Events::TEST_FAIL_PRINT => 'printFailed',
         Events::RESULT_PRINT_AFTER => 'afterResult',
     ];
@@ -120,5 +122,11 @@ class DotReporter extends Extension
         $this->output->writeln('');
         $this->output->writeln('');
         $this->standardReporter->afterResult($event);
+    }
+
+    public function afterTest(TestEvent $event): void
+    {
+        // count assertions
+        $this->standardReporter->afterTest($event);
     }
 }

--- a/ext/SimpleReporter.php
+++ b/ext/SimpleReporter.php
@@ -17,7 +17,6 @@ class SimpleReporter extends Extension
 {
     public function _initialize(): void
     {
-        $this->options['silent'] = false; // turn on printing for this extension
         $this->_reconfigure(['settings' => ['silent' => true]]); // turn off printing for everything else
     }
 
@@ -36,22 +35,22 @@ class SimpleReporter extends Extension
 
     public function beforeSuite(): void
     {
-        $this->writeln('');
+        $this->output->writeln('');
     }
 
     public function success(): void
     {
-        $this->write('[+] ');
+        $this->output->write('[+] ');
     }
 
     public function fail(): void
     {
-        $this->write('[-] ');
+        $this->output->write('[-] ');
     }
 
     public function error(): void
     {
-        $this->write('[E] ');
+        $this->output->write('[E] ');
     }
 
     // we are printing test status and time taken
@@ -62,7 +61,7 @@ class SimpleReporter extends Extension
         $seconds = ($milliseconds = (int)($secondsInput * 1000)) / 1000;
         $time = ($seconds % 60) . (($milliseconds === 0) ? '' : '.' . $milliseconds);
 
-        $this->write(Descriptor::getTestSignature($event->getTest()));
-        $this->writeln(' (' . $time . 's)');
+        $this->output->write(Descriptor::getTestSignature($event->getTest()));
+        $this->output->writeln(' (' . $time . 's)');
     }
 }

--- a/src/Codeception/Subscriber/Console.php
+++ b/src/Codeception/Subscriber/Console.php
@@ -275,7 +275,6 @@ class Console implements EventSubscriberInterface
         $outputFormatter->setStyle('warning', new OutputFormatterStyle('black', 'yellow'));
         $outputFormatter->setStyle('success', new OutputFormatterStyle('black', 'green'));
         $this->printResourceUsage($duration);
-        $this->output->writeln('');
 
         $this->printDefects($result->errors(), 'error');
         $this->printDefects($result->failures(), 'failure');

--- a/src/Codeception/Subscriber/Console.php
+++ b/src/Codeception/Subscriber/Console.php
@@ -253,7 +253,7 @@ class Console implements EventSubscriberInterface
         $this->failedStep[] = $step;
     }
 
-    public function afterTest(TestEvent $event)
+    public function afterTest(TestEvent $event): void
     {
         $test = $event->getTest();
 

--- a/tests/cli/ExtensionsCest.php
+++ b/tests/cli/ExtensionsCest.php
@@ -26,7 +26,7 @@ final class ExtensionsCest
     {
         $I->amInPath('tests/data/sandbox');
         $I->executeCommand('run dummy --ext DotReporter');
-        $I->seeShellOutputMatches('#\n\n......\n\nTime: 00:00\.\d+, Memory: \d+\.\d+ MB\n\nOK \(6 tests, 0 assertions\)#m');
+        $I->seeShellOutputMatches('#\n\n......\n\nTime: 00:00\.\d+, Memory: \d+\.\d+ MB\n\nOK \(6 tests, 3 assertions\)#m');
         $I->dontSeeInShellOutput('Optimistic');
         $I->dontSeeInShellOutput('AnotherCest');
     }

--- a/tests/cli/ExtensionsCest.php
+++ b/tests/cli/ExtensionsCest.php
@@ -26,7 +26,7 @@ final class ExtensionsCest
     {
         $I->amInPath('tests/data/sandbox');
         $I->executeCommand('run dummy --ext DotReporter');
-        $I->seeInShellOutput('......');
+        $I->seeShellOutputMatches('#\n\n......\n\nTime: 00:00\.\d+, Memory: \d+\.\d+ MB\n\nOK \(6 tests, 0 assertions\)#m');
         $I->dontSeeInShellOutput('Optimistic');
         $I->dontSeeInShellOutput('AnotherCest');
     }


### PR DESCRIPTION
Follow up to  #6441

Before:
![image](https://user-images.githubusercontent.com/395992/164724992-9dfd604b-c28e-43b0-b556-30f369fec0fc.png)


After:
![image](https://user-images.githubusercontent.com/395992/164724903-80c14107-fde7-417c-ba5d-de33f169d694.png)

I will investigate why it reports 0 assertions later.

cc: @Orchestrator404