### PR TITLE
Fix failed step output

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         "behat/gherkin": "^4.6.2",
         "codeception/lib-asserts": "2.0.*@dev",
         "codeception/stub": "^4.1",
-        "phpunit/phpunit": "^9.5",
+        "phpunit/phpunit": "^9.5.20",
         "phpunit/php-code-coverage": "^9.2",
         "phpunit/php-text-template": "^2.0",
         "phpunit/php-timer": "^5.0.3",

--- a/src/Codeception/ResultAggregator.php
+++ b/src/Codeception/ResultAggregator.php
@@ -214,4 +214,9 @@ class ResultAggregator
     {
         return count($this->useless);
     }
+
+    public function popLastFailure(): ?FailEvent
+    {
+        return array_pop($this->failures);
+    }
 }

--- a/src/Codeception/Scenario.php
+++ b/src/Codeception/Scenario.php
@@ -10,6 +10,7 @@ use Codeception\Exception\ConditionalAssertionFailed;
 use Codeception\Exception\InjectionException;
 use Codeception\Step\Comment;
 use Codeception\Step\Meta;
+use Codeception\Test\Interfaces\ScenarioDriven;
 use Codeception\Test\Metadata;
 use PHPUnit\Framework\IncompleteTestError;
 use PHPUnit\Framework\SkippedTestError;
@@ -77,7 +78,10 @@ class Scenario
             $testResult = $this->test->getResultAggregator();
             $failEvent = new FailEvent(clone($this->test), $f, 0);
             $testResult->addFailure($failEvent);
-            $dispatcher->dispatch($failEvent, Events::TEST_FAIL);
+            if (!$this->test instanceof ScenarioDriven) {
+                // step failure can't  be checked later in non-scenario driven formats
+                $dispatcher->dispatch($failEvent, Events::TEST_FAIL);
+            }
         } finally {
             $dispatcher->dispatch(new StepEvent($this->test, $step), Events::STEP_AFTER);
         }

--- a/src/Codeception/Scenario.php
+++ b/src/Codeception/Scenario.php
@@ -78,10 +78,6 @@ class Scenario
             $testResult = $this->test->getResultAggregator();
             $failEvent = new FailEvent(clone($this->test), $f, 0);
             $testResult->addFailure($failEvent);
-            if (!$this->test instanceof ScenarioDriven) {
-                // step failure can't  be checked later in non-scenario driven formats
-                $dispatcher->dispatch($failEvent, Events::TEST_FAIL);
-            }
         } finally {
             $dispatcher->dispatch(new StepEvent($this->test, $step), Events::STEP_AFTER);
         }

--- a/src/Codeception/Test/Cept.php
+++ b/src/Codeception/Test/Cept.php
@@ -33,6 +33,11 @@ class Cept extends Test implements Interfaces\Plain, Interfaces\ScenarioDriven, 
         $this->parser = new Parser($this->getScenario(), $this->getMetadata());
     }
 
+    public function __clone(): void
+    {
+        $this->scenario = clone $this->scenario;
+    }
+
     public function preload(): void
     {
         $this->getParser()->prepareToRun($this->getSourceCode());

--- a/src/Codeception/Test/Cest.php
+++ b/src/Codeception/Test/Cest.php
@@ -72,6 +72,11 @@ class Cest extends Test implements
         $this->parser = new Parser($this->getScenario(), $this->getMetadata());
     }
 
+    public function __clone(): void
+    {
+        $this->scenario = clone $this->scenario;
+    }
+
     public function preload(): void
     {
         $this->scenario->setFeature($this->getSpecFromMethod());

--- a/src/Codeception/Test/Gherkin.php
+++ b/src/Codeception/Test/Gherkin.php
@@ -53,6 +53,11 @@ class Gherkin extends Test implements ScenarioDriven, Reported
         $this->getMetadata()->setFilename($featureNode->getFile());
     }
 
