### PR TITLE
Provide typed signatures for attributes

### DIFF
--- a/src/Codeception/Attribute/After.php
+++ b/src/Codeception/Attribute/After.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Codeception\Attribute;
 
 use Attribute;
@@ -7,4 +9,7 @@ use Attribute;
 #[Attribute(Attribute::TARGET_METHOD | Attribute::IS_REPEATABLE)]
 final class After
 {
+    public function __construct(string ...$methodNames)
+    {
+    }
 }

--- a/src/Codeception/Attribute/AfterClass.php
+++ b/src/Codeception/Attribute/AfterClass.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Codeception\Attribute;
 
 use Attribute;

--- a/src/Codeception/Attribute/Before.php
+++ b/src/Codeception/Attribute/Before.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Codeception\Attribute;
 
 use Attribute;
@@ -7,4 +9,7 @@ use Attribute;
 #[Attribute(Attribute::TARGET_METHOD | Attribute::IS_REPEATABLE)]
 final class Before
 {
+    public function __construct(string ...$methodNames)
+    {
+    }
 }

--- a/src/Codeception/Attribute/BeforeClass.php
+++ b/src/Codeception/Attribute/BeforeClass.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Codeception\Attribute;
 
 use Attribute;

--- a/src/Codeception/Attribute/DataProvider.php
+++ b/src/Codeception/Attribute/DataProvider.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Codeception\Attribute;
 
 use Attribute;
@@ -7,4 +9,7 @@ use Attribute;
 #[Attribute(Attribute::TARGET_METHOD)]
 final class DataProvider
 {
+    public function __construct(string $methodName)
+    {
+    }
 }

--- a/src/Codeception/Attribute/Depends.php
+++ b/src/Codeception/Attribute/Depends.php
@@ -9,7 +9,7 @@ use Attribute;
 #[Attribute(Attribute::TARGET_CLASS | Attribute::TARGET_METHOD | Attribute::IS_REPEATABLE)]
 final class Depends
 {
-    public function __construct(string $testName)
+    public function __construct(string ...$testNames)
     {
     }
 }

--- a/src/Codeception/Attribute/Depends.php
+++ b/src/Codeception/Attribute/Depends.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Codeception\Attribute;
 
 use Attribute;
@@ -7,4 +9,7 @@ use Attribute;
 #[Attribute(Attribute::TARGET_CLASS | Attribute::TARGET_METHOD | Attribute::IS_REPEATABLE)]
 final class Depends
 {
+    public function __construct(string $testName)
+    {
+    }
 }

--- a/src/Codeception/Attribute/Env.php
+++ b/src/Codeception/Attribute/Env.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Codeception\Attribute;
 
 use Attribute;
@@ -7,4 +9,7 @@ use Attribute;
 #[Attribute(Attribute::TARGET_METHOD | Attribute::IS_REPEATABLE)]
 final class Env
 {
+    public function __construct(string ...$envValues)
+    {
+    }
 }

--- a/src/Codeception/Attribute/Examples.php
+++ b/src/Codeception/Attribute/Examples.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Codeception\Attribute;
 
 use Attribute;
@@ -7,4 +9,7 @@ use Attribute;
 #[Attribute(Attribute::TARGET_METHOD | Attribute::IS_REPEATABLE)]
 final class Examples
 {
+    public function __construct(mixed ...$values)
+    {
+    }
 }

--- a/src/Codeception/Attribute/Given.php
+++ b/src/Codeception/Attribute/Given.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Codeception\Attribute;
 
 use Attribute;
@@ -7,4 +9,7 @@ use Attribute;
 #[Attribute(Attribute::TARGET_METHOD | Attribute::IS_REPEATABLE)]
 final class Given
 {
+    public function __construct(string $description)
+    {
+    }
 }

--- a/src/Codeception/Attribute/Group.php
+++ b/src/Codeception/Attribute/Group.php
@@ -1,10 +1,15 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Codeception\Attribute;
 
 use Attribute;
 
-#[Attribute(Attribute::TARGET_METHOD | Attribute::TARGET_CLASS |  Attribute::IS_REPEATABLE)]
+#[Attribute(Attribute::TARGET_METHOD | Attribute::TARGET_CLASS | Attribute::IS_REPEATABLE)]
 final class Group
 {
+    public function __construct(string ...$groups)
+    {
+    }
 }

--- a/src/Codeception/Attribute/Incomplete.php
+++ b/src/Codeception/Attribute/Incomplete.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Codeception\Attribute;
 
 use Attribute;
@@ -7,4 +9,7 @@ use Attribute;
 #[Attribute(Attribute::TARGET_METHOD | Attribute::TARGET_CLASS)]
 class Incomplete
 {
+    public function __construct(string $reason = '')
+    {
+    }
 }

--- a/src/Codeception/Attribute/Prepare.php
+++ b/src/Codeception/Attribute/Prepare.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Codeception\Attribute;
 
 use Attribute;
@@ -7,4 +9,7 @@ use Attribute;
 #[Attribute(Attribute::TARGET_METHOD | Attribute::IS_REPEATABLE)]
 final class Prepare
 {
+    public function __construct(string ...$methodNames)
+    {
+    }
 }

--- a/src/Codeception/Attribute/Skip.php
+++ b/src/Codeception/Attribute/Skip.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Codeception\Attribute;
 
 use Attribute;
@@ -7,4 +9,7 @@ use Attribute;
 #[Attribute(Attribute::TARGET_METHOD | Attribute::TARGET_CLASS)]
 final class Skip
 {
+    public function __construct(string $reason = '')
+    {
+    }
 }

--- a/src/Codeception/Attribute/Then.php
+++ b/src/Codeception/Attribute/Then.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Codeception\Attribute;
 
 use Attribute;
@@ -7,4 +9,7 @@ use Attribute;
 #[Attribute(Attribute::TARGET_METHOD | Attribute::IS_REPEATABLE)]
 final class Then
 {
+    public function __construct(string $description)
+    {
+    }
 }

--- a/src/Codeception/Attribute/When.php
+++ b/src/Codeception/Attribute/When.php
@@ -1,10 +1,15 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Codeception\Attribute;
 
 use Attribute;
 
-#[Attribute(Attribute::TARGET_METHOD  | Attribute::IS_REPEATABLE)]
+#[Attribute(Attribute::TARGET_METHOD | Attribute::IS_REPEATABLE)]
 final class When
 {
+    public function __construct(string $description)
+    {
+    }
 }

--- a/tests/data/claypit/tests/unit/DependsTest.php
+++ b/tests/data/claypit/tests/unit/DependsTest.php
@@ -26,6 +26,12 @@ final class DependsTest extends Unit
         $this->assertTrue(true);
     }
 
+    #[Depends('testThree', 'testFour')]
+    public function testFive()
+    {
+        $this->assertTrue(true);
+    }
+
     #[Group('depends')]
     public function testOne(): int
     {


### PR DESCRIPTION
Hey there.

The current implementation of attributes does not include any signatures and thus IDEs like PhpStorm report that attributes accept no arguments and also provide no hints on the type or number of arguments supported.

![image](https://user-images.githubusercontent.com/2145319/201398238-2416cec9-38a5-4b4b-bd64-7c88d2e217b2.png)

I have added constructors with proper signatures to fix this.

![image](https://user-images.githubusercontent.com/2145319/201398573-df22f5d6-e5dc-44c4-bcf6-bf04ddf84172.png)

Due to the way attributes are read, there is no further change needed.

#### Out of scope
Looking forward, it could be beneficial to make the passed in values available via getters instead of using `ReflectionAttribute::getArguments` in the code processing attributes. But that is for another time.