### PR TITLE
PHP 8.5: Avoid accessing deprecated $http_response_header

### DIFF
--- a/src/Codeception/Coverage/Subscriber/LocalServer.php
+++ b/src/Codeception/Coverage/Subscriber/LocalServer.php
@@ -196,21 +196,19 @@ class LocalServer extends SuiteSubscriber
         $contents = file_get_contents("{$c3Url}/c3/report/{$action}", false, $context);
 
         // $http_response_header is deprecated as of PHP 8.5
-        if (!function_exists('http_get_last_response_headers')) {
-            $responseHeaders = $http_response_header;
-        } else {
-            $responseHeaders = http_get_last_response_headers();
+        if (function_exists('http_get_last_response_headers')) {
+            $http_response_header = http_get_last_response_headers();
         }
 
         $okHeaders = array_filter(
-            $responseHeaders,
+            $http_response_header,
             fn ($h) => preg_match('#^HTTP(.*?)\s200#', $h)
         );
         if ($okHeaders === []) {
-            throw new RemoteException("Request was not successful. See response header: " . $responseHeaders[0]);
+            throw new RemoteException("Request was not successful. See response header: " . $http_response_header[0]);
         }
         if ($contents === false) {
-            $this->getRemoteError($responseHeaders);
+            $this->getRemoteError($http_response_header);
         }
         return $contents;
     }


### PR DESCRIPTION
Follow-up of https://github.com/Codeception/Codeception/pull/6919

The current check does still trigger a deprecation warning in PHP 8.5.

This is fixed by using the check as suggested in https://wiki.php.net/rfc/deprecations_php_8_5#deprecate_the_http_response_header_predefined_variable