### PR TITLE
Avoid infinite loop while waiting for all running tests to finish

### DIFF
--- a/src/Codeception/Coverage/Subscriber/LocalServer.php
+++ b/src/Codeception/Coverage/Subscriber/LocalServer.php
@@ -151,7 +151,8 @@ class LocalServer extends SuiteSubscriber
         // wait for all running tests to finish
         $blockfilename = Configuration::outputDir() . 'c3tmp/block_report';
         if (file_exists($blockfilename) && filesize($blockfilename) !== 0) {
-            while (file_get_contents($blockfilename) !== '0') {
+            $retries = 10;
+            while (file_get_contents($blockfilename) !== '0' && --$retries >= 0) {
                 usleep(250_000); // 0.25 sec
             }
         }

--- a/src/Codeception/Coverage/Subscriber/LocalServer.php
+++ b/src/Codeception/Coverage/Subscriber/LocalServer.php
@@ -13,6 +13,7 @@ use Codeception\Events;
 use Codeception\Exception\ModuleException;
 use Codeception\Exception\RemoteException;
 use Codeception\Lib\Interfaces\Web as WebInterface;
+use Codeception\Lib\Notification;
 use Codeception\Module\WebDriver as WebDriverModule;
 use Facebook\WebDriver\Exception\NoSuchAlertException;
 use RuntimeException;
@@ -151,9 +152,15 @@ class LocalServer extends SuiteSubscriber
         // wait for all running tests to finish
         $blockfilename = Configuration::outputDir() . 'c3tmp/block_report';
         if (file_exists($blockfilename) && filesize($blockfilename) !== 0) {
-            $retries = 10;
+            $retries = 120; // 30 sec total
             while (file_get_contents($blockfilename) !== '0' && --$retries >= 0) {
                 usleep(250_000); // 0.25 sec
+            }
+            if (file_get_contents($blockfilename) !== '0' && $retries === -1) {
+                Notification::warning(
+                    'Timeout: Some coverage data is not included in the coverage report.',
+                    '',
+                );
             }
         }
 


### PR DESCRIPTION
This could potentially close #6709 but on the other hand it might result in truncated reports again. This would happen if the accumulated runtime of the [registered shutdown functions in c3.php](https://github.com/Codeception/c3/blob/e23298a1cd5e7745973ea26a53572a3d9b013439/c3.php#L416) exceeds 10 * 0.25 = 2.5 sec which seems possible.
Maybe a bigger value for `retries` is necessary.