### PR TITLE
Prevent serialization of non-backed enums

### DIFF
--- a/src/Codeception/Test/Descriptor.php
+++ b/src/Codeception/Test/Descriptor.php
@@ -4,10 +4,12 @@ declare(strict_types=1);
 
 namespace Codeception\Test;
 
+use BackedEnum;
 use Codeception\Test\Interfaces\Descriptive;
 use Codeception\Test\Interfaces\Plain;
 use Codeception\TestInterface;
 use PHPUnit\Framework\SelfDescribing;
+use UnitEnum;
 
 use function codecept_relative_path;
 use function json_encode;
@@ -49,8 +51,20 @@ class Descriptor
             method_exists($testCase, 'getMetaData')
             && !empty($testCase->getMetadata()->getCurrent('example'))
         ) {
-            $currentExample = json_encode($testCase->getMetadata()->getCurrent('example'), JSON_THROW_ON_ERROR | JSON_INVALID_UTF8_SUBSTITUTE);
-            $example = ':' . substr(sha1($currentExample), 0, 7);
+            $isSerializable = true;
+            if(is_array($testCase->getMetadata()->getCurrent('example'))){
+                foreach ($testCase->getMetadata()->getCurrent('example') as $item) {
+                    if($item instanceof UnitEnum && !($item instanceof BackedEnum)){
+                        $isSerializable = false;
+                        break;
+                    }
+                }
+            }
+
+            if($isSerializable){
+                $currentExample = json_encode($testCase->getMetadata()->getCurrent('example'), JSON_THROW_ON_ERROR | JSON_INVALID_UTF8_SUBSTITUTE);
+                $example = ':' . substr(sha1($currentExample), 0, 7);
+            }
         }
 
         return self::getTestSignature($testCase) . $env . $example;

--- a/src/Codeception/Test/Descriptor.php
+++ b/src/Codeception/Test/Descriptor.php
@@ -52,16 +52,16 @@ class Descriptor
             && !empty($testCase->getMetadata()->getCurrent('example'))
         ) {
             $isSerializable = true;
-            if(is_array($testCase->getMetadata()->getCurrent('example'))){
+            if (is_array($testCase->getMetadata()->getCurrent('example'))) {
                 foreach ($testCase->getMetadata()->getCurrent('example') as $item) {
-                    if($item instanceof UnitEnum && !($item instanceof BackedEnum)){
+                    if ($item instanceof UnitEnum && !($item instanceof BackedEnum)) {
                         $isSerializable = false;
                         break;
                     }
                 }
             }
 
-            if($isSerializable){
+            if ($isSerializable) {
                 $currentExample = json_encode($testCase->getMetadata()->getCurrent('example'), JSON_THROW_ON_ERROR | JSON_INVALID_UTF8_SUBSTITUTE);
                 $example = ':' . substr(sha1($currentExample), 0, 7);
             }


### PR DESCRIPTION
Fixes an [issue #6753](https://github.com/Codeception/Codeception/issues/6753), when `json_encode` fails to serialize non-backed enum