### PR TITLE
4.2  Backport test.useless event from Codeception 5.0

### DIFF
--- a/src/Codeception/Events.php
+++ b/src/Codeception/Events.php
@@ -99,6 +99,14 @@ final class Events
      */
     const TEST_WARNING = 'test.warning';
 
+    /**
+     * The <b>TEST_USELESS</b> event occurs whenever test does not execute any assertions
+     * or when it calls expectNotToPerformAssertions and then performs some assertion.
+     *
+     * The event listener method receives a {@link \Codeception\Event\FailEvent} instance.
+     */
+    const TEST_USELESS = 'test.useless';
+
 
     /**
      * The event listener method receives a {@link Codeception\Event\TestEvent} instance.

--- a/src/Codeception/Subscriber/Console.php
+++ b/src/Codeception/Subscriber/Console.php
@@ -42,6 +42,7 @@ class Console implements EventSubscriberInterface
         Events::TEST_INCOMPLETE    => 'testIncomplete',
         Events::TEST_SKIPPED       => 'testSkipped',
         Events::TEST_WARNING       => 'testWarning',
+        Events::TEST_USELESS       => 'testUseless',
         Events::TEST_FAIL_PRINT    => 'printFail',
         Events::RESULT_PRINT_AFTER => 'afterResult',
     ];
@@ -290,6 +291,11 @@ class Console implements EventSubscriberInterface
             return;
         }
         $this->writelnFinishedTest($e, $this->message('I')->style('pending'));
+    }
+
+    public function testUseless(FailEvent $event)
+    {
+        $this->writelnFinishedTest($event, $this->message('U')->style('pending'));
     }
 
     protected function isDetailed($test)

--- a/tests/cli/IncludedCest.php
+++ b/tests/cli/IncludedCest.php
@@ -212,7 +212,7 @@ class IncludedCest
      */
     public function overwrittenConfigurationIsAlsoAppliedWhenRunningAnIncludedAppFromTheRootApp(CliGuy $I)
     {
-        if(PHP_VERSION_ID < 70100) {
+        if (version_compare(\PHPUnit\Runner\Version::id(), '7.0.0', '<')) {
             $I->markTestSkipped('This test can only run on PHP >= 7.1 because of reporter type declarations.');
         }
         $I->executeCommand('run jazz/tests/functional --report -o "reporters: report: Jazz\CustomReporter1"');

--- a/tests/cli/RunUselessTestsCest.php
+++ b/tests/cli/RunUselessTestsCest.php
@@ -1,0 +1,136 @@
+<?php
+
+class RunUselessTestsCest
+{
+    public function checkOutput(CliGuy $I)
+    {
+        $I->amInPath('tests/data/useless');
+        $I->executeCommand('run');
+        // $I->seeInShellOutput('U UselessCept: Make no assertions');
+        // $I->seeInShellOutput('U UselessCest: Make no assertions');
+        $I->seeInShellOutput('U UselessTest: Make no assertions');
+        $I->seeInShellOutput('OK, but incomplete, skipped, or risky tests!');
+
+        if (version_compare(\PHPUnit\Runner\Version::id(), '7.2.0', '>=')) {
+            $I->seeInShellOutput('There were 2 risky tests:');
+            $I->seeInShellOutput('U UselessTest: Make unexpected assertion');
+        } else {
+            $I->seeInShellOutput('There was 1 risky test:');
+            $I->seeInShellOutput('S UselessTest: Make unexpected assertion');
+        }
+
+        if (DIRECTORY_SEPARATOR === '/') {
+//            $I->seeInShellOutput(
+//                '1) UselessCept: Make no assertions
+// Test  tests/unit/UselessCept.php
+//This test did not perform any assertions'
+//            );
+//            $I->seeInShellOutput(
+//                '
+//2) UselessCest: Make no assertions
+// Test  tests/unit/UselessCest.php:makeNoAssertions
+//This test did not perform any assertions
+//
+//Scenario Steps:
+//
+// 1. // make no assertions'
+//            );
+            $I->seeInShellOutput(
+                '
+1) UselessTest: Make no assertions
+ Test  tests/unit/UselessTest.php:testMakeNoAssertions
+This test did not perform any assertions'
+            );
+            if (version_compare(\PHPUnit\Runner\Version::id(), '7.2.0', '>=')) {
+                $I->seeInShellOutput(
+                    '
+2) UselessTest: Make unexpected assertion
+ Test  tests/unit/UselessTest.php:testMakeUnexpectedAssertion
+This test is annotated with "@doesNotPerformAssertions" but performed 1 assertions'
+                );
+            }
+
+            return;
+        }
+
+//        $I->seeInShellOutput(
+//            '1) UselessCept: Make no assertions
+// Test  tests\unit\UselessCept.php
+//This test did not perform any assertions'
+//        );
+//        $I->seeInShellOutput(
+//            '
+//2) UselessCest: Make no assertions
+// Test  tests\unit\UselessCest.php:makeNoAssertions
+//This test did not perform any assertions
+//
+//Scenario Steps:
+//
+// 1. // make no assertions'
+//        );
+        $I->seeInShellOutput(
+            '
+1) UselessTest: Make no assertions
+ Test  tests\unit\UselessTest.php:testMakeNoAssertions
+This test did not perform any assertions'
+        );
+        if (version_compare(\PHPUnit\Runner\Version::id(), '7.2.0', '>=')) {
+            $I->seeInShellOutput(
+                '
+2) UselessTest: Make unexpected assertion
+ Test  tests\unit\UselessTest.php:testMakeUnexpectedAssertion
+This test is annotated with "@doesNotPerformAssertions" but performed 1 assertions'
+            );
+        }
+    }
+
+    public function checkReports(CliGuy $I)
+    {
+        $I->amInPath('tests/data/useless');
+        $I->executeCommand('run --report --xml --phpunit-xml --html');
+
+        if (version_compare(\PHPUnit\Runner\Version::id(), '7.2.0', '>=')) {
+            $useless = 2;
+            $skipped = 0;
+            $assertions = 1;
+            $I->seeInShellOutput('UselessTest: Make unexpected assertion.....................................Useless');
+        } else {
+            $useless = 1;
+            $skipped = 1;
+            $assertions = 0;
+            $I->seeInShellOutput('UselessTest: Make unexpected assertion.....................................Skipped');
+        }
+        $I->seeInShellOutput("Skipped: $skipped. Useless: $useless");
+
+        // $I->seeInShellOutput('UselessCept: Make no assertions............................................Useless');
+        // $I->seeInShellOutput('UselessCest: Make no assertions............................................Useless');
+        $I->seeInShellOutput('UselessTest: Make no assertions............................................Useless');
+
+        $I->seeFileFound('report.xml', 'tests/_output');
+        $I->seeInThisFile(
+            "<testsuite name=\"unit\" tests=\"4\" assertions=\"$assertions\" errors=\"$useless\" failures=\"0\" skipped=\"$skipped\" time=\""
+        );
+        // $I->seeInThisFile('<testcase name="Useless"');
+        // $I->seeInThisFile('<testcase name="makeNoAssertions" class="UselessCest"');
+        $I->seeInThisFile('<testcase name="testMakeNoAssertions" class="UselessTest" file="');
+        $I->seeInThisFile('<testcase name="testMakeUnexpectedAssertion" class="UselessTest" file="');
+        $I->seeInThisFile('Risky Test');
+
+        $I->seeFileFound('phpunit-report.xml', 'tests/_output');
+        $I->seeInThisFile(
+            "<testsuite name=\"unit\" tests=\"4\" assertions=\"$assertions\" errors=\"$useless\" failures=\"0\" skipped=\"$skipped\" time=\""
+        );
+        // $I->seeInThisFile('<testcase name="Useless"');
+        // $I->seeInThisFile('<testcase name="makeNoAssertions" class="UselessCest"');
+        $I->seeInThisFile('<testcase name="testMakeNoAssertions" class="UselessTest" file="');
+        $I->seeInThisFile('<testcase name="testMakeUnexpectedAssertion" class="UselessTest" file="');
+        $I->seeInThisFile('Risky Test');
+
+        $I->seeFileFound('report.html', 'tests/_output');
+        $I->seeInThisFile('<td class="scenarioUseless">Useless scenarios:</td>');
+        $I->seeInThisFile("<td class=\"scenarioUselessValue\"><strong>$useless</strong></td>");
+        $I->seeInThisFile('UselessCest');
+        $I->seeInThisFile('UselessTest');
+        $I->seeInThisFile('UselessCept');
+    }
+}

