### PR TITLE
Fix loading keywords in behat/gherkin v4.12

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "ext-curl": "*",
         "ext-json": "*",
         "ext-mbstring": "*",
-        "behat/gherkin": "^4.6.2",
+        "behat/gherkin": "^4.12",
         "codeception/lib-asserts": "^2.0",
         "codeception/stub": "^4.1",
         "phpunit/phpunit": "^9.5.20 || ^10.0 || ^11.0 || ^12.0",

--- a/src/Codeception/Test/Loader/Gherkin.php
+++ b/src/Codeception/Test/Loader/Gherkin.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Codeception\Test\Loader;
 
 use Behat\Gherkin\Filter\RoleFilter;
-use Behat\Gherkin\Keywords\ArrayKeywords as GherkinKeywords;
+use Behat\Gherkin\Keywords\CachedArrayKeywords as GherkinKeywords;
 use Behat\Gherkin\Lexer as GherkinLexer;
 use Behat\Gherkin\Node\ExampleNode;
 use Behat\Gherkin\Node\FeatureNode;
@@ -24,7 +24,6 @@ use function array_keys;
 use function array_map;
 use function array_merge;
 use function class_exists;
-use function dirname;
 use function file_get_contents;
 use function get_class_methods;
 use function glob;
@@ -72,10 +71,7 @@ class Gherkin implements LoaderInterface
         if (!class_exists(GherkinKeywords::class)) {
             throw new TestParseException('Feature file can only be parsed with Behat\Gherkin library. Please install `behat/gherkin` with Composer');
         }
-        $gherkin = new ReflectionClass(\Behat\Gherkin\Gherkin::class);
-        $gherkinClassPath = dirname($gherkin->getFileName());
-        $i18n = require $gherkinClassPath . '/../../../i18n.php';
-        $keywords = new GherkinKeywords($i18n);
+        $keywords = GherkinKeywords::withDefaultKeywords();
         $lexer = new GherkinLexer($keywords);
         $this->parser = new GherkinParser($lexer);
         $this->fetchGherkinSteps();


### PR DESCRIPTION
Fixes https://github.com/Codeception/Codeception/issues/6833

Replaces https://github.com/Codeception/Codeception/pull/6836

I overlooked that the release notes https://github.com/Behat/Gherkin/releases/tag/v4.12.0 already suggest a simple way to load the keywords independently from the file path:

> Provide CachedArrayKeywords::withDefaultKeywords() to create an instance without an external dependency on the path to the i18n.php file in this repo. NOTE that paths to source files will change in the next Gherkin release - use the new constructor to avoid any impact.

This PR uses this approach and bumps the minimum version of `behat/gherkin` to 4.12 which should be okay because this version does still support PHP 8.1 which is also the case for codeception v5.