### PR TITLE
Update Scenario.php: Adding default value to `current()`

### DIFF
--- a/src/Codeception/Scenario.php
+++ b/src/Codeception/Scenario.php
@@ -53,7 +53,7 @@ class Scenario
         return $this->metadata->getGroups();
     }
 
-    public function current(?string $key)
+    public function current(?string $key = null)
     {
         return $this->metadata->getCurrent($key);
     }


### PR DESCRIPTION
`->current()` is mentioned at https://codeception.com/docs/AdvancedUsage

So if you don't merge this, the docs need to be changed to `->current(null)`