### PR TITLE
PHPUnit 10 compatibility: Stop using ErrorTestCase in Unit Loader

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,6 +37,7 @@ jobs:
       extensions: curl, mbstring, openssl, pdo, pdo_sqlite
       SYMFONY_DEPRECATIONS_HELPER: weak
       COMPOSER_ROOT_VERSION: 5.0.99
+      COLUMNS: 120
 
     runs-on: ${{ matrix.os }}
 

--- a/src/Codeception/Exception/InvalidTestException.php
+++ b/src/Codeception/Exception/InvalidTestException.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Codeception\Exception;
+
+use Exception;
+
+class InvalidTestException extends Exception
+{
+}

--- a/src/Codeception/Test/DataProvider.php
+++ b/src/Codeception/Test/DataProvider.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Codeception\Test;
 
+use Codeception\Exception\InvalidTestException;
 use Codeception\Exception\TestParseException;
 use Codeception\Util\Annotation;
 use Codeception\Util\ReflectionHelper;
@@ -83,15 +84,12 @@ class DataProvider
                     }
                 }
             } catch (ReflectionException) {
-                throw new TestParseException(
-                    $testClass->getFileName(),
-                    sprintf(
-                        "DataProvider '%s' for %s->%s is invalid or not callable.\nMake sure that the data provider exist within the test class.",
-                        $dataProviderAnnotation,
-                        $testClassName,
-                        $methodName
-                    ),
-                );
+                throw new InvalidTestException(sprintf(
+                    "DataProvider '%s' for %s::%s is invalid or not callable",
+                    $dataProviderAnnotation,
+                    $testClassName,
+                    $methodName
+                ));
             }
         }
 
