### PR TITLE
Added basic attributes support

### DIFF
--- a/src/Codeception/Attribute/After.php
+++ b/src/Codeception/Attribute/After.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Codeception\Attribute;
+
+use Attribute;
+
+#[Attribute(Attribute::TARGET_METHOD)]
+final class After
+{
+
+}

--- a/src/Codeception/Attribute/After.php
+++ b/src/Codeception/Attribute/After.php
@@ -7,5 +7,4 @@ use Attribute;
 #[Attribute(Attribute::TARGET_METHOD)]
 final class After
 {
-
 }

--- a/src/Codeception/Attribute/Before.php
+++ b/src/Codeception/Attribute/Before.php
@@ -1,0 +1,10 @@
+<?php
+namespace Codeception\Attribute;
+
+use Attribute;
+
+#[Attribute(Attribute::TARGET_METHOD)]
+final class Before
+{
+
+}

--- a/src/Codeception/Attribute/Before.php
+++ b/src/Codeception/Attribute/Before.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Codeception\Attribute;
 
 use Attribute;
@@ -6,5 +7,4 @@ use Attribute;
 #[Attribute(Attribute::TARGET_METHOD)]
 final class Before
 {
-
 }

--- a/src/Codeception/Attribute/DataProvider.php
+++ b/src/Codeception/Attribute/DataProvider.php
@@ -7,5 +7,4 @@ use Attribute;
 #[Attribute(Attribute::TARGET_METHOD)]
 class DataProvider
 {
-
 }

--- a/src/Codeception/Attribute/DataProvider.php
+++ b/src/Codeception/Attribute/DataProvider.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Codeception\Attribute;
+
+use Attribute;
+
+#[Attribute(Attribute::TARGET_METHOD)]
+class DataProvider
+{
+
+}

--- a/src/Codeception/Attribute/Depends.php
+++ b/src/Codeception/Attribute/Depends.php
@@ -7,5 +7,4 @@ use Attribute;
 #[Attribute(Attribute::TARGET_METHOD)]
 class Depends
 {
-
 }

--- a/src/Codeception/Attribute/Depends.php
+++ b/src/Codeception/Attribute/Depends.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Codeception\Attribute;
+
+use Attribute;
+
+#[Attribute(Attribute::TARGET_METHOD)]
+class Depends
+{
+
+}

--- a/src/Codeception/Attribute/Env.php
+++ b/src/Codeception/Attribute/Env.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Codeception\Attribute;
+
+class Env
+{
+
+}

--- a/src/Codeception/Attribute/Env.php
+++ b/src/Codeception/Attribute/Env.php
@@ -4,5 +4,4 @@ namespace Codeception\Attribute;
 
 class Env
 {
-
 }

--- a/src/Codeception/Attribute/Examples.php
+++ b/src/Codeception/Attribute/Examples.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Codeception\Attribute;
+
+use Attribute;
+
+#[Attribute(Attribute::TARGET_METHOD)]
+class Examples
+{
+
+}

--- a/src/Codeception/Attribute/Examples.php
+++ b/src/Codeception/Attribute/Examples.php
@@ -7,5 +7,4 @@ use Attribute;
 #[Attribute(Attribute::TARGET_METHOD)]
 class Examples
 {
-
 }

--- a/src/Codeception/Attribute/Group.php
+++ b/src/Codeception/Attribute/Group.php
@@ -7,5 +7,4 @@ use Attribute;
 #[Attribute(Attribute::TARGET_METHOD | Attribute::TARGET_CLASS)]
 class Group
 {
-
 }

--- a/src/Codeception/Attribute/Group.php
+++ b/src/Codeception/Attribute/Group.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Codeception\Attribute;
+
+use Attribute;
+
+#[Attribute(Attribute::TARGET_METHOD | Attribute::TARGET_CLASS)]
+class Group
+{
+
+}

--- a/src/Codeception/Attribute/Incomplete.php
+++ b/src/Codeception/Attribute/Incomplete.php
@@ -7,5 +7,4 @@ use Attribute;
 #[Attribute(Attribute::TARGET_METHOD | Attribute::TARGET_CLASS)]
 class Incomplete
 {
-
 }

--- a/src/Codeception/Attribute/Incomplete.php
+++ b/src/Codeception/Attribute/Incomplete.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Codeception\Attribute;
+
+use Attribute;
+
+#[Attribute(Attribute::TARGET_METHOD | Attribute::TARGET_CLASS)]
+class Incomplete
+{
+
+}

--- a/src/Codeception/Attribute/Skip.php
+++ b/src/Codeception/Attribute/Skip.php
@@ -7,5 +7,4 @@ use Attribute;
 #[Attribute(Attribute::TARGET_METHOD | Attribute::TARGET_CLASS)]
 class Skip
 {
-
 }

--- a/src/Codeception/Attribute/Skip.php
+++ b/src/Codeception/Attribute/Skip.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Codeception\Attribute;
+
+use Attribute;
+
+#[Attribute(Attribute::TARGET_METHOD | Attribute::TARGET_CLASS)]
+class Skip
+{
+
+}

