### PR TITLE
#5368 Be able to merge coverage from Local and LocalServer subscribers

### DIFF
--- a/src/Codeception/Coverage/Subscriber/Local.php
+++ b/src/Codeception/Coverage/Subscriber/Local.php
@@ -33,7 +33,6 @@ class Local extends SuiteSubscriber
     protected function isEnabled(): bool
     {
         return !$this->settings['remote'] && $this->settings['enabled'];
-        //return !$this->module instanceof Remote && $this->settings['enabled'];
     }
 
     /**

--- a/src/Codeception/Coverage/Subscriber/Local.php
+++ b/src/Codeception/Coverage/Subscriber/Local.php
@@ -32,7 +32,8 @@ class Local extends SuiteSubscriber
 
     protected function isEnabled(): bool
     {
-        return !$this->module instanceof Remote && $this->settings['enabled'];
+        return !$this->settings['remote'] && $this->settings['enabled'];
+        //return !$this->module instanceof Remote && $this->settings['enabled'];
     }
 
     /**

--- a/src/Codeception/Coverage/Subscriber/LocalServer.php
+++ b/src/Codeception/Coverage/Subscriber/LocalServer.php
@@ -153,10 +153,11 @@ class LocalServer extends SuiteSubscriber
         $this->waitForFile($coverageFile, 5, 500_000);
 
         if (!file_exists($coverageFile)) {
+            /*
+            We want LocalServer subscriber to end gracefully even if there isn't any coverage data collected
+            Scenario: we are collecting both Local and LocalServer coverage
+            */
             return;
-            throw new RuntimeException(
-                file_exists($errorFile) ? file_get_contents($errorFile) : "Code coverage file {$coverageFile} does not exist"
-            );
         }
         if ($coverage = @unserialize(file_get_contents($coverageFile))) {
             $this->preProcessCoverage($coverage)->mergeToPrint($coverage);

--- a/src/Codeception/Coverage/Subscriber/LocalServer.php
+++ b/src/Codeception/Coverage/Subscriber/LocalServer.php
@@ -157,7 +157,7 @@ class LocalServer extends SuiteSubscriber
                 file_exists($errorFile) ? file_get_contents($errorFile) : "Code coverage file {$coverageFile} does not exist"
             );
         }
-
+        return;
         if ($coverage = @unserialize(file_get_contents($coverageFile))) {
             $this->preProcessCoverage($coverage)->mergeToPrint($coverage);
         }

--- a/src/Codeception/Coverage/Subscriber/LocalServer.php
+++ b/src/Codeception/Coverage/Subscriber/LocalServer.php
@@ -153,11 +153,11 @@ class LocalServer extends SuiteSubscriber
         $this->waitForFile($coverageFile, 5, 500_000);
 
         if (!file_exists($coverageFile)) {
+            return;
             throw new RuntimeException(
                 file_exists($errorFile) ? file_get_contents($errorFile) : "Code coverage file {$coverageFile} does not exist"
             );
         }
-        return;
         if ($coverage = @unserialize(file_get_contents($coverageFile))) {
             $this->preProcessCoverage($coverage)->mergeToPrint($coverage);
         }


### PR DESCRIPTION
Hi,
in our project, we have many existing tests that need to use the REST module, but at the same time they directly call functions of the codebase.
We noticed that when we enable the REST module or the WebDriver module the code coverage coming from Local (src/Codeception/Coverage/Subscriber/Local.php) is not counted.

So we modified Local to be able to collect coverage even when using Remote modules.

At the same time we had to modify the LocalServer (src/Codeception/Coverage/Subscriber/LocalServer.php) so that it would not give an error in case no coverage was collected via c3.php