### PR TITLE
Fixed 'expectNotToPerformAssertions override in unit tests

### DIFF
--- a/src/Codeception/Test/Test.php
+++ b/src/Codeception/Test/Test.php
@@ -199,7 +199,12 @@ abstract class Test extends TestWrapper implements TestInterface, Interfaces\Des
             $this->assertionCount = Assert::getCount();
             $result->addToAssertionCount($this->assertionCount);
 
-            if ($this->reportUselessTests && $this->assertionCount === 0 && $eventType === Events::TEST_SUCCESS) {
+            if (
+                $this->reportUselessTests &&
+                $this->assertionCount === 0 &&
+                !$this->doesNotPerformAssertions() &&
+                $eventType === Events::TEST_SUCCESS
+            ) {
                 $eventType = Events::TEST_USELESS;
                 $e = new UselessTestException('This test did not perform any assertions');
                 $result->addUseless(new FailEvent($this, $e, $time));
@@ -224,6 +229,15 @@ abstract class Test extends TestWrapper implements TestInterface, Interfaces\Des
 
         $this->fire(Events::TEST_AFTER, new TestEvent($this, $time));
         $this->eventDispatcher->dispatch(new TestEvent($this, $time), Events::TEST_END);
+    }
+
+    /**
+     * Return false by default, the Unit-specific TestCaseWrapper implements this properly as it supports the PHPUnit
+     * test override `->expectNotToPerformAssertions()`.
+     */
+    protected function doesNotPerformAssertions(): bool
+    {
+        return false;
     }
 
     public function getResultAggregator(): ResultAggregator

--- a/src/Codeception/Test/TestCaseWrapper.php
+++ b/src/Codeception/Test/TestCaseWrapper.php
@@ -146,11 +146,19 @@ class TestCaseWrapper extends Test implements Reported, Dependent, StrictCoverag
         ) {
             throw new UselessTestException(
                 sprintf(
-                    'This test is annotated with "@doesNotPerformAssertions" but performed %d assertions',
+                    'This test indicates it does not perform assertions but %d assertions were performed',
                     $numberOfAssertionsPerformed
                 )
             );
         }
+    }
+
+    /**
+     * Is the test expected to not perform assertions with `expectNotToPerformAssertions`?
+     */
+    protected function doesNotPerformAssertions(): bool
+    {
+         return $this->testCase->doesNotPerformAssertions();
     }
 
     public function toString(): string

--- a/tests/cli/RunUselessTestsCest.php
+++ b/tests/cli/RunUselessTestsCest.php
@@ -8,6 +8,14 @@ class RunUselessTestsCest
         $I->executeCommand('run');
         $I->seeInShellOutput('U UselessCept: Make no assertions');
         $I->seeInShellOutput('U UselessCest: Make no assertions');
+        if (DIRECTORY_SEPARATOR === '\\') {
+            // Windows shows a plus for a successful test.
+            $I->canSeeInShellOutput('+ UselessTest: Expects not to perform assertions');
+        } else {
+            // Linux/macOS shows a tick for a successful test.
+            $I->canSeeInShellOutput('✔ UselessTest: Expects not to perform assertions');
+        }
+        $I->dontSeeInShellOutput('U UselessTest: Expects not to perform assertions');
         $I->seeInShellOutput('U UselessTest: Make no assertions');
         $I->seeInShellOutput('U UselessTest: Make unexpected assertion');
         $I->seeInShellOutput('OK, but incomplete, skipped, or useless tests!');
@@ -39,7 +47,7 @@ This test did not perform any assertions'
                 '
 4) UselessTest: Make unexpected assertion
  Test  tests/unit/UselessTest.php:testMakeUnexpectedAssertion
-This test is annotated with "@doesNotPerformAssertions" but performed 1 assertions'
+This test indicates it does not perform assertions but 1 assertions were performed'
             );
 
             return;
@@ -70,7 +78,7 @@ This test did not perform any assertions'
             '
 4) UselessTest: Make unexpected assertion
  Test  tests\unit\UselessTest.php:testMakeUnexpectedAssertion
