### PR TITLE
[6759] Add separate errors tab in HTML report (redirected to 'main')

### DIFF
--- a/src/Codeception/Reporter/HtmlReporter.php
+++ b/src/Codeception/Reporter/HtmlReporter.php
@@ -93,7 +93,7 @@ class HtmlReporter implements EventSubscriberInterface
 
     public function testError(FailEvent $event): void
     {
-        $this->printTestEvent($event, 'scenarioFailed');
+        $this->printTestEvent($event, 'scenarioError');
     }
 
     public function testFailure(FailEvent $event): void
@@ -343,6 +343,7 @@ class HtmlReporter implements EventSubscriberInterface
                 'header'              => $header,
                 'scenarios'           => $this->scenarios,
                 'successfulScenarios' => $result->successfulCount(),
+                'errorScenarios'     => $result->errorCount(),
                 'failedScenarios'     => $result->failureCount(),
                 'skippedScenarios'    => $result->skippedCount(),
                 'incompleteScenarios' => $result->incompleteCount(),

--- a/src/Codeception/Reporter/template/scenarios.html.dist
+++ b/src/Codeception/Reporter/template/scenarios.html.dist
@@ -94,6 +94,7 @@
 
 		 td.scenarioSuccess { color: green }
 		 td.scenarioFailed { color: red }
+		 td.scenarioError { color: darkred }
 		 .scenarioSkipped { color: teal; }
 		 .scenarioIncomplete { color: gray; }
 		 .scenarioUseless { color: orange; }
@@ -212,6 +213,7 @@
      <li> <a href="#" title="Show all" onClick="showAllScenarios()">◯</a></li>
      <li> <a href="#" title="Successful" onClick="toggleScenarios('scenarioSuccess', this.parentElement)"><strong>✔</strong> {successfulScenarios}</a></li>
      <li> <a href="#" title="Failed" onClick="toggleScenarios('scenarioFailed', this.parentElement)"><strong>✗</strong> {failedScenarios}</a></li>
+     <li> <a href="#" title="Errors" onClick="toggleScenarios('scenarioError', this.parentElement)"><strong>E</strong> {errorScenarios}</a></li>
      <li> <a href="#" title="Skipped" onClick="toggleScenarios('scenarioSkipped', this.parentElement)"><strong>S</strong> {skippedScenarios}</a></li>
      <li> <a href="#" title="Incomplete" onClick="toggleScenarios('scenarioIncomplete', this.parentElement)"><strong>I</strong> {incompleteScenarios}</a></li>
      <li> <a href="#" title="Useless" onClick="toggleScenarios('scenarioUseless', this.parentElement)"><strong>U</strong> {uselessScenarios}</a></li>
@@ -230,10 +232,13 @@
         <td width="250" class="scenarioSuccess">Successful scenarios:</td>
         <td class="scenarioSuccessValue"><strong>{successfulScenarios}</strong></td>
        </tr>
-       <tr>
         <td class="scenarioFailed">Failed scenarios:</td>
         <td class="scenarioFailedValue"><strong>{failedScenarios}</strong></td>
        </tr>
+       <tr>
+        <td class="scenarioError">Errors:</td>
+        <td class="scenarioErrorValue"><strong>{errorScenarios}</strong></td>
+       <tr>
        <tr>
         <td class="scenarioSkipped">Skipped scenarios:</td>
         <td class="scenarioSkippedValue"><strong>{skippedScenarios}</strong></td>

--- a/tests/unit/Codeception/Reporter/HtmlReporterTest.php
+++ b/tests/unit/Codeception/Reporter/HtmlReporterTest.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Codeception\Reporter;
+
+use Codeception\Attribute\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+final class ExecutorTest extends TestCase
+{
+
+    public function testShouldError()
+    {
+        throw new \Exception('Error for testing');
+    }
+
+}


### PR DESCRIPTION
(copied from https://github.com/Codeception/Codeception/pull/6765)

Fix for https://github.com/Codeception/Codeception/issues/6759

I added a separate tab for errors. I also added an internal test that errors to test the HTML reporter itself. I can imagine this is undesirable, so please let me know if I have to remove it!