### PR TITLE
Replace Doctrine2 with Doctrine module

### DIFF
--- a/src/Codeception/Lib/ModuleContainer.php
+++ b/src/Codeception/Lib/ModuleContainer.php
@@ -45,7 +45,7 @@ class ModuleContainer
         'Cli' => 'codeception/module-cli',
         'DataFactory' => 'codeception/module-datafactory',
         'Db' => 'codeception/module-db',
-        'Doctrine2' => "codeception/module-doctrine2",
+        'Doctrine' => "codeception/module-doctrine",
         'Filesystem' => 'codeception/module-filesystem',
         'FTP' => 'codeception/module-ftp',
         'Laravel5' => 'codeception/module-laravel5',


### PR DESCRIPTION
The Doctrine2 module was replaced by the Doctrine module which adds support for newer Doctrine versions while keeping compatibility with Doctrine ORMv2/DBALv3.

See https://github.com/Codeception/module-doctrine/pull/28