@@ -109,7 +107,7 @@ class DataProvider
     ): array {
         $parts = explode('::', $annotation);
         if (count($parts) > 2) {
-            throw new TestParseException(
+            throw new InvalidTestException(
                 sprintf(
                     'Data provider "%s" specified for %s::%s is invalid',
                     $annotation,

--- a/src/Codeception/Test/Filter.php
+++ b/src/Codeception/Test/Filter.php
@@ -4,9 +4,6 @@ declare(strict_types=1);
 
 namespace Codeception\Test;
 
-use PHPUnit\Framework\ErrorTestCase;
-use PHPUnit\Framework\WarningTestCase;
-
 class Filter
 {
     private ?string $namePattern = null;
@@ -79,11 +76,7 @@ class Filter
             return true;
         }
 
-        if ($test instanceof ErrorTestCase || $test instanceof WarningTestCase) {
-            $name = $test->getMessage();
-        } else {
-            $name = Descriptor::getTestSignature($test) . Descriptor::getTestDataSetIndex($test);
-        }
+        $name = Descriptor::getTestSignature($test) . Descriptor::getTestDataSetIndex($test);
 
         $accepted = preg_match($this->namePattern, $name, $matches);
 

--- a/src/Codeception/Test/Loader/Unit.php
+++ b/src/Codeception/Test/Loader/Unit.php
@@ -8,15 +8,11 @@ use Codeception\Lib\Parser;
 use Codeception\Test\DataProvider;
 use Codeception\Test\TestCaseWrapper;
 use Codeception\Util\Annotation;
-use PHPUnit\Framework\ErrorTestCase;
-use PHPUnit\Framework\IncompleteTestCase;
-use PHPUnit\Framework\SkippedTestCase;
 use PHPUnit\Framework\TestCase;
 use PHPUnit\Runner\Version as PHPUnitVersion;
 use PHPUnit\Util\Test as TestUtil;
 use ReflectionClass;
 use ReflectionMethod;
-use Throwable;
 
 class Unit implements LoaderInterface
 {
@@ -85,33 +81,10 @@ class Unit implements LoaderInterface
         $className = $class->getName();
         $methodName = $method->getName();
 
-        try {
-            $data = DataProvider::getDataForMethod($method, $class);
-        } catch (Throwable $t) {
-            $message = sprintf(
-                "The data provider specified for %s::%s is invalid.\n%s",
-                $className,
-                $methodName,
-                $t->getMessage(),
-            );
-
-            if (PHPUnitVersion::series() < 10) {
-                $data = new ErrorTestCase($message);
-            } else {
-                $data = new ErrorTestCase($className, $methodName, $message);
-            }
-        }
+        $data = DataProvider::getDataForMethod($method, $class);
 
         if (!isset($data)) {
             return [ new $className($methodName) ];
-        }
-
-        if (
-            $data instanceof ErrorTestCase ||
-            $data instanceof SkippedTestCase ||
-            $data instanceof IncompleteTestCase
-        ) {
-            return [ $data ];
         }
 
         $result = [];

--- a/src/Codeception/Test/TestCaseWrapper.php
+++ b/src/Codeception/Test/TestCaseWrapper.php
@@ -14,7 +14,6 @@ use Codeception\TestInterface;
 use Codeception\Util\Annotation;
 use Codeception\Util\ReflectionHelper;
 use PHPUnit\Framework\Assert;
-use PHPUnit\Framework\ErrorTestCase;
 use PHPUnit\Framework\TestCase;
 use PHPUnit\Metadata\Api\CodeCoverage;
 use PHPUnit\Runner\Version as PHPUnitVersion;
@@ -54,9 +53,6 @@ class TestCaseWrapper extends Test implements Reported, Dependent, StrictCoverag
             $metadata->setIndex($testCase->dataName());
         }
 
-        if ($testCase instanceof ErrorTestCase) {
-            return;
-        }
         $classAnnotations = Annotation::forClass($testCase);
         $metadata->setParamsFromAnnotations($classAnnotations->raw());
         $metadata->setParamsFromAttributes($classAnnotations->attributes());

--- a/tests/cli/DataProviderFailuresAndExceptionsCest.php
+++ b/tests/cli/DataProviderFailuresAndExceptionsCest.php
@@ -39,11 +39,8 @@ final class DataProviderFailuresAndExceptionsCest
     public function runTestWithDataProvidersFailureStderr(CliGuy $I)
     {
         $I->executeCommand('run -n unit DataProvidersFailureCest 2>&1', false);
-        $I->seeInShellOutput("Couldn't parse test");
-        $I->seeInShellOutput("DataProvider 'rectangle' for DataProvidersFailureCest->testIsTriangle");
-        $I->seeInShellOutput('Make sure that the data provider exist within the test class.');
+        $I->seeInShellOutput("DataProvider 'rectangle' for DataProvidersFailureCest::testIsTriangle is invalid or not callable");
         // For Unit tests PHPUnit throws the errors, this confirms that we haven't ended up running PHPUnit test Loader
-        $I->dontSeeInShellOutput('PHPUnit_Framework_Warning');
         $I->dontSeeInShellOutput('The data provider specified for DataProvidersFailureCest::testIsTriangle');
         $I->dontSeeInShellOutput('Method rectangle does not exist');
         $I->dontSeeInShellOutput('FAILURES!');
@@ -62,9 +59,7 @@ final class DataProviderFailuresAndExceptionsCest
     public function runTestWithDataProvidersFailureStderrVerbose(CliGuy $I)
     {
         $I->executeCommand('run -n unit DataProvidersFailureCest -v 2>&1', false);
-        $I->seeInShellOutput("Couldn't parse test");
-        $I->seeInShellOutput("DataProvider 'rectangle' for DataProvidersFailureCest->testIsTriangle");
-        $I->seeInShellOutput('Make sure that the data provider exist within the test class.');
+        $I->seeInShellOutput("DataProvider 'rectangle' for DataProvidersFailureCest::testIsTriangle");
         // For Unit tests PHPUnit throws the errors, this confirms that we haven't ended up running PHPUnit test Loader
         $I->dontSeeInShellOutput('PHPUnit_Framework_Warning');
         $I->dontSeeInShellOutput('The data provider specified for DataProvidersFailureCest::testIsTriangle');
@@ -74,7 +69,7 @@ final class DataProviderFailuresAndExceptionsCest
         $I->dontSeeInShellOutput('OK');
         $I->dontSeeInShellOutput('Tests: 1, Assertions: 0, Warnings: 1.');
         // In verbose mode the Exception trace should be output.
-        $I->seeInShellOutput('[Codeception\Exception\TestParseException]');
+        $I->seeInShellOutput('[Codeception\Exception\InvalidTestException]');
         $I->seeInShellOutput('Exception trace');
         $I->seeResultCodeIs(1);
     }
@@ -117,7 +112,7 @@ final class DataProviderFailuresAndExceptionsCest
         // We should not see the messages related to a failure to parse the dataProvider function
         $I->dontSeeInShellOutput('[Codeception\Exception\TestParseException]');
         $I->dontSeeInShellOutput("Couldn't parse test");
-        $I->dontSeeInShellOutput("DataProvider 'rectangle' for DataProvidersFailureCest->testIsTriangle ");
+        $I->dontSeeInShellOutput("DataProvider 'rectangle' for DataProvidersFailureCest::testIsTriangle ");
 
         // We should just see the message
         $I->seeInShellOutput('Something went wrong!!!');
@@ -143,7 +138,7 @@ final class DataProviderFailuresAndExceptionsCest
         // We should not see the messages related to a failure to parse the dataProvider function
         $I->dontSeeInShellOutput('[Codeception\Exception\TestParseException]');
         $I->dontSeeInShellOutput("Couldn't parse test");
-        $I->dontSeeInShellOutput("DataProvider 'rectangle' for DataProvidersFailureCest->testIsTriangle is ");
+        $I->dontSeeInShellOutput("DataProvider 'rectangle' for DataProvidersFailureCest::testIsTriangle is ");
 
         // We should just see the message
         $I->seeInShellOutput('Something went wrong!!!');
@@ -151,5 +146,15 @@ final class DataProviderFailuresAndExceptionsCest
         $I->seeInShellOutput('[Exception]');
         $I->seeInShellOutput('Exception trace:');
         $I->seeResultCodeIs(1);
+    }
+
+    #[Before('moveToPath')]
+    public function runInvalidDataProvider(CliGuy $I)
+    {
+        $I->executeCommand('run -n unit InvalidDataProviderTest.php -v 2>&1', false);
+        $I->seeInShellOutput('[Exception]');
+        $I->seeInShellOutput('Data provider failed');
+        $I->dontSeeInShellOutput('Tests: 1');
+        $I->dontSeeInShellOutput('Errors: 1');
     }
 }

--- a/tests/cli/RunCest.php
+++ b/tests/cli/RunCest.php
@@ -636,15 +636,6 @@ EOF
         $I->seeInShellOutput('Failures: 2.');
     }
 
-    public function runInvalidDataProvider(CliGuy $I)
-    {
-        $I->executeCommand('run unit InvalidDataProviderTest.php', false);
-        $I->seeInShellOutput('There was 1 error');
-        $I->seeInShellOutput('[PHPUnit\Framework\Error] The data provider specified for InvalidDataProviderTest::testInvalidDataProvider is invalid');
-        $I->seeInShellOutput('Tests: 1,');
-        $I->seeInShellOutput('Errors: 1.');
-    }
-
     #[Group('shuffle')]
     public function showSeedNumberOnShuffle(CliGuy $I)
     {

--- a/tests/data/dataprovider_failures_and_exceptions/tests/unit/InvalidDataProviderTest.php
+++ b/tests/data/dataprovider_failures_and_exceptions/tests/unit/InvalidDataProviderTest.php
@@ -15,6 +15,6 @@ final class InvalidDataProviderTest extends Unit
 
     public function dependentProvider()
     {
-        throw new Exception();
+        throw new Exception('Data provider failed');
     }
 }

--- a/tests/unit/Codeception/Test/DataProviderTest.php
+++ b/tests/unit/Codeception/Test/DataProviderTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-use Codeception\Exception\TestParseException;
+use Codeception\Exception\InvalidTestException;
 use Codeception\Test\DataProvider;
 use Codeception\Test\Unit;
 
@@ -28,7 +28,7 @@ class DataProviderTest extends Unit
 
     public function testParseAnnotationThrowsExceptionIfAnnotationContainsTooManyDoubleColons(): void
     {
-        $this->expectException(TestParseException::class);
+        $this->expectException(InvalidTestException::class);
         $this->expectExceptionMessage('Data provider "AnotherClass::bug::getData" specified for UnitTest::testMethod is invalid');
         $result = DataProvider::parseDataProviderAnnotation('AnotherClass::bug::getData', 'UnitTest', 'testMethod');
     }


### PR DESCRIPTION
Because it no longer exists in PHPUnit 10
Invalid or failing data provider will stop test execution immediately.

See https://github.com/sebastianbergmann/phpunit/commit/7ccf97c28f81e1edf6f9045ddf7a847a746bf3fe