### PR TITLE
Add actor to Cest tests dataProviders

### DIFF
--- a/src/Codeception/Command/Shared/ActorTrait.php
+++ b/src/Codeception/Command/Shared/ActorTrait.php
@@ -4,9 +4,11 @@ declare(strict_types=1);
 
 namespace Codeception\Command\Shared;
 
+use Codeception\Scenario;
+
 trait ActorTrait
 {
-    protected function getActor(): ?string
+    protected function getActorClassName(): ?string
     {
         if (empty($this->settings['actor'])) {
             return null;
@@ -21,8 +23,16 @@ trait ActorTrait
         if (isset($this->settings['support_namespace'])) {
             $namespace .= '\\' . $this->settings['support_namespace'];
         }
+
         $namespace = rtrim($namespace, '\\') . '\\';
 
         return $namespace . $this->settings['actor'];
+    }
+
+    private function getActor($test)
+    {
+        $actorClass = $this->getActorClassName();
+
+        return $actorClass ? new $actorClass(new Scenario($test)) : null;
     }
 }

--- a/src/Codeception/Command/Shared/ActorTrait.php
+++ b/src/Codeception/Command/Shared/ActorTrait.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Codeception\Command\Shared;
+
+trait ActorTrait
+{
+    protected function getActor(): ?string
+    {
+        if (empty($this->settings['actor'])) {
+            return null;
+        }
+
+        $namespace = "";
+
+        if ($this->settings['namespace']) {
+            $namespace .= '\\' . $this->settings['namespace'];
+        }
+
+        if (isset($this->settings['support_namespace'])) {
+            $namespace .= '\\' . $this->settings['support_namespace'];
+        }
+        $namespace = rtrim($namespace, '\\') . '\\';
+
+        return $namespace . $this->settings['actor'];
+    }
+}

--- a/src/Codeception/SuiteManager.php
+++ b/src/Codeception/SuiteManager.php
@@ -206,7 +206,7 @@ class SuiteManager
             'modules' => $this->moduleContainer
         ]);
         $test->getMetadata()->setCurrent([
-            'actor' => $this->getActor(),
+            'actor' => $this->getActorClassName(),
             'env' => $this->env,
             'modules' => $this->moduleContainer->all()
         ]);

--- a/src/Codeception/SuiteManager.php
+++ b/src/Codeception/SuiteManager.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Codeception;
 
+use Codeception\Command\Shared\ActorTrait;
 use Codeception\Lib\Di;
 use Codeception\Lib\GroupManager;
 use Codeception\Lib\ModuleContainer;
