### PR TITLE
Fix static $defaultName deprecated

### DIFF
--- a/src/Codeception/Command/CompletionFallback.php
+++ b/src/Codeception/Command/CompletionFallback.php
@@ -10,10 +10,10 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class CompletionFallback extends Command
 {
-    /**
-     * @var string
-     */
-    protected static $defaultName = '_completion';
+    public function __construct()
+    {
+        parent::__construct('_completion');
+    }
 
     protected function configure(): void
     {


### PR DESCRIPTION
I don't have `stecman/symfony-console-completion` package, so Symfony 6.2 throws deprecated error:
```
PHP Deprecated: Since symfony/console 6.1: Relying on the static property "$defaultName" for setting a command name is deprecated. Add the "Symfony\Component\Console\Attribute\AsCommand" attribute to the "Codeception\Command\CompletionFallback" class instead. in /var/www/vendor/symfony/deprecation-contracts/function.php on line 25
```
I think we can skip using `AsCommand` since it have constructor variable for it and supported by all Symfony versions.