### PR TITLE
Fix include path for behat/gherkin v4.12

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,6 +22,7 @@
         "behat/gherkin": "^4.6.2",
         "codeception/lib-asserts": "^2.0",
         "codeception/stub": "^4.1",
+        "composer-runtime-api": "^2.1",
         "phpunit/phpunit": "^9.5.20 || ^10.0 || ^11.0 || ^12.0",
         "phpunit/php-code-coverage": "^9.2 || ^10.0 || ^11.0 || ^12.0",
         "phpunit/php-text-template": "^2.0 || ^3.0 || ^4.0 || ^5.0",

--- a/src/Codeception/Test/Loader/Gherkin.php
+++ b/src/Codeception/Test/Loader/Gherkin.php
@@ -18,13 +18,13 @@ use Codeception\Exception\TestParseException;
 use Codeception\Lib\Generator\Shared\Classname;
 use Codeception\Test\Gherkin as GherkinFormat;
 use Codeception\Util\Annotation;
+use Composer\InstalledVersions;
 use ReflectionClass;
 
 use function array_keys;
 use function array_map;
 use function array_merge;
 use function class_exists;
-use function dirname;
 use function file_get_contents;
 use function get_class_methods;
 use function glob;
@@ -72,9 +72,8 @@ class Gherkin implements LoaderInterface
         if (!class_exists(GherkinKeywords::class)) {
             throw new TestParseException('Feature file can only be parsed with Behat\Gherkin library. Please install `behat/gherkin` with Composer');
         }
-        $gherkin = new ReflectionClass(\Behat\Gherkin\Gherkin::class);
-        $gherkinClassPath = dirname($gherkin->getFileName());
-        $i18n = require $gherkinClassPath . '/../../../i18n.php';
+        $gherkinVendorPath = InstalledVersions::getInstallPath('behat/gherkin');
+        $i18n = require $gherkinVendorPath . '/i18n.php';
         $keywords = new GherkinKeywords($i18n);
         $lexer = new GherkinLexer($keywords);
         $this->parser = new GherkinParser($lexer);


### PR DESCRIPTION
Fixes https://github.com/Codeception/Codeception/issues/6833

https://getcomposer.org/doc/07-runtime.md#knowing-the-path-in-which-a-package-is-installed is used to determine the vendor directory of the `behat/gherkin` composer package.
This way it is no longer necessary to work with paths relative to some source files which was broken because `behat/gherkin:4.12` relocated some source files.