### PR TITLE
Declare nullable parameter types explicitly for PHP 8.4 compatibility

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -12,5 +12,6 @@ return $config->setRules([
     'array_syntax' => ['syntax' => 'short'],
     'braces' => ['allow_single_line_closure' => true,],
     'no_spaces_after_function_name' => true,
+    'nullable_type_declaration_for_default_null_value' => true,
     'single_blank_line_at_eof' => true,
 ])->setFinder($finder);

--- a/src/Codeception/Application.php
+++ b/src/Codeception/Application.php
@@ -99,7 +99,7 @@ class Application extends BaseApplication
      *
      * @inheritDoc
      */
-    public function run(InputInterface $input = null, OutputInterface $output = null): int
+    public function run(?InputInterface $input = null, ?OutputInterface $output = null): int
     {
         if ($input === null) {
             $input = $this->getCoreArguments();

--- a/src/Codeception/Codecept.php
+++ b/src/Codeception/Codecept.php
@@ -200,7 +200,7 @@ class Codecept
         return Configuration::outputDir() . $path;
     }
 
-    public function run(string $suite, string $test = null, array $config = null): void
+    public function run(string $suite, ?string $test = null, ?array $config = null): void
     {
         ini_set(
             'memory_limit',
@@ -249,7 +249,7 @@ class Codecept
         }
     }
 
-    public function runSuite(array $settings, string $suite, string $test = null): void
+    public function runSuite(array $settings, string $suite, ?string $test = null): void
     {
         $settings['shard'] = $this->options['shard'];
         $suiteManager = new SuiteManager($this->dispatcher, $suite, $settings, $this->options);

--- a/src/Codeception/Command/Shared/ConfigTrait.php
+++ b/src/Codeception/Command/Shared/ConfigTrait.php
@@ -26,7 +26,7 @@ trait ConfigTrait
         return Configuration::suiteSettings($suite, $this->getGlobalConfig());
     }
 
-    protected function getGlobalConfig(string $conf = null): array
+    protected function getGlobalConfig(?string $conf = null): array
     {
         return Configuration::config($conf);
     }

--- a/src/Codeception/Configuration.php
+++ b/src/Codeception/Configuration.php
@@ -148,7 +148,7 @@ class Configuration
      * @return array<string, mixed>
      * @throws ConfigurationException
      */
-    public static function config(string $configFile = null): array
+    public static function config(?string $configFile = null): array
     {
         if (!$configFile && self::$config) {
             return self::$config;

--- a/src/Codeception/Exception/Error.php
+++ b/src/Codeception/Exception/Error.php
@@ -8,7 +8,7 @@ use Exception;
 
 class Error extends Exception
 {
-    public function __construct(string $message, int $code, string $file, int $line, \Exception $previous = null)
+    public function __construct(string $message, int $code, string $file, int $line, ?\Exception $previous = null)
     {
         parent::__construct($message, $code, $previous);
 

--- a/src/Codeception/Exception/ExtensionException.php
+++ b/src/Codeception/Exception/ExtensionException.php
@@ -15,7 +15,7 @@ class ExtensionException extends Exception
      *
      * @param object|string $extension
      */
-    public function __construct($extension, string $message, Exception $previous = null)
+    public function __construct($extension, string $message, ?Exception $previous = null)
     {
         parent::__construct($message, 0, $previous);
         if (is_object($extension)) {

--- a/src/Codeception/Exception/ModuleConfigException.php
+++ b/src/Codeception/Exception/ModuleConfigException.php
@@ -17,7 +17,7 @@ class ModuleConfigException extends Exception
      *
      * @param object|string $module
      */
-    public function __construct($module, string $message, Exception $previous = null)
+    public function __construct($module, string $message, ?Exception $previous = null)
     {
         if (is_object($module)) {
             $module = $module::class;

--- a/src/Codeception/Exception/TestParseException.php
+++ b/src/Codeception/Exception/TestParseException.php
@@ -8,7 +8,7 @@ use Exception;
 
 class TestParseException extends Exception
 {
-    public function __construct(string $fileName, string $errors = null, int $line = null)
+    public function __construct(string $fileName, ?string $errors = null, ?int $line = null)
     {
         $this->message = "Couldn't parse test '{$fileName}'";
         if ($line !== null) {

--- a/src/Codeception/InitTemplate.php
+++ b/src/Codeception/InitTemplate.php
@@ -97,7 +97,7 @@ abstract class InitTemplate
      *
      * @return mixed|string
      */
-    protected function ask(string $question, string|bool|array $answer = null): mixed
+    protected function ask(string $question, string|bool|array|null $answer = null): mixed
     {
         $question = "? {$question}";
         $dialog = new QuestionHelper();

--- a/src/Codeception/Lib/Actor/Shared/Friend.php
+++ b/src/Codeception/Lib/Actor/Shared/Friend.php
@@ -13,7 +13,7 @@ trait Friend
 
     abstract protected function getScenario(): Scenario;
 
-    public function haveFriend(string $name, string $actorClass = null): LibFriend
+    public function haveFriend(string $name, ?string $actorClass = null): LibFriend
     {
         if (!isset($this->friends[$name])) {
             $actor = $actorClass === null ? $this : new $actorClass($this->getScenario());

--- a/src/Codeception/Lib/Di.php
+++ b/src/Codeception/Lib/Di.php
@@ -26,7 +26,7 @@ class Di
 
     protected ?Di $fallback = null;
 
-    public function __construct(Di $fallback = null)
+    public function __construct(?Di $fallback = null)
     {
         $this->fallback = $fallback;
     }
@@ -50,7 +50,7 @@ class Di
      */
     public function instantiate(
         string $className,
-        array $constructorArgs = null,
+        ?array $constructorArgs = null,
         string $injectMethodName = self::DEFAULT_INJECT_METHOD_NAME
     ): ?object {
         // normalize namespace

--- a/src/Codeception/Lib/ModuleContainer.php
+++ b/src/Codeception/Lib/ModuleContainer.php
@@ -171,7 +171,7 @@ class ModuleContainer
     /**
      * Should a method be included as an action?
      */
-    private function includeMethodAsAction(Module $module, ReflectionMethod $method, array $configuredParts = null): bool
+    private function includeMethodAsAction(Module $module, ReflectionMethod $method, ?array $configuredParts = null): bool
     {
         // Filter out excluded actions
         if ($module::$excludeActions && in_array($method->name, $module::$excludeActions)) {

--- a/src/Codeception/Module.php
+++ b/src/Codeception/Module.php
@@ -298,7 +298,7 @@ abstract class Module
      * @param string|null $key
      * @return mixed the config item's value or null if it doesn't exist
      */
-    public function _getConfig(string $key = null): mixed
+    public function _getConfig(?string $key = null): mixed
     {
         if (!$key) {
             return $this->config;

--- a/src/Codeception/Step.php
+++ b/src/Codeception/Step.php
@@ -276,7 +276,7 @@ abstract class Step implements Stringable
     /**
      * @return mixed
      */
-    public function run(ModuleContainer $container = null)
+    public function run(?ModuleContainer $container = null)
     {
         $this->executed = true;
         if ($container === null) {

--- a/src/Codeception/Step/Comment.php
+++ b/src/Codeception/Step/Comment.php
@@ -31,7 +31,7 @@ class Comment extends CodeceptionStep
         return '// ' . $this->getAction();
     }
 
-    public function run(ModuleContainer $container = null): void
+    public function run(?ModuleContainer $container = null): void
     {
         // don't do anything, let's rest
     }

--- a/src/Codeception/Step/ConditionalAssertion.php
+++ b/src/Codeception/Step/ConditionalAssertion.php
@@ -15,7 +15,7 @@ use function ucfirst;
 
 class ConditionalAssertion extends Assertion implements GeneratedStep
 {
-    public function run(ModuleContainer $container = null): void
+    public function run(?ModuleContainer $container = null): void
     {
         try {
             parent::run($container);

--- a/src/Codeception/Step/Executor.php
+++ b/src/Codeception/Step/Executor.php
@@ -19,7 +19,7 @@ class Executor extends CodeceptionStep
         $this->callable = $callable;
     }
 
-    public function run(ModuleContainer $container = null)
+    public function run(?ModuleContainer $container = null)
     {
         $callable = $this->callable;
 

--- a/src/Codeception/Step/Incomplete.php
+++ b/src/Codeception/Step/Incomplete.php
@@ -10,7 +10,7 @@ use PHPUnit\Framework\IncompleteTestError;
 
 class Incomplete extends CodeceptionStep
 {
-    public function run(ModuleContainer $container = null): void
+    public function run(?ModuleContainer $container = null): void
     {
         throw new IncompleteTestError($this->getAction());
     }

--- a/src/Codeception/Step/Meta.php
+++ b/src/Codeception/Step/Meta.php
@@ -14,7 +14,7 @@ use function str_replace;
 
 class Meta extends CodeceptionStep
 {
-    public function run(ModuleContainer $container = null): void
+    public function run(?ModuleContainer $container = null): void
     {
     }
 

--- a/src/Codeception/Step/Retry.php
+++ b/src/Codeception/Step/Retry.php
@@ -38,7 +38,7 @@ EOF;
         $this->arguments = $arguments;
     }
 
-    public function run(ModuleContainer $container = null)
+    public function run(?ModuleContainer $container = null)
     {
         $retry = 0;
         $interval = $this->retryInterval;

--- a/src/Codeception/Step/Skip.php
+++ b/src/Codeception/Step/Skip.php
@@ -12,7 +12,7 @@ use PHPUnit\Runner\Version as PHPUnitVersion;
 
 class Skip extends CodeceptionStep
 {
-    public function run(ModuleContainer $container = null): void
+    public function run(?ModuleContainer $container = null): void
     {
         $skipMessage = $this->getAction();
 

--- a/src/Codeception/Step/TryTo.php
+++ b/src/Codeception/Step/TryTo.php
@@ -13,7 +13,7 @@ use function ucfirst;
 
 class TryTo extends Assertion implements GeneratedStep
 {
-    public function run(ModuleContainer $container = null): bool
+    public function run(?ModuleContainer $container = null): bool
     {
         $this->isTry = true;
         try {

--- a/src/Codeception/Subscriber/Console.php
+++ b/src/Codeception/Subscriber/Console.php
@@ -542,7 +542,7 @@ class Console implements EventSubscriberInterface
         }
     }
 
-    public function printException($exception, string $cause = null): void
+    public function printException($exception, ?string $cause = null): void
     {
         if ($exception instanceof SkippedTest || $exception instanceof IncompleteTestError) {
             if ($exception->getMessage() !== '') {

--- a/src/Codeception/SuiteManager.php
+++ b/src/Codeception/SuiteManager.php
@@ -81,7 +81,7 @@ class SuiteManager
         ini_set('xdebug.show_exception_trace', '0'); // Issue https://github.com/symfony/symfony/issues/7646
     }
 
-    public function loadTests(string $path = null): void
+    public function loadTests(?string $path = null): void
     {
         $testLoader = new Loader($this->settings);
         $testLoader->loadTests($path);

--- a/src/Codeception/Test/Loader.php
+++ b/src/Codeception/Test/Loader.php
@@ -170,7 +170,7 @@ class Loader
         throw new Exception('Test format not supported. Please, check you use the right suffix. Available filetypes: Cept, Cest, Test');
     }
 
-    public function loadTests(string $fileName = null): void
+    public function loadTests(?string $fileName = null): void
     {
         if ($fileName) {
             $this->loadTest($fileName);

--- a/src/Codeception/Test/Metadata.php
+++ b/src/Codeception/Test/Metadata.php
@@ -181,7 +181,7 @@ class Metadata
      * Returns test params like: env, group, skip, incomplete, etc.
      * Can return by annotation or return all if no key passed
      */
-    public function getParam(string $key = null): mixed
+    public function getParam(?string $key = null): mixed
     {
         if ($key) {
             if (isset($this->params[$key])) {

--- a/src/Codeception/Util/ReflectionHelper.php
+++ b/src/Codeception/Util/ReflectionHelper.php
@@ -37,7 +37,7 @@ class ReflectionHelper
      *
      * @throws ReflectionException
      */
-    public static function readPrivateProperty(object $object, string $property, string $class = null): mixed
+    public static function readPrivateProperty(object $object, string $property, ?string $class = null): mixed
     {
         if (is_null($class)) {
             $class = $object;
@@ -54,7 +54,7 @@ class ReflectionHelper
      *
      * @throws ReflectionException
      */
-    public static function setPrivateProperty(object $object, string $property, $value, string $class = null): void
+    public static function setPrivateProperty(object $object, string $property, $value, ?string $class = null): void
     {
         if (is_null($class)) {
             $class = $object;
@@ -71,7 +71,7 @@ class ReflectionHelper
      *
      * @throws ReflectionException
      */
-    public static function invokePrivateMethod(?object $object, string $method, array $args = [], string $class = null): mixed
+    public static function invokePrivateMethod(?object $object, string $method, array $args = [], ?string $class = null): mixed
     {
         if (is_null($class)) {
             $class = $object;

--- a/tests/data/included/jazz/pianist/tests/functional/TestGuy.php
+++ b/tests/data/included/jazz/pianist/tests/functional/TestGuy.php
@@ -291,7 +291,7 @@ class TestGuy extends \Codeception\Actor
      * Conditional Assertion: Test won't be stopped on fail
      * @see \Codeception\Module\Filesystem::seeFileFound()
      */
-    public function canSeeFileFound($filename, string $path = null)
+    public function canSeeFileFound($filename, ?string $path = null)
     {
         return $this->scenario->runStep(new \Codeception\Step\ConditionalAssertion('seeFileFound', func_get_args()));
     }
@@ -312,7 +312,7 @@ class TestGuy extends \Codeception\Actor
      * @param string|null $path
      * @see \Codeception\Module\Filesystem::seeFileFound()
      */
-    public function seeFileFound($filename, string $path = null)
+    public function seeFileFound($filename, ?string $path = null)
     {
         return $this->scenario->runStep(new \Codeception\Step\Assertion('seeFileFound', func_get_args()));
     }
@@ -328,7 +328,7 @@ class TestGuy extends \Codeception\Actor
      * Conditional Assertion: Test won't be stopped on fail
      * @see \Codeception\Module\Filesystem::dontSeeFileFound()
      */
-    public function cantSeeFileFound($filename, string $path = null)
+    public function cantSeeFileFound($filename, ?string $path = null)
     {
         return $this->scenario->runStep(new \Codeception\Step\ConditionalAssertion('dontSeeFileFound', func_get_args()));
     }
@@ -342,7 +342,7 @@ class TestGuy extends \Codeception\Actor
      * @param string|null $path
      * @see \Codeception\Module\Filesystem::dontSeeFileFound()
      */
-    public function dontSeeFileFound($filename, string $path = null)
+    public function dontSeeFileFound($filename, ?string $path = null)
     {
         return $this->scenario->runStep(new \Codeception\Step\Assertion('dontSeeFileFound', func_get_args()));
     }

--- a/tests/data/included/jazz/tests/functional/TestGuy.php
+++ b/tests/data/included/jazz/tests/functional/TestGuy.php
@@ -291,7 +291,7 @@ class TestGuy extends \Codeception\Actor
      * Conditional Assertion: Test won't be stopped on fail
      * @see \Codeception\Module\Filesystem::seeFileFound()
      */
-    public function canSeeFileFound($filename, string $path = null)
+    public function canSeeFileFound($filename, ?string $path = null)
     {
         return $this->scenario->runStep(new \Codeception\Step\ConditionalAssertion('seeFileFound', func_get_args()));
     }
@@ -312,7 +312,7 @@ class TestGuy extends \Codeception\Actor
      * @param string|null $path
      * @see \Codeception\Module\Filesystem::seeFileFound()
      */
-    public function seeFileFound($filename, string $path = null)
+    public function seeFileFound($filename, ?string $path = null)
     {
         return $this->scenario->runStep(new \Codeception\Step\Assertion('seeFileFound', func_get_args()));
     }
@@ -328,7 +328,7 @@ class TestGuy extends \Codeception\Actor
      * Conditional Assertion: Test won't be stopped on fail
      * @see \Codeception\Module\Filesystem::dontSeeFileFound()
      */
-    public function cantSeeFileFound($filename, string $path = null)
+    public function cantSeeFileFound($filename, ?string $path = null)
     {
         return $this->scenario->runStep(new \Codeception\Step\ConditionalAssertion('dontSeeFileFound', func_get_args()));
     }
@@ -342,7 +342,7 @@ class TestGuy extends \Codeception\Actor
      * @param string|null $path
      * @see \Codeception\Module\Filesystem::dontSeeFileFound()
      */
-    public function dontSeeFileFound($filename, string $path = null)
+    public function dontSeeFileFound($filename, ?string $path = null)
     {
         return $this->scenario->runStep(new \Codeception\Step\Assertion('dontSeeFileFound', func_get_args()));
     }

--- a/tests/data/included/shire/tests/functional/TestGuy.php
+++ b/tests/data/included/shire/tests/functional/TestGuy.php
@@ -291,7 +291,7 @@ class TestGuy extends \Codeception\Actor
      * Conditional Assertion: Test won't be stopped on fail
      * @see \Codeception\Module\Filesystem::seeFileFound()
      */
-    public function canSeeFileFound($filename, string $path = null)
+    public function canSeeFileFound($filename, ?string $path = null)
     {
         return $this->scenario->runStep(new \Codeception\Step\ConditionalAssertion('seeFileFound', func_get_args()));
     }
@@ -312,7 +312,7 @@ class TestGuy extends \Codeception\Actor
      * @param string|null $path
      * @see \Codeception\Module\Filesystem::seeFileFound()
      */
-    public function seeFileFound($filename, string $path = null)
+    public function seeFileFound($filename, ?string $path = null)
     {
         return $this->scenario->runStep(new \Codeception\Step\Assertion('seeFileFound', func_get_args()));
     }
@@ -328,7 +328,7 @@ class TestGuy extends \Codeception\Actor
      * Conditional Assertion: Test won't be stopped on fail
      * @see \Codeception\Module\Filesystem::dontSeeFileFound()
      */
-    public function cantSeeFileFound($filename, string $path = null)
+    public function cantSeeFileFound($filename, ?string $path = null)
     {
         return $this->scenario->runStep(new \Codeception\Step\ConditionalAssertion('dontSeeFileFound', func_get_args()));
     }
@@ -342,7 +342,7 @@ class TestGuy extends \Codeception\Actor
      * @param string|null $path
      * @see \Codeception\Module\Filesystem::dontSeeFileFound()
      */
-    public function dontSeeFileFound($filename, string $path = null)
+    public function dontSeeFileFound($filename, ?string $path = null)
     {
         return $this->scenario->runStep(new \Codeception\Step\Assertion('dontSeeFileFound', func_get_args()));
     }


### PR DESCRIPTION
https://wiki.php.net/rfc/deprecate-implicitly-nullable-types deprecates implicitly nullable parameter types in PHP 8.4