### PR TITLE
Prevent serialization of non-backed enums

### DIFF
--- a/src/Codeception/Test/Descriptor.php
+++ b/src/Codeception/Test/Descriptor.php
@@ -7,6 +7,7 @@ namespace Codeception\Test;
 use Codeception\Test\Interfaces\Descriptive;
 use Codeception\Test\Interfaces\Plain;
 use Codeception\TestInterface;
+use JsonException;
 use PHPUnit\Framework\SelfDescribing;
 
 use function codecept_relative_path;
@@ -33,9 +34,13 @@ class Descriptor
         if (method_exists($testCase, 'getScenario') && $env = $testCase->getScenario()?->current('env')) {
             $signature .= ':' . $env;
         }
-        if (method_exists($testCase, 'getMetadata') && $example = $testCase->getMetadata()->getCurrent('example')) {
-            $encoded = json_encode($example, JSON_THROW_ON_ERROR | JSON_INVALID_UTF8_SUBSTITUTE);
-            $signature .= ':' . substr(sha1($encoded), 0, 7);
+        try {
+            if (method_exists($testCase, 'getMetadata') && $example = $testCase->getMetadata()->getCurrent('example')) {
+                $encoded = json_encode($example, JSON_THROW_ON_ERROR | JSON_INVALID_UTF8_SUBSTITUTE);
+                $signature .= ':' . substr(sha1($encoded), 0, 7);
+            }
+        } catch (JsonException $e) {
+            codecept_debug('Failed serializing example: ' . $e->getMessage());
         }
 
         return $signature;

--- a/src/Codeception/Test/Descriptor.php
+++ b/src/Codeception/Test/Descriptor.php
@@ -89,7 +89,7 @@ class Descriptor
         };
     }
 
-      private static function normalizeForJsonEncoding(mixed $value): mixed
+    private static function normalizeForJsonEncoding(mixed $value): mixed
     {
         return match (true) {
             is_array($value) => array_map(self::normalizeForJsonEncoding(...), $value),

--- a/src/Codeception/Test/Descriptor.php
+++ b/src/Codeception/Test/Descriptor.php
@@ -93,8 +93,7 @@ class Descriptor
     {
         return match (true) {
             is_array($value) => array_map(self::normalizeForJsonEncoding(...), $value),
-            $value instanceof BackedEnum => $value->value,
-            $value instanceof UnitEnum => $value->name,
+            $value instanceof UnitEnum && !($value instanceof BackedEnum) => $value->name,
             default => $value,
         };
     }

--- a/tests/unit/Codeception/Test/DescriptorTest.php
+++ b/tests/unit/Codeception/Test/DescriptorTest.php
@@ -119,6 +119,6 @@ class DescriptorTest extends PHPUnitTestCase
         };
 
         $signature = Descriptor::getTestSignatureUnique($testCase);
-        $this->assertSame($testCase->getSignature() . ':e3d81e2', $signature);
+        $this->assertSame($testCase->getSignature() . ':8aed566', $signature);
     }
 }

--- a/tests/unit/Codeception/Test/DescriptorTest.php
+++ b/tests/unit/Codeception/Test/DescriptorTest.php
@@ -1,0 +1,116 @@
+<?php
+
+declare(strict_types=1);
+
+namespace unit\Codeception\Test;
+
+use Codeception\Test\Descriptor;
+use Codeception\Test\Interfaces\Descriptive;
+use PHPUnit\Framework\TestCase as PHPUnitTestCase;
+
+enum UnitEnumExample
+{
+    case FOO;
+    case BAR;
+}
+
+enum BackedEnumExample: string
+{
+    case FOO = 'one';
+    case BAR = 'two';
+}
+
+class TestCase implements Descriptive
+{
+    public function toString(): string
+    {
+        return 'TestCase';
+    }
+
+    public function getFileName(): string
+    {
+        return __FILE__;
+    }
+
+    public function getSignature(): string
+    {
+        return 'TestCaseSignature';
+    }
+}
+
+class DescriptorTest extends PHPUnitTestCase
+{
+    public function testUnitEnumSerialization(): void
+    {
+        $testCase = new class extends TestCase {
+            public function getMetadata(): object
+            {
+                return new class {
+                    public function getCurrent(string $key): mixed
+                    {
+                        return ['enum' => UnitEnumExample::FOO];
+                    }
+                };
+            }
+
+            public function getSignature(): string
+            {
+                return 'TestCaseMethod';
+            }
+        };
+
+        $signature = Descriptor::getTestSignatureUnique($testCase);
+        $this->assertSame('TestCaseMethod:41e8901', $signature);
+    }
+
+    public function testBackedEnumSerialization(): void
+    {
+        $testCase = new class extends TestCase {
+            public function getMetadata(): object
+            {
+                return new class {
+                    public function getCurrent(string $key): mixed
+                    {
+                        return ['enum' => BackedEnumExample::FOO];
+                    }
+                };
+            }
+
+            public function getSignature(): string
+            {
+                return 'TestCaseMethod';
+            }
+        };
+
+        $signature = Descriptor::getTestSignatureUnique($testCase);
+        $this->assertSame('TestCaseMethod:f863384', $signature);
+    }
+
+
+    public function testNestedEnumSerialization(): void
+    {
+        $testCase = new class extends TestCase {
+            public function getMetadata(): object
+            {
+                return new class {
+                    public function getCurrent(string $key): mixed
+                    {
+                        return [
+                            'unit' => UnitEnumExample::BAR,
+                            'backed' => BackedEnumExample::BAR,
+                            'nested' => ['enum' => UnitEnumExample::FOO]
+                        ];
+                    }
+                };
+            }
+
+            public function getSignature(): string
+            {
+                return 'TestCaseMethod';
+            }
+        };
+
+        $signature = Descriptor::getTestSignatureUnique($testCase);
+        $this->assertSame('TestCaseMethod:db6e561', $signature);
+    }
+}

