### PR TITLE
Fix remote code coverage for namespaced suites

### DIFF
--- a/src/Codeception/Configuration.php
+++ b/src/Codeception/Configuration.php
@@ -331,7 +331,7 @@ class Configuration
     {
         // cut namespace name from suite name
         if ($suite != $config['namespace'] && str_starts_with($suite, $config['namespace'])) {
-            $suite = substr($suite, strlen($config['namespace']));
+            $suite = ltrim(substr($suite, strlen($config['namespace'])), '.');
         }
 
         if (!in_array($suite, self::$suites)) {


### PR DESCRIPTION
Fixes #6533
Fixes #6519

If the test is namespaced, Suite basename is in dot separated format "NAMESPACE.SUITE", e.g. "Tests.acceptance".
When c3.php calls `Configuration::suiteSettings`, it removes namespace, but leaves the dot: https://github.com/Codeception/Codeception/blob/5.0.1/src/Codeception/Configuration.php#L332-L335
and throws exception `Suite .acceptance was not loaded`

Removing the dot solves the problem.