### PR TITLE
CI: fix module-phpbrowser test in experimental build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -101,7 +101,8 @@ jobs:
           if [ "${{ matrix.mode }}" = "stable" ]; then
             composer update --no-interaction --no-progress --optimize-autoloader --ansi
           else
-            composer update --prefer-lowest --no-interaction --no-progress --optimize-autoloader --ansi
+            composer update --prefer-lowest --no-interaction --no-progress --ansi
+            composer require --dev "codeception/module-phpbrowser:>=3.0.2" -W --prefer-lowest --no-interaction --no-progress --optimize-autoloader --ansi
           fi
 
       - name: Test that failing test really fails


### PR DESCRIPTION
`composer --prefer-lowest` installs version `2.5` of `module-phpbrowser` which does not contain https://github.com/Codeception/module-phpbrowser/pull/43

That's why this PR makes sure that at least version `3.0.2` is installed.