### PR TITLE
Docker Image Makeover

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,81 +1,55 @@
-FROM php:8.1-cli
+ARG flavor=bullseye
+
+FROM php:8.1-cli-${flavor}
 
 LABEL maintainer="Tobias Munk <tobias@diemeisterei.de>"
 
-# Install required system packages
-RUN apt-get update && \
-    apt-get -y install \
-            git \
-            zlib1g-dev \
-            libmemcached-dev \
-            libpq-dev \
-            libssl-dev \
-            libxml2-dev \
-            libzip-dev \
-            unzip \
-        --no-install-recommends && \
-        apt-get clean && \
-        rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+COPY --from=mlocati/php-extension-installer /usr/bin/install-php-extensions /usr/local/bin/
 
-# Install php extensions
-RUN docker-php-ext-install \
-    bcmath \
-    mysqli \
-    pdo pdo_mysql pdo_pgsql \
-    soap \
-    sockets \
-    zip
-
-# Install pecl extensions
-RUN pecl install \
-        apcu \
-        memcached \
-        mongodb \
+RUN set -eux; \
+    install-php-extensions \
+        bcmath \
+        mysqli \
+        pdo pdo_mysql pdo_pgsql \
         soap \
-        xdebug && \
-    docker-php-ext-enable \
-        apcu.so \
-        memcached.so \
-        mongodb.so \
-        soap.so \
-        xdebug
+        sockets \
+        zip \
+        apcu-stable \
+        memcached-stable \
+        mongodb-stable \
+        xdebug-stable \
+        # and composer \
+        @composer; \
+    # Configure php \
+    echo "date.timezone = UTC" >> /usr/local/etc/php/php.ini;
 
-# Configure php
-RUN echo "date.timezone = UTC" >> /usr/local/etc/php/php.ini
+ENV COMPOSER_ALLOW_SUPERUSER '1'
 
-# Install composer
-ENV COMPOSER_ALLOW_SUPERUSER=1
-RUN curl -sS https://getcomposer.org/installer | php -- \
-        --filename=composer \
-        --install-dir=/usr/local/bin
+WORKDIR /codecept
 
-# Add source-code
-COPY . /repo
+# Install codeception
+RUN set -eux; \
+    composer require --no-update \
+        codeception/codeception \
+        codeception/module-apc \
+        codeception/module-asserts \
+        codeception/module-cli \
+        codeception/module-db \
+        codeception/module-filesystem \
+        codeception/module-ftp \
+        codeception/module-memcache \
+        codeception/module-mongodb \
+        codeception/module-phpbrowser \
+        codeception/module-redis \
+        codeception/module-rest \
+        codeception/module-sequence \
+        codeception/module-soap \
+        codeception/module-webdriver; \
+    composer update --no-dev --prefer-dist --no-interaction --optimize-autoloader --apcu-autoloader; \
+    ln -s /codecept/vendor/bin/codecept /usr/local/bin/codecept; \
+    mkdir /project;
 
-# Prepare application
-WORKDIR /repo
-
-# Install modules
-RUN composer require --no-update \
-codeception/module-apc \
-codeception/module-asserts \
-codeception/module-cli \
-codeception/module-db \
-codeception/module-filesystem \
-codeception/module-ftp \
-codeception/module-memcache \
-codeception/module-mongodb \
-codeception/module-phpbrowser \
-codeception/module-redis \
-codeception/module-rest \
-codeception/module-sequence \
-codeception/module-soap \
-codeception/module-webdriver && \
-composer update --no-dev --prefer-dist --no-interaction --optimize-autoloader --apcu-autoloader
-
-ENV PATH /repo:${PATH}
 ENTRYPOINT ["codecept"]
 
 # Prepare host-volume working directory
-RUN mkdir /project
 WORKDIR /project


### PR DESCRIPTION
The current `codeception/codeception` Docker image is huge (707.46 MB), I've tried to reduce the size a bit.

By utilizing https://github.com/mlocati/docker-php-extension-installer (which uninstalls unneccessary packages after extension install) and layer optimization I've created two flavors of the image:

* debian bullseye based: 486.36 MB (`docker pull djbasster/codeception:latest`)
* alpine based: 158.49 MB (`docker pull djbasster/codeception:latest-alpine`)

My images are also multi-arch images (amd64/arm64) to run natively on Apple Silicone, as well.

I've used the following script to build:

```bash
#!/usr/bin/env sh

architecture=$(arch)
image=djbasster/codeception:latest

if [ "$architecture" = "arm64" ] || [ "$CI" = true ]; then
    docker buildx build \
        --platform linux/arm64/v8,linux/amd64 \
        --no-cache --pull \
        -t "${image}" \
        --push .
        
    docker buildx build \
          --platform linux/arm64/v8,linux/amd64 \
          --no-cache --pull \
          --build-arg flavor=alpine \
          -t "${image}-alpine" \
          --push .
else
    docker build --no-cache --pull -t "${image}" .
    docker build --no-cache --pull --build-arg flavor=alpine -t "${image}-alpine" .
    docker push "${image}"
    docker push "${image}-alpine"
fi
```

Maybe you can adopt it to github actions. I'm more of a GitLab-CI guy 😉

Feedback appreciated.
