### PR TITLE
Execute before/after class hooks only once

### DIFF
--- a/src/Codeception/Subscriber/BeforeAfterTest.php
+++ b/src/Codeception/Subscriber/BeforeAfterTest.php
@@ -20,6 +20,8 @@ class BeforeAfterTest implements EventSubscriberInterface
 
     public function beforeClass(SuiteEvent $e)
     {
+        $this->hooks = [];
+
         foreach ($e->getSuite()->tests() as $test) {
             /** @var $test \PHPUnit\Framework\Test  * */
             $testClass = get_class($test);

--- a/tests/cli/OrderCest.php
+++ b/tests/cli/OrderCest.php
@@ -114,4 +114,15 @@ class OrderCest
         $I->seeFileFound('order.txt', 'tests/_output');
         $I->seeInThisFile('BIBP(T)');
     }
+
+    public function checkAfterBeforeHooksAreExecutedOnlyOnce(CliGuy $I)
+    {
+        $I->amInPath('tests/data/sandbox');
+        $I->executeCommand('run math,order,scenario,skipped :BeforeAfterClassTest');
+        $I->seeFileFound('order.txt', 'tests/_output');
+        // Codeception 4 executes beforeClass hooks of all classes in TestSuite
+        // Codeception 5 - only matching
+        $I->seeInThisFile('BIBP({{{{[1][2]}}}})');
+        // $I->seeInThisFile('BIB({[1][2]})'); // Codeception 5 behaviour
+    }
 }


### PR DESCRIPTION
Fixes #5416