--- a/tests/unit/Codeception/Test/DescriptorTest.php
+++ b/tests/unit/Codeception/Test/DescriptorTest.php
@@ -52,15 +52,10 @@ class DescriptorTest extends PHPUnitTestCase
                     }
                 };
             }
-
-            public function getSignature(): string
-            {
-                return 'TestCaseMethod';
-            }
         };
 
         $signature = Descriptor::getTestSignatureUnique($testCase);
-        $this->assertSame('TestCaseMethod' . ':41e8901', $signature);
+        $this->assertSame($testCase->getSignature() . ':41e8901', $signature);
     }
 
     public function testBackedEnumSerialization(): void
@@ -75,43 +70,10 @@ class DescriptorTest extends PHPUnitTestCase
                     }
                 };
             }
-
-            public function getSignature(): string
-            {
-                return 'TestCaseMethod';
-            }
         };
 
         $signature = Descriptor::getTestSignatureUnique($testCase);
-        $this->assertSame('TestCaseMethod:f863384', $signature);
-    }
-
-
-    public function testNestedEnumSerialization(): void
-    {
-        $testCase = new class extends TestCase {
-            public function getMetadata(): object
-            {
-                return new class {
-                    public function getCurrent(string $key): mixed
-                    {
-                        return [
-                            'unit' => UnitEnumExample::BAR,
-                            'backed' => BackedEnumExample::BAR,
-                            'nested' => ['enum' => UnitEnumExample::FOO]
-                        ];
-                    }
-                };
-            }
-
-            public function getSignature(): string
-            {
-                return 'TestCaseMethod';
-            }
-        };
-
-        $signature = Descriptor::getTestSignatureUnique($testCase);
-        $this->assertSame('TestCaseMethod:db6e561', $signature);
+        $this->assertSame($testCase->getSignature() . ':f863384', $signature);
     }
 
     public function testStringSerialization(): void
@@ -126,15 +88,10 @@ class DescriptorTest extends PHPUnitTestCase
                     }
                 };
             }
-
-            public function getSignature(): string
-            {
-                return 'TestCaseMethod';
-            }
         };
 
         $signature = Descriptor::getTestSignatureUnique($testCase);
-        $this->assertSame('TestCaseMethod:5cf307a', $signature);
+        $this->assertSame($testCase->getSignature() . ':5cf307a', $signature);
     }
 
     public function testArraySerialization(): void
@@ -146,20 +103,22 @@ class DescriptorTest extends PHPUnitTestCase
                     public function getCurrent(string $key): mixed
                     {
                         return [
-                            'array' => ['one', 'two', 'three'],
-                            'nested' => ['key' => 'value']
+                            'array' => [
+                                'one',
+                                'two',
+                                'three' => [
+                                    'key' => 'value',
+                                    'enum1' => UnitEnumExample::FOO,
+                                    'enum2' => BackedEnumExample::BAR,
+                                ]
+                            ],
                         ];
                     }
                 };
             }
-
-            public function getSignature(): string
-            {
-                return 'TestCaseMethod';
-            }
         };
 
         $signature = Descriptor::getTestSignatureUnique($testCase);
-        $this->assertSame('TestCaseMethod:020e182', $signature);
+        $this->assertSame($testCase->getSignature() . ':e3d81e2', $signature);
     }
 }

