### PR TITLE
Improve handling of coverage exclude option on PHPUnit 11+

### DIFF
--- a/src/Codeception/Coverage/Filter.php
+++ b/src/Codeception/Coverage/Filter.php
@@ -118,7 +118,7 @@ class Filter
         $coveredFiles = array_udiff(
             $allIncludedFiles,
             $allExcludedFiles,
-            function (SplFileInfo $file1, SplFileInfo $file2): array {
+            function (SplFileInfo $file1, SplFileInfo $file2): int {
                 return $file1->getRealPath() <=> $file2->getRealPath();
             }
         );

--- a/src/Codeception/Coverage/Filter.php
+++ b/src/Codeception/Coverage/Filter.php
@@ -118,7 +118,7 @@ class Filter
         $coveredFiles = array_udiff(
             $allIncludedFiles,
             $allExcludedFiles,
-            function(SplFileInfo $file1, SplFileInfo $file2) {
+            function (SplFileInfo $file1, SplFileInfo $file2): array {
                 return $file1->getRealPath() <=> $file2->getRealPath();
             }
         );

--- a/src/Codeception/Coverage/Filter.php
+++ b/src/Codeception/Coverage/Filter.php
@@ -12,6 +12,7 @@ use SebastianBergmann\CodeCoverage\CodeCoverage;
 use SebastianBergmann\CodeCoverage\Filter as PhpUnitFilter;
 use Symfony\Component\Finder\Exception\DirectoryNotFoundException;
 use Symfony\Component\Finder\Finder;
+use Symfony\Component\Finder\SplFileInfo;
 
 use function array_pop;
 use function explode;
@@ -114,7 +115,13 @@ class Filter
         $allIncludedFiles = $this->matchFiles($include);
         $allExcludedFiles = $this->matchFiles($exclude);
 
-        $coveredFiles = array_diff($allIncludedFiles, $allExcludedFiles);
+        $coveredFiles = array_udiff(
+            $allIncludedFiles,
+            $allExcludedFiles,
+            function(SplFileInfo $file1, SplFileInfo $file2) {
+                return $file1->getRealPath() <=> $file2->getRealPath();
+            }
+        );
 
         foreach ($coveredFiles as $coveredFile) {
             $this->phpUnitFilter->includeFile((string) $coveredFile);


### PR DESCRIPTION
In https://github.com/Codeception/Codeception/pull/6739 the `exclude` option for running coverage on PHPUnit11+ was reimplemented by @Naktibalda 

The alternative implementation (`function newWhiteList()`) creates a regression when running on Windows with a config like:
```
coverage:
  enabled: true
  include:
    - application/foo/*.php
  exclude:
    - application/foo/bar/*
```

The `array_diff()` compares files between both file lists based on string paths which may not use exactly the same formatting. In the case above, files in `bar` are not excluded because when comparing paths they _partially_ contain `\` instead of `/` as a directory separator.

This PR improves the compare function looking at normalized real paths.

