### PR TITLE
Fix PHPUnit 10 compatibility

### DIFF
--- a/src/Codeception/Exception/Deprecation.php
+++ b/src/Codeception/Exception/Deprecation.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Codeception\Exception;
+
+class Deprecation extends Error
+{
+}

--- a/src/Codeception/Exception/Error.php
+++ b/src/Codeception/Exception/Error.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Codeception\Exception;
+
+use Exception;
+
+class Error extends Exception
+{
+    public function __construct(string $message, int $code, string $file, int $line, \Exception $previous = null)
+    {
+        parent::__construct($message, $code, $previous);
+
+        $this->file = $file;
+        $this->line = $line;
+    }
+}

--- a/src/Codeception/Exception/Notice.php
+++ b/src/Codeception/Exception/Notice.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Codeception\Exception;
+
+class Notice extends Error
+{
+}

--- a/src/Codeception/Exception/Warning.php
+++ b/src/Codeception/Exception/Warning.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Codeception\Exception;
+
+class Warning extends Error
+{
+}

--- a/src/Codeception/Subscriber/ErrorHandler.php
+++ b/src/Codeception/Subscriber/ErrorHandler.php
@@ -4,6 +4,10 @@ declare(strict_types=1);
 
 namespace Codeception\Subscriber;
 
+use Codeception\Exception\Deprecation;
+use Codeception\Exception\Error;
+use Codeception\Exception\Notice;
+use Codeception\Exception\Warning;
 use Codeception\Event\SuiteEvent;
 use Codeception\Events;
 use Codeception\Lib\Notification;
@@ -12,10 +16,6 @@ use PHPUnit\Framework\Error\Error as PHPUnit9Error;
 use PHPUnit\Framework\Error\Notice as PHPUnit9Notice;
 use PHPUnit\Framework\Error\Warning as PHPUnit9Warning;
 use PHPUnit\Runner\Version as PHPUnitVersion;
-use PHPUnit\Util\Error\Deprecation as PHPUnit10Deprecation;
-use PHPUnit\Util\Error\Error as PHPUnit10Error;
-use PHPUnit\Util\Error\Notice as PHPUnit10Notice;
-use PHPUnit\Util\Error\Warning as PHPUnit10Warning;
 use Symfony\Bridge\PhpUnit\DeprecationErrorHandler as SymfonyDeprecationErrorHandler;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
@@ -127,11 +127,12 @@ class ErrorHandler implements EventSubscriberInterface
                 default => new PHPUnit9Error($errMsg, $errNum, $errFile, $errLine),
             };
         } else {
+            $errMsg .= ' at ' . $errFile . ':' . $errLine;
             throw match ($errNum) {
-                E_DEPRECATED, E_USER_DEPRECATED => new PHPUnit10Deprecation($errMsg, $errNum, $errFile, $errLine),
-                E_NOTICE, E_STRICT, E_USER_NOTICE => new PHPUnit10Notice($errMsg, $errNum, $errFile, $errLine),
-                E_WARNING, E_USER_WARNING => new PHPUnit10Warning($errMsg, $errNum, $errFile, $errLine),
-                default => new PHPUnit10Error($errMsg, $errNum, $errFile, $errLine),
+                E_DEPRECATED, E_USER_DEPRECATED => new Deprecation($errMsg, $errNum, $errFile, $errLine),
+                E_NOTICE, E_STRICT, E_USER_NOTICE => new Notice($errMsg, $errNum, $errFile, $errLine),
+                E_WARNING, E_USER_WARNING => new Warning($errMsg, $errNum, $errFile, $errLine),
+                default => new Error($errMsg, $errNum, $errFile, $errLine),
             };
         }
     }

--- a/tests/cli/ErrorExpectationsCest.php
+++ b/tests/cli/ErrorExpectationsCest.php
@@ -2,8 +2,11 @@
 
 class ErrorExpectationsCest
 {
-    public function _before(\CliGuy $I)
+    public function _before(\CliGuy $I, \Codeception\Scenario $scenario)
     {
+        if (\PHPUnit\Runner\Version::series() > 9) {
+            $scenario->skip('Error expectations are not supported on PHPUnit 10');
+        }
         $I->amInPath('tests/data/error_handling');
     }
 

--- a/tests/unit/Codeception/Subscriber/ErrorHandlerTest.php
+++ b/tests/unit/Codeception/Subscriber/ErrorHandlerTest.php
@@ -3,9 +3,11 @@
 declare(strict_types=1);
 
 use Codeception\Event\SuiteEvent;
+use Codeception\Exception\Warning;
 use Codeception\Lib\Notification;
 use Codeception\Subscriber\ErrorHandler;
 use Codeception\Suite;
+use PHPUnit\Runner\Version;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 
 class ErrorHandlerTest extends \Codeception\PHPUnit\TestCase
@@ -46,8 +48,13 @@ class ErrorHandlerTest extends \Codeception\PHPUnit\TestCase
 
     public function testShowsLocationOfWarning()
     {
-        $this->expectWarning();
-        $this->expectWarningMessage('Undefined variable: file');
+        if (Version::series() < 10) {
+            $this->expectWarning();
+            $this->expectWarningMessage('Undefined variable: file');
+        } else {
+            $this->expectException(Warning::class);
+            $this->expectExceptionMessageMatches('/Undefined variable: file at ' . preg_quote(__FILE__, '/') . ':58/');
+        }
         trigger_error('Undefined variable: file', E_USER_WARNING);
     }
 }


### PR DESCRIPTION
Error exceptions have been removed from PHPUnit 10,

Error expectations (`expectDeprecation*()`, `expectError*()`, `expectNotice*()`, and `expectWarning*()`) won't be supported
`expectException*()` can be used instead.

P.S. There is non-zero possibility that `expectException` will be broken later, if it happens we can reimplement all these methods in `Codeception\Test\Unit`, but method names must be different.
P.P.S. There is non-zero possibility that some future change will be so big that Codeception won't be able to support PHPUnit 10.