### PR TITLE
added support to binary data

### DIFF
--- a/src/Codeception/Module.php
+++ b/src/Codeception/Module.php
@@ -245,7 +245,7 @@ abstract class Module
     protected function debugSection(string $title, mixed $message): void
     {
         if (is_array($message) || is_object($message)) {
-            $message = stripslashes(json_encode($message, JSON_THROW_ON_ERROR));
+            $message = stripslashes(json_encode($message, JSON_THROW_ON_ERROR | JSON_INVALID_UTF8_SUBSTITUTE));
         }
         $this->debug("[{$title}] {$message}");
     }

--- a/src/Codeception/Step.php
+++ b/src/Codeception/Step.php
@@ -177,7 +177,7 @@ abstract class Step implements Stringable
                 $argument = $this->getClassName($argument);
             }
         }
-        $arg_str = json_encode($argument, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
+        $arg_str = json_encode($argument, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_INVALID_UTF8_SUBSTITUTE);
         return str_replace('\"', '"', $arg_str);
     }
 


### PR DESCRIPTION
In test data providers, there may be binary data (example inet_pton result) that causes a json encoding error, since the JSON_THROW_ON_ERROR flag is added and strict_types=1 (by the way, this problem may occur in other Codeception modules, such as Codeception/module-db)