### PR TITLE
Add guard before deleting directory

### DIFF
--- a/tests/unit/C3Test.php
+++ b/tests/unit/C3Test.php
@@ -33,7 +33,10 @@ class C3Test extends \Codeception\PHPUnit\TestCase
     {
         unset($_SERVER['HTTP_X_CODECEPTION_CODECOVERAGE_DEBUG']);
         unset($_SERVER['HTTP_X_CODECEPTION_CODECOVERAGE']);
-        \Codeception\Util\FileSystem::deleteDir($this->c3_dir);
+
+        if (is_string($this->c3_dir)) {
+            \Codeception\Util\FileSystem::deleteDir($this->c3_dir);
+        }
 
         if (method_exists('CodeCoverage', 'deactivate')) {
             // PHPUnit 10+


### PR DESCRIPTION
In case the xdebug extension is not loaded, the directory variable does not get initialized in `_setUp()` which results in a type error inside `_tearDown()`.

```php
 [TypeError] Codeception\Util\FileSystem::deleteDir(): Argument #1 ($dir) must be of type string, null given, called in tests/unit/C3Test.php on line 36
```

This PR just adds a guard to fix this issue.