### PR TITLE
Template patches

### DIFF
--- a/src/Codeception/InitTemplate.php
+++ b/src/Codeception/InitTemplate.php
@@ -248,8 +248,8 @@ abstract class InitTemplate
                     continue;
                 }
                 $package = $packages[$module];
-                $this->say(sprintf('"%s": "%s"', $package, "^1.0.0"));
-                $composer[$section][$package] = "^1.0.0";
+                $this->say(sprintf('"%s": "%s"', $package, "*"));
+                $composer[$section][$package] = "*";
             }
             $this->say('');
             return null;
@@ -279,7 +279,7 @@ abstract class InitTemplate
                 continue;
             }
             $this->sayInfo("Adding {$package} for {$module} to composer.json");
-            $composer[$section][$package] = "^1.0.0";
+            $composer[$section][$package] = "*";
             ++$packageCounter;
         }
 

--- a/src/Codeception/Template/Acceptance.php
+++ b/src/Codeception/Template/Acceptance.php
@@ -28,7 +28,6 @@ suites:
             - Codeception\Step\TryTo
             - Codeception\Step\Retry
 
-support_namespace: Support
 extensions:
     enabled: [Codeception\Extension\RunFailed]
 

--- a/src/Codeception/Template/Acceptance.php
+++ b/src/Codeception/Template/Acceptance.php
@@ -54,7 +54,7 @@ EOF;
 
 namespace {{namespace}};
 
-use {{support_namespace}}\AcceptanceTester;
+use {{namespace}}\{{support_namespace}}\AcceptanceTester;
 
 class LoginCest 
 {    
@@ -116,7 +116,10 @@ EOF;
         $configFile = "namespace: $namespace\nsupport_namespace: {$this->supportNamespace}\n" . $configFile;
 
         $this->createFile('codeception.yml', $configFile);
-        $this->createActor('AcceptanceTester', $supportDir, Yaml::parse($configFile)['suites']['acceptance']);
+
+        $settings = Yaml::parse($configFile)['suites']['acceptance'];
+        $settings['support_namespace'] = $this->supportNamespace;
+        $this->createActor('AcceptanceTester', $supportDir, $settings);
 
         $this->sayInfo("Created global config codeception.yml inside the root directory");
         $this->createFile(

--- a/src/Codeception/Template/Api.php
+++ b/src/Codeception/Template/Api.php
@@ -40,7 +40,7 @@ EOF;
 <?php
 namespace {{namespace}};
 
-use {{support_namespace}}\ApiTester;
+use {{namespace}}\{{support_namespace}}\ApiTester;
 
 class ApiCest 
 {    
@@ -84,7 +84,9 @@ EOF;
         $configFile = "namespace: $namespace\nsupport_namespace: {$this->supportNamespace}\n" . $configFile;
 
         $this->createFile('codeception.yml', $configFile);
-        $this->createActor('ApiTester', $supportDir, Yaml::parse($configFile)['suites']['api']);
+        $settings = Yaml::parse($configFile)['suites']['api'];
+        $settings['support_namespace'] = $this->supportNamespace;
+        $this->createActor('ApiTester', $supportDir, $settings);
 
         $this->sayInfo("Created global config codeception.yml inside the root directory");
 

--- a/src/Codeception/Template/Api.php
+++ b/src/Codeception/Template/Api.php
@@ -14,7 +14,7 @@ class Api extends InitTemplate
     protected string $configTemplate = <<<EOF
 # suite config
 suites:
-    Api:
+    api:
         actor: ApiTester
         path: .
         modules:

--- a/src/Codeception/Template/Unit.php
+++ b/src/Codeception/Template/Unit.php
@@ -73,7 +73,9 @@ EOF;
         }
 
         if ($haveTester) {
-            $this->createActor('UnitTester', $supportDir, Yaml::parse($configFile)['suites']['unit']);
+            $settings = Yaml::parse($configFile)['suites']['unit'];
+            $settings['support_namespace'] = $this->supportNamespace;
+            $this->createActor('UnitTester', $supportDir, $settings);
         }
 
         $this->gitIgnore($outputDir);

--- a/tests/unit/Codeception/Command/BuildTest.php
+++ b/tests/unit/Codeception/Command/BuildTest.php
@@ -50,4 +50,15 @@ class BuildTest extends BaseCommandRunner
         $this->assertStringContainsString('use _generated\HobbitGuyActions;', $this->content);
         $this->assertIsValidPhp($this->content);
     }
+
+    public function testBuildNamespacedActorInSupportNamespace()
+    {
+        $this->config['namespace'] = 'Shire';
+        $this->config['support_namespace'] = 'Support';
+        $this->execute();
+        $this->assertStringContainsString('namespace Shire\Support;', $this->content);
+        $this->assertStringContainsString('class HobbitGuy extends \Codeception\Actor', $this->content);
+        $this->assertStringContainsString('use _generated\HobbitGuyActions;', $this->content);
+        $this->assertIsValidPhp($this->content);
+    }
 }


### PR DESCRIPTION
I tested template functionality and fixed 5 issues:

* Templates added incompatible versions of modules to composer.json
* `codecept init Acceptance` generated invalid codeception.yml file with 2 `support_namespace` settings
* `codecept init Api` generated codeception.yml with suite name `Api` and crashed (single suite commands all generate suite names in lowercase`.
* Acceptance, Api and Unit templates generated Actor files not in Support namespace.
* Acceptance and Api templates generated first test with incorrect `use` statement.

Fixes #6542 
Replaces #6545