### PR TITLE
Don't disable test shuffling when --shard option is used

### DIFF
--- a/src/Codeception/Command/Run.php
+++ b/src/Codeception/Command/Run.php
@@ -421,8 +421,6 @@ class Run extends Command
             $this->output->writeln(
                 "[Shard ${userOptions['shard']}] <info>Running subset of tests</info>"
             );
-            // disable shuffle for sharding
-            $config['settings']['shuffle'] = false;
         }
 
         if (!$this->options['silent'] && $config['settings']['shuffle']) {


### PR DESCRIPTION
Fixes #6589