### PR TITLE
Fixed false negative message about missing stecman/symfony-console-completion packege

### DIFF
--- a/src/Codeception/Command/Completion.php
+++ b/src/Codeception/Command/Completion.php
@@ -4,12 +4,6 @@ declare(strict_types=1);
 
 namespace Codeception\Command;
 
-// phpcs:ignoreFile PSR1.Files.SideEffects.FoundWithSymbols
-if (!class_exists(ConsoleCompletion::class)) {
-    echo "Please install `stecman/symfony-console-completion\n` to enable auto completion";
-    return;
-}
-
 use Codeception\Configuration;
 use Stecman\Component\Symfony\Console\BashCompletion\Completion as ConsoleCompletion;
 use Stecman\Component\Symfony\Console\BashCompletion\Completion\CompletionInterface as ConsoleCompletionInterface;
@@ -20,6 +14,12 @@ use Symfony\Component\Console\Input\InputDefinition as SymfonyInputDefinition;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
+
+// phpcs:ignoreFile PSR1.Files.SideEffects.FoundWithSymbols
+if (!class_exists(ConsoleCompletion::class)) {
+    echo "Please install `stecman/symfony-console-completion\n` to enable auto completion";
+    return;
+}
 
 class Completion extends CompletionCommand
 {


### PR DESCRIPTION
`class_exists(ConsoleCompletion::class)` return always **false** in position before import class namespaces. 

The output of this message provokes a problem with establishing a session and adding session handlers.
Like this: 
```                                                            
  session_set_save_handler(): Session save handler cannot be changed after headers have already been sent  
```
