### PR TITLE
Update Actor.php: Fixing return types of inherited methods

### DIFF
--- a/src/Codeception/Lib/Generator/Actor.php
+++ b/src/Codeception/Lib/Generator/Actor.php
@@ -84,15 +84,17 @@ EOF;
         $methods = $class->getMethods(ReflectionMethod::IS_PUBLIC);
 
         foreach ($methods as $method) {
-            if ($method->name == '__call') {
+            if ($method->name === '__call') {
                 continue;
             } // skipping magic
-            if ($method->name == '__construct') {
+            if ($method->name === '__construct') {
                 continue;
             } // skipping magic
             $returnType = 'void';
-            if ($method->name == 'haveFriend') {
+            if ($method->name === 'haveFriend') {
                 $returnType = Friend::class;
+            } elseif (in_array($method->name, ['execute', 'expectTo', 'expect', 'amGoingTo', 'am', 'lookForwardTo', 'comment'], true)) {
+                $returnType = 'self';
             }
             $params = $this->getParamsString($method);
             $inherited[] = (new Template($this->inheritedMethodTemplate))


### PR DESCRIPTION
Thanks to psalm I found out that the result should be:
```php
/**
 * Inherited Methods
 * @method void wantTo($text)
 * @method void wantToTest($text)
 * @method self execute($callable)
 * @method self expectTo($prediction)
 * @method self expect($prediction)
 * @method self amGoingTo($argumentation)
 * @method self am($role)
 * @method self lookForwardTo($achieveValue)
 * @method self comment($description)
 * @method void pause($vars = [])
 *
 * @SuppressWarnings(PHPMD)
*/
```

However, I'm not sure if this is really the best way to do it...