### PR TITLE
Fix JUnitReporter compatibility with PHPUnit 10.0.16

### DIFF
--- a/src/Codeception/Reporter/JUnitReporter.php
+++ b/src/Codeception/Reporter/JUnitReporter.php
@@ -247,12 +247,12 @@ class JUnitReporter implements EventSubscriberInterface
 
         if ($test instanceof TestCaseWrapper) {
             $testCase = $test->getTestCase();
-            if ($testCase->hasOutput()) {
+            if (!$testCase->hasExpectationOnOutput()) {
                 $testOutput = $testCase->getActualOutputForAssertion();
             }
         }
 
-        if (!empty($testOutput)) {
+        if ($testOutput !== '') {
             $systemOut = $this->document->createElement(
                 'system-out',
                 Xml::prepareString($testOutput)


### PR DESCRIPTION
`hasOutput()` method was renamed to `hasUnexpectedOutput()` in PHPUnit 10.0.16, but we don't have to use it, because it only checks if output is not empty and expectation on output is not set.

Fixes #6654