### PR TITLE
Include mock expectations in assertion count 

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -90,6 +90,8 @@
             "tests/data/register_command/examples",
             "tests/data/DummyClass.php",
             "tests/data/DummyOverloadableClass.php",
+            "tests/data/services/UserModel.php",
+            "tests/data/services/UserService.php",
             "tests/unit/Codeception/Command/BaseCommandRunner.php",
             "tests/unit/Codeception/Util/MockAutoload.php",
             "tests/unit/Codeception/Util/ReflectionTestClass.php"

--- a/tests/cli/RunUselessTestsCest.php
+++ b/tests/cli/RunUselessTestsCest.php
@@ -92,30 +92,33 @@ This test indicates it does not perform assertions but 1 assertions were perform
         $I->seeInShellOutput('UselessTest: Make no assertions............................................Useless');
         $I->seeInShellOutput('UselessTest: Expects not to perform assertions.............................Ok');
         $I->seeInShellOutput('UselessTest: Make unexpected assertion.....................................Useless');
+        $I->seeInShellOutput('UselessTest: Mock expectations.............................................Ok');
 
         $I->seeInShellOutput('JUNIT XML report generated in');
         $I->seeInShellOutput('PHPUNIT XML report generated in');
         $I->seeInShellOutput('HTML report generated in');
         $I->seeFileFound('report.xml', 'tests/_output');
         $I->seeInThisFile(
-            '<testsuite name="unit" tests="5" assertions="1" errors="0" failures="0" skipped="0" useless="4" time="'
+            '<testsuite name="unit" tests="6" assertions="2" errors="0" failures="0" skipped="0" useless="4" time="'
         );
         $I->seeInThisFile('<testcase name="Useless"');
         $I->seeInThisFile('<testcase name="makeNoAssertions" class="UselessCest"');
         $I->seeInThisFile('<testcase name="testMakeNoAssertions" class="UselessTest" file="');
         $I->seeInThisFile('<testcase name="testExpectsNotToPerformAssertions" class="UselessTest" file="');
         $I->seeInThisFile('<testcase name="testMakeUnexpectedAssertion" class="UselessTest" file="');
+        $I->seeInThisFile('<testcase name="testMockExpectations" class="UselessTest" file="');
         $I->seeInThisFile('<error>Useless Test</error>');
 
         $I->seeFileFound('phpunit-report.xml', 'tests/_output');
         $I->seeInThisFile(
-            '<testsuite name="unit" tests="5" assertions="1" errors="0" failures="0" skipped="0" useless="4" time="'
+            '<testsuite name="unit" tests="6" assertions="2" errors="0" failures="0" skipped="0" useless="4" time="'
         );
         $I->seeInThisFile('<testcase name="Useless"');
         $I->seeInThisFile('<testcase name="makeNoAssertions" class="UselessCest"');
         $I->seeInThisFile('<testcase name="testMakeNoAssertions" class="UselessTest" file="');
         $I->seeInThisFile('<testcase name="testExpectsNotToPerformAssertions" class="UselessTest" file="');
         $I->seeInThisFile('<testcase name="testMakeUnexpectedAssertion" class="UselessTest" file="');
+        $I->seeInThisFile('<testcase name="testMockExpectations" class="UselessTest" file="');
         $I->seeInThisFile('<error>Useless Test</error>');
 
         $I->seeFileFound('report.html', 'tests/_output');

--- a/tests/data/useless/tests/unit/UselessTest.php
+++ b/tests/data/useless/tests/unit/UselessTest.php
@@ -1,5 +1,7 @@
 <?php
 
+use Codeception\Stub\Expected;
+
 class UselessTest extends \Codeception\Test\Unit
 {
     /**
@@ -20,5 +22,18 @@ class UselessTest extends \Codeception\Test\Unit
     {
         $this->expectNotToPerformAssertions();
         $this->assertTrue(true);
+    }
+
+    public function testMockExpectations(): void
+    {
+        $user = $this->make(
+            UserModel::class,
+            [
+                'setName' => Expected::once('Foo'),
+            ],
+        );
+
+        $userService = new UserService($user);
+        $userService->create('Foo');
     }
 }


### PR DESCRIPTION
This fixes #6671.

The fix works for both PHPUnit and Codeception mocking methods. It also works when using a external mocking library like Mockery.