### PR TITLE
Execute beforeClass and afterClass hooks for Cest format

### DIFF
--- a/src/Codeception/Subscriber/BeforeAfterTest.php
+++ b/src/Codeception/Subscriber/BeforeAfterTest.php
@@ -4,8 +4,10 @@ declare(strict_types=1);
 
 namespace Codeception\Subscriber;
 
+use Codeception\Actor;
 use Codeception\Event\SuiteEvent;
 use Codeception\Events;
+use Codeception\Test\Cest;
 use Codeception\Test\Test;
 use Codeception\Test\TestCaseWrapper;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
@@ -39,15 +41,34 @@ class BeforeAfterTest implements EventSubscriberInterface
         }
     }
 
+    /**
+     * @param string[] $methods
+     */
     private function executeMethods(Test $test, array $methods): void
     {
+        if ($methods === []) {
+            return;
+        }
         if ($test instanceof TestCaseWrapper) {
             $test = $test->getTestCase();
         }
 
-        foreach ($methods as $method) {
-            if (is_callable([$test, $method])) {
-                call_user_func([$test, $method]);
+        if ($test instanceof Cest) {
+            $actorClass = $test->getMetadata()->getCurrent('actor');
+            $scenario = $test->getScenario();
+            $actor = new $actorClass($scenario);
+            $testInstance = $test->getTestInstance();
+
+            foreach ($methods as $method) {
+                if (is_callable([$testInstance, $method])) {
+                    call_user_func([$testInstance, $method], $actor, $scenario);
+                }
+            }
+        } else {
+            foreach ($methods as $method) {
+                if (is_callable([$test, $method])) {
+                    call_user_func([$test,$method]);
+                }
             }
         }
     }

--- a/src/Codeception/Test/Loader/Cest.php
+++ b/src/Codeception/Test/Loader/Cest.php
@@ -7,6 +7,7 @@ namespace Codeception\Test\Loader;
 use Codeception\Lib\Parser;
 use Codeception\Test\Cest as CestFormat;
 use Codeception\Test\DataProvider;
+use Codeception\Util\Annotation;
 use ReflectionClass;
 
 use function get_class_methods;
@@ -46,6 +47,24 @@ class Cest implements LoaderInterface
             $unit = new $testClass();
 
             $methods = get_class_methods($testClass);
+
+            $beforeClassMethods = [];
+            $afterClassMethods = [];
+
+            foreach ($methods as $methodName) {
+                $methodAnnotations = Annotation::forMethod($testClass, $methodName);
+
+                $beforeClassAnnotation = $methodAnnotations->fetch('beforeClass');
+                if ($beforeClassAnnotation !== null) {
+                    $beforeClassMethods [] = $methodName;
+                }
+
+                $afterClassAnnotation = $methodAnnotations->fetch('afterClass');
+                if ($afterClassAnnotation !== null) {
+                    $afterClassMethods [] = $methodName;
+                }
+            }
+
             foreach ($methods as $method) {
                 if (str_starts_with($method, '_')) {
                     continue;
@@ -54,17 +73,20 @@ class Cest implements LoaderInterface
                 $examples = DataProvider::getDataForMethod(new \ReflectionMethod($testClass, $method));
 
                 if ($examples === null) {
-                    $this->tests[] = new CestFormat($unit, $method, $filename);
-                    continue;
-                }
-
-                foreach ($examples as $i => $example) {
                     $test = new CestFormat($unit, $method, $filename);
-                    $test->getMetadata()->setCurrent(['example' => $example]);
-                    $test->getMetadata()->setIndex($i);
                     $this->tests[] = $test;
+                } else {
+                    foreach ($examples as $i => $example) {
+                        $test = new CestFormat($unit, $method, $filename);
+                        $test->getMetadata()->setCurrent(['example' => $example]);
+                        $test->getMetadata()->setIndex($i);
+                        $this->tests[] = $test;
+                    }
                 }
             }
+
+            $test->getMetadata()->setBeforeClassMethods($beforeClassMethods);
+            $test->getMetadata()->setAfterClassMethods($afterClassMethods);
         }
     }
 }

--- a/tests/cli/ConfigParamsCest.php
+++ b/tests/cli/ConfigParamsCest.php
@@ -2,21 +2,31 @@
 
 declare(strict_types=1);
 
+use Codeception\Attribute\AfterClass;
 use Codeception\Attribute\Before;
+use Codeception\Attribute\BeforeClass;
 
 final class ConfigParamsCest
 {
+    #[BeforeClass]
+    public function _beforeClass(CliGuy $I)
+    {
+        $I->amInPath(codecept_root_dir('tests/data/params'));
+        $I->executeCommand('build');
+        $I->amInPath(codecept_root_dir());
+    }
+
+    #[AfterClass]
+    public function _afterClass(CliGuy $I)
+    {
+        $I->amInPath(codecept_root_dir('tests/data/params'));
+        $I->executeCommand('clean');
+        $I->amInPath(codecept_root_dir());
+    }
+
     private function moveToTestDir(CliGuy $I): void
     {
-        static $prepared = false;
-
         $I->amInPath('tests/data/params');
-
-        if ($prepared) {
-            return;
-        }
-        $I->executeCommand('build');
-        $prepared = true;
     }
 
     #[Before('moveToTestDir')]

--- a/tests/data/params/codeception.yml
+++ b/tests/data/params/codeception.yml
@@ -1,8 +1,8 @@
 actor: Tester
 paths:
     tests: tests
-    output: .
-    data: .
+    output: tests/_output
+    data: tests/_data
     support: tests/_support
 params:
     - environment

--- a/tests/support/CliHelper.php
+++ b/tests/support/CliHelper.php
@@ -20,7 +20,7 @@ class CliHelper extends \Codeception\Module
     {
         codecept_debug('deleting dirs');
         $this->getModule('Filesystem')->deleteDir(codecept_data_dir() . 'sandbox');
-        chdir(\Codeception\Configuration::projectDir());
+        $this->getModule('Filesystem')->amInPath(codecept_root_dir());
     }
 
     public function executeCommand($command, bool $fail = true, $phpOptions = '')


### PR DESCRIPTION
I was looking at [Subscriber\BeforeAfterTest](https://github.com/Codeception/Codeception/blob/0355833627f27bcf1b8e995bdd8de20ecaf3bd8b/src/Codeception/Subscriber/BeforeAfterTest.php) for another issue and realized that it wouldn't be too difficult to implement beforeClass and afterClass hooks for Cest format.

It would probably be good to implement attributes too.

Closes https://github.com/Codeception/Codeception/issues/5164