### PR TITLE
Don't override test feature at runtime

### DIFF
--- a/src/Codeception/Actor.php
+++ b/src/Codeception/Actor.php
@@ -24,14 +24,20 @@ abstract class Actor
         return $this->scenario;
     }
 
-    public function wantToTest(string $text): void
-    {
-        $this->wantTo('test ' . $text);
-    }
-
+    /**
+     * This method is used by Cept format to add description to test output
+     *
+     * It can be used by Cest format too.
+     * It doesn't do anything when called, but it is parsed by Parser before execution
+     *
+     * @see \Codeception\Lib\Parser::parseFeature
+     */
     public function wantTo(string $text): void
     {
-        $this->scenario->setFeature($text);
+    }
+
+    public function wantToTest(string $text): void
+    {
     }
 
     public function __call(string $method, array $arguments)

--- a/src/Codeception/Test/Cept.php
+++ b/src/Codeception/Test/Cept.php
@@ -16,6 +16,8 @@ use function file_get_contents;
 /**
  * Executes tests delivered in Cept format.
  * Prepares metadata, parses test body on preload, and executes a test in `test` method.
+ *
+ * Note: If the time came to delete Cept format, please delete Actor::wantTo method too
  */
 class Cept extends Test implements Interfaces\Plain, Interfaces\ScenarioDriven, Interfaces\Reported, Interfaces\Dependent
 {

--- a/tests/cli/WantToCest.php
+++ b/tests/cli/WantToCest.php
@@ -1,0 +1,62 @@
+<?php
+
+class WantToCest
+{
+    public function iWantToSetsFeatureInCeptFormat(CliGuy $I): void
+    {
+        $I->amInPath('tests/data/want_to');
+        $I->executeCommand('run --no-ansi unit WantToCept.php');
+        $I->seeInShellOutput('+ WantToCept: Check if wantTo works');
+    }
+
+    public function iWantToSetsFeatureInCestFormat(CliGuy $I): void
+    {
+        $I->amInPath('tests/data/want_to');
+        $I->executeCommand('run --no-ansi unit WantToCest.php:^IWantTo');
+        $I->seeInShellOutput('+ WantToCest: Check if I->wantTo works');
+    }
+
+    public function testerWantToSetsFeatureInCestFormat(CliGuy $I): void
+    {
+        $I->amInPath('tests/data/want_to');
+        $I->executeCommand('run --no-ansi unit WantToCest.php:^TesterWantTo');
+        $I->seeInShellOutput('+ WantToCest: Check if tester->wantTo works');
+    }
+
+    public function variablePassedToIWantToIsEvaluated(CliGuy $I): void
+    {
+        $I->amInPath('tests/data/want_to');
+        $I->executeCommand('run --no-ansi unit WantToCest.php:Variable');
+        $I->seeInShellOutput('+ WantToCest: Check if variable wantTo is evaluated');
+    }
+
+    public function iWantToIncorrectlyOverridesDataproviderData(CliGuy $I): void
+    {
+        $I->amInPath('tests/data/want_to');
+        $I->executeCommand('run --no-ansi unit WantToCest.php:DataProviderIWantTo');
+        $I->seeInShellOutput('+ WantToCest: Check if I->wantTo doesn\'t override data provider data');
+    }
+
+    public function testerWantToIncorrectlyOverridesDataproviderData(CliGuy $I): void
+    {
+        $I->amInPath('tests/data/want_to');
+        $I->executeCommand('run --no-ansi unit WantToCest.php:DataProviderTesterWantTo');
+        $I->seeInShellOutput('+ WantToCest: Check if tester->wantTo doesn\'t override data provider data');
+    }
+
+    public function wantToTextIsUsedInXmlReport(CliGuy $I): void
+    {
+        $I->amInPath('tests/data/want_to');
+        $I->executeCommand('run unit --xml');
+        $I->seeShellOutputMatches('!\- JUNIT XML report generated in file:.*report\.xml!');
+        $I->seeFileFound('tests/_output/report.xml');
+        $I->seeInThisFile('WantToCept.php" feature="check if wantTo works"');
+        $I->seeInThisFile('WantToCest.php" feature="check if I-&gt;wantTo works"');
+        $I->seeInThisFile('WantToCest.php" feature="tester want to');
+        $I->seeInThisFile('WantToCest.php" feature="check if I-&gt;wantTo doesn\\\'t override data provider data | &quot;aaa&quot;"');
+        $I->seeInThisFile('WantToCest.php" feature="check if I-&gt;wantTo doesn\\\'t override data provider data | &quot;bbb&quot;"');
+        $I->seeInThisFile('WantToCest.php" feature="data provider tester want to | &quot;aaa&quot;"');
+        $I->seeInThisFile('WantToCest.php" feature="data provider tester want to | &quot;bbb&quot;"');
+        $I->seeInThisFile('WantToCest.php" feature="variable argument of want to"');
+    }
+}

--- a/tests/cli/WantToCest.php
+++ b/tests/cli/WantToCest.php
@@ -16,32 +16,40 @@ class WantToCest
         $I->seeInShellOutput('+ WantToCest: Check if I->wantTo works');
     }
 
-    public function testerWantToSetsFeatureInCestFormat(CliGuy $I): void
+    /**
+     * Tests https://github.com/Codeception/Codeception/issues/4123
+     */
+    public function testerWantDoesntSetFeatureInCestFormat(CliGuy $I): void
     {
         $I->amInPath('tests/data/want_to');
         $I->executeCommand('run --no-ansi unit WantToCest.php:^TesterWantTo');
-        $I->seeInShellOutput('+ WantToCest: Check if tester->wantTo works');
+        $I->seeInShellOutput('+ WantToCest: Tester want to');
     }
 
