### PR TITLE
Remove Reflection*::setAccessible() usage

### DIFF
--- a/src/Codeception/Lib/Di.php
+++ b/src/Codeception/Lib/Di.php
@@ -115,7 +115,6 @@ class Di
                 );
             }
 
-            $reflectedMethod->setAccessible(true);
             $reflectedMethod->invokeArgs($object, $args);
         }
     }

--- a/src/Codeception/Util/ReflectionHelper.php
+++ b/src/Codeception/Util/ReflectionHelper.php
@@ -21,21 +21,18 @@ class ReflectionHelper
     public static function readPrivateProperty(object $object, string $property, ?string $class = null): mixed
     {
         $ref = new ReflectionProperty($class ?? $object, $property);
-        $ref->setAccessible(true);
         return $ref->getValue($object);
     }
 
     public static function setPrivateProperty(object $object, string $property, mixed $value, ?string $class = null): void
     {
         $ref = new ReflectionProperty($class ?? $object, $property);
-        $ref->setAccessible(true);
         $ref->setValue($object, $value);
     }
 
     public static function invokePrivateMethod(?object $object, string $method, array $args = [], ?string $class = null): mixed
     {
         $ref = new ReflectionMethod($class ?? $object, $method);
-        $ref->setAccessible(true);
         return $ref->invokeArgs($object, $args);
     }
 


### PR DESCRIPTION
> Note: As of PHP 8.1.0, calling this method has no effect; all properties are accessible by default. 

https://www.php.net/manual/en/reflectionproperty.setaccessible.php
https://www.php.net/manual/en/reflectionmethod.setaccessible.php

This would eventually raise a deprecation notice