### PR TITLE
Update Console.php: Adding line number before each step

### DIFF
--- a/src/Codeception/Subscriber/Console.php
+++ b/src/Codeception/Subscriber/Console.php
@@ -461,6 +461,9 @@ class Console implements EventSubscriberInterface
         if ($this->metaStep instanceof Meta) {
             $msg->append('  ');
         }
+        if (is_int($step->getLineNumber())) {
+            $msg->append((string)$step->getLineNumber() . ' ');
+        }
         $msg->append($step->getPrefix());
         $prefixLength = $msg->getLength();
         if (!$this->metaStep instanceof Meta) {


### PR DESCRIPTION
I never noticed that the `I` in the beginning of each line is printed in bold ;-) Now, with the line number, this looks ugly. So IMO the bold could be removed.