### PR TITLE
Add support for never return type in DryRun

### DIFF
--- a/src/Codeception/Command/DryRun.php
+++ b/src/Codeception/Command/DryRun.php
@@ -184,7 +184,7 @@ class DryRun extends Command
     private function getDefaultValueForBuiltinType(ReflectionNamedType $returnType): mixed
     {
         return match ($returnType->getName()) {
-            'mixed', 'void' => null,
+            'mixed', 'never', 'void' => null,
             'string' => '',
             'int' => 0,
             'float' => 0.0,


### PR DESCRIPTION
Fixes some errors in the test suite, f.e.

> In DryRun.php line 194:
>                                  
>   Unsupported return type never  
>                                  
> 
> dry-run <suite> [<test>]
> 
> ✖ DryRunCest: Run cest with examples (0.10s)