--- a/tests/unit/Codeception/Test/DescriptorTest.php
+++ b/tests/unit/Codeception/Test/DescriptorTest.php
@@ -40,6 +40,8 @@ class TestCase implements Descriptive
 
 class DescriptorTest extends PHPUnitTestCase
 {
+    private const TEST_CASE_METHOD = 'TestCaseMethod';
+
     public function testUnitEnumSerialization(): void
     {
         $testCase = new class extends TestCase {
@@ -55,12 +57,12 @@ class DescriptorTest extends PHPUnitTestCase
 
             public function getSignature(): string
             {
-                return 'TestCaseMethod';
+                return self::TEST_CASE_METHOD;
             }
         };
 
         $signature = Descriptor::getTestSignatureUnique($testCase);
-        $this->assertSame('TestCaseMethod:41e8901', $signature);
+        $this->assertSame(self::TEST_CASE_METHOD . ':41e8901', $signature);
     }
 
     public function testBackedEnumSerialization(): void
@@ -78,12 +80,12 @@ class DescriptorTest extends PHPUnitTestCase
 
             public function getSignature(): string
             {
-                return 'TestCaseMethod';
+                return self::TEST_CASE_METHOD;
             }
         };
 
         $signature = Descriptor::getTestSignatureUnique($testCase);
-        $this->assertSame('TestCaseMethod:f863384', $signature);
+        $this->assertSame(self::TEST_CASE_METHOD . ':f863384', $signature);
     }
 
 
@@ -112,5 +114,54 @@ class DescriptorTest extends PHPUnitTestCase
 
         $signature = Descriptor::getTestSignatureUnique($testCase);
         $this->assertSame('TestCaseMethod:db6e561', $signature);
+    }
+
+    public function testStringSerialization(): void
+    {
+        $testCase = new class extends TestCase {
+            public function getMetadata(): object
+            {
+                return new class {
+                    public function getCurrent(string $key): mixed
+                    {
+                        return ['string' => 'test value'];
+                    }
+                };
+            }
+
+            public function getSignature(): string
+            {
+                return 'TestCaseMethod';
+            }
+        };
+
+        $signature = Descriptor::getTestSignatureUnique($testCase);
+        $this->assertSame('TestCaseMethod:d6f6623', $signature);
+    }
+
+    public function testArraySerialization(): void
+    {
+        $testCase = new class extends TestCase {
+            public function getMetadata(): object
+            {
+                return new class {
+                    public function getCurrent(string $key): mixed
+                    {
+                        return [
+                            'array' => ['one', 'two', 'three'],
+                            'nested' => ['key' => 'value']
+                        ];
+                    }
+                };
+            }
+
+            public function getSignature(): string
+            {
+                return 'TestCaseMethod';
+            }
+        };
+
+        $signature = Descriptor::getTestSignatureUnique($testCase);
+        $this->assertSame('TestCaseMethod:e6c31e6', $signature);
     }
 }

--- a/tests/unit/Codeception/Test/DescriptorTest.php
+++ b/tests/unit/Codeception/Test/DescriptorTest.php
@@ -40,8 +40,6 @@ class TestCase implements Descriptive
 
 class DescriptorTest extends PHPUnitTestCase
 {
-    private const TEST_CASE_METHOD = 'TestCaseMethod';
-
     public function testUnitEnumSerialization(): void
     {
         $testCase = new class extends TestCase {
@@ -57,12 +55,12 @@ class DescriptorTest extends PHPUnitTestCase
 
             public function getSignature(): string
             {
-                return self::TEST_CASE_METHOD;
+                return 'TestCaseMethod';
             }
         };
 
         $signature = Descriptor::getTestSignatureUnique($testCase);
-        $this->assertSame(self::TEST_CASE_METHOD . ':41e8901', $signature);
+        $this->assertSame('TestCaseMethod' . ':41e8901', $signature);
     }
 
     public function testBackedEnumSerialization(): void
@@ -80,12 +78,12 @@ class DescriptorTest extends PHPUnitTestCase
 
             public function getSignature(): string
             {
-                return self::TEST_CASE_METHOD;
+                return 'TestCaseMethod';
             }
         };
 
         $signature = Descriptor::getTestSignatureUnique($testCase);
-        $this->assertSame(self::TEST_CASE_METHOD . ':f863384', $signature);
+        $this->assertSame('TestCaseMethod:f863384', $signature);
     }
 
 
@@ -136,7 +134,7 @@ class DescriptorTest extends PHPUnitTestCase
         };
 
         $signature = Descriptor::getTestSignatureUnique($testCase);
-        $this->assertSame('TestCaseMethod:d6f6623', $signature);
+        $this->assertSame('TestCaseMethod:5cf307a', $signature);
     }
 
     public function testArraySerialization(): void
@@ -162,6 +160,6 @@ class DescriptorTest extends PHPUnitTestCase
         };
 
         $signature = Descriptor::getTestSignatureUnique($testCase);
-        $this->assertSame('TestCaseMethod:e6c31e6', $signature);
+        $this->assertSame('TestCaseMethod:020e182', $signature);
     }
 }


### PR DESCRIPTION
Fixes an https://github.com/Codeception/Codeception/issues/6753, when json_encode fails to serialize non-backed enum.   
Follow up https://github.com/Codeception/Codeception/pull/6762#issuecomment-2343641842