### PR TITLE
[BUGFIX] #6652 Class BaseCommandRunner not found

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,6 +24,7 @@ RUN set -eux; \
     echo "date.timezone = UTC" >> /usr/local/etc/php/php.ini;
 
 ENV COMPOSER_ALLOW_SUPERUSER '1'
+ENV XDEBUG_MODE 'coverage'
 
 WORKDIR /codecept
 
@@ -45,7 +46,9 @@ RUN set -eux; \
         codeception/module-sequence \
         codeception/module-soap \
         codeception/module-webdriver; \
-    composer update --no-dev --prefer-dist --no-interaction --optimize-autoloader --apcu-autoloader; \
+    composer require --dev \
+        codeception/util-universalframework; \
+    composer update --prefer-dist --no-interaction --optimize-autoloader --apcu-autoloader; \
     ln -s /codecept/vendor/bin/codecept /usr/local/bin/codecept; \
     mkdir /project;
 

--- a/tests/unit/_bootstrap.php
+++ b/tests/unit/_bootstrap.php
@@ -2,3 +2,7 @@
 
 // Here you can initialize variables that will for your tests
 \Codeception\Configuration::$lock = true;
+
+\Codeception\Util\Autoload::addNamespace('', 'tests/unit/Codeception/Command');
+\Codeception\Util\Autoload::addNamespace('Codeception\Util', 'tests/unit/Codeception/Util');
+\Codeception\Util\Autoload::addNamespace('Project\Command', 'tests/data/register_command/examples');


### PR DESCRIPTION
Fixed autoloader for unit tests.
Fixed xdebug mode warning message.

Command runs with all green:
docker-compose run --rm codecept run unit Codeception/Command

Known issues:
1. `docker-compose run --rm codecept run unit Codeception/Lib/DiTest` fail with **Failed asserting that exception of type "ReflectionException" matches expected exception "Codeception\Exception\InjectionException".**
2. `docker-compose run --rm codecept run unit Codeception/Coverage/FilterTest::testWhitelistFilterApplied` fails with **[Symfony\Component\Finder\Exception\DirectoryNotFoundException] The "/repo/vendor" directory does not exist.** 
3. `docker-compose run --rm codecept run cli` fail with **Could not open input file: /repo/codecept**

