### PR TITLE
Fix incorrect Annotation::fetchAll() return structure for single Examples attribute

### DIFF
--- a/src/Codeception/Util/Annotation.php
+++ b/src/Codeception/Util/Annotation.php
@@ -130,6 +130,9 @@ class Annotation
         $attr = $this->attribute($annotation);
         if ($attr) {
             if (!$attr->isRepeated()) {
+                if ($annotation === 'example') {
+                    return [$attr->getArguments()];
+                }
                 return $attr->getArguments();
             }
             $attrs = $this->attributes();

--- a/tests/unit/Codeception/Util/AnnotationTest.php
+++ b/tests/unit/Codeception/Util/AnnotationTest.php
@@ -92,4 +92,63 @@ EOF;
                 ->method('testSingleLineAnnotation')
                 ->fetch('value'));
     }
+
+    public function testFetchAllExamples()
+    {
+        $class = new class {
+            /**
+             * @example ["example 1/2"]
+             * @example ["example 2/2"]
+             */
+            public function multipleAnnotations() {}
+
+            /**
+             * @example ["example 1/1"]
+             */
+            public function singleAnnotation() {}
+
+            #[\Codeception\Attribute\Examples('example 1/2')]
+            #[\Codeception\Attribute\Examples('example 2/2')]
+            public function multipleAttributes() {}
+
+            #[\Codeception\Attribute\Examples('example 1/1')]
+            public function singleAttribute() {}
+        };
+
+        $this->assertSame(
+            ['["example 1/2"]', '["example 2/2"]'],
+            Annotation::forMethod($class, 'multipleAnnotations')->fetchAll('example'));
+
+        $this->assertSame(
+            ['["example 1/1"]'],
+            Annotation::forMethod($class, 'singleAnnotation')->fetchAll('example'));
+
+        $this->assertSame(
+            [['example 1/2'], ['example 2/2']],
+            Annotation::forMethod($class, 'multipleAttributes')->fetchAll('example'));
+
+        $this->assertSame(
+            [['example 1/1']],
+            Annotation::forMethod($class, 'singleAttribute')->fetchAll('example'));
+    }
+
+    public function testFetchAllGiven()
+    {
+        $class = new class {
+            #[\Codeception\Attribute\Given('given 1/2')]
+            #[\Codeception\Attribute\Given('given 2/2')]
+            public function multipleAttributes() {}
+
+            #[\Codeception\Attribute\Given('given 1/1')]
+            public function singleAttribute() {}
+        };
+
+        $this->assertSame(
+            ['given 1/2', 'given 2/2'],
+            Annotation::forMethod($class, 'multipleAttributes')->fetchAll('Given'));
+
+        $this->assertSame(
+            ['given 1/1'],
+            Annotation::forMethod($class, 'singleAttribute')->fetchAll('Given'));
+    }
 }

--- a/tests/unit/Codeception/Util/AnnotationTest.php
+++ b/tests/unit/Codeception/Util/AnnotationTest.php
@@ -100,36 +100,48 @@ EOF;
              * @example ["example 1/2"]
              * @example ["example 2/2"]
              */
-            public function multipleAnnotations() {}
+            public function multipleAnnotations()
+            {
+            }
 
             /**
              * @example ["example 1/1"]
              */
-            public function singleAnnotation() {}
+            public function singleAnnotation()
+            {
+            }
 
             #[\Codeception\Attribute\Examples('example 1/2')]
             #[\Codeception\Attribute\Examples('example 2/2')]
-            public function multipleAttributes() {}
+            public function multipleAttributes()
+            {
+            }
 
             #[\Codeception\Attribute\Examples('example 1/1')]
-            public function singleAttribute() {}
+            public function singleAttribute()
+            {
+            }
         };
 
         $this->assertSame(
             ['["example 1/2"]', '["example 2/2"]'],
-            Annotation::forMethod($class, 'multipleAnnotations')->fetchAll('example'));
+            Annotation::forMethod($class, 'multipleAnnotations')->fetchAll('example')
+        );
 
         $this->assertSame(
             ['["example 1/1"]'],
-            Annotation::forMethod($class, 'singleAnnotation')->fetchAll('example'));
+            Annotation::forMethod($class, 'singleAnnotation')->fetchAll('example')
+        );
 
         $this->assertSame(
             [['example 1/2'], ['example 2/2']],
-            Annotation::forMethod($class, 'multipleAttributes')->fetchAll('example'));
+            Annotation::forMethod($class, 'multipleAttributes')->fetchAll('example')
+        );
 
         $this->assertSame(
             [['example 1/1']],
-            Annotation::forMethod($class, 'singleAttribute')->fetchAll('example'));
+            Annotation::forMethod($class, 'singleAttribute')->fetchAll('example')
+        );
     }
 
     public function testFetchAllGiven()
@@ -137,18 +149,24 @@ EOF;
         $class = new class {
             #[\Codeception\Attribute\Given('given 1/2')]
             #[\Codeception\Attribute\Given('given 2/2')]
-            public function multipleAttributes() {}
+            public function multipleAttributes()
+            {
+            }
 
             #[\Codeception\Attribute\Given('given 1/1')]
-            public function singleAttribute() {}
+            public function singleAttribute()
+            {
+            }
         };
 
         $this->assertSame(
             ['given 1/2', 'given 2/2'],
-            Annotation::forMethod($class, 'multipleAttributes')->fetchAll('Given'));
+            Annotation::forMethod($class, 'multipleAttributes')->fetchAll('Given')
+        );
 
         $this->assertSame(
             ['given 1/1'],
-            Annotation::forMethod($class, 'singleAttribute')->fetchAll('Given'));
+            Annotation::forMethod($class, 'singleAttribute')->fetchAll('Given')
+        );
     }
 }


### PR DESCRIPTION
I had an issue similar to #6726, caused by how `Annotation::fetchAll()` handles the single `#[Examples]` attribute.

Here are comparison of `fetchAll()` return structures:


```php

# Multiple Example attributes:
array (
  0 => array (
    0 => 'example 1',
  ),
  1 => array (
    0 => 'example 2',
  ),
)

# ❌ Single Example attribute (actual):
array (
  0 => 'example 1', 
)

# ✔️ Single Example attribute (expected):
array (
  0 => array (
    0 => 'example 1',
  ),
)
```

This PR includes a fix and unit-tests update for this issue. It also has a test for the `#[Given]` attribute to show that the changes do not break it.