### PR TITLE
Fix typo in Debug::debug() docblock

### DIFF
--- a/src/Codeception/Util/Debug.php
+++ b/src/Codeception/Util/Debug.php
@@ -24,7 +24,7 @@ class Debug
     }
 
     /**
-     * Prints data to screen. Message can be any time of data
+     * Prints data to screen. Message can be any type of data
      */
     public static function debug(mixed $message): void
     {


### PR DESCRIPTION
Fixes #6933 