### PR TITLE
Separate generated methods with 1 newline only

### DIFF
--- a/src/Codeception/Lib/Generator/Actions.php
+++ b/src/Codeception/Lib/Generator/Actions.php
@@ -119,7 +119,7 @@ EOF;
             ->place('namespace', $namespace !== '' ? $namespace . '\\' : '')
             ->place('hash', self::genHash($this->modules, $this->settings))
             ->place('name', $this->name)
-            ->place('methods', implode("\n\n ", $code))
+            ->place('methods', implode("\n", $code))
             ->produce();
     }
 


### PR DESCRIPTION
There were 2 newlines and a trailing space between generated methods.

https://github.com/Codeception/Codeception/blob/ed4af7fd4103cdd035916fbb8f35124edd2d018b/tests/data/included/jazz/tests/functional/TestGuy.php#L65C6-L68
