### PR TITLE
Removing "hidden" `memory_limit`

### DIFF
--- a/src/Codeception/Codecept.php
+++ b/src/Codeception/Codecept.php
@@ -197,8 +197,6 @@ class Codecept
 
     public function run(string $suite, ?string $test = null, ?array $config = null): void
     {
-        ini_set('memory_limit', $this->config['settings']['memory_limit'] ?? '1024M');
-
         $config = Configuration::suiteSettings($suite, $config ?: Configuration::config());
         $selectedEnvironments = $this->options['env'];
 


### PR DESCRIPTION
Fixes https://github.com/Codeception/Codeception/issues/6840

This line was introduced in 2013 by https://github.com/Codeception/Codeception/commit/558498efbf8f125c14e9a0bc55791b26b1b44162

Overriding what the user has in `php.ini` doesn't make sense to me.