### PR TITLE
Not powered by PHPUnit

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -11,7 +11,6 @@
 
 Codeception is a modern full-stack testing framework for PHP.
 Inspired by BDD, it provides an absolutely new way of writing acceptance, functional and even unit tests.
-Powered by PHPUnit.
 
 | Build | Webdriver  |
 | ----- | -------- |

--- a/src/Codeception/Command/Run.php
+++ b/src/Codeception/Command/Run.php
@@ -10,7 +10,6 @@ use Codeception\Exception\ConfigurationException;
 use Codeception\Exception\ParseException;
 use Exception;
 use InvalidArgumentException;
-use PHPUnit\Runner\Version as PHPUnitVersion;
 use RuntimeException;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Exception\InvalidArgumentException as SymfonyConsoleInvalidArgumentException;
@@ -291,8 +290,7 @@ class Run extends Command
 
         if (!$this->options['silent']) {
             $this->output->writeln(
-                Codecept::versionString() . " https://helpukrainewin.org\nPowered by "
-                . PHPUnitVersion::getVersionString()
+                Codecept::versionString() . ' https://helpukrainewin.org'
             );
 
             if ($this->options['seed']) {

--- a/tests/cli/DataProviderFailuresAndExceptionsCest.php
+++ b/tests/cli/DataProviderFailuresAndExceptionsCest.php
@@ -27,7 +27,7 @@ final class DataProviderFailuresAndExceptionsCest
         $devNull = (DIRECTORY_SEPARATOR === '\\') ? 'NUL' : '/dev/null';
         $I->executeCommand('run -n -v unit DataProvidersFailureCest 2> ' . $devNull, false);
         // We should only see the version headers in stdout when there is this kind of failure.
-        $I->canSeeShellOutputMatches('#^Codeception PHP Testing Framework v.+\nPowered by PHPUnit .+#');
+        $I->canSeeShellOutputMatches('#^Codeception PHP Testing Framework v.+#');
         $I->seeResultCodeIs(1);
     }
 
@@ -95,7 +95,7 @@ final class DataProviderFailuresAndExceptionsCest
         $devNull = (DIRECTORY_SEPARATOR === '\\') ? 'NUL' : '/dev/null';
         $I->executeCommand('run -n unit DataProvidersExceptionCest -v 2> ' . $devNull, false);
         // Depending on the test environment, we either see nothing or just the headers here.
-        $I->canSeeShellOutputMatches('#^Codeception PHP Testing Framework v.+\nPowered by PHPUnit .+#');
+        $I->canSeeShellOutputMatches('#^Codeception PHP Testing Framework v.+#');
         $I->seeResultCodeIs(1);
     }
 


### PR DESCRIPTION
Initially Codeception was a wrapper for PHPUnit with additional test formats and modules. Test orchestration and reporting was performed by PHPUnit code.

This is no longer the case in Codeception 5, the role of PHPUnit was reduced to provider of assertions, also PHPUnit TestCase test format is supported. We use a few utility classes too - `PHPUnit\Runner\Version` class to implement compatibility with PHPUnit 9 and 10, `PHPUnit\Util\Test` to get linesToBeCovered and LinesToBeUsed and we catch and throw a few PHPUnit exceptions.

We use `phpunit/php-code-coverage` and `sebastian/diff` libraries too, but Codeception 5 is no longer powered by PHPUnit, we have our own engine :)