### PR TITLE
Differentiate parsing errors in a parent class from the ones in the test class

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -90,6 +90,8 @@
             "tests/data/register_command/examples",
             "tests/data/DummyClass.php",
             "tests/data/DummyOverloadableClass.php",
+            "tests/data/InvalidClass.php",
+            "tests/data/InvalidChildClass.php",
             "tests/data/services/UserModel.php",
             "tests/data/services/UserService.php",
             "tests/unit/Codeception/Command/BaseCommandRunner.php",

--- a/src/Codeception/Exception/TestParseException.php
+++ b/src/Codeception/Exception/TestParseException.php
@@ -8,14 +8,23 @@ use Exception;
 
 class TestParseException extends Exception
 {
-    public function __construct(string $fileName, string $errors = null, int $line = null)
+    public function __construct(string $fileName, string $errors = null, int $line = null, string $testFile = null)
     {
+        $fileName = self::normalizePathSeparators($fileName);
         $this->message = "Couldn't parse test '{$fileName}'";
         if ($line !== null) {
             $this->message .= " on line {$line}";
         }
         if ($errors) {
-            $this->message .= PHP_EOL . $errors;
+            $this->message .= ":" . PHP_EOL . $errors;
         }
+        if (($testFile = self::normalizePathSeparators($testFile)) && realpath($fileName) !== realpath($testFile)) {
+            $this->message .= PHP_EOL . "(Error occurred while parsing Test '{$testFile}')";
+        }
+    }
+
+    public static function normalizePathSeparators(?string $testFile): ?string
+    {
+        return str_replace(['/', '\\'], DIRECTORY_SEPARATOR, $testFile ?? '');
     }
 }

--- a/src/Codeception/Lib/Parser.php
+++ b/src/Codeception/Lib/Parser.php
@@ -100,7 +100,7 @@ class Parser
         try {
             self::includeFile($file);
         } catch (ParseError $e) {
-            throw new TestParseException($file, $e->getMessage(), $e->getLine());
+            throw new TestParseException($e->getFile(), $e->getMessage(), $e->getLine(), $file);
         } catch (Exception) {
             // file is valid otherwise
         }

--- a/tests/data/InvalidChildClass.php
+++ b/tests/data/InvalidChildClass.php
@@ -1,0 +1,5 @@
+<?php
+
+class InvalidChildClass extends InvalidClass
+{
+}

--- a/tests/data/InvalidClass.php
+++ b/tests/data/InvalidClass.php
@@ -1,0 +1,6 @@
+<?php
+
+class InvalidClass
+{
+    foo
+}


### PR DESCRIPTION
Currently, when a test inherits from a parent class, and there is a parsing error happening while parsing this parent class, then the error shows the parse error and line number from the parent class, but the file name from the (child) test class.

This patch will show the file name in which the error actually happens. And if it's not in the test class it self, it will additionally indicate to the name of the test class.