### PR TITLE
Inject dependencies to actor in Cest and Gherkin formats

### DIFF
--- a/src/Codeception/Test/Cest.php
+++ b/src/Codeception/Test/Cest.php
@@ -7,6 +7,7 @@ namespace Codeception\Test;
 use Codeception\Example;
 use Codeception\Exception\ConfigurationException;
 use Codeception\Lib\Console\Message;
+use Codeception\Lib\Di;
 use Codeception\Lib\Parser;
 use Codeception\Step\Comment;
 use Codeception\Util\Annotation;
@@ -113,7 +114,11 @@ class Cest extends Test implements
             );
         }
 
-        $I = new $actorClass($this->getScenario());
+        /** @var Di $di */
+        $di = $this->getMetadata()->getService('di');
+        $di->set($this->getScenario());
+        $I = $di->instantiate($actorClass);
+
         try {
             $this->executeHook($I, 'before');
             $this->executeBeforeMethods($this->testMethod, $I);

--- a/src/Codeception/Test/Gherkin.php
+++ b/src/Codeception/Test/Gherkin.php
@@ -191,7 +191,7 @@ class Gherkin extends Test implements ScenarioDriven, Reported
 
         $actorClass = $this->getMetadata()->getCurrent('actor');
         if ($actorClass) {
-            $di->set(new $actorClass($this->getScenario()));
+            $di->instantiate($actorClass);
         }
 
         foreach ($this->steps as $pattern => $step) {


### PR DESCRIPTION
Fixes #4947

[Unit format](https://github.com/Codeception/Codeception/blob/6021a4a7e7f7351a3c187ff6b8761f49a0d83ce6/src/Codeception/Test/Unit.php#L70-L77) injected dependencies to actor class already, so it was easy to make Gherkin and Cest formats work in the same way. 