--- a/src/Codeception/Subscriber/ErrorHandler.php
+++ b/src/Codeception/Subscriber/ErrorHandler.php
@@ -123,7 +123,7 @@ class ErrorHandler implements EventSubscriberInterface
 
         if (
             !$this->suiteFinished && (
-            $error === null || !in_array($error['type'], [E_ERROR, E_COMPILE_ERROR, E_CORE_ERROR])
+                $error === null || !in_array($error['type'], [E_ERROR, E_COMPILE_ERROR, E_CORE_ERROR])
             )
         ) {
             echo "\n\n\nCOMMAND DID NOT FINISH PROPERLY.\n";

--- a/src/Codeception/Test/Cest.php
+++ b/src/Codeception/Test/Cest.php
@@ -66,6 +66,7 @@ class Cest extends Test implements
         $code = $this->getSourceCode();
         $this->parser->parseFeature($code);
         $this->getMetadata()->setParamsFromAnnotations(Annotation::forMethod($this->testClassInstance, $this->testMethod)->raw());
+        $this->getMetadata()->setParamsFromAttributes(Annotation::forMethod($this->testClassInstance, $this->testMethod)->attributes());
         $this->getMetadata()->getService('di')->injectDependencies($this->testClassInstance);
 
         // add example params to feature
@@ -120,6 +121,13 @@ class Cest extends Test implements
 
     protected function executeBeforeMethods(string $testMethod, $I): void
     {
+        $attribute = Annotation::forMethod(get_class($this->testClassInstance), $testMethod)->attribute('before');
+        if ($attribute) {
+            foreach ($attribute->getArguments() as $m) {
+                $this->executeContextMethod(trim($m), $I);
+            }
+            return;
+        }
         if (PHPUnitVersion::series() < 10) {
             $annotations = TestUtil::parseTestMethodAnnotations(get_class($this->testClassInstance), $testMethod);
             if (!empty($annotations['method']['before'])) {
@@ -138,6 +146,13 @@ class Cest extends Test implements
 
     protected function executeAfterMethods(string $testMethod, $I): void
     {
+        $attribute = Annotation::forMethod(get_class($this->testClassInstance), $testMethod)->attribute('after');
+        if ($attribute) {
+            foreach ($attribute->getArguments() as $m) {
+                $this->executeContextMethod(trim($m), $I);
+            }
+            return;
+        }
         if (PHPUnitVersion::series() < 10) {
             $annotations = TestUtil::parseTestMethodAnnotations(get_class($this->testClassInstance), $testMethod);
             if (!empty($annotations['method']['after'])) {

--- a/src/Codeception/Test/Loader/Cest.php
+++ b/src/Codeception/Test/Loader/Cest.php
@@ -66,7 +66,7 @@ class Cest implements LoaderInterface
                             fn ($v): ?array => Annotation::arrayValue($v),
                             $rawExamples
                         );
-                    } elseif($rawExamples) {
+                    } elseif ($rawExamples) {
                         $examples = $rawExamples;
                     }
                 }

--- a/src/Codeception/Test/Loader/Cest.php
+++ b/src/Codeception/Test/Loader/Cest.php
@@ -60,10 +60,14 @@ class Cest implements LoaderInterface
                 // example Annotation
                 $rawExamples = Annotation::forMethod($unit, $method)->fetchAll('example');
                 if ($rawExamples !== []) {
-                    $examples = array_map(
-                        fn ($v): ?array => Annotation::arrayValue($v),
-                        $rawExamples
-                    );
+                    if (is_string($rawExamples)) {
+                        $examples = array_map(
+                            fn ($v): ?array => Annotation::arrayValue($v),
+                            $rawExamples
+                        );
+                    } elseif(is_array($rawExamples)) {
+                        $examples = $rawExamples;
+                    }
                 }
 
                 // dataProvider Annotation

--- a/src/Codeception/Test/Loader/Cest.php
+++ b/src/Codeception/Test/Loader/Cest.php
@@ -60,12 +60,13 @@ class Cest implements LoaderInterface
                 // example Annotation
                 $rawExamples = Annotation::forMethod($unit, $method)->fetchAll('example');
                 if ($rawExamples !== []) {
-                    if (is_string($rawExamples)) {
+                    $rawExample = reset($rawExamples);
+                    if (is_string($rawExample)) {
                         $examples = array_map(
                             fn ($v): ?array => Annotation::arrayValue($v),
                             $rawExamples
                         );
-                    } elseif(is_array($rawExamples)) {
+                    } elseif($rawExamples) {
                         $examples = $rawExamples;
                     }
                 }

--- a/src/Codeception/Test/Loader/Unit.php
+++ b/src/Codeception/Test/Loader/Unit.php
@@ -97,6 +97,7 @@ class Unit implements LoaderInterface
         if ($test instanceof UnitFormat) {
             $annotations = Annotation::forMethod($test, $methodName)->raw();
             $test->getMetadata()->setParamsFromAnnotations($annotations);
+            $test->getMetadata()->setParamsFromAttributes(Annotation::forMethod($test, $methodName)->attributes());
             $test->getMetadata()->setFilename(Descriptor::getTestFileName($test));
         }
     }

--- a/src/Codeception/Test/Metadata.php
+++ b/src/Codeception/Test/Metadata.php
@@ -196,6 +196,19 @@ class Metadata
         }
     }
 
+    public function setParamsFromAttributes($attributes): void
+    {
+        $params = [];
+        foreach ($attributes as $attribute) {
+            $params[$attribute->getName()] = $attribute->getArguments();
+        }
+        $this->params = array_merge_recursive($this->params, $params);
+        // set singular value for some params
+        foreach (['skip', 'incomplete'] as $single) {
+            $this->params[$single] = empty($this->params[$single]) ? null : (string)$this->params[$single][0];
+        }
+    }
+
     public function setParams(array $params): void
     {
         $this->params = array_merge_recursive($this->params, $params);

--- a/src/Codeception/Test/Metadata.php
+++ b/src/Codeception/Test/Metadata.php
@@ -200,7 +200,8 @@ class Metadata
     {
         $params = [];
         foreach ($attributes as $attribute) {
-            $params[$attribute->getName()] = $attribute->getArguments();
+            $name = lcfirst(str_replace('Codeception\\Attribute\\', '', $attribute->getName()));
+            $params[$name] = $attribute->getArguments();
         }
         $this->params = array_merge_recursive($this->params, $params);
         // set singular value for some params

--- a/src/Codeception/Test/Unit.php
+++ b/src/Codeception/Test/Unit.php
@@ -12,6 +12,7 @@ use Codeception\PHPUnit\TestCase;
 use Codeception\Scenario;
 use Codeception\Test\Feature\Stub;
 use Codeception\TestInterface;
+use Codeception\Util\Annotation;
 use PHPUnit\Framework\TestResult;
 
 use function get_class;
@@ -40,6 +41,7 @@ class Unit extends TestCase implements
 
     protected function _setUp()
     {
+        $this->getMetadata()->setParamsFromAttributes(Annotation::forMethod($this, $this->getName())->attributes());
         if ($this->getMetadata()->isBlocked()) {
             if ($this->getMetadata()->getSkip() !== null) {
                 $this->markTestSkipped($this->getMetadata()->getSkip());

--- a/src/Codeception/Test/Unit.php
+++ b/src/Codeception/Test/Unit.php
@@ -43,7 +43,6 @@ class Unit extends TestCase implements
 
     protected function _setUp()
     {
-        $this->getMetadata()->setParamsFromAttributes(Annotation::forMethod($this, $this->getName())->attributes());
         if ($this->getMetadata()->isBlocked()) {
             if ($this->getMetadata()->getSkip() !== null) {
                 $this->markTestSkipped($this->getMetadata()->getSkip());

--- a/src/Codeception/Util/Annotation.php
+++ b/src/Codeception/Util/Annotation.php
@@ -110,6 +110,11 @@ class Annotation
 
     public function fetch(string $annotation): ?string
     {
+        $attr = $this->attribute($annotation);
+        if ($attr) {
+            $arguments = $attr->getArguments();
+            return reset($arguments);
+        }
         $docBlock = (string)$this->currentReflectedItem->getDocComment();
         if (preg_match(sprintf(self::$regex, $annotation), $docBlock, $matched)) {
             return $matched[1];
@@ -119,11 +124,30 @@ class Annotation
 
     public function fetchAll(string $annotation): array
     {
+        $attr = $this->attribute($annotation);
+        if ($attr) {
+            return $attr->getArguments();
+        }
         $docBlock = (string)$this->currentReflectedItem->getDocComment();
         if (preg_match_all(sprintf(self::$regex, $annotation), $docBlock, $matched)) {
             return $matched[1];
         }
         return [];
+    }
+
+    public function attributes(): array
+    {
+        return $this->currentReflectedItem->getAttributes();
+    }
+
+    public function attribute($name): ?\ReflectionAttribute
+    {
+        $attrs = $this->attributes();
+        $attrs = array_filter($attrs, fn($a) => $a->getName() === $name);
+        if (empty($attrs)) {
+            return null;
+        }
+        return reset($attrs);
     }
 
     public function raw(): string|false

--- a/src/Codeception/Util/Annotation.php
+++ b/src/Codeception/Util/Annotation.php
@@ -150,7 +150,7 @@ class Annotation
             $name = 'examples'; // we renamed this annotation
         }
         $name = ucfirst($name);
-        $attrs = array_filter($attrs, fn($a) => $a->getName() === "Codeception\\Attribute\\$name");
+        $attrs = array_filter($attrs, fn ($a) => $a->getName() === "Codeception\\Attribute\\$name");
         if (empty($attrs)) {
             return null;
         }

--- a/src/Codeception/Util/Annotation.php
+++ b/src/Codeception/Util/Annotation.php
@@ -137,13 +137,20 @@ class Annotation
 
     public function attributes(): array
     {
-        return $this->currentReflectedItem->getAttributes();
+        $attrs = $this->currentReflectedItem->getAttributes();
+        $attrs = array_filter($attrs);
+        $attrs = array_filter($attrs, fn (\ReflectionAttribute $a) => str_starts_with($a->getName(), 'Codeception\\Attribute\\'));
+        return $attrs;
     }
 
     public function attribute($name): ?\ReflectionAttribute
     {
         $attrs = $this->attributes();
-        $attrs = array_filter($attrs, fn($a) => $a->getName() === $name);
+        if ($name === 'example') {
+            $name = 'examples'; // we renamed this annotation
+        }
+        $name = ucfirst($name);
+        $attrs = array_filter($attrs, fn($a) => $a->getName() === "Codeception\\Attribute\\$name");
         if (empty($attrs)) {
             return null;
         }

--- a/tests/cli/RunCest.php
+++ b/tests/cli/RunCest.php
@@ -1,5 +1,7 @@
 <?php
 
+use Codeception\Attribute\DataProvider;
+use Codeception\Attribute\Group;
 use Codeception\Scenario;
 
 final class RunCest
@@ -58,7 +60,7 @@ final class RunCest
         $I->seeInShellOutput('SuccessCest');
     }
 
-    #[group('reports')]
+    #[Group('reports')]
     public function runHtml(CliGuy $I)
     {
         $I->wantTo('execute tests with html output');
@@ -67,7 +69,7 @@ final class RunCest
     }
 
 
-    #[group('reports')]
+    #[Group('reports')]
     public function runXmlReport(CliGuy $I)
     {
         $I->wantTo('check xml reports');
@@ -79,7 +81,7 @@ final class RunCest
         $I->seeInThisFile('feature="');
     }
 
-    #[group('reports')]
+    #[Group('reports')]
     public function runXmlReportsInStrictMode(CliGuy $I)
     {
         $I->wantTo('check xml in strict mode');
@@ -91,7 +93,7 @@ final class RunCest
         $I->dontSeeInThisFile('feature="');
     }
 
-    #[group('reports')]
+    #[Group('reports')]
     public function runPhpUnitXmlReport(CliGuy $I)
     {
         $I->wantTo('check phpunit xml reports');
@@ -115,7 +117,7 @@ final class RunCest
         $I->seeInThisFile('feature="');
     }
 
-    #[group('reports')]
+    #[Group('reports')]
     public function runPhpUnitXmlReportsInStrictMode(CliGuy $I)
     {
         $I->wantTo('check phpunit xml in strict mode');
@@ -139,7 +141,7 @@ final class RunCest
         $I->dontSeeInThisFile('feature="');
     }
 
-    #[group('reports')]
+    #[Group('reports')]
     public function runCustomReport(CliGuy $I)
     {
         $I->executeCommand('run dummy --ext=MyReportPrinter -c codeception_custom_report.yml');
@@ -147,7 +149,7 @@ final class RunCest
         $I->dontSeeInShellOutput('Ok');
     }
 
-    #[group('reports')]
+    #[Group('reports')]
     public function runCompactReport(CliGuy $I)
     {
         $I->executeCommand('run dummy --report');
@@ -170,7 +172,7 @@ final class RunCest
         $I->dontSeeInShellOutput("IncompleteMeCept");
     }
 
-    #[group('attrs')]
+    #[Group('attrs')]
     public function runOneGroupByAttr(CliGuy $I)
     {
         $I->executeCommand('run Attrs -g g1');
@@ -178,7 +180,7 @@ final class RunCest
         $I->seeInShellOutput("OK (1 test");
     }
 
-    #[group('attrs')]
+    #[Group('attrs')]
     public function runWithBeforeAfter(CliGuy $I)
     {
         $I->executeCommand('run Attrs --steps -g g1');
@@ -189,7 +191,7 @@ final class RunCest
     }
 
 
-    #[group('attrs')]
+    #[Group('attrs')]
     public function runWithExamples(CliGuy $I)
     {
         $I->executeCommand('run Attrs --steps -g e1');
@@ -197,28 +199,28 @@ final class RunCest
     }
 
 
-    #[group('attrs')]
+    #[Group('attrs')]
     public function runWithDataprovider(CliGuy $I)
     {
         $I->executeCommand('run Attrs --steps -g d1');
         $I->seeInShellOutput("OK (2 test");
     }
 
-    #[group('attrs')]
+    #[Group('attrs')]
     public function runWithDepends(CliGuy $I)
     {
         $I->executeCommand('run Attrs --steps -g dp');
         $I->seeInShellOutput("This test depends on Attrs\BasicScenarioCest:validTest to pass");
     }
 
-    #[group('attrs')]
+    #[Group('attrs')]
     public function runWithUnitSkipped(CliGuy $I)
     {
         $I->executeCommand('run Attrs --steps -g uskip');
         $I->seeInShellOutput("Skipped: 1");
     }
 
-    #[group('attrs')]
+    #[Group('attrs')]
     public function runWithUnitIncomplete(CliGuy $I)
     {
         $I->executeCommand('run Attrs --steps -g uincomplete');
@@ -358,7 +360,7 @@ final class RunCest
         $I->seeInShellOutput('There were 3 failures');
     }
 
-    #[group('reports')]
+    #[Group('reports')]
     public function runWithCustomOutputPath(CliGuy $I)
     {
         $I->executeCommand('run dummy --xml myverycustom.xml --html myownhtmlreport.html');
@@ -776,7 +778,7 @@ EOF
         $I->assertEmpty(array_intersect($tests1, $tests3), 'same tests in shards');
     }
 
-    #[group('reports')]
+    #[Group('reports')]
     public function runHtmlWithPhpBrowserCheckReport(CliGuy $I)
     {
         $I->wantTo('execute tests with PhpBrowser with html output and check html');
@@ -920,8 +922,8 @@ EOF
         ];
     }
 
-    #[group('reports')]
-    #[dataProvider('htmlReportRegexCheckProvider')]
+    #[Group('reports')]
+    #[DataProvider('htmlReportRegexCheckProvider')]
     public function runHtmlCheckReport(CliGuy $I, \Codeception\Example $example, Scenario $scenario)
     {
         /** @var TestHtmlReportRegexBuilder $testBuilder */

--- a/tests/cli/RunCest.php
+++ b/tests/cli/RunCest.php
@@ -58,12 +58,7 @@ final class RunCest
         $I->seeInShellOutput('SuccessCest');
     }
 
-    /**
-     * @group reports
-     * @group core
-     *
-     * @param CliGuy $I
-     */
+    #[group('reports')]
     public function runHtml(CliGuy $I)
     {
         $I->wantTo('execute tests with html output');
@@ -72,11 +67,7 @@ final class RunCest
     }
 
 
-    /**
-     * @group reports
-     *
-     * @param CliGuy $I
-     */
+    #[group('reports')]
     public function runXmlReport(CliGuy $I)
     {
         $I->wantTo('check xml reports');
@@ -88,10 +79,7 @@ final class RunCest
         $I->seeInThisFile('feature="');
     }
 
-    /**
-     * @group reports
-     * @param CliGuy $I
-     */
+    #[group('reports')]
     public function runXmlReportsInStrictMode(CliGuy $I)
     {
         $I->wantTo('check xml in strict mode');
@@ -103,11 +91,7 @@ final class RunCest
         $I->dontSeeInThisFile('feature="');
     }
 
-    /**
-     * @group reports
-     *
-     * @param CliGuy $I
-     */
+    #[group('reports')]
     public function runPhpUnitXmlReport(CliGuy $I)
     {
         $I->wantTo('check phpunit xml reports');
@@ -131,10 +115,7 @@ final class RunCest
         $I->seeInThisFile('feature="');
     }
 
-    /**
-     * @group reports
-     * @param CliGuy $I
-     */
+    #[group('reports')]
     public function runPhpUnitXmlReportsInStrictMode(CliGuy $I)
     {
         $I->wantTo('check phpunit xml in strict mode');
@@ -158,11 +139,7 @@ final class RunCest
         $I->dontSeeInThisFile('feature="');
     }
 
-    /**
-     * @group reports
-     *
-     * @param CliGuy $I
-     */
+    #[group('reports')]
     public function runCustomReport(CliGuy $I)
     {
         $I->executeCommand('run dummy --ext=MyReportPrinter -c codeception_custom_report.yml');
@@ -170,11 +147,7 @@ final class RunCest
         $I->dontSeeInShellOutput('Ok');
     }
 
-    /**
-     * @group reports
-     *
-     * @param CliGuy $I
-     */
+    #[group('reports')]
     public function runCompactReport(CliGuy $I)
     {
         $I->executeCommand('run dummy --report');
@@ -195,6 +168,61 @@ final class RunCest
         $I->seeInShellOutput('Skipped Tests (2)');
         $I->seeInShellOutput("SkipMeCept");
         $I->dontSeeInShellOutput("IncompleteMeCept");
+    }
+
+    #[group('attrs')]
+    public function runOneGroupByAttr(CliGuy $I)
+    {
+        $I->executeCommand('run Attrs -g g1');
+        $I->seeInShellOutput("Valid test");
+        $I->seeInShellOutput("OK (1 test");
+    }
+
+    #[group('attrs')]
+    public function runWithBeforeAfter(CliGuy $I)
+    {
+        $I->executeCommand('run Attrs --steps -g g1');
+        $I->seeInShellOutput("open1");
+        $I->seeInShellOutput("open2");
+        $I->seeInShellOutput("close1");
+        $I->seeInShellOutput("OK (1 test");
+    }
+
+
+    #[group('attrs')]
+    public function runWithExamples(CliGuy $I)
+    {
+        $I->executeCommand('run Attrs --steps -g e1');
+        $I->seeInShellOutput("OK (2 test");
+    }
+
+
+    #[group('attrs')]
+    public function runWithDataprovider(CliGuy $I)
+    {
+        $I->executeCommand('run Attrs --steps -g d1');
+        $I->seeInShellOutput("OK (2 test");
+    }
+
+    #[group('attrs')]
+    public function runWithDepends(CliGuy $I)
+    {
+        $I->executeCommand('run Attrs --steps -g dp');
+        $I->seeInShellOutput("This test depends on Attrs\BasicScenarioCest:validTest to pass");
+    }
+
+    #[group('attrs')]
+    public function runWithUnitSkipped(CliGuy $I)
+    {
+        $I->executeCommand('run Attrs --steps -g uskip');
+        $I->seeInShellOutput("Skipped: 1");
+    }
+
+    #[group('attrs')]
+    public function runWithUnitIncomplete(CliGuy $I)
+    {
+        $I->executeCommand('run Attrs --steps -g uincomplete');
+        $I->seeInShellOutput("Incomplete: 1");
     }
 
     public function skipGroupOfCest(CliGuy $I)
@@ -330,9 +358,7 @@ final class RunCest
         $I->seeInShellOutput('There were 3 failures');
     }
 
-    /**
-     * @group reports
-     */
+    #[group('reports')]
     public function runWithCustomOutputPath(CliGuy $I)
     {
         $I->executeCommand('run dummy --xml myverycustom.xml --html myownhtmlreport.html');
@@ -706,11 +732,7 @@ EOF
         $I->seeInShellOutput("OK (");
     }
 
-    /**
-     * @group reports
-     *
-     * @param CliGuy $I
-     */
+    #[group('reports')]
     public function runHtmlWithPhpBrowserCheckReport(CliGuy $I)
     {
         $I->wantTo('execute tests with PhpBrowser with html output and check html');
@@ -854,15 +876,8 @@ EOF
         ];
     }
 
-    /**
-     * @group reports
-     *
-     * @dataProvider htmlReportRegexCheckProvider
-     *
-     * @param CliGuy               $I
-     * @param \Codeception\Example $example
-     * @param Scenario             $scenario
-     */
+    #[group('reports')]
+    #[dataProvider('htmlReportRegexCheckProvider')]
     public function runHtmlCheckReport(CliGuy $I, \Codeception\Example $example, Scenario $scenario)
     {
         /** @var TestHtmlReportRegexBuilder $testBuilder */

--- a/tests/cli/SnapshotCest.php
+++ b/tests/cli/SnapshotCest.php
@@ -9,10 +9,8 @@ final class SnapshotCest
         $I->amInPath('tests/data/snapshots');
     }
 
-    /**
-     * @before _openSnapshotSuite
-     * @param CliGuy $I
-     */
+    #[skip]
+    #[before('_openSnapshotSuite')]
     public function runAllSnapshotTests(CliGuy $I)
     {
         $I->executeCommand('run tests/SnapshotDataCest.php');
@@ -21,10 +19,8 @@ final class SnapshotCest
         $I->seeInShellOutput('Load snapshot and refresh');
     }
 
-    /**
-     * @before _openSnapshotSuite
-     * @param CliGuy $I
-     */
+    #[group('user')]
+    #[before('_openSnapshotSuite')]
     public function runSnapshotRefresh(CliGuy $I)
     {
         $I->executeCommand('run tests/SnapshotDataCest.php:loadSnapshotAndRefresh --debug --no-colors');
@@ -34,10 +30,7 @@ final class SnapshotCest
         $I->seeInShellOutput('Snapshot data updated');
     }
 
-    /**
-     * @before _openSnapshotSuite
-     * @param CliGuy $I
-     */
+    #[before('_openSnapshotSuite')]
     public function runSnapshotRefreshFail(CliGuy $I)
     {
         $I->executeCommand('run tests/SnapshotDataCest.php:loadSnapshotAndSkipRefresh --debug  --no-colors');
@@ -47,20 +40,14 @@ final class SnapshotCest
         $I->dontSeeInShellOutput('Snapshot data updated');
     }
 
-    /**
-     * @before _openSnapshotSuite
-     * @param CliGuy $I
-     */
+    #[before('_openSnapshotSuite')]
     public function runSnapshotDiffDisplay(CliGuy $I)
     {
         $I->executeCommand('run tests/SnapshotDisplayDiffCest.php');
         $I->seeInShellOutput('OK (1 test');
     }
 
-    /**
-     * @before _openSnapshotSuite
-     * @param CliGuy $I
-     */
+    #[before('_openSnapshotSuite')]
     public function loadSnapshotInDebugAndFailOnProd(CliGuy $I)
     {
         $I->executeCommand('run tests/SnapshotFailCest.php --debug');
@@ -97,10 +84,7 @@ final class SnapshotCest
         $I->dontSeeInThisFile('public function __construct(\DumbGuy $I)');
     }
 
-    /**
-     * @before _openSnapshotSuite
-     * @param CliGuy $I
-     */
+    #[before('_openSnapshotSuite')]
     public function runNonJsonContentSnapshotTests(CliGuy $I)
     {
         $I->executeCommand('run tests/SnapshotNonJsonDataCest.php');

--- a/tests/cli/SnapshotCest.php
+++ b/tests/cli/SnapshotCest.php
@@ -2,6 +2,9 @@
 
 declare(strict_types=1);
 
+use Codeception\Attribute\Before;
+use Codeception\Attribute\Group;
+
 final class SnapshotCest
 {
     public function _openSnapshotSuite(CliGuy $I)
@@ -9,8 +12,7 @@ final class SnapshotCest
         $I->amInPath('tests/data/snapshots');
     }
 
-    #[skip]
-    #[before('_openSnapshotSuite')]
+    #[Before('_openSnapshotSuite')]
     public function runAllSnapshotTests(CliGuy $I)
     {
         $I->executeCommand('run tests/SnapshotDataCest.php');
@@ -19,8 +21,8 @@ final class SnapshotCest
         $I->seeInShellOutput('Load snapshot and refresh');
     }
 
-    #[group('user')]
-    #[before('_openSnapshotSuite')]
+    #[Group('user')]
+    #[Before('_openSnapshotSuite')]
     public function runSnapshotRefresh(CliGuy $I)
     {
         $I->executeCommand('run tests/SnapshotDataCest.php:loadSnapshotAndRefresh --debug --no-colors');
@@ -30,7 +32,7 @@ final class SnapshotCest
         $I->seeInShellOutput('Snapshot data updated');
     }
 
-    #[before('_openSnapshotSuite')]
+    #[Before('_openSnapshotSuite')]
     public function runSnapshotRefreshFail(CliGuy $I)
     {
         $I->executeCommand('run tests/SnapshotDataCest.php:loadSnapshotAndSkipRefresh --debug  --no-colors');
@@ -40,14 +42,14 @@ final class SnapshotCest
         $I->dontSeeInShellOutput('Snapshot data updated');
     }
 
-    #[before('_openSnapshotSuite')]
+    #[Before('_openSnapshotSuite')]
     public function runSnapshotDiffDisplay(CliGuy $I)
     {
         $I->executeCommand('run tests/SnapshotDisplayDiffCest.php');
         $I->seeInShellOutput('OK (1 test');
     }
 
-    #[before('_openSnapshotSuite')]
+    #[Before('_openSnapshotSuite')]
     public function loadSnapshotInDebugAndFailOnProd(CliGuy $I)
     {
         $I->executeCommand('run tests/SnapshotFailCest.php --debug');
@@ -84,7 +86,7 @@ final class SnapshotCest
         $I->dontSeeInThisFile('public function __construct(\DumbGuy $I)');
     }
 
-    #[before('_openSnapshotSuite')]
+    #[Before('_openSnapshotSuite')]
     public function runNonJsonContentSnapshotTests(CliGuy $I)
     {
         $I->executeCommand('run tests/SnapshotNonJsonDataCest.php');

--- a/tests/data/claypit/tests/Attrs.suite.yml
+++ b/tests/data/claypit/tests/Attrs.suite.yml
@@ -1,0 +1,5 @@
+actor: AttrsTester
+suite_namespace: \Attrs
+modules:
+    # enable helpers as array
+    enabled: [Asserts]

--- a/tests/data/claypit/tests/Attrs/BasicScenarioCest.php
+++ b/tests/data/claypit/tests/Attrs/BasicScenarioCest.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace Attrs;
+
+use \AttrsTester;
+use Codeception\Example;
+
+class BasicScenarioCest
+{
+    #[\before('open1', 'open2')]
+    #[\after('close1')]
+    #[\group('g1', 'g2')]
+    public function validTest(AttrsTester $I)
+    {
+        $I->assertEquals(1, 1);
+    }
+
+    private function open1(AttrsTester $I)
+    {
+        $I->comment('open1');
+    }
+
+    private function open2(AttrsTester $I)
+    {
+        $I->comment('open2');
+    }
+
+    private function close1(AttrsTester $I)
+    {
+        $I->comment('close1');
+    }
+
+    #[\group('e1')]
+    #[\example([1, 1], [2, 2])]
+    public function exampleTest(AttrsTester $I, Example $e)
+    {
+        $I->assertEquals($e[1], $e[0]);
+    }
+
+    #[\group('d1')]
+    #[\dataProvider('_listItems')]
+    public function dataProviderTest(AttrsTester $I, Example $e)
+    {
+        $I->assertEquals($e[1], $e[0]);
+    }
+
+    #[\group('dp')]
+    #[\depends('validTest')]
+    public function dependsTest(AttrsTester $I)
+    {
+        $I->assertEquals(2, 2);
+    }
+
+
+    private function _listItems() {
+        return [
+            [1,1],
+            [2,2],
+        ];
+    }
+
+    #[\group('incomplete')]
+    #[\incomplete]
+    public function incompleteTest(AttrsTester $I)
+    {
+        $I->assertEquals(1, 2);
+    }
+
+    #[\group('skip')]
+    #[\skip]
+    public function skipTest(AttrsTester $I)
+    {
+        $I->assertEquals(1, 2);
+    }
+
+}

--- a/tests/data/claypit/tests/Attrs/BasicScenarioCest.php
+++ b/tests/data/claypit/tests/Attrs/BasicScenarioCest.php
@@ -2,7 +2,7 @@
 
 namespace Attrs;
 
-use \AttrsTester;
+use AttrsTester;
 use Codeception\Attribute\After;
 use Codeception\Attribute\Before;
 use Codeception\Attribute\DataProvider;
@@ -60,7 +60,8 @@ class BasicScenarioCest
     }
 
 
-    private function _listItems() {
+    private function _listItems()
+    {
         return [
             [1,1],
             [2,2],
@@ -80,5 +81,4 @@ class BasicScenarioCest
     {
         $I->assertEquals(1, 2);
     }
-
 }

--- a/tests/data/claypit/tests/Attrs/BasicScenarioCest.php
+++ b/tests/data/claypit/tests/Attrs/BasicScenarioCest.php
@@ -3,13 +3,21 @@
 namespace Attrs;
 
 use \AttrsTester;
+use Codeception\Attribute\After;
+use Codeception\Attribute\Before;
+use Codeception\Attribute\DataProvider;
+use Codeception\Attribute\Depends;
+use Codeception\Attribute\Examples;
+use Codeception\Attribute\Group;
+use Codeception\Attribute\Incomplete;
+use Codeception\Attribute\Skip;
 use Codeception\Example;
 
 class BasicScenarioCest
 {
-    #[\before('open1', 'open2')]
-    #[\after('close1')]
-    #[\group('g1', 'g2')]
+    #[Before('open1', 'open2')]
+    #[After('close1')]
+    #[Group('g1', 'g2')]
     public function validTest(AttrsTester $I)
     {
         $I->assertEquals(1, 1);
@@ -30,22 +38,22 @@ class BasicScenarioCest
         $I->comment('close1');
     }
 
-    #[\group('e1')]
-    #[\example([1, 1], [2, 2])]
+    #[Group('e1')]
+    #[Examples([1, 1], [2, 2])]
     public function exampleTest(AttrsTester $I, Example $e)
     {
         $I->assertEquals($e[1], $e[0]);
     }
 
-    #[\group('d1')]
-    #[\dataProvider('_listItems')]
+    #[Group('d1')]
+    #[DataProvider('_listItems')]
     public function dataProviderTest(AttrsTester $I, Example $e)
     {
         $I->assertEquals($e[1], $e[0]);
     }
 
-    #[\group('dp')]
-    #[\depends('validTest')]
+    #[Group('dp')]
+    #[Depends('validTest')]
     public function dependsTest(AttrsTester $I)
     {
         $I->assertEquals(2, 2);
@@ -59,15 +67,15 @@ class BasicScenarioCest
         ];
     }
 
-    #[\group('incomplete')]
-    #[\incomplete]
+    #[Group('incomplete')]
+    #[Incomplete]
     public function incompleteTest(AttrsTester $I)
     {
         $I->assertEquals(1, 2);
     }
 
-    #[\group('skip')]
-    #[\skip]
+    #[Group('skip')]
+    #[Skip]
     public function skipTest(AttrsTester $I)
     {
         $I->assertEquals(1, 2);

--- a/tests/data/claypit/tests/Attrs/BasicUnitTest.php
+++ b/tests/data/claypit/tests/Attrs/BasicUnitTest.php
@@ -2,37 +2,39 @@
 
 namespace Attrs;
 
-use \AttrsTester;
-use Codeception\Example;
+use Codeception\Attribute\Examples as ExampleAttr;
+use Codeception\Attribute\Group;
+use Codeception\Attribute\Incomplete;
+use Codeception\Attribute\Skip;
 use Codeception\Test\Unit;
 
 class BasicUnitTest extends Unit
 {
-    #[\group('uincomplete')]
-    #[\incomplete]
+    #[Group('uincomplete')]
+    #[Incomplete]
     public function testIncomplete()
     {
         $this->assertEquals(1, 2);
     }
 
-    #[\group('uskip')]
-    #[\skip]
+    #[Group('uskip')]
+    #[Skip]
     public function testSkip()
     {
         $this->assertEquals(1, 2);
     }
 
-    #[\skip]
-    #[\group('ue1')]
-    #[\example([1, 1], [2, 2])]
+    #[Skip]
+    #[Group('ue1')]
+    #[ExampleAttr([1, 1], [2, 2])]
     public function testExample($e)
     {
         $this->assertEquals($e[1], $e[0]);
     }
 
-    #[\group('ud1')]
-    #[\skip]
-    #[\dataProvider('_listItems')]
+    #[Group('ud1')]
+    #[Skip]
+    #[DataProvider('_listItems')]
     public function testDataProvider($e1, $e2)
     {
         $this->assertEquals($e1, $e2);

--- a/tests/data/claypit/tests/Attrs/BasicUnitTest.php
+++ b/tests/data/claypit/tests/Attrs/BasicUnitTest.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Attrs;
+
+use \AttrsTester;
+use Codeception\Example;
+use Codeception\Test\Unit;
+
+class BasicUnitTest extends Unit
+{
+    #[\group('uincomplete')]
+    #[\incomplete]
+    public function testIncomplete()
+    {
+        $this->assertEquals(1, 2);
+    }
+
+    #[\group('uskip')]
+    #[\skip]
+    public function testSkip()
+    {
+        $this->assertEquals(1, 2);
+    }
+
+    #[\skip]
+    #[\group('ue1')]
+    #[\example([1, 1], [2, 2])]
+    public function testExample($e)
+    {
+        $this->assertEquals($e[1], $e[0]);
+    }
+
+    #[\group('ud1')]
+    #[\skip]
+    #[\dataProvider('_listItems')]
+    public function testDataProvider($e1, $e2)
+    {
+        $this->assertEquals($e1, $e2);
+    }
+
+    private function _listItems() {
+        return [
+            [1,1],
+            [2,2],
+        ];
+    }
+}

--- a/tests/data/claypit/tests/Attrs/BasicUnitTest.php
+++ b/tests/data/claypit/tests/Attrs/BasicUnitTest.php
@@ -40,7 +40,8 @@ class BasicUnitTest extends Unit
         $this->assertEquals($e1, $e2);
     }
 
-    private function _listItems() {
+    private function _listItems()
+    {
         return [
             [1,1],
             [2,2],

--- a/tests/data/claypit/tests/_support/AttrsTester.php
+++ b/tests/data/claypit/tests/_support/AttrsTester.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+
+/**
+ * Inherited Methods
+ * @method void wantToTest($text)
+ * @method void wantTo($text)
+ * @method void execute($callable)
+ * @method void expectTo($prediction)
+ * @method void expect($prediction)
+ * @method void amGoingTo($argumentation)
+ * @method void am($role)
+ * @method void lookForwardTo($achieveValue)
+ * @method void comment($description)
+ * @method void pause()
+ *
+ * @SuppressWarnings(PHPMD)
+*/
+class AttrsTester extends \Codeception\Actor
+{
+    use _generated\AttrsTesterActions;
+
+    /**
+     * Define custom actions here
+     */
+}

--- a/tests/data/claypit/tests/_support/AttrsTester.php
+++ b/tests/data/claypit/tests/_support/AttrsTester.php
@@ -1,8 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
-
 /**
  * Inherited Methods
  * @method void wantToTest($text)

--- a/tests/data/claypit/tests/order/ParsedLoadedTest.php
+++ b/tests/data/claypit/tests/order/ParsedLoadedTest.php
@@ -1,4 +1,5 @@
 <?php
+
 // phpcs:ignoreFile PSR1.Files.SideEffects.FoundWithSymbols
 
 \Codeception\Module\OrderHelper::appendToFile('P'); // parsed


### PR DESCRIPTION
Added attributes for Cest format (some of them also work for Test)

Usage example (updated):

```php
    #[Incomplete]
    #[Skip]
    #[Group('ue1')]
    #[Example([1, 1], [2, 2])]
    #[Depends('test1')]
    #[Before('test1')]
    #[Before('test2')]
    public function myTest($I) 
    {
    }
```