### PR TITLE
Allow multiple test dependencies - 2

### DIFF
--- a/src/Codeception/Test/TestCaseWrapper.php
+++ b/src/Codeception/Test/TestCaseWrapper.php
@@ -92,11 +92,13 @@ class TestCaseWrapper extends Test implements Reported, Dependent, StrictCoverag
     public function fetchDependencies(): array
     {
         $names = [];
-        foreach ($this->metadata->getDependencies() as $required) {
-            if (!str_contains($required, ':') && method_exists($this->testCase::class, $required)) {
-                $required = $this->testCase::class . ':' . $required;
+        foreach ($this->metadata->getDependencies() as $dependency) {
+            foreach ((array)$dependency as $required) {
+                if (!str_contains($required, ':') && method_exists($this->testCase::class, $required)) {
+                    $required = $this->testCase::class . ':' . $required;
+                }
+                $names[] = $required;
             }
-            $names[] = $required;
         }
         return $names;
     }

--- a/src/Codeception/Test/Unit.php
+++ b/src/Codeception/Test/Unit.php
@@ -156,11 +156,13 @@ class Unit extends TestCase implements
     public function fetchDependencies(): array
     {
         $names = [];
-        foreach ($this->getMetadata()->getDependencies() as $required) {
-            if (!str_contains((string) $required, ':') && method_exists($this, $required)) {
-                $required = static::class . ":{$required}";
+        foreach ($this->getMetadata()->getDependencies() as $dependency) {
+            foreach ((array)$dependency as $required) {
+                if (!str_contains((string)$required, ':') && method_exists($this, $required)) {
+                    $required = static::class . ":{$required}";
+                }
+                $names[] = $required;
             }
-            $names[] = $required;
         }
         return $names;
     }


### PR DESCRIPTION
In #6676, a fix has been made that allows for multiple `Depends`. It seems that two other places have a similar logic which have been forgotten.

<details>

<summary>The exception I got</summary>

```
Fatal error: Uncaught TypeError: str_contains(): Argument #1 ($haystack) must be of type string, array given in /data/vendor/codeception/codeception/src/Codeception/Test/TestCaseWrapper.php:96
Stack trace:
#0 /data/vendor/codeception/codeception/src/Codeception/Test/TestCaseWrapper.php(96): str_contains(Array, ':')
#1 /data/vendor/codeception/codeception/src/Codeception/Suite.php(157): Codeception\Test\TestCaseWrapper->fetchDependencies()
#2 /data/vendor/codeception/codeception/src/Codeception/Suite.php(136): Codeception\Suite->getDependencies(Object(Codeception\Test\TestCaseWrapper))
#3 /data/vendor/codeception/codeception/src/Codeception/SuiteManager.php(93): Codeception\Suite->reorderDependencies()
#4 /data/vendor/codeception/codeception/src/Codeception/Codecept.php(251): Codeception\SuiteManager->loadTests(NULL)
#5 /data/vendor/codeception/codeception/src/Codeception/Codecept.php(209): Codeception\Codecept->runSuite(Array, 'Business', NULL)
#6 /data/vendor/codeception/codeception/src/Codeception/Command/Run.php(576): Codeception\Codecept->run('Business')
#7 /data/vendor/codeception/codeception/src/Codeception/Command/Run.php(541): Codeception\Command\Run->runSuites(Array, Array)
#8 /data/vendor/codeception/codeception/src/Codeception/Command/Run.php(416): Codeception\Command\Run->runIncludedSuites(Array, '/data/', Array, Array)
#9 /data/vendor/symfony/console/Command/Command.php(298): Codeception\Command\Run->execute(Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
#10 /data/vendor/symfony/console/Application.php(1040): Symfony\Component\Console\Command\Command->run(Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
#11 /data/vendor/symfony/console/Application.php(301): Symfony\Component\Console\Application->doRunCommand(Object(Codeception\Command\Run), Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
#12 /data/vendor/symfony/console/Application.php(171): Symfony\Component\Console\Application->doRun(Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
#13 /data/vendor/codeception/codeception/src/Codeception/Application.php(112): Symfony\Component\Console\Application->run(Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
#14 /data/vendor/codeception/codeception/app.php(45): Codeception\Application->run()
#15 /data/vendor/codeception/codeception/app.php(46): {closure}()
#16 /data/vendor/codeception/codeception/codecept(7): require('/data/vendor/co...')
#17 /data/vendor/bin/codecept(119): include('/data/vendor/co...')
#18 {main}
  thrown in /data/vendor/codeception/codeception/src/Codeception/Test/TestCaseWrapper.php on line 96
```
</details>