-This test is annotated with "@doesNotPerformAssertions" but performed 1 assertions'
+This test indicates it does not perform assertions but 1 assertions were performed'
         );
     }
 
@@ -82,6 +90,7 @@ This test is annotated with "@doesNotPerformAssertions" but performed 1 assertio
         $I->seeInShellOutput('UselessCept: Make no assertions............................................Useless');
         $I->seeInShellOutput('UselessCest: Make no assertions............................................Useless');
         $I->seeInShellOutput('UselessTest: Make no assertions............................................Useless');
+        $I->seeInShellOutput('UselessTest: Expects not to perform assertions.............................Ok');
         $I->seeInShellOutput('UselessTest: Make unexpected assertion.....................................Useless');
 
         $I->seeInShellOutput('JUNIT XML report generated in');
@@ -89,21 +98,23 @@ This test is annotated with "@doesNotPerformAssertions" but performed 1 assertio
         $I->seeInShellOutput('HTML report generated in');
         $I->seeFileFound('report.xml', 'tests/_output');
         $I->seeInThisFile(
-            '<testsuite name="unit" tests="4" assertions="1" errors="0" failures="0" skipped="0" useless="4" time="'
+            '<testsuite name="unit" tests="5" assertions="1" errors="0" failures="0" skipped="0" useless="4" time="'
         );
         $I->seeInThisFile('<testcase name="Useless"');
         $I->seeInThisFile('<testcase name="makeNoAssertions" class="UselessCest"');
         $I->seeInThisFile('<testcase name="testMakeNoAssertions" class="UselessTest" file="');
+        $I->seeInThisFile('<testcase name="testExpectsNotToPerformAssertions" class="UselessTest" file="');
         $I->seeInThisFile('<testcase name="testMakeUnexpectedAssertion" class="UselessTest" file="');
         $I->seeInThisFile('<error>Useless Test</error>');
 
         $I->seeFileFound('phpunit-report.xml', 'tests/_output');
         $I->seeInThisFile(
-            '<testsuite name="unit" tests="4" assertions="1" errors="0" failures="0" skipped="0" useless="4" time="'
+            '<testsuite name="unit" tests="5" assertions="1" errors="0" failures="0" skipped="0" useless="4" time="'
         );
         $I->seeInThisFile('<testcase name="Useless"');
         $I->seeInThisFile('<testcase name="makeNoAssertions" class="UselessCest"');
         $I->seeInThisFile('<testcase name="testMakeNoAssertions" class="UselessTest" file="');
+        $I->seeInThisFile('<testcase name="testExpectsNotToPerformAssertions" class="UselessTest" file="');
         $I->seeInThisFile('<testcase name="testMakeUnexpectedAssertion" class="UselessTest" file="');
         $I->seeInThisFile('<error>Useless Test</error>');
 

--- a/tests/data/useless/tests/unit/UselessTest.php
+++ b/tests/data/useless/tests/unit/UselessTest.php
@@ -11,6 +11,11 @@ class UselessTest extends \Codeception\Test\Unit
     {
     }
 
+    public function testExpectsNotToPerformAssertions(): void
+    {
+        $this->expectNotToPerformAssertions();
+    }
+
     public function testMakeUnexpectedAssertion(): void
     {
         $this->expectNotToPerformAssertions();


### PR DESCRIPTION
I noticed that the PHPUnit TestCase method `expectNotToPerformAssertions()` wasn't being correctly applied by the TestCaseWrapper in Codeception. Unit tests with `expectNotToPerformAssertions` were being identified as useless tests, despite having informed the test runner that it does not perform assertions.

What I propose fixes the issue however it may not be the preferred way to do it. Happy to make alterations if required.

Side note, the test `RunUselessTestsCest:checkOutput` is failing because the `UselessCest` and `UselessCept` output isn't showing correctly in the test. Doesn't appear to be related but I'll make sure and fix in a subsequent commit if it it my fault.