### PR TITLE
Fix test for lib-asserts v3

### DIFF
--- a/tests/cli/BuildCest.php
+++ b/tests/cli/BuildCest.php
@@ -32,7 +32,8 @@ final class BuildCest
         $I->seeFileFound('CliGuyActions.php', 'tests/support/_generated');
         $I->seeThisFileMatches("!^<\?php .*\n// phpcs:ignoreFile!");
         $I->seeInThisFile('seeFileFound(');
-        $I->seeInThisFile('public function assertSame($expected, $actual, string $message = "") {');
+        // native mixed and void return type was added in codeception/lib-asserts:3
+        $I->seeThisFileMatches('!public function assertSame\((mixed )?\$expected, (mixed )?\$actual, string \$message = ""\)(: void)? \{!');
     }
 
     public function usesLiteralTypes(CliGuy $I, Scenario $scenario)


### PR DESCRIPTION
Seems like I overlooked the failing test in https://github.com/Codeception/Codeception/pull/6887