### PR TITLE
Allow a test with only one #Examples() attribute

### DIFF
--- a/src/Codeception/Test/Metadata.php
+++ b/src/Codeception/Test/Metadata.php
@@ -215,7 +215,7 @@ class Metadata
         $params = [];
         foreach ($attributes as $attribute) {
             $name = lcfirst(str_replace('Codeception\\Attribute\\', '', $attribute->getName()));
-            if ($attribute->isRepeated()) {
+            if ($attribute->isRepeated() || $name === 'examples') {
                 $params[$name] ??= [];
                 $params[$name][] = $attribute->getArguments();
                 continue;

--- a/src/Codeception/Util/Annotation.php
+++ b/src/Codeception/Util/Annotation.php
@@ -129,13 +129,13 @@ class Annotation
     {
         $attr = $this->attribute($annotation);
         if ($attr) {
-            if (!$attr->isRepeated()) {
-                return $attr->getArguments();
-            }
-            $attrs = $this->attributes();
             if ($annotation === 'example') {
                 $annotation = 'examples'; // we renamed this annotation
             }
+            if (!$attr->isRepeated() && $annotation !== 'examples') {
+                return $attr->getArguments();
+            }
+            $attrs = $this->attributes();
             $name = ucfirst($annotation);
             $attrs = array_filter($attrs, fn ($a) => $a->getName() === "Codeception\\Attribute\\$name");
             if ($annotation === 'examples') {


### PR DESCRIPTION
If a cest test does only have one `#Examples()` attribute it is not handled as if there are multiple but an InjectionException occurs.
The Examples attribute does now also work if it is not repeated