@@ -20,6 +21,8 @@ use Symfony\Component\EventDispatcher\EventDispatcher;
 
 class SuiteManager
 {
+    use ActorTrait;
+
     protected ?Suite $suite = null;
 
     protected ?EventDispatcher $dispatcher = null;
@@ -158,26 +161,6 @@ class SuiteManager
     public function getModuleContainer(): ModuleContainer
     {
         return $this->moduleContainer;
-    }
-
-    protected function getActor(): ?string
-    {
-        if (!$this->settings['actor']) {
-            return null;
-        }
-
-        $namespace = "";
-
-        if ($this->settings['namespace']) {
-            $namespace .= '\\' . $this->settings['namespace'];
-        }
-
-        if (isset($this->settings['support_namespace'])) {
-            $namespace .= '\\' . $this->settings['support_namespace'];
-        }
-        $namespace = rtrim($namespace, '\\') . '\\';
-
-        return $namespace . $this->settings['actor'];
     }
 
     protected function checkEnvironmentExists(TestInterface $test): void

--- a/src/Codeception/Test/DataProvider.php
+++ b/src/Codeception/Test/DataProvider.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Codeception\Test;
 
+use Codeception\Actor;
 use Codeception\Exception\InvalidTestException;
 use Codeception\Exception\TestParseException;
 use Codeception\Util\Annotation;
@@ -16,7 +17,7 @@ use function sprintf;
 
 class DataProvider
 {
-    public static function getDataForMethod(ReflectionMethod $method, ?ReflectionClass $class = null): ?iterable
+    public static function getDataForMethod(ReflectionMethod $method, ?ReflectionClass $class = null, ?Actor $I = null): ?iterable
     {
         $testClass = self::getTestClass($method, $class);
         $testClassName = $testClass->getName();
@@ -62,16 +63,17 @@ class DataProvider
             try {
                 $dataProviderMethod = new ReflectionMethod($dataProviderClassName, $dataProviderMethodName);
                 if ($dataProviderMethod->isStatic()) {
-                    $dataProviderResult = call_user_func([$dataProviderClassName, $dataProviderMethodName]);
+                    $dataProviderResult = call_user_func([$dataProviderClassName, $dataProviderMethodName], $I);
                 } else {
                     $testInstance = new $dataProviderClassName($dataProviderMethodName);
 
                     if ($dataProviderMethod->isPublic()) {
-                        $dataProviderResult = $testInstance->$dataProviderMethodName();
+                        $dataProviderResult = $testInstance->$dataProviderMethodName($I);
                     } else {
                         $dataProviderResult = ReflectionHelper::invokePrivateMethod(
                             $testInstance,
                             $dataProviderMethodName,
+                            [$I]
                         );
                     }
                 }

--- a/src/Codeception/Test/Loader.php
+++ b/src/Codeception/Test/Loader.php
@@ -68,7 +68,7 @@ class Loader
 
         $this->formats = [
             new CeptLoader(),
-            new CestLoader(),
+            new CestLoader($suiteSettings),
             new UnitLoader(),
             new GherkinLoader($suiteSettings)
         ];

--- a/src/Codeception/Test/Loader/Cest.php
+++ b/src/Codeception/Test/Loader/Cest.php
@@ -63,8 +63,7 @@ class Cest implements LoaderInterface
                 }
 
                 $test = new CestFormat($unit, $method, $filename);
-                $actorClass = $this->getActor();
-                $I = $actorClass ? new $actorClass(new Scenario($test)) : null;
+                $I = $this->getActor($test);
 
                 $examples = DataProvider::getDataForMethod(
                     new \ReflectionMethod($testClass, $method),

--- a/src/Codeception/Test/Loader/Cest.php
+++ b/src/Codeception/Test/Loader/Cest.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace Codeception\Test\Loader;
 
+use Codeception\Command\Shared\ActorTrait;
 use Codeception\Lib\Parser;
+use Codeception\Scenario;
 use Codeception\Test\Cest as CestFormat;
 use Codeception\Test\DataProvider;
 use ReflectionClass;
@@ -13,10 +15,19 @@ use function get_class_methods;
 
 class Cest implements LoaderInterface
 {
+    use ActorTrait;
+
     /**
      * @var CestFormat[]
      */
     protected array $tests = [];
+
+    protected array $settings = [];
+
+    public function __construct(array $settings = [])
+    {
+        $this->settings = $settings;
+    }
 
     /**
      * @return CestFormat[]
@@ -51,9 +62,14 @@ class Cest implements LoaderInterface
                     continue;
                 }
 
+                $test = new CestFormat($unit, $method, $filename);
+                $actorClass = $this->getActor();
+                $I = $actorClass ? new $actorClass(new Scenario($test)) : null;
+
                 $examples = DataProvider::getDataForMethod(
                     new \ReflectionMethod($testClass, $method),
-                    new \ReflectionClass($testClass)
+                    new \ReflectionClass($testClass),
+                    $I,
                 );
 
                 if ($examples === null) {

--- a/tests/data/data_provider/DataProviderReceivesActorTest.php
+++ b/tests/data/data_provider/DataProviderReceivesActorTest.php
@@ -14,7 +14,6 @@ class DataProviderReceivesActorTest extends TestCase
     #[DataProvider('getData')]
     public function testDataProvider(): void
     {
-
     }
 
     public function getData(CodeGuy $I): array

--- a/tests/data/data_provider/DataProviderReceivesActorTest.php
+++ b/tests/data/data_provider/DataProviderReceivesActorTest.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace data\data_provider;
+
+use Codeception\Attribute\DataProvider;
+use Codeception\Attribute\Examples;
+use CodeGuy;
+use PHPUnit\Framework\TestCase;
+
+class DataProviderReceivesActorTest extends TestCase
+{
+    #[DataProvider('getData')]
+    public function testDataProvider(): void
+    {
+
+    }
+
+    public function getData(CodeGuy $I): array
+    {
+        return [
+            $I->codeGuyMethod()
+        ];
+    }
+}

--- a/tests/support/CodeGuy.php
+++ b/tests/support/CodeGuy.php
@@ -18,4 +18,9 @@
 class CodeGuy extends \Codeception\Actor
 {
     use _generated\CodeGuyActions;
+
+    public function codeGuyMethod(): string
+    {
+        return 'codeGuyMethod() exists';
+    }
 }

--- a/tests/unit/Codeception/Test/DataProviderTest.php
+++ b/tests/unit/Codeception/Test/DataProviderTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 use Codeception\Exception\InvalidTestException;
 use Codeception\Test\DataProvider;
 use Codeception\Test\Unit;
+use data\data_provider\DataProviderReceivesActorTest;
 
 class DataProviderTest extends Unit
 {
@@ -204,6 +205,19 @@ class DataProviderTest extends Unit
 
         $expectedResult = [
             'foo' => ['foo'],
+        ];
+
+        self::assertSame($expectedResult, $result);
+    }
+
+    public function testDataProviderReceivesActor(): void
+    {
+        require_once codecept_data_dir('data_provider/DataProviderReceivesActorTest.php');
+        $method = new ReflectionMethod(DataProviderReceivesActorTest::class, 'testDataProvider');
+        $result = DataProvider::getDataForMethod($method, I: $this->tester);
+
+        $expectedResult = [
+            'codeGuyMethod() exists'
         ];
 
         self::assertSame($expectedResult, $result);


### PR DESCRIPTION
It makes possible to use actors inside dataProviders. It's a very useful functionality, during testing it happens that data need to be retrieved ie.: from the database, but it's not possible to use it with the current solution. There was a discussion about it in the past: #4087 

I am not sure if I implemented it in the correct way, I am new to Codeception and open source contribution as well. What do you think of it @DavertMik?