### PR TITLE
Update Run.php (Fix depricated messages when running tests)

### DIFF
--- a/src/Codeception/Command/Run.php
+++ b/src/Codeception/Command/Run.php
@@ -419,7 +419,7 @@ class Run extends Command
 
         if ($this->options['shard']) {
             $this->output->writeln(
-                "[Shard ${userOptions['shard']}] <info>Running subset of tests</info>"
+                "[Shard {$userOptions['shard']}] <info>Running subset of tests</info>"
             );
         }
 
@@ -502,7 +502,7 @@ class Run extends Command
 
         if ($this->options['shard']) {
             $this->output->writeln(
-                "[Shard ${userOptions['shard']}] <info>Merge this result with other shards to see the complete report</info>"
+                "[Shard {$userOptions['shard']}] <info>Merge this result with other shards to see the complete report</info>"
             );
         }
 


### PR DESCRIPTION
Fix depricated messages when running tests:
Deprecated: Using ${var} in strings is deprecated, use {$var} instead in ../vendor/codeception/codeception/src/Codeception/Command/Run.php on line 422
Deprecated: Using ${var} in strings is deprecated, use {$var} instead in ../vendor/codeception/codeception/src/Codeception/Command/Run.php on line 505