### PR TITLE
Prevent unrelated error from being displayed if a scenario step has failed

### DIFF
--- a/src/Codeception/ResultAggregator.php
+++ b/src/Codeception/ResultAggregator.php
@@ -219,4 +219,9 @@ class ResultAggregator
     {
         return array_pop($this->failures);
     }
+
+    public function getLastFailure(): ?FailEvent
+    {
+        return end($this->failures) ?: null;
+    }
 }

--- a/src/Codeception/Test/Test.php
+++ b/src/Codeception/Test/Test.php
@@ -169,17 +169,8 @@ abstract class Test extends TestWrapper implements TestInterface, Interfaces\Des
                 $status = self::STATUS_OK;
                 $eventType = Events::TEST_SUCCESS;
 
-                if (method_exists($this, 'getScenario')) {
-                    foreach ($this->getScenario()?->getSteps() ?? [] as $step) {
-                        if ($step->hasFailed()) {
-                            $lastFailure = $result->getLastFailure();
-                            if ($lastFailure?->getTest() === $this) {
-                                $result->popLastFailure();
-                                throw $lastFailure->getFail();
-                            }
-                        }
-                    }
-                }
+                $this->checkConditionalAsserts($result);
+
             } catch (UselessTestException $e) {
                 $result->addUseless(new FailEvent($this, $e, $time));
                 $status = self::STATUS_USELESS;
@@ -300,6 +291,29 @@ abstract class Test extends TestWrapper implements TestInterface, Interfaces\Des
             }
             if (method_exists($this, $hook . 'End')) {
                 $this->{$hook . 'End'}($status, $time, $e);
+            }
+        }
+    }
+
+    private function checkConditionalAsserts(ResultAggregator $result): void
+    {
+        if ( ! method_exists($this, 'getScenario')) {
+            return;
+        }
+
+        $lastFailure = $result->getLastFailure();
+        if ($lastFailure === null) {
+            return;
+        }
+
+        if (Descriptor::getTestSignatureUnique($lastFailure->getTest()) !== Descriptor::getTestSignatureUnique($this)) {
+            return;
+        }
+
+        foreach ($this->getScenario()?->getSteps() ?? [] as $step) {
+            if ($step->hasFailed()) {
+                $result->popLastFailure();
+                throw $lastFailure->getFail();
             }
         }
     }

--- a/src/Codeception/Test/Test.php
+++ b/src/Codeception/Test/Test.php
@@ -170,7 +170,6 @@ abstract class Test extends TestWrapper implements TestInterface, Interfaces\Des
                 $eventType = Events::TEST_SUCCESS;
 
                 $this->checkConditionalAsserts($result);
-
             } catch (UselessTestException $e) {
                 $result->addUseless(new FailEvent($this, $e, $time));
                 $status = self::STATUS_USELESS;
@@ -297,7 +296,7 @@ abstract class Test extends TestWrapper implements TestInterface, Interfaces\Des
 
     private function checkConditionalAsserts(ResultAggregator $result): void
     {
-        if ( ! method_exists($this, 'getScenario')) {
+        if (!method_exists($this, 'getScenario')) {
             return;
         }
 

--- a/src/Codeception/Test/Test.php
+++ b/src/Codeception/Test/Test.php
@@ -172,8 +172,9 @@ abstract class Test extends TestWrapper implements TestInterface, Interfaces\Des
                 if (method_exists($this, 'getScenario')) {
                     foreach ($this->getScenario()?->getSteps() ?? [] as $step) {
                         if ($step->hasFailed()) {
-                            $lastFailure = $result->popLastFailure();
-                            if ($lastFailure !== null) {
+                            $lastFailure = $result->getLastFailure();
+                            if ($lastFailure?->getTest() === $this) {
+                                $result->popLastFailure();
                                 throw $lastFailure->getFail();
                             }
                         }

--- a/tests/cli/RunCest.php
+++ b/tests/cli/RunCest.php
@@ -668,6 +668,16 @@ EOF
         $I->seeInShellOutput(' 13. $I->canSeeFileFound("nothing") at ' . $filename . ':19');
     }
 
+    public function scenarioFailuresDontShowForIncorrectTest(CliGuy $I)
+    {
+        $I->executeCommand('run scenario ExpectedFailureTest --no-ansi', false);
+        $I->seeInShellOutput('x ExpectedFailureTest: Expected failure');
+        $I->seeInShellOutput('+ ExpectedFailureTest: Expected exception');
+        $I->seeInShellOutput('There was 1 failure:');
+        $I->seeInShellOutput('1) ExpectedFailureTest: Expected failure');
+        $I->seeInShellOutput('Tests: 2, Assertions: 2, Failures: 1');
+    }
+
     #[Group('shuffle')]
     public function showSeedNumberOnShuffle(CliGuy $I)
     {

--- a/tests/data/claypit/tests/scenario/ExpectedFailureTest.php
+++ b/tests/data/claypit/tests/scenario/ExpectedFailureTest.php
@@ -1,0 +1,22 @@
+<?php
+
+use Codeception\Test\Unit;
+use PHPUnit\Framework\AssertionFailedError;
+
+class ExpectedFailureTest extends Unit
+{
+
+    protected ScenarioGuy $tester;
+
+    public function testExpectedFailure()
+    {
+        static::fail(':-(');
+    }
+
+    public function testExpectedException()
+    {
+        $this->expectException(AssertionFailedError::class);
+        $this->tester->assertFalse(true);
+    }
+
+}

--- a/tests/data/claypit/tests/scenario/ExpectedFailureTest.php
+++ b/tests/data/claypit/tests/scenario/ExpectedFailureTest.php
@@ -5,7 +5,6 @@ use PHPUnit\Framework\AssertionFailedError;
 
 class ExpectedFailureTest extends Unit
 {
-
     protected ScenarioGuy $tester;
 
     public function testExpectedFailure()
@@ -18,5 +17,4 @@ class ExpectedFailureTest extends Unit
         $this->expectException(AssertionFailedError::class);
         $this->tester->assertFalse(true);
     }
-
 }


### PR DESCRIPTION
This fixes https://github.com/Codeception/Codeception/issues/6716 which results in incorrect test failures being reported where a scenario has a failed assertion that has been caught within the test itself or via `expectException`