### PR TITLE
Fix skip issues

### DIFF
--- a/src/Codeception/Test/Metadata.php
+++ b/src/Codeception/Test/Metadata.php
@@ -198,12 +198,14 @@ class Metadata
         $params = Annotation::fetchAllAnnotationsFromDocblock((string)$annotations);
         $this->params = array_merge_recursive($this->params, $params);
 
-        // set singular value for some params
+        $this->setSingularValueForSomeParams();
+    }
+
+    private function setSingularValueForSomeParams(): void
+    {
         foreach (['skip', 'incomplete'] as $single) {
-            if (empty($this->params[$single])) {
-                $this->params[$single] = null;
-            } else {
-                $this->params[$single] = (string)($this->params[$single][0] ?? $this->params[$single][1]);
+            if (is_array($this->params[$single])) {
+                $this->params[$single] = $this->params[$single][0] ?? $this->params[$single][1] ?? '';
             }
         }
     }
@@ -235,13 +237,12 @@ class Metadata
             $this->params[$single] = array_merge(...$this->params[$single]);
         }
 
-
-        // set singular value for some params
-        foreach (['skip', 'incomplete'] as $single) {
-            $this->params[$single] = empty($this->params[$single]) ? null : (string)$this->params[$single][0];
-        }
+        $this->setSingularValueForSomeParams();
     }
 
