### PR TITLE
Issue 6857: Upddate Actor::__call() to have return type 'mixed'

### DIFF
--- a/src/Codeception/Actor.php
+++ b/src/Codeception/Actor.php
@@ -40,7 +40,7 @@ abstract class Actor
     {
     }
 
-    public function __call(string $method, array $arguments): never
+    public function __call(string $method, array $arguments): mixed
     {
         throw new RuntimeException(sprintf('Call to undefined method %s::%s', static::class, $method));
     }


### PR DESCRIPTION
A previous PR set the return type of Actor::__call() to 'never'.  This means that any classes that inherit from Actor must also declare __call() with return type 'never'.   Any "tester" classes that use __call() to delegate or proxy other services will fail.  Additionally, the PHP documentation specifies a return type of 'mixed" for __call().  See https://www.php.net/manual/en/language.oop5.overloading.php#object.call.  Thank you for accepting this PR.