### PR TITLE
Fixed issue when include groups and test groups empty

### DIFF
--- a/src/Codeception/Test/Filter.php
+++ b/src/Codeception/Test/Filter.php
@@ -96,7 +96,7 @@ class Filter
 
     public function isGroupAccepted(Test $test, array $groups): bool
     {
-        if ($this->includeGroups !== null && count(\array_intersect($groups, $this->includeGroups)) === 0) {
+        if ($this->includeGroups !== null && $this->includeGroups !== [] && count(\array_intersect($groups, $this->includeGroups)) === 0) {
             return false;
         }
         if ($this->excludeGroups !== null && count(\array_intersect($groups, $this->excludeGroups)) > 0) {

--- a/src/Codeception/Test/Filter.php
+++ b/src/Codeception/Test/Filter.php
@@ -99,7 +99,7 @@ class Filter
         if ($this->includeGroups !== null && $this->includeGroups !== [] && count(\array_intersect($groups, $this->includeGroups)) === 0) {
             return false;
         }
-        if ($this->excludeGroups !== null && count(\array_intersect($groups, $this->excludeGroups)) > 0) {
+        if ($this->excludeGroups !== null && $this->excludeGroups !== [] && count(\array_intersect($groups, $this->excludeGroups)) > 0) {
             return false;
         }
 


### PR DESCRIPTION
Had some bug in my own custom command 
When we have included groups as an empty array and the test don't have any groups isGroupAccepted is always false. 
Example
```
count(array_intersect([], [])) === 0) 
```