### PR TITLE
Support for Attributes in Actions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -48,7 +48,8 @@
         "codeception/util-universalframework": "*@dev",
         "symfony/process": ">=4.4.24 <7.0",
         "symfony/dotenv": ">=4.4.24 <7.0",
-        "vlucas/phpdotenv": "^5.1"
+        "vlucas/phpdotenv": "^5.1",
+        "jetbrains/phpstorm-attributes": "^1.0"
     },
     "conflict": {
         "codeception/lib-innerbrowser": "<3.1",

--- a/tests/cli/BuildCest.php
+++ b/tests/cli/BuildCest.php
@@ -141,7 +141,7 @@ final class BuildCest
         $I->seeInThisFile('public function seeDirFound(mixed $dir = NULL): mixed');
     }
 
-    public function generateCorrectTypeWhenSelfTypeIsUsed(CliGuy $I, Scenario $scenario)
+    public function generateCorrectTypeWhenSelfTypeIsUsed(CliGuy $I, Scenario $scenario): void
     {
         if (PHP_MAJOR_VERSION < 7) {
             $scenario->skip('Does not work in PHP < 7');
@@ -159,7 +159,7 @@ final class BuildCest
         $I->seeInThisFile('public function seeDirFound(\Codeception\Module\CliHelper $dir): \Codeception\Module\CliHelper');
     }
 
-    public function generateCorrectTypeWhenParentTypeIsUsed(CliGuy $I, Scenario $scenario)
+    public function generateCorrectTypeWhenParentTypeIsUsed(CliGuy $I, Scenario $scenario): void
     {
         if (PHP_MAJOR_VERSION < 7) {
             $scenario->skip('Does not work in PHP < 7');
@@ -177,7 +177,7 @@ final class BuildCest
         $I->seeInThisFile('public function seeDirFound(\Codeception\Module $dir): \Codeception\Module');
     }
 
-    public function noReturnForNeverType(CliGuy $I, Scenario $scenario)
+    public function noReturnForNeverType(CliGuy $I, Scenario $scenario): void
     {
         if (PHP_VERSION_ID < 80100) {
             $scenario->skip('Does not work in PHP < 8.1');
@@ -198,5 +198,185 @@ final class BuildCest
         $I->seeInThisFile('public function seeDirFound($dir): never');
         $I->seeInThisFile('$this->getScenario()->runStep(new \Codeception\Step\ConditionalAssertion(\'seeDirFound\', func_get_args()));');
         $I->dontSeeInThisFile('return $this->getScenario()->runStep(new \Codeception\Step\ConditionalAssertion(\'seeDirFound\', func_get_args()));');
+    }
+
+    public function generateAttributeForMethodAttributeWithNoParametersAndNoBrackets(CliGuy $I, Scenario $scenario): void
+    {
+        $I->wantToTest('attribute generation for method attribute with no parameters and no brackets');
+
+        $cliHelperContents = file_get_contents(codecept_root_dir('tests/support/CliHelper.php'));
+        $cliHelperContents = str_replace('public function seeDirFound($dir)', "#[\Codeception\Attribute\Examples]\n    public function seeDirFound(\$dir)", $cliHelperContents);
+        file_put_contents(codecept_root_dir('tests/support/CliHelper.php'), $cliHelperContents);
+
+        $I->runShellCommand('php codecept build');
+        $I->seeInShellOutput('generated successfully');
+        $I->seeInSupportDir('CliGuy.php');
+        $I->seeInThisFile('class CliGuy extends \Codeception\Actor');
+        $I->seeInThisFile('use _generated\CliGuyActions');
+        $I->seeFileFound('CliGuyActions.php', 'tests/support/_generated');
+        $I->seeInThisFile("*/\n    #[\Codeception\Attribute\Examples()]\n    public function seeDirFound(\$dir) {");
+        $I->seeInThisFile("*/\n    #[\Codeception\Attribute\Examples()]\n    public function canSeeDirFound(\$dir) {");
+    }
+
+    public function generateAttributeForMethodAttributeWithNoParametersAndEmptyBrackets(CliGuy $I, Scenario $scenario): void
+    {
+        $I->wantToTest('attribute generation for method attribute with no parameters and empty brackets');
+
+        $cliHelperContents = file_get_contents(codecept_root_dir('tests/support/CliHelper.php'));
+        $cliHelperContents = str_replace('public function seeDirFound($dir)', "#[\Codeception\Attribute\Examples()]\n    public function seeDirFound(\$dir)", $cliHelperContents);
+        file_put_contents(codecept_root_dir('tests/support/CliHelper.php'), $cliHelperContents);
+
+        $I->runShellCommand('php codecept build');
+        $I->seeInShellOutput('generated successfully');
+        $I->seeInSupportDir('CliGuy.php');
+        $I->seeInThisFile('class CliGuy extends \Codeception\Actor');
+        $I->seeInThisFile('use _generated\CliGuyActions');
+        $I->seeFileFound('CliGuyActions.php', 'tests/support/_generated');
+        $I->seeInThisFile("*/\n    #[\Codeception\Attribute\Examples()]\n    public function seeDirFound(\$dir) {");
+        $I->seeInThisFile("*/\n    #[\Codeception\Attribute\Examples()]\n    public function canSeeDirFound(\$dir) {");
+    }
+
+    public function generateAttributeForMethodAttributeWithASingleParameter(CliGuy $I, Scenario $scenario): void
+    {
+        $I->wantToTest('attribute generation for method attribute with a single parameter');
+
+        $cliHelperContents = file_get_contents(codecept_root_dir('tests/support/CliHelper.php'));
+        $cliHelperContents = str_replace('public function seeDirFound($dir)', "#[\Codeception\Attribute\Examples('magic')]\n    public function seeDirFound(\$dir)", $cliHelperContents);
+        file_put_contents(codecept_root_dir('tests/support/CliHelper.php'), $cliHelperContents);
+
+        $I->runShellCommand('php codecept build');
+        $I->seeInShellOutput('generated successfully');
+        $I->seeInSupportDir('CliGuy.php');
+        $I->seeInThisFile('class CliGuy extends \Codeception\Actor');
+        $I->seeInThisFile('use _generated\CliGuyActions');
+        $I->seeFileFound('CliGuyActions.php', 'tests/support/_generated');
+        $I->seeInThisFile("*/\n    #[\Codeception\Attribute\Examples(\"magic\")]\n    public function seeDirFound(\$dir) {");
+        $I->seeInThisFile("*/\n    #[\Codeception\Attribute\Examples(\"magic\")]\n    public function canSeeDirFound(\$dir) {");
+    }
+
+    public function generateAttributeForMethodAttributeWithMultipleParameters(CliGuy $I, Scenario $scenario): void
+    {
+        $I->wantToTest('attribute generation for method attribute with multiple parameters');
+
+        $cliHelperContents = file_get_contents(codecept_root_dir('tests/support/CliHelper.php'));
+        $cliHelperContents = str_replace('public function seeDirFound($dir)', "#[\Codeception\Attribute\Examples('magic', \"dark\")]\n    public function seeDirFound(\$dir)", $cliHelperContents);
+        file_put_contents(codecept_root_dir('tests/support/CliHelper.php'), $cliHelperContents);
+
+        $I->runShellCommand('php codecept build');
+        $I->seeInShellOutput('generated successfully');
+        $I->seeInSupportDir('CliGuy.php');
+        $I->seeInThisFile('class CliGuy extends \Codeception\Actor');
+        $I->seeInThisFile('use _generated\CliGuyActions');
+        $I->seeFileFound('CliGuyActions.php', 'tests/support/_generated');
+        $I->seeInThisFile("*/\n    #[\Codeception\Attribute\Examples(\"magic\", \"dark\")]\n    public function seeDirFound(\$dir) {");
+        $I->seeInThisFile("*/\n    #[\Codeception\Attribute\Examples(\"magic\", \"dark\")]\n    public function canSeeDirFound(\$dir) {");
+    }
+
+    public function generateAttributeForMethodAttributeWithMultipleParametersOverMultipleLines(CliGuy $I, Scenario $scenario): void
+    {
+        $I->wantToTest('attribute generation for method attribute with multiple parameters over multiple lines');
+
+        $cliHelperContents = file_get_contents(codecept_root_dir('tests/support/CliHelper.php'));
+        $cliHelperContents = str_replace('public function seeDirFound($dir)', "#[\Codeception\Attribute\Examples(\n'magic',\n\"dark\")]\n    public function seeDirFound(\$dir)", $cliHelperContents);
+        file_put_contents(codecept_root_dir('tests/support/CliHelper.php'), $cliHelperContents);
+
+        $I->runShellCommand('php codecept build');
+        $I->seeInShellOutput('generated successfully');
+        $I->seeInSupportDir('CliGuy.php');
+        $I->seeInThisFile('class CliGuy extends \Codeception\Actor');
+        $I->seeInThisFile('use _generated\CliGuyActions');
+        $I->seeFileFound('CliGuyActions.php', 'tests/support/_generated');
+        $I->seeInThisFile("*/\n    #[\Codeception\Attribute\Examples(\"magic\", \"dark\")]\n    public function seeDirFound(\$dir) {");
+        $I->seeInThisFile("*/\n    #[\Codeception\Attribute\Examples(\"magic\", \"dark\")]\n    public function canSeeDirFound(\$dir) {");
+    }
+
+    public function generateAttributesForMultipleMethodAttributeDeclarations(CliGuy $I, Scenario $scenario): void
+    {
+        $I->wantToTest('attribute generation for multiple method attribute declarations');
+
+        $cliHelperContents = file_get_contents(codecept_root_dir('tests/support/CliHelper.php'));
+        $cliHelperContents = str_replace('public function seeDirFound($dir)', "#[\Codeception\Attribute\Examples()]\n   #[\Codeception\Attribute\Before(\"doX\")]\n   public function seeDirFound(\$dir)", $cliHelperContents);
+        file_put_contents(codecept_root_dir('tests/support/CliHelper.php'), $cliHelperContents);
+
+        $I->runShellCommand('php codecept build');
+        $I->seeInShellOutput('generated successfully');
+        $I->seeInSupportDir('CliGuy.php');
+        $I->seeInThisFile('class CliGuy extends \Codeception\Actor');
+        $I->seeInThisFile('use _generated\CliGuyActions');
+        $I->seeFileFound('CliGuyActions.php', 'tests/support/_generated');
+        $I->seeInThisFile("*/\n    #[\Codeception\Attribute\Examples()]\n    #[\Codeception\Attribute\Before(\"doX\")]\n    public function seeDirFound(\$dir) {");
+        $I->seeInThisFile("*/\n    #[\Codeception\Attribute\Examples()]\n    #[\Codeception\Attribute\Before(\"doX\")]\n    public function canSeeDirFound(\$dir) {");
+    }
+
+    public function generateAttributeForParameterAttributeWithNoParametersAndNoBrackets(CliGuy $I, Scenario $scenario): void
+    {
+        $I->wantToTest('attribute generation for parameter attribute with no parameters and no brackets');
+
+        $cliHelperContents = file_get_contents(codecept_root_dir('tests/support/CliHelper.php'));
+        $cliHelperContents = str_replace('public function seeDirFound($dir)', "public function seeDirFound(#[\JetBrains\PhpStorm\Deprecated] \$dir)", $cliHelperContents);
+        file_put_contents(codecept_root_dir('tests/support/CliHelper.php'), $cliHelperContents);
+
+        $I->runShellCommand('php codecept build');
+        $I->seeInShellOutput('generated successfully');
+        $I->seeInSupportDir('CliGuy.php');
+        $I->seeInThisFile('class CliGuy extends \Codeception\Actor');
+        $I->seeInThisFile('use _generated\CliGuyActions');
+        $I->seeFileFound('CliGuyActions.php', 'tests/support/_generated');
+        $I->seeInThisFile("*/\n    public function seeDirFound(#[\JetBrains\PhpStorm\Deprecated()] \$dir) {");
+        $I->seeInThisFile("*/\n    public function canSeeDirFound(#[\JetBrains\PhpStorm\Deprecated()] \$dir) {");
+    }
+
+    public function generateAttributeForParameterAttributeWithMultipleParameters(CliGuy $I, Scenario $scenario): void
+    {
+        $I->wantToTest('attribute generation for parameter attribute with multiple parameters');
+
+        $cliHelperContents = file_get_contents(codecept_root_dir('tests/support/CliHelper.php'));
+        $cliHelperContents = str_replace('public function seeDirFound($dir)', "public function seeDirFound(#[\JetBrains\PhpStorm\Deprecated(\"it's old\", 'see a better method')] \$dir)", $cliHelperContents);
+        file_put_contents(codecept_root_dir('tests/support/CliHelper.php'), $cliHelperContents);
+
+        $I->runShellCommand('php codecept build');
+        $I->seeInShellOutput('generated successfully');
+        $I->seeInSupportDir('CliGuy.php');
+        $I->seeInThisFile('class CliGuy extends \Codeception\Actor');
+        $I->seeInThisFile('use _generated\CliGuyActions');
+        $I->seeFileFound('CliGuyActions.php', 'tests/support/_generated');
+        $I->seeInThisFile("*/\n    public function seeDirFound(#[\JetBrains\PhpStorm\Deprecated(\"it's old\", \"see a better method\")] \$dir) {");
+        $I->seeInThisFile("*/\n    public function canSeeDirFound(#[\JetBrains\PhpStorm\Deprecated(\"it's old\", \"see a better method\")] \$dir) {");
+    }
+
+    public function generateAttributesForParameterAttributesWithMultipleAttributeDeclarations(CliGuy $I, Scenario $scenario): void
+    {
+        $I->wantToTest('attribute generation for parameter attribute with multiple attribute declarations');
+
+        $cliHelperContents = file_get_contents(codecept_root_dir('tests/support/CliHelper.php'));
+        $cliHelperContents = str_replace('public function seeDirFound($dir)', "public function seeDirFound(#[\JetBrains\PhpStorm\Deprecated(\"it's old\")] #[\JetBrains\PhpStorm\ExpectedValues([ 1, 2 ])] \$dir)", $cliHelperContents);
+        file_put_contents(codecept_root_dir('tests/support/CliHelper.php'), $cliHelperContents);
+
+        $I->runShellCommand('php codecept build');
+        $I->seeInShellOutput('generated successfully');
+        $I->seeInSupportDir('CliGuy.php');
+        $I->seeInThisFile('class CliGuy extends \Codeception\Actor');
+        $I->seeInThisFile('use _generated\CliGuyActions');
+        $I->seeFileFound('CliGuyActions.php', 'tests/support/_generated');
+        $I->seeInThisFile("*/\n    public function seeDirFound(#[\JetBrains\PhpStorm\Deprecated(\"it's old\")]#[\JetBrains\PhpStorm\ExpectedValues([1, 2])] \$dir) {");
+        $I->seeInThisFile("*/\n    public function canSeeDirFound(#[\JetBrains\PhpStorm\Deprecated(\"it's old\")]#[\JetBrains\PhpStorm\ExpectedValues([1, 2])] \$dir) {");
+    }
+
+    public function generateAttributesForParameterAttributesWithMultipleAttributesInASingleDeclaration(CliGuy $I, Scenario $scenario): void
+    {
+        $I->wantToTest('attribute generation for parameter attribute with multiple attributes in a single declaration');
+
+        $cliHelperContents = file_get_contents(codecept_root_dir('tests/support/CliHelper.php'));
+        $cliHelperContents = str_replace('public function seeDirFound($dir)', "public function seeDirFound(#[\JetBrains\PhpStorm\Deprecated(\"it's old\"), \JetBrains\PhpStorm\ExpectedValues([ 1, 2 ])] \$dir)", $cliHelperContents);
+        file_put_contents(codecept_root_dir('tests/support/CliHelper.php'), $cliHelperContents);
+
+        $I->runShellCommand('php codecept build');
+        $I->seeInShellOutput('generated successfully');
+        $I->seeInSupportDir('CliGuy.php');
+        $I->seeInThisFile('class CliGuy extends \Codeception\Actor');
+        $I->seeInThisFile('use _generated\CliGuyActions');
+        $I->seeFileFound('CliGuyActions.php', 'tests/support/_generated');
+        $I->seeInThisFile("*/\n    public function seeDirFound(#[\JetBrains\PhpStorm\Deprecated(\"it's old\")]#[\JetBrains\PhpStorm\ExpectedValues([1, 2])] \$dir) {");
+        $I->seeInThisFile("*/\n    public function canSeeDirFound(#[\JetBrains\PhpStorm\Deprecated(\"it's old\")]#[\JetBrains\PhpStorm\ExpectedValues([1, 2])] \$dir) {");
     }
 }


### PR DESCRIPTION
This adds support for attributes in generated Action traits as discussed [here](https://github.com/Codeception/Codeception/issues/6592). This closes #6592.

- ~I've also tidied up a few CI-related things~ see #6604 instead.
- ~Added parameters to the attributes so IDEs don't complain about parameters being there when they think there shouldn't be~ see #6600 instead.

### TODO

- [x] Handle parameter attributes.
- [x] Tests for parameter attributes.
- [x] Update docs, including note about named parameters ([in my branch](https://github.com/yesdevnull/codeception-website/commits/add-attributes)).