### PR TITLE
Fix  FAIL message color highlighting

### DIFF
--- a/src/Codeception/Reporter/ReportPrinter.php
+++ b/src/Codeception/Reporter/ReportPrinter.php
@@ -64,7 +64,7 @@ class ReportPrinter implements ConsolePrinter
 
     public function testFailure(FailEvent $event): void
     {
-        $this->printTestResult($event->getTest(), "\033[41;37mFAIL\033[0m");
+        $this->printTestResult($event->getTest(), "FAIL");
         $this->failureCount++;
     }
 


### PR DESCRIPTION
Closes #6740

When I run `codecept run --report --no-ansi` there is still color output  
<img width="648" alt="image" src="https://github.com/Codeception/Codeception/assets/20132986/6cf4ae37-d982-4831-af8b-ed0aa4e3f4d8">

So I fixed it by removing extra chars in `ReportPrinter::testFailure`, I think it just typo