### PR TITLE
Fix empty data provider case

### DIFF
--- a/src/Codeception/Test/DataProvider.php
+++ b/src/Codeception/Test/DataProvider.php
@@ -81,7 +81,7 @@ class DataProvider
             }
         }
 
-        return $data ?: null;
+        return $data;
     }
 
     /**

--- a/tests/data/data_provider/PublicEmptyDataProviderTest.php
+++ b/tests/data/data_provider/PublicEmptyDataProviderTest.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace data\data_provider;
+
+use PHPUnit\Framework\TestCase;
+
+class PublicEmptyDataProviderTest extends TestCase
+{
+    /**
+     * @dataProvider getData
+     */
+    public function testDataProvider($arg1, $arg2): void
+    {
+    }
+
+    public function getData(): array
+    {
+        return [];
+    }
+}

--- a/tests/unit/Codeception/Test/DataProviderTest.php
+++ b/tests/unit/Codeception/Test/DataProviderTest.php
@@ -6,6 +6,7 @@ use Codeception\Exception\InvalidTestException;
 use Codeception\Test\DataProvider;
 use Codeception\Test\Unit;
 use data\data_provider\DataProviderReceivesActorTest;
+use data\data_provider\PublicEmptyDataProviderTest;
 
 class DataProviderTest extends Unit
 {
@@ -68,6 +69,17 @@ class DataProviderTest extends Unit
             'bar' => ['bar', 6],
             'not baz' => ['baz', 7],
         ];
+
+        $this->assertSame($expectedResult, $result);
+    }
+
+    public function testExecutesPublicEmptyDataProviderInTheSameClass()
+    {
+        require_once codecept_data_dir('data_provider/PublicEmptyDataProviderTest.php');
+        $method = new ReflectionMethod(PublicEmptyDataProviderTest::class, 'testDataProvider');
+        $result = DataProvider::getDataForMethod($method);
+
+        $expectedResult = [];
 
         $this->assertSame($expectedResult, $result);
     }


### PR DESCRIPTION
With the changes made in https://github.com/Codeception/Codeception/commit/209bc3c3e9ec9848ccdfd2740215359d33df850f#diff-491b603924b17185d68644a66e22a2ff3a83d8e0cf8a2af533114967cf9b9b49R31-R84, when a function has an empty data provider, the result of the method is `null` instead of an empty array.