### PR TITLE
Reduce the size of vendor dir in Github Actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -85,11 +85,11 @@ jobs:
 
       - name: Install latest versions of dependencies in stable mode
         if: matrix.mode == 'stable'
-        run: composer update --prefer-source --no-interaction --no-progress --optimize-autoloader --ansi
+        run: composer update --no-interaction --no-progress --optimize-autoloader --ansi
 
       - name: Composer install lowest versions of dependencies on PHP 8.0 in experimental mode
         if: matrix.php == '8.0' && matrix.mode == 'experimental'
-        run: composer update --prefer-source --prefer-lowest --no-interaction --no-progress --optimize-autoloader --ansi
+        run: composer update --prefer-lowest --no-interaction --no-progress --optimize-autoloader --ansi
 
       - name: Test that failing test really fails
         run: if php codecept run -c tests/data/claypit/ scenario FailedCept -vvv; then echo "Test hasn't failed"; false; fi;

--- a/composer.json
+++ b/composer.json
@@ -103,5 +103,14 @@
     "scripts-descriptions": {
         "cs-prod": "Check production code style",
         "cs-tests": "Check test code style"
+    },
+    "config": {
+        "preferred-install": {
+            "codeception/module-asserts": "source",
+            "codeception/module-db": "source",
+            "codeception/module-filesystem": "source",
+            "codeception/module-phpbrowser": "source",
+            "*": "dist"
+        }
     }
 }


### PR DESCRIPTION
I noticed that Github Actions build was downloading 1.1G of composer files from cache because Github action runs `composer update --prefer-source`.
We need the source, because CI runs tests of module-asserts, module-db, module-filesystem, module-phpbrowser.

On my computer vendor dir was actually 1.3G large.
`composer update --prefer-dist` reduced the size of vendor dir to 19G, but it removed tests of the 4 modules that we care about.

Setting `preferred-install` `source` for these 4 modules increased the size of vendor dir to 22M, but it is very good improvement from 1.1 - 1.3 G.

Cache size was reduced from 1.1G to 4.2M 