### PR TITLE
catch general Throwable for before test execution code

### DIFF
--- a/src/Codeception/Test/Test.php
+++ b/src/Codeception/Test/Test.php
@@ -144,7 +144,7 @@ abstract class Test extends TestWrapper implements TestInterface, Interfaces\Des
             $this->fire(Events::TEST_BEFORE, new TestEvent($this));
             $this->runHooks('Start');
             $failedToStart = false;
-        } catch (\Exception $e) {
+        } catch (\Throwable $e) {
             $failedToStart = true;
             $this->dispatchOutcome(Events::TEST_ERROR, $e, $time);
         }


### PR DESCRIPTION
We had an error in a seeder and this was not caught by codeception. No test was running but codeception return 0 so it looked like everything was fine.
This is a fix this that case.