### PR TITLE
Bump GitHub actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: 'ubuntu-latest'
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Install PHP
         uses: shivammathur/setup-php@v2
@@ -50,7 +50,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Install PHP
         uses: shivammathur/setup-php@v2
@@ -65,7 +65,7 @@ jobs:
         run: echo "COMPOSER_CACHE_DIR=$(composer config cache-dir)" >> $GITHUB_ENV
 
       - name: Cache dependencies installed with composer
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ${{ env.COMPOSER_CACHE_DIR }}
           key: php${{ matrix.php }}-${{ matrix.mode }}-composer-${{ hashFiles('**/composer.json') }}
@@ -144,7 +144,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Install PHP
         uses: shivammathur/setup-php@v2
@@ -158,7 +158,7 @@ jobs:
         run: echo "COMPOSER_CACHE_DIR=~\AppData\Local\Composer" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
 
       - name: Cache dependencies installed with composer
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ${{ env.COMPOSER_CACHE_DIR }}
           key: php${{ matrix.php }}-composer-${{ hashFiles('**/composer.json') }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,10 +25,10 @@ jobs:
           tools: phpcs
 
       - name: Check production code style
-        run: phpcs src/ ext/ *.php
+        run: composer cs-prod
 
       - name: Check test code style
-        run: phpcs tests/ --standard=tests/phpcs.xml
+        run: composer cs-tests
 
   linux:
     name: PHP ${{ matrix.php }}-${{ matrix.os }}-${{ matrix.mode }}

--- a/composer.json
+++ b/composer.json
@@ -94,5 +94,13 @@
             "tests/unit/Codeception/Util/ReflectionTestClass.php"
         ]
     },
-    "bin":["codecept"]
+    "bin":["codecept"],
+    "scripts": {
+        "cs-prod": "phpcs src/ ext/ *.php",
+        "cs-tests": "phpcs tests/ --standard=tests/phpcs.xml"
+    },
+    "scripts-descriptions": {
+        "cs-prod": "Check production code style",
+        "cs-tests": "Check test code style"
+    }
 }


### PR DESCRIPTION
This:

- Updates the version for several GitHub-branded actions from `v2` to `v3`.
- Consolidates the PHPCS commands into composer scripts so they can easily be run by devs before committing/pushing.

_(This was originally part of #6593, I have pulled it out into a separate PR to make things cleaner)_