### PR TITLE
JUnitReporter: Do not set 'useless' testsuite attribute in strict mode

### DIFF
--- a/src/Codeception/Reporter/JUnitReporter.php
+++ b/src/Codeception/Reporter/JUnitReporter.php
@@ -186,17 +186,17 @@ class JUnitReporter implements EventSubscriberInterface
             (string)$this->testSuiteSkipped[$this->testSuiteLevel]
         );
 
-        $this->testSuites[$this->testSuiteLevel]->setAttribute(
-            'time',
-            sprintf('%F', $this->testSuiteTimes[$this->testSuiteLevel])
-        );
-
         if (!$this->isStrict) {
             $this->testSuites[$this->testSuiteLevel]->setAttribute(
                 'useless',
                 (string)$this->testSuiteUseless[$this->testSuiteLevel]
             );
         }
+
+        $this->testSuites[$this->testSuiteLevel]->setAttribute(
+            'time',
+            sprintf('%F', $this->testSuiteTimes[$this->testSuiteLevel])
+        );
 
         if ($this->testSuiteLevel > 1) {
             $this->testSuiteTests[$this->testSuiteLevel - 1] += $this->testSuiteTests[$this->testSuiteLevel];

--- a/src/Codeception/Reporter/JUnitReporter.php
+++ b/src/Codeception/Reporter/JUnitReporter.php
@@ -187,14 +187,16 @@ class JUnitReporter implements EventSubscriberInterface
         );
 
         $this->testSuites[$this->testSuiteLevel]->setAttribute(
-            'useless',
-            (string)$this->testSuiteUseless[$this->testSuiteLevel]
-        );
-
-        $this->testSuites[$this->testSuiteLevel]->setAttribute(
             'time',
             sprintf('%F', $this->testSuiteTimes[$this->testSuiteLevel])
         );
+
+        if (!$this->isStrict) {
+            $this->testSuites[$this->testSuiteLevel]->setAttribute(
+                'useless',
+                (string)$this->testSuiteUseless[$this->testSuiteLevel]
+            );
+        }
 
         if ($this->testSuiteLevel > 1) {
             $this->testSuiteTests[$this->testSuiteLevel - 1] += $this->testSuiteTests[$this->testSuiteLevel];

--- a/tests/cli/RunCest.php
+++ b/tests/cli/RunCest.php
@@ -128,7 +128,7 @@ final class RunCest
         $I->seeInThisFile('<?xml');
         $I->seeInThisFile(
             '<testsuite name="dummy" tests="6" assertions="3" errors="0" failures="0" skipped="0"'
-            . ' useless="0" time='
+            . ' time='
         );
         $I->seeThisFileMatches('/<testsuite name="AnotherCest" file=".*?AnotherCest.php"/');
         $I->seeThisFileMatches('/<testsuite name="AnotherTest" file=".*?AnotherTest.php"/');

--- a/tests/cli/RunCest.php
+++ b/tests/cli/RunCest.php
@@ -134,7 +134,7 @@ final class RunCest
         $I->seeThisFileMatches('/<testsuite name="AnotherTest" file=".*?AnotherTest.php"/');
         $I->seeThisFileMatches(
             '/<testsuite name="AnotherTest" file=".*?AnotherTest.php" tests="2" assertions="2" errors="0"'
-            . ' failures="0" skipped="0" useless="0" time=/'
+            . ' failures="0" skipped="0" time=/'
         );
         //FileExistsCept file
         $I->seeInThisFile('<testsuite name="FileExists"');


### PR DESCRIPTION
Fixes #6634