### PR TITLE
Add missing "Attribute::IS_REPEATABLE" to \Codeception\Attribute\Data…

### DIFF
--- a/src/Codeception/Attribute/DataProvider.php
+++ b/src/Codeception/Attribute/DataProvider.php
@@ -6,7 +6,7 @@ namespace Codeception\Attribute;
 
 use Attribute;
 
-#[Attribute(Attribute::TARGET_METHOD)]
+#[Attribute(Attribute::TARGET_METHOD | Attribute::IS_REPEATABLE)]
 final class DataProvider
 {
     public function __construct(string $methodName)

--- a/tests/data/data_provider/AttributeDataProviderTest.php
+++ b/tests/data/data_provider/AttributeDataProviderTest.php
@@ -12,12 +12,27 @@ class AttributeDataProviderTest extends TestCase
     {
     }
 
+    #[DataProvider('getData')]
+    #[DataProvider('getData2')]
+    public function testDataProviderMultipleTimes($arg1, $arg2): void
+    {
+    }
+
     public function getData(): array
     {
         return [
             'foo' => ['foo', 5],
             'bar' => ['bar', 6],
             'not baz' => ['baz', 7],
+        ];
+    }
+
+    public function getData2(): array
+    {
+        return [
+            'foo2' => ['foo2', 8],
+            'bar2' => ['bar2', 9],
+            'not baz2' => ['baz2', 10],
         ];
     }
 }


### PR DESCRIPTION
ref https://github.com/Codeception/Codeception/issues/6650

I found an other DataProvider related "problem".  `#Attribute(Attribute::IS_REPEATABLE)]` is missing from the `\Codeception\Attribute\DataProvider`

the code works fine, but phpstan was not happy about it

https://phpstan.org/r/58859de2-c361-4060-bc66-1851c3fdf08b