### PR TITLE
Fix compatibility with sebastian/diff v8.3.0 + v9.0.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
         "phpunit/phpunit": "^9.5.20 | ^10.0 | ^11.0 | ^12.0 | ^13.0",
         "psy/psysh": "^0.11.2 | ^0.12",
         "sebastian/comparator": "^4.0.5 | ^5.0 | ^6.0 | ^7.0 | ^8.0",
-        "sebastian/diff": "^4.0.3 | ^5.0 | ^6.0 | ^7.0 | ^8.0",
+        "sebastian/diff": "^4.0.3 | ^5.0 | ^6.0 | ^7.0 | ^8.0 | ^9.0",
         "symfony/console": ">=5.4.24 <9.0",
         "symfony/css-selector": ">=5.4.24 <9.0",
         "symfony/event-dispatcher": ">=5.4.24 <9.0",

--- a/src/Codeception/Lib/Console/DiffFactory.php
+++ b/src/Codeception/Lib/Console/DiffFactory.php
@@ -6,6 +6,7 @@ namespace Codeception\Lib\Console;
 
 use SebastianBergmann\Comparator\ComparisonFailure;
 use SebastianBergmann\Diff\Differ;
+use SebastianBergmann\Diff\Output\StrictUnifiedDiffOutputBuilder;
 use SebastianBergmann\Diff\Output\UnifiedDiffOutputBuilder;
 
 class DiffFactory
@@ -17,7 +18,23 @@ class DiffFactory
 
     private function getDiff(string $expected = '', string $actual = ''): string
     {
-        $differ = new Differ(new UnifiedDiffOutputBuilder(''));
+        // Ensure compatibility with sebastian/diff v8.3.0
+        // v8.3.0 added the parameter $emitNoLineEndEofWarning
+        // v9.0.0 removed the class UnifiedDiffOutputBuilder, therefore
+        // use StrictUnifiedDiffOutputBuilder right away.
+        if (
+            !class_exists(UnifiedDiffOutputBuilder::class)
+            || property_exists(UnifiedDiffOutputBuilder::class, 'emitNoLineEndEofWarning')
+        ) {
+            $outputBuilder = new StrictUnifiedDiffOutputBuilder([
+                'addLineNumbers' => false,
+                'emitNoLineEndEofWarning' => false,
+                'header' => '',
+            ]);
+        } else {
+            $outputBuilder = new UnifiedDiffOutputBuilder('');
+        }
+        $differ = new Differ($outputBuilder);
         return ($expected || $actual) ? $differ->diff($expected, $actual) : '';
     }
 }


### PR DESCRIPTION
Fixes the tests for PHP 8.4 + 8.5, f.e. https://github.com/Codeception/Codeception/actions/runs/27507867517/job/81302295365

From https://github.com/sebastianbergmann/diff/releases/tag/8.3.0:

> UnifiedDiffOutputBuilder now accepts a fourth $emitNoLineEndEofWarning constructor parameter (default true) to suppress the \ No newline at end of file marker for use cases such as PHPUnit comparison failures that are not related to files

This PR sets the parameter to `false`.