### PR TITLE
Trying to fix `vendor/bin/codecept bootstrap` command for Codeception 5

### DIFF
--- a/src/Codeception/InitTemplate.php
+++ b/src/Codeception/InitTemplate.php
@@ -248,8 +248,8 @@ abstract class InitTemplate
                     continue;
                 }
                 $package = $packages[$module];
-                $this->say(sprintf('"%s": "%s"', $package, "^1.0.0"));
-                $composer[$section][$package] = "^1.0.0";
+                $this->say(sprintf('"%s": "%s"', $package, "^3.0.0"));
+                $composer[$section][$package] = "^3.0.0";
             }
             $this->say('');
             return null;
@@ -279,7 +279,7 @@ abstract class InitTemplate
                 continue;
             }
             $this->sayInfo("Adding {$package} for {$module} to composer.json");
-            $composer[$section][$package] = "^1.0.0";
+            $composer[$section][$package] = "^3.0.0";
             ++$packageCounter;
         }
 


### PR DESCRIPTION
I don't really know what I'm doing here, so this is probably not the right way to fix it!

Anyway - when following https://codeception.com/quickstart, I'm getting v1.0.0 of module-phpbrowser and module-asserts added to `composer.json`, which aren't compatible with Codeception 5.

Output:

```
$ php vendor/bin/codecept bootstrap
 Bootstrapping Codeception 

File codeception.yml created       <- global configuration
 Adding codeception/module-phpbrowser for PhpBrowser to composer.json
 Adding codeception/module-asserts for Asserts to composer.json
2 new packages added to require-dev
? composer.json updated. Do you want to run "composer update"? (y/n) y
 Running composer update
Loading composer repositories with package information
Updating dependencies
Your requirements could not be resolved to an installable set of packages.

  Problem 1
    - codeception/module-phpbrowser[1.0.0, ..., 1.0.1] require php >=5.6.0 <8.0 -> your php version (8.1.8) does not satisfy that requirement.
    - codeception/module-phpbrowser 1.0.2 requires codeception/codeception ^4.0 -> found codeception/codeception[4.0.0, ..., 4.2.1] but it conflicts with your root composer.json require (^5.0).
    - codeception/module-phpbrowser 1.0.3 requires codeception/codeception ^4.1 -> found codeception/codeception[4.1.0, ..., 4.2.1] but it conflicts with your root composer.json require (^5.0).
    - Root composer.json requires codeception/module-phpbrowser ^1.0.0 -> satisfiable by codeception/module-phpbrowser[1.0.0, 1.0.1, 1.0.2, 1.0.3].

Use the option --with-all-dependencies (-W) to allow upgrades, downgrades and removals for packages currently locked to specific versions.
 Composer installation failed. Please check composer.json and try to run "composer update" manually

In ModuleContainer.php line 100:
                                                     
  Module Asserts is not installed.                   
  Use Composer to install corresponding package:     
                                                     
  composer require codeception/module-asserts --dev  
                                                     

bootstrap [-s|--namespace [NAMESPACE]] [-a|--actor [ACTOR]] [-e|--empty] [--] [<path>]
```