### PR TITLE
fix sharding for empty tests file

### DIFF
--- a/src/Codeception/Test/Loader.php
+++ b/src/Codeception/Test/Loader.php
@@ -106,6 +106,9 @@ class Loader
 
     private function splitTestsIntoChunks(int $chunks): array
     {
+        if (empty($this->tests)) {
+            return [];
+        }
         return array_chunk($this->tests, intval(ceil(sizeof($this->tests) / $chunks)));
     }
 


### PR DESCRIPTION
A file without tests will cause sharding to break:
```sh
Fatal error: Uncaught ValueError: array_chunk(): Argument #2 ($length) must be greater than 0 in /project/vendor/codeception/codeception/src/Codeception/Test/Loader.php:109
Stack trace:
#0 /project/vendor/codeception/codeception/src/Codeception/Test/Loader.php(109): array_chunk(Array, 0)
#1 /project/vendor/codeception/codeception/src/Codeception/Test/Loader.php(100): Codeception\Test\Loader->splitTestsIntoChunks(4)
#2 /project/vendor/codeception/codeception/src/Codeception/SuiteManager.php(86): Codeception\Test\Loader->getTests()
#3 /project/vendor/codeception/codeception/src/Codeception/Codecept.php(258): Codeception\SuiteManager->loadTests(NULL)
#4 /project/vendor/codeception/codeception/src/Codeception/Codecept.php(216): Codeception\Codecept->runSuite(Array, 'acceptance', NULL)
#5 /project/vendor/codeception/codeception/src/Codeception/Command/Run.php(646): Codeception\Codecept->run('acceptance')
#6 /project/vendor/codeception/codeception/src/Codeception/Command/Run.php(467): Codeception\Command\Run->runSuites(Array, Array)
