### PR TITLE
Respect CoversNothing in Cest coverage

### DIFF
--- a/src/Codeception/Test/Cest.php
+++ b/src/Codeception/Test/Cest.php
@@ -18,6 +18,7 @@ use LogicException;
 use PHPUnit\Framework\IncompleteTestError;
 use PHPUnit\Framework\SkippedTest;
 use PHPUnit\Metadata\Api\CodeCoverage;
+use PHPUnit\Metadata\Parser\Registry as MetadataRegistry;
 use PHPUnit\Runner\Version as PHPUnitVersion;
 use PHPUnit\Util\Test as TestUtil;
 use ReflectionMethod;
@@ -251,6 +252,11 @@ class Cest extends Test implements
     {
         if (PHPUnitVersion::series() < 10) {
             return TestUtil::getLinesToBeCovered($this->testClass, $this->testMethod);
+        }
+
+        $metadata = MetadataRegistry::parser()->forClassAndMethod($this->testClass, $this->testMethod);
+        if ($metadata->isCoversNothing()->isNotEmpty()) {
+            return false;
         }
 
         if (version_compare(CodeCoverageVersion::id(), '12', '>=')) {

--- a/src/Codeception/Test/Feature/CodeCoverage.php
+++ b/src/Codeception/Test/Feature/CodeCoverage.php
@@ -54,6 +54,10 @@ trait CodeCoverage
                         class_exists($tcClass)
                         && method_exists($tcClass, 'fromArray')
                     ) {
+                        if ($linesToBeCovered === false) {
+                            $codeCoverage->stop(false, $status);
+                            return;
+                        }
                         $linesToBeCovered = $tcClass::fromArray($linesToBeCovered);
                         $linesToBeUsed    = $tcClass::fromArray($linesToBeUsed);
                     }

--- a/tests/unit/Codeception/Test/CestTest.php
+++ b/tests/unit/Codeception/Test/CestTest.php
@@ -6,7 +6,9 @@ use Tests\Support\CodeTester;
 use Codeception\Attribute\Group;
 use Codeception\Test\Cest;
 use Codeception\Test\Descriptor;
+use Codeception\Test\Test;
 use Codeception\Test\Unit;
+use PHPUnit\Framework\Attributes\CoversNothing;
 
 final class CestTest extends Unit
 {
@@ -38,5 +40,44 @@ final class CestTest extends Unit
         );
 
         $this->assertSame(['bootstrap'], $cest->getMetadata()->getGroups());
+    }
+
+    public function testCoversNothingDisablesCodeCoverage(): void
+    {
+        $cest = new Cest(new CoversNothingCest(), 'example', __FILE__);
+
+        $this->assertFalse($cest->getLinesToBeCovered());
+
+        $cest->codeCoverageStart();
+        $cest->codeCoverageEnd(Test::STATUS_OK, 0.0);
+    }
+
+    public function testMethodLevelCoversNothingDisablesCodeCoverage(): void
+    {
+        $cest = new Cest(new MethodCoversNothingCest(), 'withoutCoverage', __FILE__);
+        $ordinaryCest = new Cest(new MethodCoversNothingCest(), 'withCoverage', __FILE__);
+
+        $this->assertFalse($cest->getLinesToBeCovered());
+        $this->assertSame([], $ordinaryCest->getLinesToBeCovered());
+    }
+}
+
+#[CoversNothing]
+final class CoversNothingCest
+{
+    public function example(): void
+    {
+    }
+}
+
+final class MethodCoversNothingCest
+{
+    #[CoversNothing]
+    public function withoutCoverage(): void
+    {
+    }
+
+    public function withCoverage(): void
+    {
     }
 }


### PR DESCRIPTION
## Summary

- preserve class- and method-level `#[CoversNothing]` metadata for Cest tests
- discard coverage collected for those tests before php-code-coverage converts target arrays
- add focused regression coverage for the sentinel and the coverage end path

## Root cause

For PHPUnit 10 and newer, Cest coverage target extraction returned an empty target list for `CoversNothing`, losing the historical `false` sentinel. Restoring that sentinel exposed a second issue in php-code-coverage 12 and newer, where it was passed to the array-only `TargetCollection::fromArray()` API.

## Verification

- `php codecept run unit Codeception/Test/CestTest --no-colors`
- `php codecept run unit Codeception/Test --no-colors`
- full unit suite: 260 tests, 513 assertions, 6 skipped
- focused PHPStan analysis of both changed production files
- production and test PSR-12 checks
- PHP syntax checks and `git diff --check`

Fixes #6940
