### PR TITLE
Allow multiple test dependencies

### DIFF
--- a/src/Codeception/Test/Cest.php
+++ b/src/Codeception/Test/Cest.php
@@ -242,11 +242,13 @@ class Cest extends Test implements
     public function fetchDependencies(): array
     {
         $names = [];
-        foreach ($this->getMetadata()->getDependencies() as $required) {
-            if (!str_contains($required, ':') && method_exists($this->getTestInstance(), $required)) {
-                $required = $this->testClass . ":{$required}";
+        foreach ($this->getMetadata()->getDependencies() as $dependency) {
+            foreach ((array)$dependency as $required) {
+                if (!str_contains($required, ':') && method_exists($this->getTestInstance(), $required)) {
+                    $required = $this->testClass . ":{$required}";
+                }
+                $names[] = $required;
             }
-            $names[] = $required;
         }
         return $names;
     }


### PR DESCRIPTION
The Depends attribute can be added multiple times to tests now to indicate dependencies on various other tests.

Fixes #6675