--- a/tests/cli/RunUselessTestsCest.php
+++ b/tests/cli/RunUselessTestsCest.php
@@ -5,7 +5,7 @@ class RunUselessTestsCest
     public function checkOutput(CliGuy $I)
     {
         $I->amInPath('tests/data/useless');
-        $I->executeCommand('run');
+        $I->executeCommand('run -v');
         // $I->seeInShellOutput('U UselessCept: Make no assertions');
         // $I->seeInShellOutput('U UselessCest: Make no assertions');
         $I->seeInShellOutput('U UselessTest: Make no assertions');
@@ -107,9 +107,16 @@ This test is annotated with "@doesNotPerformAssertions" but performed 1 assertio
         $I->seeInShellOutput('UselessTest: Make no assertions............................................Useless');
 
         $I->seeFileFound('report.xml', 'tests/_output');
-        $I->seeInThisFile(
-            "<testsuite name=\"unit\" tests=\"4\" assertions=\"$assertions\" errors=\"$useless\" failures=\"0\" skipped=\"$skipped\" time=\""
-        );
+
+        if (version_compare(\PHPUnit\Runner\Version::id(), '6.0.0', '>=')) {
+            $I->seeInThisFile(
+                "<testsuite name=\"unit\" tests=\"4\" assertions=\"$assertions\" errors=\"$useless\" failures=\"0\" skipped=\"$skipped\" time=\""
+            );
+        } else {
+            $I->seeInThisFile(
+                "<testsuite name=\"unit\" tests=\"4\" assertions=\"$assertions\" failures=\"0\" errors=\"2\" time=\""
+            );
+        }
         // $I->seeInThisFile('<testcase name="Useless"');
         // $I->seeInThisFile('<testcase name="makeNoAssertions" class="UselessCest"');
         $I->seeInThisFile('<testcase name="testMakeNoAssertions" class="UselessTest" file="');
@@ -117,9 +124,16 @@ This test is annotated with "@doesNotPerformAssertions" but performed 1 assertio
         $I->seeInThisFile('Risky Test');
 
         $I->seeFileFound('phpunit-report.xml', 'tests/_output');
-        $I->seeInThisFile(
-            "<testsuite name=\"unit\" tests=\"4\" assertions=\"$assertions\" errors=\"$useless\" failures=\"0\" skipped=\"$skipped\" time=\""
-        );
+
+        if (version_compare(\PHPUnit\Runner\Version::id(), '6.0.0', '>=')) {
+            $I->seeInThisFile(
+                "<testsuite name=\"unit\" tests=\"4\" assertions=\"$assertions\" errors=\"$useless\" failures=\"0\" skipped=\"$skipped\" time=\""
+            );
+        } else {
+            $I->seeInThisFile(
+                "<testsuite name=\"unit\" tests=\"4\" assertions=\"$assertions\" failures=\"0\" errors=\"2\" time=\""
+            );
+        }
         // $I->seeInThisFile('<testcase name="Useless"');
         // $I->seeInThisFile('<testcase name="makeNoAssertions" class="UselessCest"');
         $I->seeInThisFile('<testcase name="testMakeNoAssertions" class="UselessTest" file="');

--- a/tests/data/useless/codeception.yml
+++ b/tests/data/useless/codeception.yml
@@ -1,0 +1,11 @@
+paths:
+  tests: tests
+  output: tests/_output
+  data: tests/_data
+  support: tests/_support
+  envs: tests/_envs
+actor_suffix: Tester
+settings:
+  log_incomplete_skipped: true
+  report_useless_tests: true
+  colors: false

--- a/tests/data/useless/tests/_output/.gitignore
+++ b/tests/data/useless/tests/_output/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/tests/data/useless/tests/_support/UnitTester.php
+++ b/tests/data/useless/tests/_support/UnitTester.php
@@ -1,0 +1,26 @@
+<?php
+
+
+/**
+ * Inherited Methods
+ * @method void wantToTest($text)
+ * @method void wantTo($text)
+ * @method void execute($callable)
+ * @method void expectTo($prediction)
+ * @method void expect($prediction)
+ * @method void amGoingTo($argumentation)
+ * @method void am($role)
+ * @method void lookForwardTo($achieveValue)
+ * @method void comment($description)
+ * @method \Codeception\Lib\Friend haveFriend($name, $actorClass = NULL)
+ *
+ * @SuppressWarnings(PHPMD)
+*/
+class UnitTester extends \Codeception\Actor
+{
+    use _generated\UnitTesterActions;
+
+   /**
+    * Define custom actions here
+    */
+}

--- a/tests/data/useless/tests/_support/_generated/.gitignore
+++ b/tests/data/useless/tests/_support/_generated/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/tests/data/useless/tests/unit.suite.yml
+++ b/tests/data/useless/tests/unit.suite.yml
@@ -1,0 +1,1 @@
+actor: UnitTester

--- a/tests/data/useless/tests/unit/UselessCept.php
+++ b/tests/data/useless/tests/unit/UselessCept.php
@@ -1,0 +1,3 @@
+<?php
+$I = new UnitTester($scenario);
+$I->wantTo('make no assertions');

--- a/tests/data/useless/tests/unit/UselessCest.php
+++ b/tests/data/useless/tests/unit/UselessCest.php
@@ -1,0 +1,9 @@
+<?php
+
+class UselessCest
+{
+    public function makeNoAssertions(UnitTester $I)
+    {
+        $I->comment('make no assertions');
+    }
+}

--- a/tests/data/useless/tests/unit/UselessTest.php
+++ b/tests/data/useless/tests/unit/UselessTest.php
@@ -1,0 +1,23 @@
+<?php
+
+class UselessTest extends \Codeception\Test\Unit
+{
+    /**
+     * @var \UnitTester
+     */
+    protected $tester;
+
+    public function testMakeNoAssertions()
+    {
+
+    }
+
+    public function testMakeUnexpectedAssertion()
+    {
+        if (version_compare(\PHPUnit\Runner\Version::id(), '7.2.0', '<')) {
+            $this->markTestSkipped('Not supported before PHPUnit 7.2');
+        }
+        $this->expectNotToPerformAssertions();
+        $this->assertTrue(true);
+    }
+}


### PR DESCRIPTION
Only unit tests are supported
Status U is printed in standard output

Depends on https://github.com/Codeception/phpunit-wrapper/pull/100

Before:
![image](https://user-images.githubusercontent.com/395992/168530392-6f66dd69-c520-4e94-8e85-24371572f239.png)

After:
![image](https://user-images.githubusercontent.com/395992/168530598-c6ba3cd2-b564-4f47-bab9-76c01c4b60fa.png)

Linked pull request will fix printing test summary for `--report` too:
![image](https://user-images.githubusercontent.com/395992/168530846-df7f32b6-36e3-481f-b6ba-c91b091e5c2a.png)