### PR TITLE
Avoid declaring nullable parameter implicitly in BuildCest

### DIFF
--- a/tests/cli/BuildCest.php
+++ b/tests/cli/BuildCest.php
@@ -110,7 +110,7 @@ final class BuildCest
     public function generateNullableParameters(CliGuy $I, Scenario $scenario)
     {
         $cliHelperContents = file_get_contents(codecept_root_dir('tests/support/CliHelper.php'));
-        $cliHelperContents = str_replace('public function seeDirFound($dir)', 'public function seeDirFound(\Directory $dir = null): ?bool', $cliHelperContents);
+        $cliHelperContents = str_replace('public function seeDirFound($dir)', 'public function seeDirFound(?\Directory $dir = null): ?bool', $cliHelperContents);
         file_put_contents(codecept_root_dir('tests/support/CliHelper.php'), $cliHelperContents);
 
         $I->runShellCommand('php codecept build');


### PR DESCRIPTION
Fixes the following deprecation warning when running the test suite with PHP 8.4:

> PHP Deprecated:  Codeception\Module\CliHelper::seeDirFound(): Implicitly marking parameter $dir as nullable is deprecated, the explicit nullable type must be used instead