### PR TITLE
PHP 8.4: `E_STRICT` deprecation

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,12 +46,14 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        php: ['8.1', '8.2', '8.3']
+        php: ['8.1', '8.2', '8.3', '8.4']
         mode: ['stable', 'experimental']
         exclude:
           - php: '8.2'
             mode: 'experimental'
           - php: '8.3'
+            mode: 'experimental'
+          - php: '8.4'
             mode: 'experimental'
 
     steps:
@@ -138,7 +140,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [windows-latest]
-        php: ['8.1', '8.2', '8.3']
+        php: ['8.1', '8.2', '8.3', '8.4']
 
     steps:
       - name: Checkout

--- a/src/Codeception/Configuration.php
+++ b/src/Codeception/Configuration.php
@@ -132,7 +132,7 @@ class Configuration
             'enabled' => [],
             'config' => [],
         ],
-        'error_level' => 'E_ALL & ~E_STRICT & ~E_DEPRECATED',
+        'error_level' => 'E_ALL & ~E_DEPRECATED',
         'convert_deprecations_to_exceptions' => false,
     ];
 

--- a/src/Codeception/Subscriber/ErrorHandler.php
+++ b/src/Codeception/Subscriber/ErrorHandler.php
@@ -71,7 +71,12 @@ class ErrorHandler implements EventSubscriberInterface
 
     public function __construct()
     {
-        $this->errorLevel = E_ALL & ~E_STRICT & ~E_DEPRECATED;
+        // E_STRICT is deprecated in PHP 8.4
+        if (\PHP_VERSION_ID < 80400) {
+            $this->errorLevel = E_ALL & ~E_STRICT & ~E_DEPRECATED;
+        } else {
+            $this->errorLevel = E_ALL & ~E_DEPRECATED;
+        }
     }
 
     public function onFinish(SuiteEvent $event): void
@@ -121,7 +126,7 @@ class ErrorHandler implements EventSubscriberInterface
         if (PHPUnitVersion::series() < 10) {
             throw match ($errNum) {
                 E_DEPRECATED, E_USER_DEPRECATED => new PHPUnit9Deprecation($errMsg, $errNum, $errFile, $errLine),
-                E_NOTICE, E_STRICT, E_USER_NOTICE => new PHPUnit9Notice($errMsg, $errNum, $errFile, $errLine),
+                E_NOTICE, E_USER_NOTICE => new PHPUnit9Notice($errMsg, $errNum, $errFile, $errLine),
                 E_WARNING, E_USER_WARNING => new PHPUnit9Warning($errMsg, $errNum, $errFile, $errLine),
                 default => new PHPUnit9Error($errMsg, $errNum, $errFile, $errLine),
             };
@@ -129,7 +134,7 @@ class ErrorHandler implements EventSubscriberInterface
             $errMsg .= ' at ' . $errFile . ':' . $errLine;
             throw match ($errNum) {
                 E_DEPRECATED, E_USER_DEPRECATED => new Deprecation($errMsg, $errNum, $errFile, $errLine),
-                E_NOTICE, E_STRICT, E_USER_NOTICE => new Notice($errMsg, $errNum, $errFile, $errLine),
+                E_NOTICE, E_USER_NOTICE => new Notice($errMsg, $errNum, $errFile, $errLine),
                 E_WARNING, E_USER_WARNING => new Warning($errMsg, $errNum, $errFile, $errLine),
                 default => new Error($errMsg, $errNum, $errFile, $errLine),
             };

--- a/tests/unit.suite.yml
+++ b/tests/unit.suite.yml
@@ -1,7 +1,7 @@
 # Codeception Test Suite Configuration
 
 # suite for unit (internal) tests.
-error_level: "E_ALL | E_STRICT"
+error_level: "E_ALL"
 actor: CodeGuy
 bootstrap: _bootstrap.php
 modules:


### PR DESCRIPTION
PHP 8.4 deprecates the `E_STRICT` error level constant.
RFC: https://wiki.php.net/rfc/deprecations_php_8_4#remove_e_strict_error_level_and_deprecate_e_strict_constant

This PR removes the constant from the internal test suite and the default configuration.

For the error handler the constant is only used for PHP 8.3 or lower.

Furthermore, tests against PHP 8.4 are enabled in the CI.