-    public function variablePassedToIWantToIsEvaluated(CliGuy $I): void
+    public function iWantToWithVariableIsIgnored(CliGuy $I): void
     {
         $I->amInPath('tests/data/want_to');
         $I->executeCommand('run --no-ansi unit WantToCest.php:Variable');
-        $I->seeInShellOutput('+ WantToCest: Check if variable wantTo is evaluated');
+        $I->seeInShellOutput('+ WantToCest: Variable argument of want to');
     }
 
-    public function iWantToIncorrectlyOverridesDataproviderData(CliGuy $I): void
+    /**
+     * Tests https://github.com/Codeception/Codeception/issues/4124
+     */
+    public function iWantToDoesntOverrideDataproviderData(CliGuy $I): void
     {
         $I->amInPath('tests/data/want_to');
         $I->executeCommand('run --no-ansi unit WantToCest.php:DataProviderIWantTo');
-        $I->seeInShellOutput('+ WantToCest: Check if I->wantTo doesn\'t override data provider data');
+        $I->seeInShellOutput('+ WantToCest: Check if I->wantTo doesn\\\'t override data provider data | "aaa"');
+        $I->seeInShellOutput('+ WantToCest: Check if I->wantTo doesn\\\'t override data provider data | "bbb"');
     }
 
-    public function testerWantToIncorrectlyOverridesDataproviderData(CliGuy $I): void
+    public function testerWantToDoesntOverrideDataproviderData(CliGuy $I): void
     {
         $I->amInPath('tests/data/want_to');
         $I->executeCommand('run --no-ansi unit WantToCest.php:DataProviderTesterWantTo');
-        $I->seeInShellOutput('+ WantToCest: Check if tester->wantTo doesn\'t override data provider data');
+        $I->seeInShellOutput('+ WantToCest: Data provider tester want to | "aaa"');
+        $I->seeInShellOutput('+ WantToCest: Data provider tester want to | "bbb"');
     }
 
     public function wantToTextIsUsedInXmlReport(CliGuy $I): void

--- a/tests/data/want_to/codeception.yml
+++ b/tests/data/want_to/codeception.yml
@@ -1,0 +1,9 @@
+paths:
+  tests: tests
+  output: tests/_output
+  data: tests/_data
+  support: tests/_support
+  envs: tests/_envs
+actor_suffix: Tester
+settings:
+  colors: false

--- a/tests/data/want_to/tests/_output/.gitignore
+++ b/tests/data/want_to/tests/_output/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/tests/data/want_to/tests/_support/UnitTester.php
+++ b/tests/data/want_to/tests/_support/UnitTester.php
@@ -1,0 +1,21 @@
+<?php
+
+/**
+ * Inherited Methods
+ * @method void wantToTest($text)
+ * @method void wantTo($text)
+ * @method self execute($callable)
+ * @method self expectTo($prediction)
+ * @method self expect($prediction)
+ * @method self amGoingTo($argumentation)
+ * @method self am($role)
+ * @method self lookForwardTo($achieveValue)
+ * @method self comment($description)
+ * @method \Codeception\Lib\Friend haveFriend($name, $actorClass = NULL)
+ *
+ * @SuppressWarnings(PHPMD)
+*/
+class UnitTester extends \Codeception\Actor
+{
+    use _generated\UnitTesterActions;
+}

--- a/tests/data/want_to/tests/_support/_generated/.gitignore
+++ b/tests/data/want_to/tests/_support/_generated/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/tests/data/want_to/tests/unit.suite.yml
+++ b/tests/data/want_to/tests/unit.suite.yml
@@ -1,0 +1,1 @@
+actor: UnitTester

--- a/tests/data/want_to/tests/unit/WantToCept.php
+++ b/tests/data/want_to/tests/unit/WantToCept.php
@@ -1,0 +1,4 @@
+<?php
+
+$I = new UnitTester($scenario);
+$I->wantTo('check if wantTo works');

--- a/tests/data/want_to/tests/unit/WantToCest.php
+++ b/tests/data/want_to/tests/unit/WantToCest.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Unit;
+
+use Codeception\Example;
+use UnitTester;
+
+class WantToCest
+{
+    public function iWantTo(UnitTester $I)
+    {
+        $I->wantTo('check if I->wantTo works');
+    }
+
+    public function testerWantTo(UnitTester $tester)
+    {
+        $tester->wantTo('check if tester->wantTo works');
+    }
+
+    /**
+     * @dataProvider provider
+     */
+    public function dataProviderIWantTo(UnitTester $I, Example $example)
+    {
+        $I->wantTo('check if I->wantTo doesn\'t override data provider data');
+    }
+
+    /**
+     * @dataProvider provider
+     */
+    public function dataProviderTesterWantTo(UnitTester $tester, Example $example)
+    {
+        $tester->wantTo('check if tester->wantTo doesn\'t override data provider data');
+    }
+
+    protected function provider(): array
+    {
+        return [
+            ['aaa'],
+            ['bbb'],
+        ];
+    }
+
+    public function variableArgumentOfWantTo(UnitTester $I)
+    {
+        $var = 'check if variable wantTo is evaluated';
+        $I->wantTo($var);
+    }
+}


### PR DESCRIPTION
Because it causes issues for custom reporters and hides data provider parameters in the output.

`$I->wantTo('text')`  is still parsed and applied before execution by https://github.com/Codeception/Codeception/blob/994ca6c553eb126fefda6eb5375d2ad1b93d4795/src/Codeception/Lib/Parser.php#L33-L40

Fixes #4123
Fixes #4123