### PR TITLE
Data providers support in failed group

### DIFF
--- a/ext/RunFailed.php
+++ b/ext/RunFailed.php
@@ -76,12 +76,12 @@ class RunFailed extends Extension
         }
         $output = [];
         foreach ($result->failures() as $fail) {
-            $index = $fail->getTest()->getMetadata()->getIndex();
-            $output[] = $this->localizePath(Descriptor::getTestFullName($fail->getTest())) . ($index ? "@$index" : '');
+            $output[] = $this->localizePath(Descriptor::getTestFullName($fail->getTest()))
+                . $fail->getTest()->getMetadata()->getIndexTextSuffix();
         }
         foreach ($result->errors() as $fail) {
-            $index = $fail->getTest()->getMetadata()->getIndex();
-            $output[] = $this->localizePath(Descriptor::getTestFullName($fail->getTest())) . ($index ? "@$index" : '');
+            $output[] = $this->localizePath(Descriptor::getTestFullName($fail->getTest()))
+                . $fail->getTest()->getMetadata()->getIndexTextSuffix();
         }
 
         file_put_contents($file, implode("\n", $output));

--- a/ext/RunFailed.php
+++ b/ext/RunFailed.php
@@ -76,10 +76,12 @@ class RunFailed extends Extension
         }
         $output = [];
         foreach ($result->failures() as $fail) {
-            $output[] = $this->localizePath(Descriptor::getTestFullName($fail->getTest()));
+            $index = $fail->getTest()->getMetadata()->getIndex();
+            $output[] = $this->localizePath(Descriptor::getTestFullName($fail->getTest())) . ($index ? "@$index" : '');
         }
         foreach ($result->errors() as $fail) {
-            $output[] = $this->localizePath(Descriptor::getTestFullName($fail->getTest()));
+            $index = $fail->getTest()->getMetadata()->getIndex();
+            $output[] = $this->localizePath(Descriptor::getTestFullName($fail->getTest())) . ($index ? "@$index" : '');
         }
 
         file_put_contents($file, implode("\n", $output));

--- a/src/Codeception/Lib/GroupManager.php
+++ b/src/Codeception/Lib/GroupManager.php
@@ -146,7 +146,7 @@ class GroupManager
     {
         $filename = realpath($test->getFileName());
         $testName = $test->getName();
-        $indexName = $test->getMetadata()->getIndex();
+        $indexName = $test->getMetadata()->getIndexTextSuffix();
         $groups = $test->getMetadata()->getGroups();
 
         foreach ($this->testsInGroups as $group => $tests) {
@@ -155,10 +155,7 @@ class GroupManager
                     $groups[] = $group;
                 }
 
-                if (str_starts_with($filename . ':' . $testName, (string)$testPattern)) {
-                    $groups[] = $group;
-                }
-                if (str_starts_with($filename . ':' . $testName . '@' . $indexName, (string)$testPattern)) {
+                if (str_starts_with($filename . ':' . $testName . $indexName, (string)$testPattern)) {
                     $groups[] = $group;
                 }
                 if (

--- a/src/Codeception/Lib/GroupManager.php
+++ b/src/Codeception/Lib/GroupManager.php
@@ -146,6 +146,7 @@ class GroupManager
     {
         $filename = realpath($test->getFileName());
         $testName = $test->getName();
+        $indexName = $test->getMetadata()->getIndex();
         $groups = $test->getMetadata()->getGroups();
 
         foreach ($this->testsInGroups as $group => $tests) {
@@ -155,6 +156,9 @@ class GroupManager
                 }
 
                 if (str_starts_with($filename . ':' . $testName, (string)$testPattern)) {
+                    $groups[] = $group;
+                }
+                if (str_starts_with($filename . ':' . $testName . '@' . $indexName, (string)$testPattern)) {
                     $groups[] = $group;
                 }
                 if (

--- a/src/Codeception/Test/Metadata.php
+++ b/src/Codeception/Test/Metadata.php
@@ -126,6 +126,16 @@ class Metadata
         return $this->index;
     }
 
+    public function getIndexTextSuffix(): string
+    {
+        if (is_int($this->index)) {
+            return '#' . $this->index;
+        } elseif (is_string($this->index)) {
+            return '@' . $this->index;
+        }
+        return '';
+    }
+
     public function setFilename(string $filename): void
     {
         $this->filename = $filename;
@@ -233,7 +243,7 @@ class Metadata
                 continue;
             };
 
-            $this->params[$single] = array_map(fn($a) => is_array($a) ? $a : [$a], $this->params[$single]);
+            $this->params[$single] = array_map(fn ($a) => is_array($a) ? $a : [$a], $this->params[$single]);
             $this->params[$single] = array_merge(...$this->params[$single]);
         }
 


### PR DESCRIPTION
There was an issue with large data providers. If any test failed, the entire list of tests would rerun as part of the failed group. This PR adds the ability to specify `testName@dataProviderInstanceName` in the failed group, allowing them to run independently without rerunning all the tests provided by the data provider.