### PR TITLE
Set event subscriber priority for failure events

### DIFF
--- a/src/Codeception/Subscriber/FailFast.php
+++ b/src/Codeception/Subscriber/FailFast.php
@@ -14,7 +14,7 @@ class FailFast implements EventSubscriberInterface
     use Shared\StaticEventsTrait;
 
     /**
-     * @var array<string, array<string, int>>
+     * @var array<string, array<string|int>>
      */
     protected static array $events = [
         Events::TEST_FAIL => ['stopOnFail', 128],

--- a/src/Codeception/Subscriber/FailFast.php
+++ b/src/Codeception/Subscriber/FailFast.php
@@ -14,11 +14,11 @@ class FailFast implements EventSubscriberInterface
     use Shared\StaticEventsTrait;
 
     /**
-     * @var array<string, string>
+     * @var array<string, array<string, int>>
      */
     protected static array $events = [
-        Events::TEST_FAIL => 'stopOnFail',
-        Events::TEST_ERROR => 'stopOnFail',
+        Events::TEST_FAIL => ['stopOnFail', 128],
+        Events::TEST_ERROR => ['stopOnFail', 128],
     ];
 
     private int $failureCount = 0;


### PR DESCRIPTION
### Problem

In a module I want to handle failures and see whether fail-fast is enabled or not. For example, extending the `Doctrine2` module to not cleanup when fail-fast is enabled so the state of the Doctrine data store can be introspected after a failure has occurred.

As it stands, modules catch `Events::TEST_FAIL` and `Events::TEST_ERROR` before the `FailFast` subscriber because modules are configured first.

A simple dump of the EventDispatcher's set of listeners for `test.fail` shows:

```php
    "test.fail" => array:4 [
      0 => Codeception\Subscriber\Module::failed(FailEvent $event): void^ {#28422
        returnType: "void"
        this: Codeception\Subscriber\Module^ {#308}
      }
      1 => Codeception\Subscriber\FailFast::stopOnFail(TestEvent $e): void^ {#28416
        returnType: "void"
        this: Codeception\Subscriber\FailFast {#318 …}
      }
      2 => Codeception\Extension\Logger::testFail(FailEvent $event): void^ {#28410
        returnType: "void"
        this: Codeception\Extension\Logger^ {#231}
      }
      3 => Codeception\Subscriber\Console::testFail(FailEvent $event): void^ {#28411
        returnType: "void"
        this: Codeception\Subscriber\Console {#320 …}
      }
    ]
```

### Solution

As event subscribers have been configured without a priority the order is determined by the order in which they are added to the event dispatcher's subscriber. As per the [Symfony docs](https://symfony.com/doc/current/components/event_dispatcher.html#using-event-subscribers) a priority can be set for event subscribers. 

By setting a higher positive number we ensure `FailFast` is called first when the `Events::TEST_FAIL` and `Events::TEST_ERROR` events are triggered.

With my change I can ensure that the `ResultAggregator` has been configured to stop in the event that fail-fast has been enabled, and in turn I can see that in my own Codeception modules and handle it appropriately.