### PR TITLE
feat: Support binary data

### DIFF
--- a/src/Codeception/Test/Descriptor.php
+++ b/src/Codeception/Test/Descriptor.php
@@ -49,7 +49,7 @@ class Descriptor
             method_exists($testCase, 'getMetaData')
             && !empty($testCase->getMetadata()->getCurrent('example'))
         ) {
-            $currentExample = json_encode($testCase->getMetadata()->getCurrent('example'), JSON_THROW_ON_ERROR);
+            $currentExample = json_encode($testCase->getMetadata()->getCurrent('example'), JSON_THROW_ON_ERROR | JSON_INVALID_UTF8_SUBSTITUTE);
             $example = ':' . substr(sha1($currentExample), 0, 7);
         }
 


### PR DESCRIPTION
Hi,

Unfortunately if a suite got binary data, and this suite failed, then we can't see the problem. We see json_error problem:
```
In Descriptor.php line 52:                                                            
Malformed UTF-8 characters, possibly incorrectly encoded  
```
Expected (example):
```
There was 1 failure:
1) TestCest: My suite | "��K�r��B�\"
 Test  tests/TestCest.php:mySuite
 Step  Assert equals false,true
 Fail  Failed asserting that true matches expected false.

Scenario Steps:
 1. $I->assertEquals(false,true) 
```

Was same problem in codeception-db as well: https://github.com/Codeception/module-db/pull/48