### PR TITLE
Allow single #[Examples] attribute

### DIFF
--- a/src/Codeception/Util/Annotation.php
+++ b/src/Codeception/Util/Annotation.php
@@ -130,6 +130,9 @@ class Annotation
         $attr = $this->attribute($annotation);
         if ($attr instanceof ReflectionAttribute) {
             if (!$attr->isRepeated()) {
+                if ($annotation === 'example') {
+                    return [$attr->getArguments()];
+                }
                 return $attr->getArguments();
             }
             $attrs = $this->attributes();

--- a/tests/data/SimpleWithExamplesCest.php
+++ b/tests/data/SimpleWithExamplesCest.php
@@ -17,4 +17,11 @@ class SimpleWithExamplesCest
             return count($example);
         })->seeResultEquals(2);
     }
+
+    #[Examples(first: true, second: false)]
+    public function namedArguments(\CodeGuy $I, \Codeception\Example $example)
+    {
+        $I->assertSame(true, $example['first']);
+        $I->assertSame(false, $example['second']);
+    }
 }

--- a/tests/data/claypit/tests/Attrs/BasicScenarioCest.php
+++ b/tests/data/claypit/tests/Attrs/BasicScenarioCest.php
@@ -39,7 +39,8 @@ class BasicScenarioCest
     }
 
     #[Group('e1')]
-    #[Examples([1, 1], [2, 2])]
+    #[Examples(1, 1)]
+    #[Examples(2, 2)]
     public function exampleTest(AttrsTester $I, Example $e)
     {
         $I->assertEquals($e[1], $e[0]);

--- a/tests/data/data_provider/ExampleAnnotationTest.php
+++ b/tests/data/data_provider/ExampleAnnotationTest.php
@@ -10,7 +10,14 @@ class ExampleAnnotationTest extends TestCase
      * @example ["foo", 5]
      * @example ["bar", 6]
      */
-    public function testExample($arg1, $arg2): void
+    public function testMultipleExamples($arg1, $arg2): void
+    {
+    }
+
+    /**
+     * @example ["bar", 4]
+     */
+    public function testSingleExample($arg1, $arg2): void
     {
     }
 }

--- a/tests/data/data_provider/ExamplesAttributeTest.php
+++ b/tests/data/data_provider/ExamplesAttributeTest.php
@@ -9,7 +9,12 @@ class ExamplesAttributeTest extends TestCase
 {
     #[Examples("foo", 7)]
     #[Examples("bar", 8)]
-    public function testExample($arg1, $arg2): void
+    public function testMultipleExamples($arg1, $arg2): void
+    {
+    }
+
+    #[Examples("foo", 9)]
+    public function testSingleExample($arg1, $arg2): void
     {
     }
 }

--- a/tests/unit/Codeception/Test/DataProviderTest.php
+++ b/tests/unit/Codeception/Test/DataProviderTest.php
@@ -136,10 +136,23 @@ class DataProviderTest extends Unit
         $this->assertSame($expectedResult, $result);
     }
 
-    public function testSupportsExampleAnnotations()
+    public function testSupportsSingleExampleAnnotation()
     {
         require_once codecept_data_dir('data_provider/ExampleAnnotationTest.php');
-        $method = new ReflectionMethod(ExampleAnnotationTest::class, 'testExample');
+        $method = new ReflectionMethod(ExampleAnnotationTest::class, 'testSingleExample');
+        $result = DataProvider::getDataForMethod($method);
+
+        $expectedResult = [
+            ['bar', 4],
+        ];
+
+        $this->assertSame($expectedResult, $result);
+    }
+
+    public function testSupportsMultipleExampleAnnotations()
+    {
+        require_once codecept_data_dir('data_provider/ExampleAnnotationTest.php');
+        $method = new ReflectionMethod(ExampleAnnotationTest::class, 'testMultipleExamples');
         $result = DataProvider::getDataForMethod($method);
 
         $expectedResult = [
@@ -150,10 +163,23 @@ class DataProviderTest extends Unit
         $this->assertSame($expectedResult, $result);
     }
 
-    public function testSupportsExamplesAttribute()
+    public function testSupportsSingleExamplesAttribute()
     {
         require_once codecept_data_dir('data_provider/ExamplesAttributeTest.php');
-        $method = new ReflectionMethod(ExamplesAttributeTest::class, 'testExample');
+        $method = new ReflectionMethod(ExamplesAttributeTest::class, 'testSingleExample');
+        $result = DataProvider::getDataForMethod($method);
+
+        $expectedResult = [
+            ['foo', 9],
+        ];
+
+        $this->assertSame($expectedResult, $result);
+    }
+
+    public function testSupportsMultipleExamplesAttributes()
+    {
+        require_once codecept_data_dir('data_provider/ExamplesAttributeTest.php');
+        $method = new ReflectionMethod(ExamplesAttributeTest::class, 'testMultipleExamples');
         $result = DataProvider::getDataForMethod($method);
 
         $expectedResult = [

--- a/tests/unit/Codeception/TestLoaderTest.php
+++ b/tests/unit/Codeception/TestLoaderTest.php
@@ -106,6 +106,6 @@ final class TestLoaderTest extends \Codeception\PHPUnit\TestCase
     {
         $this->testLoader->loadTest('SimpleWithExamplesCest.php');
         $tests = $this->testLoader->getTests();
-        $this->assertCount(3, $tests);
+        $this->assertCount(4, $tests);
     }
 }


### PR DESCRIPTION
Fixes https://github.com/Codeception/Codeception/issues/6726

The current implementation of the `#[Examples]` attribute differs from what is documented at https://codeception.com/docs/AdvancedUsage#Examples-Attribute (reported in https://github.com/Codeception/codeception.github.com/pull/870).

Futhermore, it is currently not possible to use a single `#[Examples]` attribute in a test.

This PR is based on https://github.com/Codeception/Codeception/pull/6752 which was closed automatically a few months ago and fixed the behavior.

This PR replaces https://github.com/Codeception/Codeception/pull/6789 which is about the same issue.