+    /**
+     * @deprecated
+     */
     public function setParams(array $params): void
     {
         $this->params = array_merge_recursive($this->params, $params);

--- a/tests/cli/RunSkippedCest.php
+++ b/tests/cli/RunSkippedCest.php
@@ -1,0 +1,80 @@
+<?php
+
+class RunSkippedCest
+{
+    public function classLevelSkipAnnotationWithMessage(CliGuy $I): void
+    {
+        $I->amInPath('tests/data/skip');
+        $I->executeCommand('run -v --no-ansi unit ClassLevelSkipAnnotationWithMessageCest.php');
+        $I->seeInShellOutput("S ClassLevelSkipAnnotationWithMessageCest: Method1");
+        $I->seeInShellOutput("S ClassLevelSkipAnnotationWithMessageCest: Method2");
+        $I->seeInShellOutput('Skip message');
+        $I->seeInShellOutput('OK, but incomplete, skipped, or useless tests!');
+    }
+
+    public function classLevelSkipAnnotationWithoutMessage(CliGuy $I): void
+    {
+        $I->amInPath('tests/data/skip');
+        $I->executeCommand('run -v --no-ansi unit ClassLevelSkipAnnotationWithoutMessageCest.php');
+        $I->seeInShellOutput("S ClassLevelSkipAnnotationWithoutMessageCest: Method1");
+        $I->seeInShellOutput("S ClassLevelSkipAnnotationWithoutMessageCest: Method2");
+        $I->seeInShellOutput('OK, but incomplete, skipped, or useless tests!');
+    }
+
+    public function classLevelSkipAttributeWithMessage(CliGuy $I): void
+    {
+        $I->amInPath('tests/data/skip');
+        $I->executeCommand('run -v --no-ansi unit ClassLevelSkipAttributeWithMessageCest.php');
+        $I->seeInShellOutput("S ClassLevelSkipAttributeWithMessageCest: Method1");
+        $I->seeInShellOutput("S ClassLevelSkipAttributeWithMessageCest: Method2");
+        $I->seeInShellOutput('Skip message');
+        $I->seeInShellOutput('OK, but incomplete, skipped, or useless tests!');
+    }
+
+    public function classLevelSkipAttributeWithoutMessage(CliGuy $I): void
+    {
+        $I->amInPath('tests/data/skip');
+        $I->executeCommand('run -v --no-ansi unit ClassLevelSkipAttributeWithoutMessageCest.php');
+        $I->seeInShellOutput("S ClassLevelSkipAttributeWithoutMessageCest: Method1");
+        $I->seeInShellOutput("S ClassLevelSkipAttributeWithoutMessageCest: Method2");
+        $I->seeInShellOutput('OK, but incomplete, skipped, or useless tests!');
+    }
+
+    public function methodLevelSkipAnnotationWithMessage(CliGuy $I): void
+    {
+        $I->amInPath('tests/data/skip');
+        $I->executeCommand('run -v --no-ansi unit MethodLevelSkipAnnotationWithMessageCest.php');
+        $I->seeInShellOutput("+ MethodLevelSkipAnnotationWithMessageCest: Method1");
+        $I->seeInShellOutput("S MethodLevelSkipAnnotationWithMessageCest: Method2");
+        $I->seeInShellOutput('Skip message');
+        $I->seeInShellOutput('OK, but incomplete, skipped, or useless tests!');
+    }
+
+    public function methodLevelSkipAnnotationWithoutMessage(CliGuy $I): void
+    {
+        $I->amInPath('tests/data/skip');
+        $I->executeCommand('run -v --no-ansi unit MethodLevelSkipAnnotationWithoutMessageCest.php');
+        $I->seeInShellOutput("+ MethodLevelSkipAnnotationWithoutMessageCest: Method1");
+        $I->seeInShellOutput("S MethodLevelSkipAnnotationWithoutMessageCest: Method2");
+        $I->seeInShellOutput('OK, but incomplete, skipped, or useless tests!');
+    }
+
+    public function methodLevelSkipAttributeWithMessage(CliGuy $I): void
+    {
+        $I->amInPath('tests/data/skip');
+        $I->executeCommand('run -v --no-ansi unit MethodLevelSkipAttributeWithMessageCest.php');
+        $I->seeInShellOutput("S MethodLevelSkipAttributeWithMessageCest: Method1");
+        $I->seeInShellOutput("+ MethodLevelSkipAttributeWithMessageCest: Method2");
+        $I->seeInShellOutput('Skip message');
+        $I->seeInShellOutput('OK, but incomplete, skipped, or useless tests!');
+    }
+
+    public function methodLevelSkipAttributeWithoutMessage(CliGuy $I): void
+    {
+        $I->amInPath('tests/data/skip');
+        $I->executeCommand('run -v --no-ansi unit MethodLevelSkipAttributeWithoutMessageCest.php');
+        $I->seeInShellOutput("+ MethodLevelSkipAttributeWithoutMessageCest: Method1");
+        $I->seeInShellOutput("S MethodLevelSkipAttributeWithoutMessageCest: Method2");
+        $I->seeInShellOutput('OK, but incomplete, skipped, or useless tests!');
+    }
+}

--- a/tests/data/skip/codeception.yml
+++ b/tests/data/skip/codeception.yml
@@ -1,0 +1,9 @@
+paths:
+  tests: tests
+  output: tests/_output
+  data: tests/_data
+  support: tests/_support
+  envs: tests/_envs
+actor_suffix: Tester
+settings:
+  colors: false

--- a/tests/data/skip/tests/_output/.gitignore
+++ b/tests/data/skip/tests/_output/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/tests/data/skip/tests/_support/UnitTester.php
+++ b/tests/data/skip/tests/_support/UnitTester.php
@@ -1,0 +1,21 @@
+<?php
+
+/**
+ * Inherited Methods
+ * @method void wantToTest($text)
+ * @method void wantTo($text)
+ * @method self execute($callable)
+ * @method self expectTo($prediction)
+ * @method self expect($prediction)
+ * @method self amGoingTo($argumentation)
+ * @method self am($role)
+ * @method self lookForwardTo($achieveValue)
+ * @method self comment($description)
+ * @method \Codeception\Lib\Friend haveFriend($name, $actorClass = NULL)
+ *
+ * @SuppressWarnings(PHPMD)
+*/
+class UnitTester extends \Codeception\Actor
+{
+    use _generated\UnitTesterActions;
+}

--- a/tests/data/skip/tests/_support/_generated/.gitignore
+++ b/tests/data/skip/tests/_support/_generated/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/tests/data/skip/tests/unit.suite.yml
+++ b/tests/data/skip/tests/unit.suite.yml
@@ -1,0 +1,1 @@
+actor: UnitTester

--- a/tests/data/skip/tests/unit/ClassLevelSkipAnnotationWithMessageCest.php
+++ b/tests/data/skip/tests/unit/ClassLevelSkipAnnotationWithMessageCest.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Unit;
+
+use UnitTester;
+
+/**
+ * @skip Skip message
+ */
+class ClassLevelSkipAnnotationWithMessageCest
+{
+    public function method1(UnitTester $I)
+    {
+    }
+
+    public function method2(UnitTester $I)
+    {
+    }
+}

--- a/tests/data/skip/tests/unit/ClassLevelSkipAnnotationWithoutMessageCest.php
+++ b/tests/data/skip/tests/unit/ClassLevelSkipAnnotationWithoutMessageCest.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Unit;
+
+use UnitTester;
+
+/**
+ * @skip
+ */
+class ClassLevelSkipAnnotationWithoutMessageCest
+{
+    public function method1(UnitTester $I)
+    {
+    }
+
+    public function method2(UnitTester $I)
+    {
+    }
+}

--- a/tests/data/skip/tests/unit/ClassLevelSkipAttributeWithMessageCest.php
+++ b/tests/data/skip/tests/unit/ClassLevelSkipAttributeWithMessageCest.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Unit;
+
+use Codeception\Attribute\Skip;
+use UnitTester;
+
+#[Skip('Skip message')]
+class ClassLevelSkipAttributeWithMessageCest
+{
+    public function method1(UnitTester $I)
+    {
+    }
+
+    public function method2(UnitTester $I)
+    {
+    }
+}

--- a/tests/data/skip/tests/unit/ClassLevelSkipAttributeWithoutMessageCest.php
+++ b/tests/data/skip/tests/unit/ClassLevelSkipAttributeWithoutMessageCest.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Unit;
+
+use Codeception\Attribute\Skip;
+use UnitTester;
+
+#[Skip]
+class ClassLevelSkipAttributeWithoutMessageCest
+{
+    public function method1(UnitTester $I)
+    {
+    }
+
+    public function method2(UnitTester $I)
+    {
+    }
+}

--- a/tests/data/skip/tests/unit/MethodLevelSkipAnnotationWithMessageCest.php
+++ b/tests/data/skip/tests/unit/MethodLevelSkipAnnotationWithMessageCest.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Unit;
+
+use UnitTester;
+
+class MethodLevelSkipAnnotationWithMessageCest
+{
+    public function method1(UnitTester $I)
+    {
+    }
+
+    /**
+     * @skip Skip message
+     */
+    public function method2(UnitTester $I)
+    {
+    }
+}

--- a/tests/data/skip/tests/unit/MethodLevelSkipAnnotationWithoutMessageCest.php
+++ b/tests/data/skip/tests/unit/MethodLevelSkipAnnotationWithoutMessageCest.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Unit;
+
+use UnitTester;
+
+class MethodLevelSkipAnnotationWithoutMessageCest
+{
+    public function method1(UnitTester $I)
+    {
+    }
+
+    /**
+     * @skip
+     */
+    public function method2(UnitTester $I)
+    {
+    }
+}

--- a/tests/data/skip/tests/unit/MethodLevelSkipAttributeWithMessageCest.php
+++ b/tests/data/skip/tests/unit/MethodLevelSkipAttributeWithMessageCest.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Unit;
+
+use Codeception\Attribute\Skip;
+use UnitTester;
+
+class MethodLevelSkipAttributeWithMessageCest
+{
+    #[Skip('Skip message')]
+    public function method1(UnitTester $I)
+    {
+    }
+
+    public function method2(UnitTester $I)
+    {
+    }
+}

--- a/tests/data/skip/tests/unit/MethodLevelSkipAttributeWithoutMessageCest.php
+++ b/tests/data/skip/tests/unit/MethodLevelSkipAttributeWithoutMessageCest.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Unit;
+
+use Codeception\Attribute\Skip;
+use UnitTester;
+
+class MethodLevelSkipAttributeWithoutMessageCest
+{
+    public function method1(UnitTester $I)
+    {
+    }
+
+    #[Skip]
+    public function method2(UnitTester $I)
+    {
+    }
+}


### PR DESCRIPTION
Fixes #6615

This change ensures that `@skip` annotation and `#[Codeception\Attribute\Skip]` with and without message are handled correctly at class and method level.