### PR TITLE
Replace backtick with shell_exec to prevent php8.5 deprecation

### DIFF
--- a/src/Codeception/Subscriber/Console.php
+++ b/src/Codeception/Subscriber/Console.php
@@ -728,7 +728,7 @@ class Console implements EventSubscriberInterface
             if (getenv('COLUMNS')) {
                 $this->width = (int)getenv('COLUMNS');
             } else {
-                $this->width = (int)(`command -v tput >> /dev/null 2>&1 && tput cols`) - 2;
+                $this->width = (int)shell_exec('command -v tput >> /dev/null 2>&1 && tput cols') - 2;
             }
         } elseif ($this->isWin() && (PHP_SAPI === "cli")) {
             exec('mode con', $output);


### PR DESCRIPTION
Prevents deprecation warning

```
Deprecated: The backtick (`) operator is deprecated, use shell_exec() instead in vendor/codeception/codeception/src/Codeception/Subscriber/Console.php on line 731
```