+    public function __clone(): void
+    {
+        $this->scenario = clone $this->scenario;
+    }
+
     public function preload(): void
     {
         $this->getMetadata()->setGroups($this->featureNode->getTags());

--- a/src/Codeception/Test/Test.php
+++ b/src/Codeception/Test/Test.php
@@ -171,8 +171,8 @@ abstract class Test extends TestWrapper implements TestInterface, Interfaces\Des
                 $status = self::STATUS_OK;
                 $eventType = Events::TEST_SUCCESS;
 
-                if ($this instanceof ScenarioDriven) {
-                    foreach ($this->getScenario()->getSteps() as $step) {
+                if (method_exists($this, 'getScenario')) {
+                    foreach ($this->getScenario()?->getSteps() ?? [] as $step) {
                         if ($step->hasFailed()) {
                             $lastFailure = $result->popLastFailure();
                             if ($lastFailure !== null) {

--- a/src/Codeception/Test/Test.php
+++ b/src/Codeception/Test/Test.php
@@ -10,6 +10,7 @@ use Codeception\Events;
 use Codeception\Exception\UselessTestException;
 use Codeception\PHPUnit\Wrapper\Test as TestWrapper;
 use Codeception\ResultAggregator;
+use Codeception\Test\Interfaces\ScenarioDriven;
 use Codeception\TestInterface;
 use PHPUnit\Framework\Assert;
 use PHPUnit\Framework\AssertionFailedError;
@@ -169,6 +170,17 @@ abstract class Test extends TestWrapper implements TestInterface, Interfaces\Des
                 $this->test();
                 $status = self::STATUS_OK;
                 $eventType = Events::TEST_SUCCESS;
+
+                if ($this instanceof ScenarioDriven) {
+                    foreach ($this->getScenario()->getSteps() as $step) {
+                        if ($step->hasFailed()) {
+                            $lastFailure = $result->popLastFailure();
+                            if ($lastFailure !== null) {
+                                throw $lastFailure->getFail();
+                            }
+                        }
+                    }
+                }
             } catch (UselessTestException $e) {
                 $result->addUseless(new FailEvent($this, $e, $time));
                 $status = self::STATUS_USELESS;

--- a/src/Codeception/Test/TestCaseWrapper.php
+++ b/src/Codeception/Test/TestCaseWrapper.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Codeception\Test;
 
 use Codeception\Exception\UselessTestException;
+use Codeception\Scenario;
 use Codeception\Test\Interfaces\Dependent;
 use Codeception\Test\Interfaces\Descriptive;
 use Codeception\Test\Interfaces\Reported;
@@ -67,6 +68,11 @@ class TestCaseWrapper extends Test implements Reported, Dependent, StrictCoverag
         $metadata->setAfterClassMethods($afterClassMethods);
     }
 
+    public function __clone(): void
+    {
+        $this->testCase = clone $this->testCase;
+    }
+
     public function getTestCase(): TestCase
     {
         return $this->testCase;
@@ -75,6 +81,15 @@ class TestCaseWrapper extends Test implements Reported, Dependent, StrictCoverag
     public function getMetadata(): Metadata
     {
         return $this->metadata;
+    }
+
+    public function getScenario(): ?Scenario
+    {
+        if ($this->testCase instanceof Unit) {
+            return $this->testCase->getScenario();
+        }
+
+        return null;
     }
 
     public function fetchDependencies(): array

--- a/src/Codeception/Test/Unit.php
+++ b/src/Codeception/Test/Unit.php
@@ -32,12 +32,26 @@ class Unit extends TestCase implements
 
     private ?Metadata $metadata = null;
 
+    private ?Scenario $scenario = null;
+
+    public function __clone(): void
+    {
+        if ($this->scenario !== null) {
+            $this->scenario = clone $this->scenario;
+        }
+    }
+
     public function getMetadata(): Metadata
     {
         if (!$this->metadata) {
             $this->metadata = new Metadata();
         }
         return $this->metadata;
+    }
+
+    public function getScenario(): ?Scenario
+    {
+        return $this->scenario;
     }
 
     public function setMetadata(?Metadata $metadata): void
@@ -68,6 +82,8 @@ class Unit extends TestCase implements
         if (($this->getMetadata()->getCurrent('actor')) && ($property = lcfirst(Configuration::config()['actor_suffix']))) {
             $this->$property = $di->instantiate($this->getMetadata()->getCurrent('actor'));
         }
+
+        $this->scenario = $di->get(Scenario::class);
 
         // Auto inject into the _inject method
         $di->injectDependencies($this); // injecting dependencies

--- a/tests/cli/OrderCest.php
+++ b/tests/cli/OrderCest.php
@@ -29,31 +29,39 @@ final class OrderCest
         $I->seeFileFound('order.txt', 'tests/_output');
         $I->expect(
             'global bootstrap, initialization, beforeSuite, before, bootstrap, test,'
-            . ' fail, fail, test, after, afterSuite'
+            . ' test, fail, after, afterSuite'
         );
-        $I->seeFileContentsEqual("BIB([STFFT])");
+        $I->seeFileContentsEqual("BIB([STTF])");
     }
 
     public function checkForCanCantFailsInCest(CliGuy $I)
     {
         $I->amInPath('tests/data/sandbox');
-        $I->executeCommand('run order CanCantFailCest.php --no-exit');
+        $I->executeCommand('run order CanCantFailCest.php --no-ansi --no-exit');
+        $I->seeInShellOutput('x CanCantFailCest: Test one [F]');
+        $I->seeInShellOutput('x CanCantFailCest: Test two [F]');
+        $I->dontSeeInShellOutput('+ CanCantFailCest: One');
+        $I->dontSeeInShellOutput('+ CanCantFailCest: Two');
         $I->seeFileFound('order.txt', 'tests/_output');
         $I->expect(
             'global bootstrap, initialization, beforeSuite, before, bootstrap, test,'
-            . ' fail, fail, test, test, fail, fail, test, after, afterSuite'
+            . ' test, fail, test, test, fail, after, afterSuite'
         );
-        $I->seeFileContentsEqual("BIB([TFT][TFT])");
+        $I->seeFileContentsEqual("BIB([TTF][TTF])");
     }
 
     public function checkForCanCantFailsInTest(CliGuy $I)
     {
         $I->amInPath('tests/data/sandbox');
-        $I->executeCommand('run order CanCantFailTest.php --no-exit');
+        $I->executeCommand('run order CanCantFailTest.php --no-ansi --no-exit');
+        $I->seeInShellOutput('x CanCantFailTest: One');
+        $I->seeInShellOutput('x CanCantFailTest: Two');
+        $I->dontSeeInShellOutput('+ CanCantFailTest: One');
+        $I->dontSeeInShellOutput('+ CanCantFailTest: Two');
         $I->seeFileFound('order.txt', 'tests/_output');
         $I->expect(
             'global bootstrap, initialization, beforeSuite, before, bootstrap, test,'
-            . ' fail, fail, test, test, fail, fail, test, after, afterSuite'
+            . ' fail, test, test, fail, test, after, afterSuite'
         );
         $I->seeFileContentsEqual("BIB([TFT][TFT])");
     }
@@ -63,7 +71,7 @@ final class OrderCest
         $I->amInPath('tests/data/sandbox');
         $I->executeCommand('run order --no-exit --group simple');
         $I->seeFileFound('order.txt', 'tests/_output');
-        $I->seeFileContentsEqual("BIBP([ST][STFFT][STF][ST])");
+        $I->seeFileContentsEqual("BIBP([ST][STTF][STF][ST])");
     }
 
     public function checkCestOrder(CliGuy $I)

--- a/tests/cli/OrderCest.php
+++ b/tests/cli/OrderCest.php
@@ -61,9 +61,9 @@ final class OrderCest
         $I->seeFileFound('order.txt', 'tests/_output');
         $I->expect(
             'global bootstrap, initialization, beforeSuite, before, bootstrap, test,'
-            . ' fail, test, test, fail, test, after, afterSuite'
+            . ' test, fail, test, test, fail, after, afterSuite'
         );
-        $I->seeFileContentsEqual("BIB([TFT][TFT])");
+        $I->seeFileContentsEqual("BIB([TTF][TTF])");
     }
 
     public function checkSimpleFiles(CliGuy $I)

--- a/tests/cli/RunCest.php
+++ b/tests/cli/RunCest.php
@@ -643,6 +643,31 @@ EOF
         $I->seeInShellOutput('Failures: 2.');
     }
 
+    public function failedTestFollowedByExceptionReportsCorrectStep(CliGuy $I)
+    {
+        $I->executeCommand('run scenario FailureAndExceptionCest', false);
+        $I->seeInShellOutput('1. $I->throwException("test exception")');
+        $I->seeInShellOutput('Step  Assert same 1,2');
+        $I->seeInShellOutput('Failed asserting that 2 is identical to 1.');
+    }
+
+    public function displaysAllFailedConditionalStepsInOneCest(CliGuy $I)
+    {
+        $I->executeCommand('run scenario MultipleConditionalFailsCest --no-ansi', false);
+        $I->seeInShellOutput('x MultipleConditionalFailsCest: Multiple fails 3x[F]');
+        $I->dontSeeInShellOutput('MultipleConditionalFailsCest: Multiple fails 2x[F]');
+        $I->dontSeeInShellOutput('MultipleConditionalFailsCest: Multiple fails [F]');
+        $I->dontSeeInShellOutput('MultipleConditionalFailsCest: Multiple fails[F]');
+        $I->seeInShellOutput('There were 3 failures:');
+        $I->seeInShellOutput('Step  Can see file found "not-a-file"');
+        $I->seeInShellOutput('Step  Can see file found "not-a-dir"');
+        $I->seeInShellOutput('Step  Can see file found "nothing"');
+        $filename = implode(DIRECTORY_SEPARATOR, ['tests', 'scenario','MultipleConditionalFailsCest.php']);
+        $I->seeInShellOutput(' 1. $I->canSeeFileFound("not-a-file") at ' . $filename . ':7');
+        $I->seeInShellOutput(' 7. $I->canSeeFileFound("not-a-dir") at ' . $filename . ':13');
+        $I->seeInShellOutput(' 13. $I->canSeeFileFound("nothing") at ' . $filename . ':19');
+    }
+
     #[Group('shuffle')]
     public function showSeedNumberOnShuffle(CliGuy $I)
     {

--- a/tests/data/claypit/tests/_support/Helper/Scenario.php
+++ b/tests/data/claypit/tests/_support/Helper/Scenario.php
@@ -4,4 +4,8 @@ namespace Helper;
 
 class Scenario extends \Codeception\Module
 {
+    public function throwException($message)
+    {
+        throw new \Exception($message);
+    }
 }

--- a/tests/data/claypit/tests/_support/ScenarioGuy.php
+++ b/tests/data/claypit/tests/_support/ScenarioGuy.php
@@ -60,7 +60,7 @@ class ScenarioGuy extends \Codeception\Actor
     {
         $this->seeFileFound($file);
         foreach ($node->getRows() as $row) {
-            $this->seeThisFileMatches('~' . implode('.*?', $row) . '~');
+            $this->seeThisFileMatches('~' . implode('.*?', $row) . '~s');
         }
     }
 

--- a/tests/data/claypit/tests/scenario.suite.yml
+++ b/tests/data/claypit/tests/scenario.suite.yml
@@ -1,6 +1,9 @@
 actor: ScenarioGuy
 modules:
-    enabled: [Filesystem, \Helper\Scenario]
+    enabled:
+        - Asserts
+        - Filesystem
+        - \Helper\Scenario
 gherkin:
     contexts:
         default: [ScenarioGuy]

--- a/tests/data/claypit/tests/scenario/FailureAndExceptionCest.php
+++ b/tests/data/claypit/tests/scenario/FailureAndExceptionCest.php
@@ -1,0 +1,14 @@
+<?php
+
+class FailureAndExceptionCest
+{
+    public function failedTest(ScenarioGuy $I)
+    {
+        $I->assertSame(1, 2);
+    }
+
+    public function exceptionTest(ScenarioGuy $I)
+    {
+        $I->throwException('test exception');
+    }
+}

--- a/tests/data/claypit/tests/scenario/MultipleConditionalFailsCest.php
+++ b/tests/data/claypit/tests/scenario/MultipleConditionalFailsCest.php
@@ -1,0 +1,21 @@
+<?php
+
+class MultipleConditionalFailsCest
+{
+    public function multipleFails(ScenarioGuy $I)
+    {
+        $I->canSeeFileFound('not-a-file');
+        $I->assertTrue(true);
+        $I->assertTrue(true);
+        $I->assertTrue(true);
+        $I->assertTrue(true);
+        $I->assertTrue(true);
+        $I->canSeeFileFound('not-a-dir');
+        $I->assertFalse(false);
+        $I->assertFalse(false);
+        $I->assertFalse(false);
+        $I->assertFalse(false);
+        $I->assertFalse(false);
+        $I->canSeeFileFound('nothing');
+    }
+}


### PR DESCRIPTION
Fixed #5820 and probably many other reports about incorrect failed step output

The problem with `$failedStep = (string)array_shift($this->failedStep);` in [src/Codeception/Subscriber/Console.php](https://github.com/Codeception/Codeception/compare/fix-failed-step-output?expand=1#diff-a66d9a47f594bb583f325ea19ee1505d50f22bc4c8232cbf025dffd8ec9a8282) was that all failed steps are added to that array in order of test execution, but errors are printed before failures and order of printing doesn't match order of execution.