### PR TITLE
Fix AssertsTest CI pipeline

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "ext-json": "*",
         "ext-mbstring": "*",
         "behat/gherkin": "^4.12",
-        "codeception/lib-asserts": "^2.0",
+        "codeception/lib-asserts": "^2.2",
         "codeception/stub": "^4.1",
         "phpunit/phpunit": "^9.5.20 || ^10.0 || ^11.0 || ^12.0",
         "phpunit/php-code-coverage": "^9.2 || ^10.0 || ^11.0 || ^12.0",


### PR DESCRIPTION
Fixes https://github.com/Codeception/module-asserts/pull/29#issuecomment-2828563411

The latest version of `codeception/module-asserts` contains unit tests for all assertions provided by this module.
However, they only work with `codeception/lib-asserts:2.2` because this version contains various compatibility fixes for newer PHPUnit versions.

That's why this PR bumps the `codeception/lib-asserts` version to 2.2 order to make the CI green again.