### PR TITLE
StrictCoverage::getLinesToBeCovered can return false

### DIFF
--- a/src/Codeception/Test/Cest.php
+++ b/src/Codeception/Test/Cest.php
@@ -246,7 +246,7 @@ class Cest extends Test implements
         return $names;
     }
 
-    public function getLinesToBeCovered(): array
+    public function getLinesToBeCovered(): array|bool
     {
         if (PHPUnitVersion::series() < 10) {
             return TestUtil::getLinesToBeCovered($this->testClass, $this->testMethod);

--- a/src/Codeception/Test/Interfaces/StrictCoverage.php
+++ b/src/Codeception/Test/Interfaces/StrictCoverage.php
@@ -4,7 +4,7 @@ namespace Codeception\Test\Interfaces;
 
 interface StrictCoverage
 {
-    public function getLinesToBeCovered(): array;
+    public function getLinesToBeCovered(): array|bool;
 
     public function getLinesToBeUsed(): array;
 }

--- a/src/Codeception/Test/TestCaseWrapper.php
+++ b/src/Codeception/Test/TestCaseWrapper.php
@@ -113,7 +113,7 @@ class TestCaseWrapper extends Test implements Reported, Dependent, StrictCoverag
         ];
     }
 
-    public function getLinesToBeCovered(): array
+    public function getLinesToBeCovered(): array|bool
     {
         $class = $this->testCase::class;
         $method = $this->metadata->getName();

--- a/tests/data/claypit/tests/math/MathTest.php
+++ b/tests/data/claypit/tests/math/MathTest.php
@@ -26,4 +26,12 @@ class MathTest extends \Codeception\Test\Unit
         $this->assertSame(5, $this->calc->divide(10, 2));
         $this->assertSame(75, $this->calc->squareOfCircle(5));
     }
+
+    /**
+     * @coversNothing
+     */
+    public function testWithoutCoversAnnotation()
+    {
+        $this->assertSame(3, $this->calc->add(1, 2));
+    }
 }


### PR DESCRIPTION
In projects where I don't use `@covers` annotations, `\PHPUnit\Util\Test::getLinesToBeCovered` can return `false`, and so it should `StrictCoverage::getLinesToBeCovered`: 

https://github.com/sebastianbergmann/phpunit/blob/3e6f90ca7e3d02025b1d147bd8d4a89fd4ca8a1d/src/Util/Test.php#L126

I didn't make it to have a test for it though: how can I generate code coverage locally so I can inspect the right place to put my test?